### PR TITLE
Voice: route Kizz speech through Codex MCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,10 +2005,10 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
 ]
@@ -2730,6 +2730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,7 +2981,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.36",
  "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
@@ -2995,7 +3001,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3160,14 +3166,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3419,6 +3425,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
@@ -3426,9 +3446,31 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3439,6 +3481,17 @@ checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3501,6 +3554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3573,29 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4140,11 +4225,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -4179,7 +4275,11 @@ checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.22.4",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.25.0",
  "tungstenite 0.21.0",
 ]
 
@@ -4421,6 +4521,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ server = [
     "dep:tower-http",
     "dep:roon-api",
     "dep:reqwest",
+    "dep:tempfile",
     "dep:tracing-subscriber",
     "dep:config",
     "dep:image",
@@ -84,7 +85,7 @@ dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version 
 # These are optional and only included when building for server
 
 # Web framework (server only)
-axum = { version = "0.8", features = ["macros"], optional = true }
+axum = { version = "0.8", features = ["macros", "ws"], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", features = ["cors", "compression-gzip", "trace"], optional = true }
@@ -95,6 +96,7 @@ roon-api = { git = "https://github.com/open-horizon-labs/rust-roon-api.git", bra
 
 # HTTP client (server only)
 reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls"], optional = true }
+tempfile = { version = "3", optional = true }
 
 # Logging subscriber (server only - needs tokio)
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ server = [
     "dep:resvg",
     "dep:tokio-stream",
     "dep:tokio-util",
+    "dep:tokio-tungstenite",
     "dep:ssdp-client",
     "dep:mdns-sd",
     "dep:gethostname",
@@ -110,6 +111,7 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 # Tokio stream utilities (server only)
 tokio-stream = { version = "0.1", features = ["sync"], optional = true }
 tokio-util = { version = "0.7", optional = true }
+tokio-tungstenite = { version = "0.21", features = ["rustls-tls-native-roots"], optional = true }
 
 # SSDP/UPnP/mDNS discovery (server only)
 ssdp-client = { version = "2", optional = true }

--- a/scripts/run_kizz_voice.sh
+++ b/scripts/run_kizz_voice.sh
@@ -55,7 +55,7 @@ trap 'kill "$server_pid" 2>/dev/null || true' EXIT INT TERM
 
 for _ in {1..50}; do
   if curl -fsS --max-time 1 http://127.0.0.1:8088/voice/reliability >/dev/null; then
-    echo "UHC voice ready on :8088 (Deepgram + AssemblyAI + ElevenLabs $ELEVENLABS_STT_MODEL)"
+    echo "UHC voice ready on :8088 (single-prompt intent gate; Deepgram + AssemblyAI + ElevenLabs $ELEVENLABS_STT_MODEL)"
     wait "$server_pid"
     exit $?
   fi

--- a/scripts/run_kizz_voice.sh
+++ b/scripts/run_kizz_voice.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 binary="$repo_dir/target/debug/unified-hifi-control"
 voice_env="${VOICE_ENV_FILE:-$HOME/.config/open-horizon-labs/voice.env}"
+voice_config_dir="${KIZZ_VOICE_CONFIG_DIR:-$HOME/.config/open-horizon-labs/kizz-voice-uhc}"
+voice_data_dir="${KIZZ_VOICE_DATA_DIR:-$HOME/.local/share/open-horizon-labs/kizz-voice-uhc}"
 
 if [[ ! -x "$binary" ]]; then
   echo "UHC binary not found: $binary" >&2
@@ -48,6 +50,28 @@ export ELEVENLABS_STT_MODEL="${ELEVENLABS_STT_MODEL:-scribe_v2_realtime}"
 export ASSEMBLYAI_MIN_TURN_SILENCE_MS="${ASSEMBLYAI_MIN_TURN_SILENCE_MS:-1200}"
 export ASSEMBLYAI_MAX_TURN_SILENCE_MS="${ASSEMBLYAI_MAX_TURN_SILENCE_MS:-3000}"
 export DEEPGRAM_EOT_TIMEOUT_MS="${DEEPGRAM_EOT_TIMEOUT_MS:-3000}"
+export UHC_PORT=8088
+export UHC_CONFIG_DIR="$voice_config_dir"
+export UHC_DATA_DIR="$voice_data_dir"
+export KIZZ_MCP_URL="${KIZZ_MCP_URL:-http://127.0.0.1:18088/mcp}"
+
+# The voice process is a sidecar, not a second controller. Isolate its state and
+# keep every music adapter disabled so it cannot compete with the existing UHC
+# for a Roon extension identity. Codex delegates actions to KIZZ_MCP_URL.
+install -d "$UHC_CONFIG_DIR/unified-hifi" "$UHC_DATA_DIR"
+printf '%s\n' \
+  '{' \
+  '  "hide_knobs_page": true,' \
+  '  "hide_hqp_page": true,' \
+  '  "hide_lms_page": true,' \
+  '  "adapters": {' \
+  '    "roon": false,' \
+  '    "upnp": false,' \
+  '    "openhome": false,' \
+  '    "lms": false,' \
+  '    "hqplayer": false' \
+  '  }' \
+  '}' > "$UHC_CONFIG_DIR/unified-hifi/app-settings.json"
 
 "$binary" &
 server_pid=$!
@@ -55,7 +79,7 @@ trap 'kill "$server_pid" 2>/dev/null || true' EXIT INT TERM
 
 for _ in {1..50}; do
   if curl -fsS --max-time 1 http://127.0.0.1:8088/voice/reliability >/dev/null; then
-    echo "UHC voice ready on :8088 (single-prompt intent gate; Deepgram + AssemblyAI + ElevenLabs $ELEVENLABS_STT_MODEL)"
+    echo "UHC voice sidecar ready on :8088 (music MCP: $KIZZ_MCP_URL; Deepgram + AssemblyAI + ElevenLabs $ELEVENLABS_STT_MODEL)"
     wait "$server_pid"
     exit $?
   fi

--- a/scripts/run_kizz_voice.sh
+++ b/scripts/run_kizz_voice.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+binary="$repo_dir/target/debug/unified-hifi-control"
+voice_env="${VOICE_ENV_FILE:-$HOME/.config/open-horizon-labs/voice.env}"
+
+if [[ ! -x "$binary" ]]; then
+  echo "UHC binary not found: $binary" >&2
+  echo "Build it first with: cargo build" >&2
+  exit 1
+fi
+
+# Kill UHC processes that own or have accepted connections on the Kizz voice
+# port. This also catches relative-path launches whose command line omits the
+# checkout path, while leaving unrelated processes alone.
+uhc_pids() {
+  while read -r pid; do
+    [[ -n "$pid" ]] || continue
+    if ps -p "$pid" -o command= 2>/dev/null | grep -q 'unified-hifi-control'; then
+      echo "$pid"
+    fi
+  done < <(lsof -t -iTCP:8088 2>/dev/null | sort -u)
+}
+
+while read -r pid; do
+  [[ -n "$pid" ]] || continue
+  kill -TERM "$pid" 2>/dev/null || true
+done < <(uhc_pids)
+sleep 1
+while read -r pid; do
+  [[ -n "$pid" ]] || continue
+  kill -KILL "$pid" 2>/dev/null || true
+done < <(uhc_pids)
+
+if [[ -f "$voice_env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$voice_env"
+  set +a
+else
+  echo "Voice environment file not found: $voice_env" >&2
+  exit 1
+fi
+
+export KIZZ_STT_PROVIDER="${KIZZ_STT_PROVIDER:-deepgram}"
+export ELEVENLABS_STT_MODEL="${ELEVENLABS_STT_MODEL:-scribe_v2_realtime}"
+export ASSEMBLYAI_MIN_TURN_SILENCE_MS="${ASSEMBLYAI_MIN_TURN_SILENCE_MS:-1200}"
+export ASSEMBLYAI_MAX_TURN_SILENCE_MS="${ASSEMBLYAI_MAX_TURN_SILENCE_MS:-3000}"
+export DEEPGRAM_EOT_TIMEOUT_MS="${DEEPGRAM_EOT_TIMEOUT_MS:-3000}"
+
+"$binary" &
+server_pid=$!
+trap 'kill "$server_pid" 2>/dev/null || true' EXIT INT TERM
+
+for _ in {1..50}; do
+  if curl -fsS --max-time 1 http://127.0.0.1:8088/voice/reliability >/dev/null; then
+    echo "UHC voice ready on :8088 (Deepgram + AssemblyAI + ElevenLabs $ELEVENLABS_STT_MODEL)"
+    wait "$server_pid"
+    exit $?
+  fi
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    wait "$server_pid" || true
+    echo "UHC exited before becoming ready" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+
+echo "UHC did not become ready on :8088" >&2
+exit 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,3 +63,5 @@ pub mod mdns;
 // Server-only: it necessarily touches both `crate::bus` and `crate::adaptive`.
 #[cfg(feature = "server")]
 pub mod producers;
+#[cfg(feature = "server")]
+pub mod voice;

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,6 +483,11 @@ mod server {
             // separate from the controller API so an embedded listener cannot
             // reach arbitrary App Server capabilities.
             .route("/voice/v1", get(voice::voice_upgrade))
+            .route(
+                "/voice/provider",
+                get(voice::provider_get).post(voice::provider_post),
+            )
+            .route("/voice/reliability", get(voice::reliability_get))
             // Knob hardware API routes
             .route("/knob/zones", get(knobs::knob_zones_handler))
             .route("/knob/now_playing", get(knobs::knob_now_playing_handler))

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 mod server {
     use unified_hifi_control::{
         adapters, aggregator, api, app, bus, config, coordinator, embedded, firmware, knobs, mcp,
-        mdns,
+        mdns, voice,
     };
 
     // Import load_app_settings for checking adapter enabled state
@@ -479,6 +479,10 @@ mod server {
             .route("/api/settings", post(api::api_settings_post_handler))
             // Event stream (SSE)
             .route("/events", get(api::events_handler))
+            // Kizz's LAN-only realtime voice transport.  This is deliberately
+            // separate from the controller API so an embedded listener cannot
+            // reach arbitrary App Server capabilities.
+            .route("/voice/v1", get(voice::voice_upgrade))
             // Knob hardware API routes
             .route("/knob/zones", get(knobs::knob_zones_handler))
             .route("/knob/now_playing", get(knobs::knob_now_playing_handler))
@@ -633,6 +637,11 @@ mod server {
                 }
             }
         };
+
+        tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            voice::prewarm().await;
+        });
 
         let server_result = axum::serve(
             listener,

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,10 +483,8 @@ mod server {
             // separate from the controller API so an embedded listener cannot
             // reach arbitrary App Server capabilities.
             .route("/voice/v1", get(voice::voice_upgrade))
-            .route(
-                "/voice/provider",
-                get(voice::provider_get).post(voice::provider_post),
-            )
+            .route("/voice/provider", get(voice::provider_get))
+            .route("/voice/provider", post(voice::provider_post))
             .route("/voice/reliability", get(voice::reliability_get))
             // Knob hardware API routes
             .route("/knob/zones", get(knobs::knob_zones_handler))

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -7,13 +7,17 @@
 
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::WebSocketUpgrade;
+use axum::http::StatusCode;
 use axum::response::Response;
 use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::VecDeque;
 use std::io::Write;
 use std::path::Path;
 use std::process::Stdio;
 use std::sync::OnceLock;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::mpsc;
@@ -30,6 +34,134 @@ const CODEX_TURN_TIMEOUT: Duration = Duration::from_secs(30);
 const DEEPGRAM_AUDIO_CHUNK_BYTES: usize = 16_000 * 2 * 80 / 1000;
 
 static CODEX_AGENT: OnceLock<Mutex<Option<CodexVoiceAgent>>> = OnceLock::new();
+static RUNTIME: OnceLock<VoiceRuntime> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SttProvider {
+    Deepgram,
+    Assemblyai,
+}
+
+impl SttProvider {
+    fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "deepgram" => Some(Self::Deepgram),
+            "assemblyai" | "assembly" => Some(Self::Assemblyai),
+            _ => None,
+        }
+    }
+    fn name(self) -> &'static str {
+        match self {
+            Self::Deepgram => "deepgram",
+            Self::Assemblyai => "assemblyai",
+        }
+    }
+}
+
+struct VoiceRuntime {
+    provider: tokio::sync::RwLock<SttProvider>,
+    reliability: Mutex<VoiceReliability>,
+}
+
+#[derive(Default, Serialize)]
+struct VoiceReliability {
+    attempts: u64,
+    connected: u64,
+    failed: u64,
+    completed: u64,
+    recent: VecDeque<VoiceTurnRecord>,
+}
+
+#[derive(Serialize)]
+struct VoiceTurnRecord {
+    timestamp: u64,
+    provider: &'static str,
+    outcome: &'static str,
+    latency_ms: Option<u64>,
+    detail: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct ProviderRequest {
+    provider: String,
+}
+
+fn runtime() -> &'static VoiceRuntime {
+    RUNTIME.get_or_init(|| VoiceRuntime {
+        provider: tokio::sync::RwLock::new(
+            std::env::var("KIZZ_STT_PROVIDER")
+                .ok()
+                .and_then(|v| SttProvider::parse(&v))
+                .unwrap_or(SttProvider::Deepgram),
+        ),
+        reliability: Mutex::new(VoiceReliability::default()),
+    })
+}
+
+async fn record_turn(
+    provider: SttProvider,
+    outcome: &'static str,
+    latency_ms: Option<u64>,
+    detail: Option<String>,
+) {
+    let state = runtime();
+    let mut reliability = state.reliability.lock().await;
+    match outcome {
+        "connected" => {
+            reliability.attempts += 1;
+            reliability.connected += 1;
+        }
+        "failed" => {
+            reliability.attempts += 1;
+            reliability.failed += 1;
+        }
+        "completed" => reliability.completed += 1,
+        _ => {}
+    }
+    reliability.recent.push_back(VoiceTurnRecord {
+        timestamp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        provider: provider.name(),
+        outcome,
+        latency_ms,
+        detail,
+    });
+    while reliability.recent.len() > 50 {
+        reliability.recent.pop_front();
+    }
+}
+
+pub async fn provider_get() -> axum::Json<Value> {
+    let provider = *runtime().provider.read().await;
+    axum::Json(json!({"provider": provider.name()}))
+}
+
+pub async fn provider_post(
+    axum::Json(request): axum::Json<ProviderRequest>,
+) -> Result<axum::Json<Value>, (StatusCode, axum::Json<Value>)> {
+    let Some(provider) = SttProvider::parse(&request.provider) else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({"error":"provider must be deepgram or assemblyai"})),
+        ));
+    };
+    *runtime().provider.write().await = provider;
+    tracing::info!(
+        provider = provider.name(),
+        "Kizz STT provider changed at runtime"
+    );
+    Ok(axum::Json(json!({"provider": provider.name()})))
+}
+
+pub async fn reliability_get() -> axum::Json<Value> {
+    let reliability = runtime().reliability.lock().await;
+    axum::Json(
+        serde_json::to_value(&*reliability).unwrap_or_else(|_| json!({"error":"unavailable"})),
+    )
+}
 
 #[derive(Debug)]
 enum DeepgramEvent {
@@ -41,12 +173,18 @@ enum DeepgramEvent {
 }
 
 struct SttTurn {
+    provider: SttProvider,
     input: mpsc::Sender<SttInput>,
 }
 
 enum SttInput {
     Audio(Vec<u8>),
     Close,
+}
+
+struct ProviderEvent {
+    provider: SttProvider,
+    event: DeepgramEvent,
 }
 
 impl SttTurn {
@@ -89,10 +227,12 @@ async fn run_session(mut socket: WebSocket) {
     let mut utterance = Vec::<u8>::new();
     let mut current_zone_id = None::<String>;
     let mut wake_sample = None::<WakeSample>;
-    let (deepgram_events_tx, mut deepgram_events_rx) = mpsc::channel(8);
-    let mut deepgram = None::<SttTurn>;
+    let (provider_events_tx, mut provider_events_rx) = mpsc::channel(16);
+    let mut stt_turns = Vec::<SttTurn>::new();
     let mut pending_fallback = None::<(Vec<u8>, Option<String>)>;
     let mut turn_completed = false;
+    let mut turn_started = None::<Instant>;
+    let mut failed_stt = 0usize;
     loop {
         tokio::select! {
             incoming = socket.recv() => {
@@ -122,10 +262,8 @@ async fn run_session(mut socket: WebSocket) {
                             let excess = utterance.len() - MAX_UTTERANCE_BYTES;
                             utterance.drain(..excess);
                         }
-                        if let Some(turn) = deepgram.as_ref() {
-                            if turn.send_audio(pcm.to_vec()).await.is_err() {
-                                deepgram = None;
-                            }
+                        for turn in &stt_turns {
+                            let _ = turn.send_audio(pcm.to_vec()).await;
                         }
                     }
                     Message::Text(message) => match parse_client_event(&message) {
@@ -134,15 +272,29 @@ async fn run_session(mut socket: WebSocket) {
                             current_zone_id = zone_id;
                             turn_completed = false;
                             pending_fallback = None;
-                            deepgram = match start_stt_turn(deepgram_events_tx.clone()).await {
-                                Ok(turn) => Some(turn),
-                                Err(error) => {
-                                    tracing::warn!(%error, "streaming speech recognition unavailable");
-                                    None
+                            let selected_provider = *runtime().provider.read().await;
+                            turn_started = Some(Instant::now());
+                            stt_turns.clear();
+                            failed_stt = 0;
+                            let providers = if selected_provider == SttProvider::Deepgram { vec![SttProvider::Deepgram, SttProvider::Assemblyai] } else { vec![SttProvider::Assemblyai, SttProvider::Deepgram] };
+                            for provider in providers {
+                                let connect_started = Instant::now();
+                                match start_provider_turn(provider, provider_events_tx.clone()).await {
+                                    Ok(turn) => {
+                                        record_turn(provider, "connected", Some(connect_started.elapsed().as_millis() as u64), None).await;
+                                        stt_turns.push(turn);
+                                    }
+                                    Err(error) => {
+                                        record_turn(provider, "failed", Some(connect_started.elapsed().as_millis() as u64), Some(error.clone())).await;
+                                        tracing::warn!(provider = provider.name(), %error, "streaming speech recognition unavailable");
+                                    }
                                 }
-                            };
+                            }
+                            if stt_turns.is_empty() {
+                                let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"I could not connect to speech recognition. Please try again."})).await;
+                            }
                             tracing::info!(zone_id = current_zone_id.as_deref().unwrap_or("unknown"),
-                                deepgram = deepgram.is_some(),
+                                providers = stt_turns.len(),
                                 "Kizz voice turn received device context");
                         }
                         Some(ClientEvent::WakeSample(sample)) => wake_sample = Some(sample),
@@ -162,17 +314,10 @@ async fn run_session(mut socket: WebSocket) {
                                 continue;
                             }
                             let _ = send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
-                            if let Some(turn) = deepgram.as_ref() {
+                            if !stt_turns.is_empty() {
                                 pending_fallback = Some((committed, zone_id));
-                                if turn.close().await.is_ok() {
-                                    tracing::info!("Deepgram Flux finalization requested by device fallback");
-                                    continue;
-                                }
-                                deepgram = None;
-                                pending_fallback = None;
-                                turn_completed = true;
-                                tracing::warn!("Deepgram Flux could not be finalized; no local speech recognizer is enabled");
-                                let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await;
+                                for turn in &stt_turns { let _ = turn.close().await; }
+                                tracing::info!("Streaming STT finalization requested by device fallback");
                                 continue;
                             }
                             turn_completed = true;
@@ -191,17 +336,23 @@ async fn run_session(mut socket: WebSocket) {
                     _ => {}
                 }
             }
-            event = deepgram_events_rx.recv() => {
-                let Some(event) = event else { continue };
+            event = provider_events_rx.recv() => {
+                let Some(ProviderEvent { provider, event }) = event else { continue };
                 match event {
                     DeepgramEvent::EndOfTurn { transcript, confidence } if !turn_completed => {
                         turn_completed = true;
-                        deepgram = None;
+                        for turn in &stt_turns { let _ = turn.close().await; }
                         let (committed, zone_id) = pending_fallback.take()
                             .unwrap_or_else(|| (std::mem::take(&mut utterance), current_zone_id.take()));
-                        tracing::info!(%transcript, confidence, bytes = committed.len(),
-                            "Deepgram Flux ended Kizz voice turn");
-                        let _ = send_event(&mut socket, json!({"type":"endpoint","reason":"deepgram_flux","confidence":confidence})).await;
+                        let latency_ms = turn_started.map(|started| started.elapsed().as_millis() as u64);
+                        record_turn(provider, "completed", latency_ms, Some(format!("transcript_chars={}", transcript.chars().count()))).await;
+                        tracing::info!(%transcript, confidence, provider = provider.name(), bytes = committed.len(), latency_ms = latency_ms.unwrap_or(0),
+                            "Streaming STT ended Kizz voice turn");
+                        let _ = send_event(&mut socket, json!({"type":"endpoint","reason":format!("{}_end_of_turn", provider.name()),"confidence":confidence})).await;
+                        // Surface the recognition result immediately. The device can
+                        // show what it heard while the Codex/MCP turn is running.
+                        let _ = send_event(&mut socket,
+                            json!({"type":"transcript","text":transcript})).await;
                         let _ = send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
                         let result = match codex_transcript_request(&transcript, zone_id.as_deref()).await {
                             Ok(result) => result,
@@ -212,15 +363,20 @@ async fn run_session(mut socket: WebSocket) {
                         };
                         let _ = send_event(&mut socket, result).await;
                     }
-                    DeepgramEvent::EndOfTurn { .. } => {}
+                    DeepgramEvent::EndOfTurn { transcript, confidence } => {
+                        let latency_ms = turn_started.map(|started| started.elapsed().as_millis() as u64);
+                        record_turn(provider, "completed", latency_ms, Some(format!("secondary_transcript_chars={};confidence={:?}", transcript.chars().count(), confidence))).await;
+                    }
                     DeepgramEvent::Failed(error) => {
-                        deepgram = None;
-                        if pending_fallback.take().is_some() {
-                            tracing::warn!(%error, "Deepgram Flux finalization failed; no local speech recognizer is enabled");
+                        failed_stt += 1;
+                        record_turn(provider, "failed", None, Some(error.clone())).await;
+                        if pending_fallback.is_some() && failed_stt >= stt_turns.len() {
+                            pending_fallback.take();
+                            tracing::warn!(provider = provider.name(), %error, "Streaming STT finalization failed");
                             turn_completed = true;
                             let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await;
                         } else {
-                            tracing::warn!(%error, "Deepgram Flux stream failed; awaiting device fallback endpoint");
+                            tracing::warn!(provider = provider.name(), %error, "Streaming STT stream failed; awaiting another provider or device fallback endpoint");
                         }
                     }
                 }
@@ -290,13 +446,35 @@ fn store_wake_sample(label: &str, pcm: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
-async fn start_stt_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttTurn, String> {
-    match std::env::var("KIZZ_STT_PROVIDER")
-        .unwrap_or_else(|_| "deepgram".to_string())
-        .as_str()
-    {
-        "assemblyai" | "assembly" => start_assemblyai_turn(events).await,
-        _ => start_deepgram_turn(events).await,
+async fn start_provider_turn(
+    provider: SttProvider,
+    events: mpsc::Sender<ProviderEvent>,
+) -> Result<SttTurn, String> {
+    let (inner_tx, mut inner_rx) = mpsc::channel(8);
+    let forward = events.clone();
+    tokio::spawn(async move {
+        while let Some(event) = inner_rx.recv().await {
+            if forward
+                .send(ProviderEvent { provider, event })
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+    let mut turn = start_stt_turn(provider, inner_tx).await?;
+    turn.provider = provider;
+    Ok(turn)
+}
+
+async fn start_stt_turn(
+    provider: SttProvider,
+    events: mpsc::Sender<DeepgramEvent>,
+) -> Result<SttTurn, String> {
+    match provider {
+        SttProvider::Assemblyai => start_assemblyai_turn(events).await,
+        SttProvider::Deepgram => start_deepgram_turn(events).await,
     }
 }
 
@@ -433,7 +611,10 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
             }
         }
     });
-    Ok(SttTurn { input: input_tx })
+    Ok(SttTurn {
+        provider: SttProvider::Deepgram,
+        input: input_tx,
+    })
 }
 
 async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttTurn, String> {
@@ -464,21 +645,46 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
     let (mut output, mut input) = socket.split();
     let (input_tx, mut input_rx) = mpsc::channel::<SttInput>(64);
     tokio::spawn(async move {
+        // The device emits 32 ms (512-sample) frames. AssemblyAI requires
+        // audio messages to be at least 50 ms, so coalesce frames before
+        // forwarding them and pad only the final tail when necessary.
+        const MIN_AUDIO_BYTES: usize = 16_000 * 2 * 50 / 1000;
+        const AUDIO_CHUNK_BYTES: usize = 16_000 * 2 * 80 / 1000;
+        let mut pending_audio = Vec::<u8>::with_capacity(AUDIO_CHUNK_BYTES * 2);
         loop {
             tokio::select! {
                 command = input_rx.recv() => {
                     match command {
                         Some(SttInput::Audio(audio)) => {
-                            if let Err(error) = output.send(DgMessage::Binary(audio)).await {
-                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
-                                return;
+                            pending_audio.extend_from_slice(&audio);
+                            while pending_audio.len() >= AUDIO_CHUNK_BYTES {
+                                let remainder = pending_audio.split_off(AUDIO_CHUNK_BYTES);
+                                let chunk = std::mem::replace(&mut pending_audio, remainder);
+                                if let Err(error) = output.send(DgMessage::Binary(chunk)).await {
+                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    return;
+                                }
                             }
                         }
                         Some(SttInput::Close) | None => {
+                            // Kizz's device-side VAD has already decided that this
+                            // utterance is complete. AssemblyAI's ForceEndpoint
+                            // flushes the final Turn; Terminate only closes the
+                            // session and can discard an in-flight final turn.
                             if let Err(error) = output.send(DgMessage::Text(
-                                json!({"type":"Terminate"}).to_string())).await {
+                                json!({"type":"ForceEndpoint"}).to_string())).await {
                                 let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
                                 return;
+                            }
+                            if !pending_audio.is_empty() {
+                                if pending_audio.len() < MIN_AUDIO_BYTES {
+                                    pending_audio.resize(MIN_AUDIO_BYTES, 0);
+                                }
+                                if let Err(error) = output.send(DgMessage::Binary(
+                                    std::mem::take(&mut pending_audio))).await {
+                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    return;
+                                }
                             }
                             match tokio::time::timeout(Duration::from_secs(5), async {
                                 while let Some(message) = input.next().await {
@@ -553,7 +759,10 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
             }
         }
     });
-    Ok(SttTurn { input: input_tx })
+    Ok(SttTurn {
+        provider: SttProvider::Assemblyai,
+        input: input_tx,
+    })
 }
 
 async fn codex_transcript_request(

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1486,6 +1486,15 @@ fn build_codex_input(transcript: &str, context: &VoiceTurnContext) -> Result<Str
     ))
 }
 
+fn codex_mcp_override(port: &str, configured_url: Option<&str>) -> String {
+    let url = configured_url
+        .filter(|value| !value.trim().is_empty())
+        .map(str::trim)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("http://127.0.0.1:{port}/mcp"));
+    format!("mcp_servers.unified-hifi-control={{url=\"{url}\",enabled=true}}")
+}
+
 struct CodexVoiceAgent {
     child: Child,
     stdin: ChildStdin,
@@ -1497,9 +1506,8 @@ struct CodexVoiceAgent {
 impl CodexVoiceAgent {
     async fn start() -> Result<Self, String> {
         let port = std::env::var("UHC_PORT").unwrap_or_else(|_| "8088".to_string());
-        let mcp_override = format!(
-            "mcp_servers.unified-hifi-control={{url=\"http://127.0.0.1:{port}/mcp\",enabled=true}}"
-        );
+        let configured_mcp_url = std::env::var("KIZZ_MCP_URL").ok();
+        let mcp_override = codex_mcp_override(&port, configured_mcp_url.as_deref());
         let mut child = Command::new("codex")
             .args([
                 "app-server",
@@ -1968,6 +1976,18 @@ mod tests {
         assert!(!input.contains("title"));
         assert!(!input.contains("artist"));
         assert!(!input.contains("album"));
+    }
+
+    #[test]
+    fn codex_mcp_override_can_delegate_to_the_existing_uhc() {
+        assert_eq!(
+            codex_mcp_override("8088", None),
+            "mcp_servers.unified-hifi-control={url=\"http://127.0.0.1:8088/mcp\",enabled=true}"
+        );
+        assert_eq!(
+            codex_mcp_override("8088", Some("http://127.0.0.1:18088/mcp")),
+            "mcp_servers.unified-hifi-control={url=\"http://127.0.0.1:18088/mcp\",enabled=true}"
+        );
     }
 
     #[test]

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1,0 +1,659 @@
+//! LAN-only Kizz voice gateway.
+//!
+//! Kizz performs wake-word detection and VAD on-device, then streams one
+//! bounded 16 kHz mono utterance. UHC wraps the PCM as WAV and hands it to a
+//! persistent Codex App Server thread whose only music capability is UHC's
+//! MCP server. Kizz, not the model, owns the audible and visual response.
+
+use crate::config::get_data_dir;
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::WebSocketUpgrade;
+use axum::response::Response;
+use serde_json::{json, Value};
+use std::io::Write;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::OnceLock;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::Mutex;
+use tokio::time::{timeout, Duration};
+
+const SAMPLE_RATE: u32 = 16_000;
+const MAX_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize * 2 * 14;
+const MIN_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize / 2;
+const CODEX_START_TIMEOUT: Duration = Duration::from_secs(20);
+const CODEX_TURN_TIMEOUT: Duration = Duration::from_secs(30);
+const TRANSCRIBE_TIMEOUT: Duration = Duration::from_secs(15);
+
+static CODEX_AGENT: OnceLock<Mutex<Option<CodexVoiceAgent>>> = OnceLock::new();
+
+pub async fn voice_upgrade(upgrade: WebSocketUpgrade) -> Response {
+    upgrade.on_upgrade(run_session)
+}
+
+/// Start the persistent audio agent after the HTTP listener is live, so the
+/// first person who speaks to Kizz does not pay App Server startup latency.
+pub async fn prewarm() {
+    let agent = CODEX_AGENT.get_or_init(|| Mutex::new(None));
+    let mut _conversation_guard = agent.lock().await;
+    if _conversation_guard.is_some() {
+        return;
+    }
+    match timeout(CODEX_START_TIMEOUT, CodexVoiceAgent::start()).await {
+        Ok(Ok(started)) => *_conversation_guard = Some(started),
+        Ok(Err(error)) => tracing::warn!(%error, "Kizz Codex agent prewarm failed"),
+        Err(_) => tracing::warn!("Kizz Codex agent prewarm timed out"),
+    }
+}
+
+async fn run_session(mut socket: WebSocket) {
+    tracing::info!("Kizz voice session opened");
+    let mut utterance = Vec::<u8>::new();
+    let mut current_zone_id = None::<String>;
+    while let Some(incoming) = socket.recv().await {
+        let message = match incoming {
+            Ok(message) => message,
+            Err(error) => {
+                tracing::warn!(%error, "Kizz voice session received a WebSocket error");
+                break;
+            }
+        };
+        match message {
+            Message::Binary(pcm) => {
+                utterance.extend_from_slice(&pcm);
+                if utterance.len() > MAX_UTTERANCE_BYTES {
+                    let excess = utterance.len() - MAX_UTTERANCE_BYTES;
+                    utterance.drain(..excess);
+                }
+            }
+            Message::Text(message) => match parse_client_event(&message) {
+                Some(ClientEvent::Start { zone_id }) => {
+                    utterance.clear();
+                    current_zone_id = zone_id;
+                    tracing::info!(
+                        zone_id = current_zone_id.as_deref().unwrap_or("unknown"),
+                        "Kizz voice turn received device context"
+                    );
+                }
+                Some(ClientEvent::Commit) => {
+                    let committed = std::mem::take(&mut utterance);
+                    let zone_id = current_zone_id.take();
+                    tracing::info!(bytes = committed.len(), "Kizz utterance committed");
+                    if committed.len() < MIN_UTTERANCE_BYTES {
+                        let _ = send_event(
+                        &mut socket,
+                        json!({"type":"state","state":"clarify","message":"I did not hear enough yet."}),
+                    )
+                    .await;
+                        continue;
+                    }
+
+                    // The sentence has ended, so Kizz may leave listening and show
+                    // thinking while the same bounded audio is reasoned over.
+                    let _ =
+                        send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
+
+                    let result = match codex_request(&committed, zone_id.as_deref()).await {
+                        Ok(result) => result,
+                        Err(error) => {
+                            tracing::warn!(%error, "Kizz Codex voice turn failed");
+                            json!({"type":"state","state":"clarify","message":"I lost that thought. Please try once more."})
+                        }
+                    };
+                    let _ = send_event(&mut socket, result).await;
+                }
+                None => tracing::warn!(%message, "Ignored unknown Kizz voice event"),
+            },
+            Message::Ping(payload) => {
+                if socket.send(Message::Pong(payload)).await.is_err() {
+                    break;
+                }
+            }
+            Message::Close(_) => {
+                tracing::info!("Kizz voice session closed by client");
+                break;
+            }
+            _ => {}
+        }
+    }
+    tracing::info!("Kizz voice session ended");
+}
+
+#[derive(Debug, PartialEq)]
+enum ClientEvent {
+    Start { zone_id: Option<String> },
+    Commit,
+}
+
+fn parse_client_event(message: &str) -> Option<ClientEvent> {
+    let event: Value = serde_json::from_str(message).ok()?;
+    match event.get("type")?.as_str()? {
+        "start" => Some(ClientEvent::Start {
+            zone_id: event
+                .pointer("/context/zone_id")
+                .and_then(Value::as_str)
+                .filter(|zone_id| !zone_id.is_empty())
+                .map(str::to_owned),
+        }),
+        "commit" => Some(ClientEvent::Commit),
+        _ => None,
+    }
+}
+
+async fn codex_request(pcm: &[u8], current_zone_id: Option<&str>) -> Result<Value, String> {
+    let (conditioned, capture_peak, gain) = condition_voice_pcm(pcm);
+    tracing::info!(
+        capture_peak,
+        gain = format_args!("{gain:.1}"),
+        "Conditioned Kizz voice capture for the audio model"
+    );
+    let mut wav = tempfile::Builder::new()
+        .prefix("kizz-utterance-")
+        .suffix(".wav")
+        .tempfile()
+        .map_err(|error| error.to_string())?;
+    write_wav(&mut wav, &conditioned).map_err(|error| error.to_string())?;
+    let transcript = transcribe_voice(wav.path()).await?;
+    tracing::info!(%transcript, "Kizz local speech recognition completed");
+
+    let agent = CODEX_AGENT.get_or_init(|| Mutex::new(None));
+    let mut _conversation_guard = agent.lock().await;
+    if _conversation_guard.is_none() {
+        *_conversation_guard = Some(
+            timeout(CODEX_START_TIMEOUT, CodexVoiceAgent::start())
+                .await
+                .map_err(|_| "Codex App Server startup timed out".to_string())??,
+        );
+    }
+
+    let first = _conversation_guard
+        .as_mut()
+        .ok_or("Codex voice agent was not initialized")?
+        .turn(&transcript, current_zone_id);
+    let first = timeout(CODEX_TURN_TIMEOUT, first)
+        .await
+        .map_err(|_| "Codex voice turn timed out".to_string())?;
+    if first.is_ok() {
+        return first;
+    }
+
+    // App Server is local and disposable. Restart once after a broken pipe or
+    // malformed terminal event, while preserving no false success state.
+    if let Some(mut stale) = _conversation_guard.take() {
+        let _ = stale.child.kill().await;
+    }
+    let mut restarted = timeout(CODEX_START_TIMEOUT, CodexVoiceAgent::start())
+        .await
+        .map_err(|_| "Codex App Server restart timed out".to_string())??;
+    let result = timeout(
+        CODEX_TURN_TIMEOUT,
+        restarted.turn(&transcript, current_zone_id),
+    )
+    .await
+    .map_err(|_| "Codex voice turn timed out after restart".to_string())?;
+    *_conversation_guard = Some(restarted);
+    result
+}
+
+struct CodexVoiceAgent {
+    child: Child,
+    stdin: ChildStdin,
+    lines: Lines<BufReader<ChildStdout>>,
+    thread_id: String,
+    next_id: u64,
+}
+
+impl CodexVoiceAgent {
+    async fn start() -> Result<Self, String> {
+        let port = std::env::var("UHC_PORT").unwrap_or_else(|_| "8088".to_string());
+        let mcp_override = format!(
+            "mcp_servers.unified-hifi-control={{url=\"http://127.0.0.1:{port}/mcp\",enabled=true}}"
+        );
+        let mut child = Command::new("codex")
+            .args([
+                "app-server",
+                "--stdio",
+                "-c",
+                "mcp_servers.amazing-marvin.enabled=false",
+                "-c",
+                "mcp_servers.node_repl.enabled=false",
+                "-c",
+                "mcp_servers.home-assistant.enabled=false",
+                "-c",
+                &mcp_override,
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|error| format!("Codex App Server is unavailable: {error}"))?;
+        let stdin = child.stdin.take().ok_or("Codex App Server has no stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("Codex App Server has no stdout")?;
+        let mut agent = Self {
+            child,
+            stdin,
+            lines: BufReader::new(stdout).lines(),
+            thread_id: String::new(),
+            next_id: 1,
+        };
+
+        let initialize_id = agent
+            .request(json!({
+                "method": "initialize",
+                "params": {
+                    "clientInfo": {"name":"kizz-voice","version":"0.1"},
+                    "capabilities": {"experimentalApi":true}
+                }
+            }))
+            .await?;
+        agent.wait_for_response(initialize_id).await?;
+        agent
+            .notify(json!({"method":"initialized","params":{}}))
+            .await?;
+
+        let model =
+            std::env::var("KIZZ_CODEX_MODEL").unwrap_or_else(|_| "gpt-5.6-luna".to_string());
+        let working_directory = std::env::temp_dir().join("kizz-codex-agent");
+        tokio::fs::create_dir_all(&working_directory)
+            .await
+            .map_err(|error| format!("Kizz agent workspace is unavailable: {error}"))?;
+        let thread_request_id = agent
+            .request(json!({
+                "method":"thread/start",
+                "params": {
+                    "ephemeral": true,
+                    "cwd": working_directory,
+                    "model": model,
+                    "approvalPolicy": "on-request",
+                    "sandbox": "read-only",
+                    "baseInstructions": KIZZ_AGENT_INSTRUCTIONS
+                }
+            }))
+            .await?;
+        let response = agent.wait_for_response(thread_request_id).await?;
+        agent.thread_id = response["result"]["thread"]["id"]
+            .as_str()
+            .ok_or("Codex App Server did not return a thread id")?
+            .to_string();
+        tracing::info!(
+            thread_id = %agent.thread_id,
+            "Kizz Codex App Server agent ready with UHC MCP"
+        );
+        Ok(agent)
+    }
+
+    async fn turn(
+        &mut self,
+        transcript: &str,
+        current_zone_id: Option<&str>,
+    ) -> Result<Value, String> {
+        let zone_context = current_zone_id
+            .map(|zone_id| {
+                format!(
+                    "\nKizz's currently selected zone id is: {zone_id}. Use it as the default only when the listener did not name a room."
+                )
+            })
+            .unwrap_or_default();
+        let request_id = self
+            .request(json!({
+                "method":"turn/start",
+                "params": {
+                    "threadId": self.thread_id,
+                    "input": [{
+                        "type":"text",
+                        "text": format!("Local speech recognition heard: {transcript}{zone_context}")
+                    }],
+                    "effort": "low",
+                    "outputSchema": kizz_result_schema()
+                }
+            }))
+            .await?;
+        self.wait_for_response(request_id).await?;
+
+        while let Some(line) = self
+            .lines
+            .next_line()
+            .await
+            .map_err(|error| format!("Codex App Server stream failed: {error}"))?
+        {
+            let message: Value = match serde_json::from_str(&line) {
+                Ok(message) => message,
+                Err(_) => continue,
+            };
+            if message.get("id").is_some() && message.get("method").is_some() {
+                tracing::info!(request = %message, "Kizz Codex App Server requested client input");
+                if message["method"] == "mcpServer/elicitation/request"
+                    && message["params"]["serverName"] == "unified-hifi-control"
+                    && message["params"]["_meta"]["codex_approval_kind"] == "mcp_tool_call"
+                {
+                    tracing::info!(
+                        tool = %message["params"]["_meta"]["tool_name"],
+                        arguments = %message["params"]["_meta"]["tool_params"],
+                        "Approved Kizz LAN UHC MCP call for this session"
+                    );
+                    let response = json!({
+                        "id": message["id"],
+                        "result": {
+                            "action": "accept",
+                            "content": {},
+                            "_meta": { "persist": "session" }
+                        }
+                    });
+                    self.write(response).await?;
+                    continue;
+                }
+            }
+            if message["method"] == "item/completed"
+                && message["params"]["item"]["type"] == "mcpToolCall"
+            {
+                let item = &message["params"]["item"];
+                tracing::info!(
+                    server = %item["server"].as_str().unwrap_or(""),
+                    tool = %item["tool"].as_str().unwrap_or(""),
+                    arguments = %item["arguments"],
+                    status = %item["status"],
+                    error = %item["error"],
+                    result = %item["result"],
+                    "Kizz Codex MCP call completed"
+                );
+            }
+            if message["method"] != "turn/completed"
+                || message["params"]["threadId"] != self.thread_id
+            {
+                continue;
+            }
+            let turn = &message["params"]["turn"];
+            if turn["status"] != "completed" {
+                return Err(format!(
+                    "Codex voice turn ended as {}: {}",
+                    turn["status"], turn["error"]
+                ));
+            }
+            let text = turn["items"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .find(|item| item["type"] == "agentMessage" && item["phase"] == "final_answer")
+                .and_then(|item| item["text"].as_str())
+                .ok_or("Codex voice turn returned no final result")?;
+            let result = normalize_codex_result(text)?;
+            tracing::info!(
+                state = %result["state"].as_str().unwrap_or("invalid"),
+                message = %result["message"].as_str().unwrap_or(""),
+                zone = %result["zone"].as_str().unwrap_or(""),
+                heard = %result["heard"].as_str().unwrap_or(""),
+                "Kizz Codex voice turn completed"
+            );
+            return Ok(result);
+        }
+        Err("Codex App Server exited before completing the voice turn".to_string())
+    }
+
+    async fn request(&mut self, mut message: Value) -> Result<u64, String> {
+        let id = self.next_id;
+        self.next_id += 1;
+        message["id"] = json!(id);
+        self.write(message).await?;
+        Ok(id)
+    }
+
+    async fn notify(&mut self, message: Value) -> Result<(), String> {
+        self.write(message).await
+    }
+
+    async fn write(&mut self, message: Value) -> Result<(), String> {
+        let mut encoded = serde_json::to_vec(&message).map_err(|error| error.to_string())?;
+        encoded.push(b'\n');
+        self.stdin
+            .write_all(&encoded)
+            .await
+            .map_err(|error| format!("Codex App Server write failed: {error}"))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|error| format!("Codex App Server flush failed: {error}"))
+    }
+
+    async fn wait_for_response(&mut self, id: u64) -> Result<Value, String> {
+        while let Some(line) = self
+            .lines
+            .next_line()
+            .await
+            .map_err(|error| format!("Codex App Server stream failed: {error}"))?
+        {
+            let message: Value = match serde_json::from_str(&line) {
+                Ok(message) => message,
+                Err(_) => continue,
+            };
+            if message["id"].as_u64() != Some(id) {
+                continue;
+            }
+            if let Some(error) = message.get("error") {
+                return Err(format!("Codex App Server request failed: {error}"));
+            }
+            return Ok(message);
+        }
+        Err("Codex App Server exited before responding".to_string())
+    }
+}
+
+const KIZZ_AGENT_INSTRUCTIONS: &str = r#"
+You are Kizz, a fast, delightful voice-controlled music companion inside a home.
+The user input is a transcript from local post-wake speech recognition.
+Understand it naturally; it is not an exact-command grammar and may contain
+ordinary speech-recognition errors.
+
+Use only the unified-hifi-control MCP for music state and music actions. Never
+use shell, filesystem, web, code editing, or any other tool. Inspect live zones
+and content when needed. Resolve natural room references and conversational
+follow-ups from this persistent thread. When a current zone id is supplied, use
+that zone by default if the listener omitted a room. An explicitly spoken room
+always overrides device context. For a clear request, perform it and
+report success only when the MCP result confirms it. If the intended content or
+zone is genuinely ambiguous, do not guess or act; ask one short clarification.
+
+Kizz itself communicates with expressions, motion, and chirps. Do not create a
+spoken model response and do not emit commentary. Return only the structured
+JSON required by the supplied output schema. Keep message under 90 characters.
+"#;
+
+fn kizz_result_schema() -> Value {
+    json!({
+        "type":"object",
+        "additionalProperties":false,
+        "required":["state","message","zone","heard"],
+        "properties":{
+            "state":{"type":"string","enum":["success","clarify","error"]},
+            "message":{"type":"string"},
+            "zone":{"type":["string","null"]},
+            "heard":{"type":["string","null"]}
+        }
+    })
+}
+
+fn normalize_codex_result(text: &str) -> Result<Value, String> {
+    let mut result: Value = serde_json::from_str(text.trim())
+        .map_err(|error| format!("Codex returned invalid Kizz state: {error}"))?;
+    let state = result["state"]
+        .as_str()
+        .ok_or("Codex returned no Kizz state")?
+        .to_string();
+    if !matches!(state.as_str(), "success" | "clarify" | "error") {
+        return Err(format!("Codex returned unsupported Kizz state: {state}"));
+    }
+    if !result["message"].is_string() {
+        return Err("Codex returned no Kizz message".to_string());
+    }
+    result["type"] = json!("state");
+    if state == "error" {
+        result["state"] = json!("clarify");
+    }
+    Ok(result)
+}
+
+fn write_wav(file: &mut tempfile::NamedTempFile, pcm: &[u8]) -> std::io::Result<()> {
+    let data_len = pcm.len() as u32;
+    file.write_all(b"RIFF")?;
+    file.write_all(&(36 + data_len).to_le_bytes())?;
+    file.write_all(b"WAVEfmt ")?;
+    file.write_all(&16u32.to_le_bytes())?;
+    file.write_all(&1u16.to_le_bytes())?;
+    file.write_all(&1u16.to_le_bytes())?;
+    file.write_all(&SAMPLE_RATE.to_le_bytes())?;
+    file.write_all(&(SAMPLE_RATE * 2).to_le_bytes())?;
+    file.write_all(&2u16.to_le_bytes())?;
+    file.write_all(&16u16.to_le_bytes())?;
+    file.write_all(b"data")?;
+    file.write_all(&data_len.to_le_bytes())?;
+    file.write_all(pcm)?;
+    file.flush()
+}
+
+fn condition_voice_pcm(pcm: &[u8]) -> (Vec<u8>, i32, f32) {
+    let peak = pcm
+        .chunks_exact(2)
+        .map(|sample| i16::from_le_bytes([sample[0], sample[1]]) as i32)
+        .map(i32::abs)
+        .max()
+        .unwrap_or(0);
+    if peak == 0 {
+        return (pcm.to_vec(), 0, 1.0);
+    }
+
+    // CoreS3's official microphone path is intentionally conservative. Raise
+    // only the captured utterance to a healthy model input level; this never
+    // touches M5Unified speaker gain or Kizz's chirp loudness.
+    let gain = (18_000.0 / peak as f32).clamp(1.0, 16.0);
+    let mut output = Vec::with_capacity(pcm.len());
+    for sample in pcm.chunks_exact(2) {
+        let value = i16::from_le_bytes([sample[0], sample[1]]) as f32;
+        let conditioned = (value * gain).round().clamp(-32_768.0, 32_767.0) as i16;
+        output.extend_from_slice(&conditioned.to_le_bytes());
+    }
+    (output, peak, gain)
+}
+
+async fn transcribe_voice(wav_path: &Path) -> Result<String, String> {
+    let model = std::env::var_os("KIZZ_WHISPER_MODEL")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| get_data_dir().join("models/ggml-base.en.bin"));
+    if !model.is_file() {
+        return Err(format!(
+            "Kizz Whisper model is missing at {} (set KIZZ_WHISPER_MODEL to override)",
+            model.display()
+        ));
+    }
+    let output = timeout(
+        TRANSCRIBE_TIMEOUT,
+        Command::new("whisper-cli")
+            .args([
+                "-m",
+                model
+                    .to_str()
+                    .ok_or("Kizz Whisper model path is not valid UTF-8")?,
+                "-f",
+                wav_path
+                    .to_str()
+                    .ok_or("Kizz WAV path is not valid UTF-8")?,
+                "-l",
+                "en",
+                "-t",
+                "4",
+                "--no-timestamps",
+                "--no-prints",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output(),
+    )
+    .await
+    .map_err(|_| "Kizz local speech recognition timed out".to_string())?
+    .map_err(|error| format!("Kizz local speech recognition is unavailable: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Kizz local speech recognition exited as {}",
+            output.status
+        ));
+    }
+    let transcript = String::from_utf8(output.stdout)
+        .map_err(|error| format!("Kizz transcript was not UTF-8: {error}"))?
+        .trim()
+        .to_string();
+    if transcript.is_empty() {
+        return Err("Kizz local speech recognition heard no words".to_string());
+    }
+    Ok(transcript)
+}
+
+async fn send_event(socket: &mut WebSocket, event: Value) -> Result<(), axum::Error> {
+    socket.send(Message::Text(event.to_string().into())).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_success_becomes_a_kizz_state_event() {
+        let result = normalize_codex_result(
+            r#"{"state":"success","message":"On it.","zone":"Kitchen","heard":null}"#,
+        )
+        .expect("valid agent result");
+        assert_eq!(result["type"], "state");
+        assert_eq!(result["state"], "success");
+        assert_eq!(result["zone"], "Kitchen");
+    }
+
+    #[test]
+    fn codex_error_never_claims_device_success() {
+        let result = normalize_codex_result(
+            r#"{"state":"error","message":"Music service unavailable","zone":null,"heard":null}"#,
+        )
+        .expect("valid agent result");
+        assert_eq!(result["state"], "clarify");
+    }
+
+    #[test]
+    fn malformed_agent_output_is_rejected() {
+        assert!(normalize_codex_result("played it").is_err());
+    }
+
+    #[test]
+    fn start_event_carries_the_devices_current_zone() {
+        assert_eq!(
+            parse_client_event(r#"{"type":"start","context":{"zone_id":"roon:kitchen"}}"#),
+            Some(ClientEvent::Start {
+                zone_id: Some("roon:kitchen".to_string())
+            })
+        );
+    }
+
+    #[test]
+    fn event_types_are_matched_exactly() {
+        assert_eq!(
+            parse_client_event(r#"{"type":"commit"}"#),
+            Some(ClientEvent::Commit)
+        );
+        assert_eq!(parse_client_event(r#"{"message":"start"}"#), None);
+    }
+
+    #[test]
+    fn quiet_voice_capture_is_raised_without_touching_duration() {
+        let pcm = [500i16.to_le_bytes(), (-750i16).to_le_bytes()].concat();
+        let (conditioned, peak, gain) = condition_voice_pcm(&pcm);
+        assert_eq!(peak, 750);
+        assert_eq!(gain, 16.0);
+        assert_eq!(conditioned.len(), pcm.len());
+        assert_eq!(i16::from_le_bytes([conditioned[0], conditioned[1]]), 8_000);
+        assert_eq!(
+            i16::from_le_bytes([conditioned[2], conditioned[3]]),
+            -12_000
+        );
+    }
+}

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -29,6 +29,7 @@ use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message as DgMes
 const SAMPLE_RATE: u32 = 16_000;
 const MAX_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize * 2 * 14;
 const MIN_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize / 2;
+const STT_CONNECT_TIMEOUT: Duration = Duration::from_secs(4);
 const CODEX_START_TIMEOUT: Duration = Duration::from_secs(20);
 const CODEX_TURN_TIMEOUT: Duration = Duration::from_secs(30);
 const DEEPGRAM_AUDIO_CHUNK_BYTES: usize = 16_000 * 2 * 80 / 1000;
@@ -352,7 +353,19 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                                 let events = provider_events_tx.clone();
                                 async move {
                                     let started = Instant::now();
-                                    let result = start_provider_turn(turn_id, provider, events).await;
+                                    let result = match timeout(
+                                        STT_CONNECT_TIMEOUT,
+                                        start_provider_turn(turn_id, provider, events),
+                                    )
+                                    .await
+                                    {
+                                        Ok(result) => result,
+                                        Err(_) => Err(format!(
+                                            "{} connection timed out after {} ms",
+                                            provider.name(),
+                                            STT_CONNECT_TIMEOUT.as_millis()
+                                        )),
+                                    };
                                     (provider, result, started.elapsed().as_millis() as u64)
                                 }
                             });

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -119,6 +119,10 @@ fn all_active_providers_finished(
     has_pending_device_commit && active > 0 && finished >= active
 }
 
+fn provider_event_is_current(active_turn_id: u64, event_turn_id: u64) -> bool {
+    active_turn_id == event_turn_id
+}
+
 struct VoiceRuntime {
     provider: tokio::sync::RwLock<SttProvider>,
     reliability: Mutex<VoiceReliability>,
@@ -433,7 +437,7 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
             }
             event = provider_events_rx.recv() => {
                 let Some(ProviderEvent { turn_id, provider, event, latency_ms }) = event else { continue };
-                if turn_id != active_turn_id {
+                if !provider_event_is_current(active_turn_id, turn_id) {
                     tracing::info!(turn_id, active_turn_id, provider = provider.name(),
                         "Ignored a late STT result from an earlier Kizz turn");
                     continue;
@@ -1685,6 +1689,13 @@ mod tests {
             deepgram_closed_event(false, Some("stale".to_string()), None),
             DeepgramEvent::Failed(_)
         ));
+    }
+
+    #[test]
+    fn late_provider_result_cannot_enter_the_active_turn() {
+        assert!(provider_event_is_current(42, 42));
+        assert!(!provider_event_is_current(42, 41));
+        assert!(!provider_event_is_current(42, 43));
     }
 
     #[test]

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -277,9 +277,12 @@ async fn run_session(mut socket: WebSocket) {
                             stt_turns.clear();
                             failed_stt = 0;
                             let providers = if selected_provider == SttProvider::Deepgram { vec![SttProvider::Deepgram, SttProvider::Assemblyai] } else { vec![SttProvider::Assemblyai, SttProvider::Deepgram] };
-                            for provider in providers {
-                                let connect_started = Instant::now();
-                                match start_provider_turn(provider, provider_events_tx.clone()).await {
+                            let connect_started = Instant::now();
+                            let first = start_provider_turn(providers[0], provider_events_tx.clone());
+                            let second = start_provider_turn(providers[1], provider_events_tx.clone());
+                            let (first_result, second_result) = tokio::join!(first, second);
+                            for (provider, result) in [(providers[0], first_result), (providers[1], second_result)] {
+                                match result {
                                     Ok(turn) => {
                                         record_turn(provider, "connected", Some(connect_started.elapsed().as_millis() as u64), None).await;
                                         stt_turns.push(turn);
@@ -345,7 +348,7 @@ async fn run_session(mut socket: WebSocket) {
                         let (committed, zone_id) = pending_fallback.take()
                             .unwrap_or_else(|| (std::mem::take(&mut utterance), current_zone_id.take()));
                         let latency_ms = turn_started.map(|started| started.elapsed().as_millis() as u64);
-                        record_turn(provider, "completed", latency_ms, Some(format!("transcript_chars={}", transcript.chars().count()))).await;
+                        record_turn(provider, "completed", latency_ms, Some(transcript.clone())).await;
                         tracing::info!(%transcript, confidence, provider = provider.name(), bytes = committed.len(), latency_ms = latency_ms.unwrap_or(0),
                             "Streaming STT ended Kizz voice turn");
                         let _ = send_event(&mut socket, json!({"type":"endpoint","reason":format!("{}_end_of_turn", provider.name()),"confidence":confidence})).await;
@@ -365,7 +368,7 @@ async fn run_session(mut socket: WebSocket) {
                     }
                     DeepgramEvent::EndOfTurn { transcript, confidence } => {
                         let latency_ms = turn_started.map(|started| started.elapsed().as_millis() as u64);
-                        record_turn(provider, "completed", latency_ms, Some(format!("secondary_transcript_chars={};confidence={:?}", transcript.chars().count(), confidence))).await;
+                        record_turn(provider, "completed", latency_ms, Some(format!("{} (confidence={:?})", transcript, confidence))).await;
                     }
                     DeepgramEvent::Failed(error) => {
                         failed_stt += 1;

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1,14 +1,14 @@
 //! LAN-only Kizz voice gateway.
 //!
 //! Kizz performs wake-word detection and VAD on-device, then streams one
-//! bounded 16 kHz mono utterance. UHC wraps the PCM as WAV and hands it to a
-//! persistent Codex App Server thread whose only music capability is UHC's
-//! MCP server. Kizz, not the model, owns the audible and visual response.
+//! bounded 16 kHz mono utterance. UHC streams it to speech recognition, then
+//! hands the transcript to a persistent Codex App Server thread whose only
+//! music capability is UHC's MCP server. Kizz owns the response character.
 
-use crate::config::get_data_dir;
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::WebSocketUpgrade;
 use axum::response::Response;
+use futures::{SinkExt, StreamExt};
 use serde_json::{json, Value};
 use std::io::Write;
 use std::path::Path;
@@ -16,8 +16,10 @@ use std::process::Stdio;
 use std::sync::OnceLock;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::mpsc;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
+use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message as DgMessage};
 
 const SAMPLE_RATE: u32 = 16_000;
 const MAX_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize * 2 * 14;
@@ -25,9 +27,43 @@ const MAX_WAKE_SAMPLE_BYTES: usize = SAMPLE_RATE as usize * 2 * 3;
 const MIN_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize / 2;
 const CODEX_START_TIMEOUT: Duration = Duration::from_secs(20);
 const CODEX_TURN_TIMEOUT: Duration = Duration::from_secs(30);
-const TRANSCRIBE_TIMEOUT: Duration = Duration::from_secs(15);
+const DEEPGRAM_AUDIO_CHUNK_BYTES: usize = 16_000 * 2 * 80 / 1000;
 
 static CODEX_AGENT: OnceLock<Mutex<Option<CodexVoiceAgent>>> = OnceLock::new();
+
+#[derive(Debug)]
+enum DeepgramEvent {
+    EndOfTurn {
+        transcript: String,
+        confidence: Option<f64>,
+    },
+    Failed(String),
+}
+
+struct DeepgramTurn {
+    input: mpsc::Sender<DeepgramInput>,
+}
+
+enum DeepgramInput {
+    Audio(Vec<u8>),
+    Close,
+}
+
+impl DeepgramTurn {
+    async fn send_audio(&self, pcm: Vec<u8>) -> Result<(), String> {
+        self.input
+            .send(DeepgramInput::Audio(pcm))
+            .await
+            .map_err(|_| "Deepgram audio task stopped".to_string())
+    }
+
+    async fn close(&self) -> Result<(), String> {
+        self.input
+            .send(DeepgramInput::Close)
+            .await
+            .map_err(|_| "Deepgram audio task stopped before finalization".to_string())
+    }
+}
 
 pub async fn voice_upgrade(upgrade: WebSocketUpgrade) -> Response {
     upgrade.on_upgrade(run_session)
@@ -53,87 +89,142 @@ async fn run_session(mut socket: WebSocket) {
     let mut utterance = Vec::<u8>::new();
     let mut current_zone_id = None::<String>;
     let mut wake_sample = None::<WakeSample>;
-    while let Some(incoming) = socket.recv().await {
-        let message = match incoming {
-            Ok(message) => message,
-            Err(error) => {
-                tracing::warn!(%error, "Kizz voice session received a WebSocket error");
-                break;
-            }
-        };
-        match message {
-            Message::Binary(pcm) => {
-                if let Some(sample) = wake_sample.take() {
-                    if pcm.len() == sample.bytes {
-                        if let Err(error) = store_wake_sample(&sample.label, &pcm) {
-                            tracing::warn!(%error, "Kizz wake training sample was not stored");
-                        }
-                    } else {
-                        tracing::warn!(
-                            expected = sample.bytes,
-                            actual = pcm.len(),
-                            "Kizz wake training sample length mismatch"
-                        );
+    let (deepgram_events_tx, mut deepgram_events_rx) = mpsc::channel(8);
+    let mut deepgram = None::<DeepgramTurn>;
+    let mut pending_fallback = None::<(Vec<u8>, Option<String>)>;
+    let mut turn_completed = false;
+    loop {
+        tokio::select! {
+            incoming = socket.recv() => {
+                let Some(incoming) = incoming else { break };
+                let message = match incoming {
+                    Ok(message) => message,
+                    Err(error) => {
+                        tracing::warn!(%error, "Kizz voice session received a WebSocket error");
+                        break;
                     }
-                    continue;
-                }
-                utterance.extend_from_slice(&pcm);
-                if utterance.len() > MAX_UTTERANCE_BYTES {
-                    let excess = utterance.len() - MAX_UTTERANCE_BYTES;
-                    utterance.drain(..excess);
-                }
-            }
-            Message::Text(message) => match parse_client_event(&message) {
-                Some(ClientEvent::Start { zone_id }) => {
-                    utterance.clear();
-                    current_zone_id = zone_id;
-                    tracing::info!(
-                        zone_id = current_zone_id.as_deref().unwrap_or("unknown"),
-                        "Kizz voice turn received device context"
-                    );
-                }
-                Some(ClientEvent::WakeSample(sample)) => {
-                    wake_sample = Some(sample);
-                }
-                Some(ClientEvent::Commit) => {
-                    let committed = std::mem::take(&mut utterance);
-                    let zone_id = current_zone_id.take();
-                    tracing::info!(bytes = committed.len(), "Kizz utterance committed");
-                    if committed.len() < MIN_UTTERANCE_BYTES {
-                        let _ = send_event(
-                        &mut socket,
-                        json!({"type":"state","state":"clarify","message":"I did not hear enough yet."}),
-                    )
-                    .await;
-                        continue;
-                    }
-
-                    // The sentence has ended, so Kizz may leave listening and show
-                    // thinking while the same bounded audio is reasoned over.
-                    let _ =
-                        send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
-
-                    let result = match codex_request(&committed, zone_id.as_deref()).await {
-                        Ok(result) => result,
-                        Err(error) => {
-                            tracing::warn!(%error, "Kizz Codex voice turn failed");
-                            json!({"type":"state","state":"clarify","message":"I lost that thought. Please try once more."})
+                };
+                match message {
+                    Message::Binary(pcm) => {
+                        if let Some(sample) = wake_sample.take() {
+                            if pcm.len() == sample.bytes {
+                                if let Err(error) = store_wake_sample(&sample.label, &pcm) {
+                                    tracing::warn!(%error, "Kizz wake training sample was not stored");
+                                }
+                            } else {
+                                tracing::warn!(expected = sample.bytes, actual = pcm.len(),
+                                    "Kizz wake training sample length mismatch");
+                            }
+                            continue;
                         }
-                    };
-                    let _ = send_event(&mut socket, result).await;
-                }
-                None => tracing::warn!(%message, "Ignored unknown Kizz voice event"),
-            },
-            Message::Ping(payload) => {
-                if socket.send(Message::Pong(payload)).await.is_err() {
-                    break;
+                        utterance.extend_from_slice(&pcm);
+                        if utterance.len() > MAX_UTTERANCE_BYTES {
+                            let excess = utterance.len() - MAX_UTTERANCE_BYTES;
+                            utterance.drain(..excess);
+                        }
+                        if let Some(turn) = deepgram.as_ref() {
+                            if turn.send_audio(pcm.to_vec()).await.is_err() {
+                                deepgram = None;
+                            }
+                        }
+                    }
+                    Message::Text(message) => match parse_client_event(&message) {
+                        Some(ClientEvent::Start { zone_id }) => {
+                            utterance.clear();
+                            current_zone_id = zone_id;
+                            turn_completed = false;
+                            pending_fallback = None;
+                            deepgram = match start_deepgram_turn(deepgram_events_tx.clone()).await {
+                                Ok(turn) => Some(turn),
+                                Err(error) => {
+                                    tracing::warn!(%error, "Deepgram Flux unavailable; local transcription remains armed");
+                                    None
+                                }
+                            };
+                            tracing::info!(zone_id = current_zone_id.as_deref().unwrap_or("unknown"),
+                                deepgram = deepgram.is_some(),
+                                "Kizz voice turn received device context");
+                        }
+                        Some(ClientEvent::WakeSample(sample)) => wake_sample = Some(sample),
+                        Some(ClientEvent::Commit) if turn_completed => {
+                            tracing::info!("Ignored device fallback commit after Flux completed the turn");
+                        }
+                        Some(ClientEvent::Commit) if pending_fallback.is_some() => {
+                            tracing::info!("Ignored duplicate device fallback commit while Flux finalizes");
+                        }
+                        Some(ClientEvent::Commit) => {
+                            let committed = std::mem::take(&mut utterance);
+                            let zone_id = current_zone_id.take();
+                            tracing::info!(bytes = committed.len(), "Kizz fallback utterance committed");
+                            if committed.len() < MIN_UTTERANCE_BYTES {
+                                let _ = send_event(&mut socket,
+                                    json!({"type":"state","state":"clarify","message":"I did not hear enough yet."})).await;
+                                continue;
+                            }
+                            let _ = send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
+                            if let Some(turn) = deepgram.as_ref() {
+                                pending_fallback = Some((committed, zone_id));
+                                if turn.close().await.is_ok() {
+                                    tracing::info!("Deepgram Flux finalization requested by device fallback");
+                                    continue;
+                                }
+                                deepgram = None;
+                                pending_fallback = None;
+                                turn_completed = true;
+                                tracing::warn!("Deepgram Flux could not be finalized; no local speech recognizer is enabled");
+                                let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await;
+                                continue;
+                            }
+                            turn_completed = true;
+                            tracing::warn!("No streaming speech recognizer was available for the Kizz turn");
+                            let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await;
+                        }
+                        None => tracing::warn!(%message, "Ignored unknown Kizz voice event"),
+                    },
+                    Message::Ping(payload) => {
+                        if socket.send(Message::Pong(payload)).await.is_err() { break; }
+                    }
+                    Message::Close(_) => {
+                        tracing::info!("Kizz voice session closed by client");
+                        break;
+                    }
+                    _ => {}
                 }
             }
-            Message::Close(_) => {
-                tracing::info!("Kizz voice session closed by client");
-                break;
+            event = deepgram_events_rx.recv() => {
+                let Some(event) = event else { continue };
+                match event {
+                    DeepgramEvent::EndOfTurn { transcript, confidence } if !turn_completed => {
+                        turn_completed = true;
+                        deepgram = None;
+                        let (committed, zone_id) = pending_fallback.take()
+                            .unwrap_or_else(|| (std::mem::take(&mut utterance), current_zone_id.take()));
+                        tracing::info!(%transcript, confidence, bytes = committed.len(),
+                            "Deepgram Flux ended Kizz voice turn");
+                        let _ = send_event(&mut socket, json!({"type":"endpoint","reason":"deepgram_flux","confidence":confidence})).await;
+                        let _ = send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
+                        let result = match codex_transcript_request(&transcript, zone_id.as_deref()).await {
+                            Ok(result) => result,
+                            Err(error) => {
+                                tracing::warn!(%error, "Kizz Codex voice turn failed");
+                                json!({"type":"state","state":"clarify","message":"I lost that thought. Please try once more."})
+                            }
+                        };
+                        let _ = send_event(&mut socket, result).await;
+                    }
+                    DeepgramEvent::EndOfTurn { .. } => {}
+                    DeepgramEvent::Failed(error) => {
+                        deepgram = None;
+                        if pending_fallback.take().is_some() {
+                            tracing::warn!(%error, "Deepgram Flux finalization failed; no local speech recognizer is enabled");
+                            turn_completed = true;
+                            let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await;
+                        } else {
+                            tracing::warn!(%error, "Deepgram Flux stream failed; awaiting device fallback endpoint");
+                        }
+                    }
+                }
             }
-            _ => {}
         }
     }
     tracing::info!("Kizz voice session ended");
@@ -199,22 +290,146 @@ fn store_wake_sample(label: &str, pcm: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
-async fn codex_request(pcm: &[u8], current_zone_id: Option<&str>) -> Result<Value, String> {
-    let (conditioned, capture_peak, gain) = condition_voice_pcm(pcm);
-    tracing::info!(
-        capture_peak,
-        gain = format_args!("{gain:.1}"),
-        "Conditioned Kizz voice capture for the audio model"
+async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<DeepgramTurn, String> {
+    let key = std::env::var("DEEPGRAM_API_KEY")
+        .map_err(|_| "DEEPGRAM_API_KEY is not configured".to_string())?;
+    let eot_threshold =
+        std::env::var("DEEPGRAM_EOT_THRESHOLD").unwrap_or_else(|_| "0.70".to_string());
+    let eot_timeout_ms =
+        std::env::var("DEEPGRAM_EOT_TIMEOUT_MS").unwrap_or_else(|_| "1800".to_string());
+    let uri = format!(
+        "wss://api.deepgram.com/v2/listen?model=flux-general-en&encoding=linear16&sample_rate=16000&eot_threshold={eot_threshold}&eot_timeout_ms={eot_timeout_ms}"
     );
-    let mut wav = tempfile::Builder::new()
-        .prefix("kizz-utterance-")
-        .suffix(".wav")
-        .tempfile()
-        .map_err(|error| error.to_string())?;
-    write_wav(&mut wav, &conditioned).map_err(|error| error.to_string())?;
-    let transcript = transcribe_voice(wav.path()).await?;
-    tracing::info!(%transcript, "Kizz local speech recognition completed");
+    let mut request = uri
+        .into_client_request()
+        .map_err(|error| format!("invalid Deepgram URI: {error}"))?;
+    request.headers_mut().insert(
+        "Authorization",
+        format!("Token {key}")
+            .parse()
+            .map_err(|error| format!("invalid Deepgram credential: {error}"))?,
+    );
+    let (socket, _) = timeout(
+        Duration::from_secs(5),
+        tokio_tungstenite::connect_async(request),
+    )
+    .await
+    .map_err(|_| "Deepgram connection timed out".to_string())?
+    .map_err(|error| format!("Deepgram connection failed: {error}"))?;
+    let (mut output, mut input) = socket.split();
+    let keyterms = std::env::var("DEEPGRAM_KEYTERMS")
+        .unwrap_or_else(|_| "HiPhi,Kizz,Roon".to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|term| !term.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if !keyterms.is_empty() {
+        output
+            .send(DgMessage::Text(
+                json!({"type":"Configure","keyterms":keyterms}).to_string(),
+            ))
+            .await
+            .map_err(|error| format!("Deepgram configuration failed: {error}"))?;
+    }
+    let (input_tx, mut input_rx) = mpsc::channel::<DeepgramInput>(64);
+    tokio::spawn(async move {
+        let mut pending = Vec::<u8>::with_capacity(DEEPGRAM_AUDIO_CHUNK_BYTES * 2);
+        let mut close_deadline = None::<tokio::time::Instant>;
+        let mut input_open = true;
+        loop {
+            tokio::select! {
+                command = input_rx.recv(), if input_open => {
+                    match command {
+                        Some(DeepgramInput::Audio(audio)) => {
+                            pending.extend_from_slice(&audio);
+                            while pending.len() >= DEEPGRAM_AUDIO_CHUNK_BYTES {
+                                let remainder = pending.split_off(DEEPGRAM_AUDIO_CHUNK_BYTES);
+                                let chunk = std::mem::replace(&mut pending, remainder);
+                                if let Err(error) = output.send(DgMessage::Binary(chunk)).await {
+                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    return;
+                                }
+                            }
+                        }
+                        Some(DeepgramInput::Close) | None => {
+                            input_open = false;
+                            if !pending.is_empty() {
+                                if let Err(error) = output.send(DgMessage::Binary(
+                                    std::mem::take(&mut pending))).await {
+                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    return;
+                                }
+                            }
+                            if let Err(error) = output.send(DgMessage::Text(
+                                json!({"type":"CloseStream"}).to_string())).await {
+                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                return;
+                            }
+                            close_deadline = Some(tokio::time::Instant::now() + Duration::from_secs(3));
+                        }
+                    }
+                }
+                message = input.next() => {
+                    let Some(message) = message else {
+                        let _ = events.send(DeepgramEvent::Failed(
+                            "Deepgram closed the stream".to_string())).await;
+                        return;
+                    };
+                    match message {
+                        Ok(DgMessage::Text(text)) => {
+                            let Ok(event) = serde_json::from_str::<Value>(&text) else { continue };
+                            if event.get("type").and_then(Value::as_str) == Some("Error") {
+                                let _ = events.send(DeepgramEvent::Failed(event.to_string())).await;
+                                return;
+                            }
+                            if event.get("type").and_then(Value::as_str) == Some("TurnInfo") &&
+                                event.get("event").and_then(Value::as_str) == Some("EndOfTurn") {
+                                let transcript = event.get("transcript")
+                                    .and_then(Value::as_str).unwrap_or("").trim().to_string();
+                                let confidence = event.get("end_of_turn_confidence")
+                                    .and_then(Value::as_f64);
+                                if transcript.is_empty() {
+                                    let _ = events.send(DeepgramEvent::Failed(
+                                        "Deepgram ended an empty turn".to_string())).await;
+                                } else {
+                                    let _ = events.send(DeepgramEvent::EndOfTurn {
+                                        transcript,
+                                        confidence,
+                                    }).await;
+                                }
+                                return;
+                            }
+                        }
+                        Ok(DgMessage::Close(_)) => {
+                            let _ = events.send(DeepgramEvent::Failed(
+                                "Deepgram closed the stream".to_string())).await;
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+                _ = tokio::time::sleep_until(close_deadline.unwrap_or_else(||
+                    tokio::time::Instant::now() + Duration::from_secs(86_400))),
+                    if close_deadline.is_some() => {
+                    let _ = events.send(DeepgramEvent::Failed(
+                        "Deepgram finalization timed out".to_string())).await;
+                    return;
+                }
+            }
+        }
+    });
+    Ok(DeepgramTurn { input: input_tx })
+}
 
+async fn codex_transcript_request(
+    transcript: &str,
+    current_zone_id: Option<&str>,
+) -> Result<Value, String> {
     let agent = CODEX_AGENT.get_or_init(|| Mutex::new(None));
     let mut _conversation_guard = agent.lock().await;
     if _conversation_guard.is_none() {
@@ -228,7 +443,7 @@ async fn codex_request(pcm: &[u8], current_zone_id: Option<&str>) -> Result<Valu
     let first = _conversation_guard
         .as_mut()
         .ok_or("Codex voice agent was not initialized")?
-        .turn(&transcript, current_zone_id);
+        .turn(transcript, current_zone_id);
     let first = timeout(CODEX_TURN_TIMEOUT, first)
         .await
         .map_err(|_| "Codex voice turn timed out".to_string())?;
@@ -246,7 +461,7 @@ async fn codex_request(pcm: &[u8], current_zone_id: Option<&str>) -> Result<Valu
         .map_err(|_| "Codex App Server restart timed out".to_string())??;
     let result = timeout(
         CODEX_TURN_TIMEOUT,
-        restarted.turn(&transcript, current_zone_id),
+        restarted.turn(transcript, current_zone_id),
     )
     .await
     .map_err(|_| "Codex voice turn timed out after restart".to_string())?;
@@ -572,83 +787,6 @@ fn write_wav(file: &mut tempfile::NamedTempFile, pcm: &[u8]) -> std::io::Result<
     file.flush()
 }
 
-fn condition_voice_pcm(pcm: &[u8]) -> (Vec<u8>, i32, f32) {
-    let peak = pcm
-        .chunks_exact(2)
-        .map(|sample| i16::from_le_bytes([sample[0], sample[1]]) as i32)
-        .map(i32::abs)
-        .max()
-        .unwrap_or(0);
-    if peak == 0 {
-        return (pcm.to_vec(), 0, 1.0);
-    }
-
-    // CoreS3's official microphone path is intentionally conservative. Raise
-    // only the captured utterance to a healthy model input level; this never
-    // touches M5Unified speaker gain or Kizz's chirp loudness.
-    let gain = (18_000.0 / peak as f32).clamp(1.0, 16.0);
-    let mut output = Vec::with_capacity(pcm.len());
-    for sample in pcm.chunks_exact(2) {
-        let value = i16::from_le_bytes([sample[0], sample[1]]) as f32;
-        let conditioned = (value * gain).round().clamp(-32_768.0, 32_767.0) as i16;
-        output.extend_from_slice(&conditioned.to_le_bytes());
-    }
-    (output, peak, gain)
-}
-
-async fn transcribe_voice(wav_path: &Path) -> Result<String, String> {
-    let model = std::env::var_os("KIZZ_WHISPER_MODEL")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| get_data_dir().join("models/ggml-base.en.bin"));
-    if !model.is_file() {
-        return Err(format!(
-            "Kizz Whisper model is missing at {} (set KIZZ_WHISPER_MODEL to override)",
-            model.display()
-        ));
-    }
-    let output = timeout(
-        TRANSCRIBE_TIMEOUT,
-        Command::new("whisper-cli")
-            .args([
-                "-m",
-                model
-                    .to_str()
-                    .ok_or("Kizz Whisper model path is not valid UTF-8")?,
-                "-f",
-                wav_path
-                    .to_str()
-                    .ok_or("Kizz WAV path is not valid UTF-8")?,
-                "-l",
-                "en",
-                "-t",
-                "4",
-                "--no-timestamps",
-                "--no-prints",
-            ])
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .output(),
-    )
-    .await
-    .map_err(|_| "Kizz local speech recognition timed out".to_string())?
-    .map_err(|error| format!("Kizz local speech recognition is unavailable: {error}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "Kizz local speech recognition exited as {}",
-            output.status
-        ));
-    }
-    let transcript = String::from_utf8(output.stdout)
-        .map_err(|error| format!("Kizz transcript was not UTF-8: {error}"))?
-        .trim()
-        .to_string();
-    if transcript.is_empty() {
-        return Err("Kizz local speech recognition heard no words".to_string());
-    }
-    Ok(transcript)
-}
-
 async fn send_event(socket: &mut WebSocket, event: Value) -> Result<(), axum::Error> {
     socket.send(Message::Text(event.to_string().into())).await
 }
@@ -717,20 +855,6 @@ mod tests {
         assert_eq!(
             parse_client_event(r#"{"type":"wake_sample","label":"hiphi_kizz","bytes":999999}"#),
             None
-        );
-    }
-
-    #[test]
-    fn quiet_voice_capture_is_raised_without_touching_duration() {
-        let pcm = [500i16.to_le_bytes(), (-750i16).to_le_bytes()].concat();
-        let (conditioned, peak, gain) = condition_voice_pcm(&pcm);
-        assert_eq!(peak, 750);
-        assert_eq!(gain, 16.0);
-        assert_eq!(conditioned.len(), pcm.len());
-        assert_eq!(i16::from_le_bytes([conditioned[0], conditioned[1]]), 8_000);
-        assert_eq!(
-            i16::from_le_bytes([conditioned[2], conditioned[3]]),
-            -12_000
         );
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1394,6 +1394,7 @@ impl CodexVoiceAgent {
             let result = normalize_codex_result(text)?;
             tracing::info!(
                 state = %result["state"].as_str().unwrap_or("invalid"),
+                intent = %result["intent"].as_str().unwrap_or("invalid"),
                 message = %result["message"].as_str().unwrap_or(""),
                 zone = %result["zone"].as_str().unwrap_or(""),
                 heard = %result["heard"].as_str().unwrap_or(""),
@@ -1468,6 +1469,15 @@ spoken room always overrides device context. For a clear request, perform it and
 report success only when the MCP result confirms it. If the intended content or
 zone is genuinely ambiguous, do not guess or act; ask one short clarification.
 
+This is a hard execution boundary. Before considering any MCP call, classify the
+transcript in the `intent` field as exactly one of `command`, `non_command`, or
+`uncertain`. `command` means a clear request to control music, playback, volume,
+content, or zones. `non_command` means ordinary conversation or unrelated
+speech. `uncertain` means the transcript is too fragmentary or ambiguous to
+establish a music request. If the intent is `non_command` or `uncertain`, do not
+call any MCP tool. Return `state` as `clarify`, set `intent` accordingly, and set
+`message` exactly to `I can't let you do that Dave`.
+
 Kizz itself communicates with expressions, motion, and chirps. Do not create a
 spoken model response and do not emit commentary. Return only the structured
 JSON required by the supplied output schema. Keep message under 90 characters.
@@ -1477,12 +1487,13 @@ fn kizz_result_schema() -> Value {
     json!({
         "type":"object",
         "additionalProperties":false,
-        "required":["state","message","zone","heard"],
+        "required":["state","message","zone","heard","intent"],
         "properties":{
             "state":{"type":"string","enum":["success","clarify","error"]},
             "message":{"type":"string"},
             "zone":{"type":["string","null"]},
-            "heard":{"type":["string","null"]}
+            "heard":{"type":["string","null"]},
+            "intent":{"type":"string","enum":["command","non_command","uncertain"]}
         }
     })
 }
@@ -1496,6 +1507,16 @@ fn normalize_codex_result(text: &str) -> Result<Value, String> {
         .to_string();
     if !matches!(state.as_str(), "success" | "clarify" | "error") {
         return Err(format!("Codex returned unsupported Kizz state: {state}"));
+    }
+    if !matches!(
+        result["intent"].as_str(),
+        Some("command" | "non_command" | "uncertain")
+    ) {
+        return Err("Codex returned unsupported Kizz intent".to_string());
+    }
+    if result["intent"] != "command" {
+        result["state"] = json!("clarify");
+        result["message"] = json!("I can't let you do that Dave");
     }
     if !result["message"].is_string() {
         return Err("Codex returned no Kizz message".to_string());
@@ -1679,7 +1700,7 @@ mod tests {
     #[test]
     fn codex_success_becomes_a_kizz_state_event() {
         let result = normalize_codex_result(
-            r#"{"state":"success","message":"On it.","zone":"Kitchen","heard":null}"#,
+            r#"{"state":"success","message":"On it.","zone":"Kitchen","heard":null,"intent":"command"}"#,
         )
         .expect("valid agent result");
         assert_eq!(result["type"], "state");
@@ -1690,7 +1711,7 @@ mod tests {
     #[test]
     fn codex_error_never_claims_device_success() {
         let result = normalize_codex_result(
-            r#"{"state":"error","message":"Music service unavailable","zone":null,"heard":null}"#,
+            r#"{"state":"error","message":"Music service unavailable","zone":null,"heard":null,"intent":"command"}"#,
         )
         .expect("valid agent result");
         assert_eq!(result["state"], "clarify");
@@ -1699,6 +1720,32 @@ mod tests {
     #[test]
     fn malformed_agent_output_is_rejected() {
         assert!(normalize_codex_result("played it").is_err());
+    }
+
+    #[test]
+    fn codex_output_requires_a_valid_intent_classification() {
+        assert!(normalize_codex_result(
+            r#"{"state":"clarify","message":"Try again.","zone":null,"heard":null}"#
+        )
+        .is_err());
+        assert!(normalize_codex_result(
+            r#"{"state":"clarify","message":"Try again.","zone":null,"heard":null,"intent":"maybe"}"#
+        )
+        .is_err());
+        let result = normalize_codex_result(
+            r#"{"state":"clarify","message":"Try again.","zone":null,"heard":null,"intent":"uncertain"}"#
+        )
+        .expect("valid uncertain intent");
+        assert_eq!(result["intent"], "uncertain");
+        assert_eq!(result["state"], "clarify");
+        assert_eq!(result["message"], "I can't let you do that Dave");
+
+        let result = normalize_codex_result(
+            r#"{"state":"success","message":"I changed it.","zone":"Kitchen","heard":null,"intent":"non_command"}"#
+        )
+        .expect("valid non-command intent");
+        assert_eq!(result["state"], "clarify");
+        assert_eq!(result["message"], "I can't let you do that Dave");
     }
 
     #[test]

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -40,28 +40,28 @@ enum DeepgramEvent {
     Failed(String),
 }
 
-struct DeepgramTurn {
-    input: mpsc::Sender<DeepgramInput>,
+struct SttTurn {
+    input: mpsc::Sender<SttInput>,
 }
 
-enum DeepgramInput {
+enum SttInput {
     Audio(Vec<u8>),
     Close,
 }
 
-impl DeepgramTurn {
+impl SttTurn {
     async fn send_audio(&self, pcm: Vec<u8>) -> Result<(), String> {
         self.input
-            .send(DeepgramInput::Audio(pcm))
+            .send(SttInput::Audio(pcm))
             .await
-            .map_err(|_| "Deepgram audio task stopped".to_string())
+            .map_err(|_| "speech recognition task stopped".to_string())
     }
 
     async fn close(&self) -> Result<(), String> {
         self.input
-            .send(DeepgramInput::Close)
+            .send(SttInput::Close)
             .await
-            .map_err(|_| "Deepgram audio task stopped before finalization".to_string())
+            .map_err(|_| "speech recognition task stopped before finalization".to_string())
     }
 }
 
@@ -90,7 +90,7 @@ async fn run_session(mut socket: WebSocket) {
     let mut current_zone_id = None::<String>;
     let mut wake_sample = None::<WakeSample>;
     let (deepgram_events_tx, mut deepgram_events_rx) = mpsc::channel(8);
-    let mut deepgram = None::<DeepgramTurn>;
+    let mut deepgram = None::<SttTurn>;
     let mut pending_fallback = None::<(Vec<u8>, Option<String>)>;
     let mut turn_completed = false;
     loop {
@@ -134,10 +134,10 @@ async fn run_session(mut socket: WebSocket) {
                             current_zone_id = zone_id;
                             turn_completed = false;
                             pending_fallback = None;
-                            deepgram = match start_deepgram_turn(deepgram_events_tx.clone()).await {
+                            deepgram = match start_stt_turn(deepgram_events_tx.clone()).await {
                                 Ok(turn) => Some(turn),
                                 Err(error) => {
-                                    tracing::warn!(%error, "Deepgram Flux unavailable; local transcription remains armed");
+                                    tracing::warn!(%error, "streaming speech recognition unavailable");
                                     None
                                 }
                             };
@@ -290,7 +290,17 @@ fn store_wake_sample(label: &str, pcm: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
-async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<DeepgramTurn, String> {
+async fn start_stt_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttTurn, String> {
+    match std::env::var("KIZZ_STT_PROVIDER")
+        .unwrap_or_else(|_| "deepgram".to_string())
+        .as_str()
+    {
+        "assemblyai" | "assembly" => start_assemblyai_turn(events).await,
+        _ => start_deepgram_turn(events).await,
+    }
+}
+
+async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttTurn, String> {
     let key = std::env::var("DEEPGRAM_API_KEY")
         .map_err(|_| "DEEPGRAM_API_KEY is not configured".to_string())?;
     let eot_threshold =
@@ -332,7 +342,7 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<Deep
             .await
             .map_err(|error| format!("Deepgram configuration failed: {error}"))?;
     }
-    let (input_tx, mut input_rx) = mpsc::channel::<DeepgramInput>(64);
+    let (input_tx, mut input_rx) = mpsc::channel::<SttInput>(64);
     tokio::spawn(async move {
         let mut pending = Vec::<u8>::with_capacity(DEEPGRAM_AUDIO_CHUNK_BYTES * 2);
         let mut close_deadline = None::<tokio::time::Instant>;
@@ -341,7 +351,7 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<Deep
             tokio::select! {
                 command = input_rx.recv(), if input_open => {
                     match command {
-                        Some(DeepgramInput::Audio(audio)) => {
+                        Some(SttInput::Audio(audio)) => {
                             pending.extend_from_slice(&audio);
                             while pending.len() >= DEEPGRAM_AUDIO_CHUNK_BYTES {
                                 let remainder = pending.split_off(DEEPGRAM_AUDIO_CHUNK_BYTES);
@@ -352,7 +362,7 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<Deep
                                 }
                             }
                         }
-                        Some(DeepgramInput::Close) | None => {
+                        Some(SttInput::Close) | None => {
                             input_open = false;
                             if !pending.is_empty() {
                                 if let Err(error) = output.send(DgMessage::Binary(
@@ -423,7 +433,127 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<Deep
             }
         }
     });
-    Ok(DeepgramTurn { input: input_tx })
+    Ok(SttTurn { input: input_tx })
+}
+
+async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttTurn, String> {
+    let key = std::env::var("ASSEMBLYAI_API_KEY")
+        .map_err(|_| "ASSEMBLYAI_API_KEY is not configured".to_string())?;
+    let min_silence =
+        std::env::var("ASSEMBLYAI_MIN_TURN_SILENCE_MS").unwrap_or_else(|_| "300".to_string());
+    let max_silence =
+        std::env::var("ASSEMBLYAI_MAX_TURN_SILENCE_MS").unwrap_or_else(|_| "1200".to_string());
+    let uri = format!(
+        "wss://streaming.assemblyai.com/v3/ws?sample_rate=16000&speech_model=u3-rt-pro&format_turns=false&min_turn_silence={min_silence}&max_turn_silence={max_silence}"
+    );
+    let mut request = uri
+        .into_client_request()
+        .map_err(|error| format!("invalid AssemblyAI URI: {error}"))?;
+    request.headers_mut().insert(
+        "Authorization",
+        key.parse()
+            .map_err(|error| format!("invalid AssemblyAI credential: {error}"))?,
+    );
+    let (socket, _) = timeout(
+        Duration::from_secs(5),
+        tokio_tungstenite::connect_async(request),
+    )
+    .await
+    .map_err(|_| "AssemblyAI connection timed out".to_string())?
+    .map_err(|error| format!("AssemblyAI connection failed: {error}"))?;
+    let (mut output, mut input) = socket.split();
+    let (input_tx, mut input_rx) = mpsc::channel::<SttInput>(64);
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                command = input_rx.recv() => {
+                    match command {
+                        Some(SttInput::Audio(audio)) => {
+                            if let Err(error) = output.send(DgMessage::Binary(audio)).await {
+                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                return;
+                            }
+                        }
+                        Some(SttInput::Close) | None => {
+                            if let Err(error) = output.send(DgMessage::Text(
+                                json!({"type":"Terminate"}).to_string())).await {
+                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                return;
+                            }
+                            match tokio::time::timeout(Duration::from_secs(5), async {
+                                while let Some(message) = input.next().await {
+                                    match message {
+                                        Ok(DgMessage::Text(text)) => {
+                                            let Ok(event) = serde_json::from_str::<Value>(&text) else { continue };
+                                            if event.get("type").and_then(Value::as_str) == Some("Turn") &&
+                                                event.get("end_of_turn").and_then(Value::as_bool) == Some(true) {
+                                                let transcript = event.get("transcript")
+                                                    .and_then(Value::as_str).unwrap_or("").trim().to_string();
+                                                if transcript.is_empty() {
+                                                    return Err("AssemblyAI ended an empty turn".to_string());
+                                                }
+                                                let confidence = event.get("end_of_turn_confidence").and_then(Value::as_f64);
+                                                let _ = events.send(DeepgramEvent::EndOfTurn { transcript, confidence }).await;
+                                                return Ok(());
+                                            }
+                                            if event.get("type").and_then(Value::as_str) == Some("Error") {
+                                                return Err(event.to_string());
+                                            }
+                                        }
+                                        Ok(DgMessage::Close(_)) => return Err("AssemblyAI closed the stream".to_string()),
+                                        Err(error) => return Err(error.to_string()),
+                                        _ => {}
+                                    }
+                                }
+                                Err("AssemblyAI closed the stream".to_string())
+                            }).await {
+                                Ok(Ok(())) => {}
+                                Ok(Err(error)) => { let _ = events.send(DeepgramEvent::Failed(error)).await; }
+                                Err(_) => { let _ = events.send(DeepgramEvent::Failed("AssemblyAI finalization timed out".to_string())).await; }
+                            }
+                            return;
+                        }
+                    }
+                }
+                message = input.next() => {
+                    let Some(message) = message else {
+                        let _ = events.send(DeepgramEvent::Failed("AssemblyAI closed the stream".to_string())).await;
+                        return;
+                    };
+                    match message {
+                        Ok(DgMessage::Text(text)) => {
+                            let Ok(event) = serde_json::from_str::<Value>(&text) else { continue };
+                            if event.get("type").and_then(Value::as_str) == Some("Error") {
+                                let _ = events.send(DeepgramEvent::Failed(event.to_string())).await;
+                                return;
+                            }
+                            if event.get("type").and_then(Value::as_str) == Some("Turn") &&
+                                event.get("end_of_turn").and_then(Value::as_bool) == Some(true) {
+                                let transcript = event.get("transcript").and_then(Value::as_str).unwrap_or("").trim().to_string();
+                                if transcript.is_empty() {
+                                    let _ = events.send(DeepgramEvent::Failed("AssemblyAI ended an empty turn".to_string())).await;
+                                } else {
+                                    let confidence = event.get("end_of_turn_confidence").and_then(Value::as_f64);
+                                    let _ = events.send(DeepgramEvent::EndOfTurn { transcript, confidence }).await;
+                                }
+                                return;
+                            }
+                        }
+                        Ok(DgMessage::Close(_)) => {
+                            let _ = events.send(DeepgramEvent::Failed("AssemblyAI closed the stream".to_string())).await;
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    });
+    Ok(SttTurn { input: input_tx })
 }
 
 async fn codex_transcript_request(

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -15,8 +15,6 @@ use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::VecDeque;
-use std::io::Write;
-use std::path::Path;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
@@ -30,7 +28,6 @@ use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message as DgMes
 
 const SAMPLE_RATE: u32 = 16_000;
 const MAX_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize * 2 * 14;
-const MAX_WAKE_SAMPLE_BYTES: usize = SAMPLE_RATE as usize * 2 * 3;
 const MIN_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize / 2;
 const CODEX_START_TIMEOUT: Duration = Duration::from_secs(20);
 const CODEX_TURN_TIMEOUT: Duration = Duration::from_secs(30);
@@ -311,7 +308,6 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
     tracing::info!("Kizz voice session opened");
     let mut utterance = Vec::<u8>::new();
     let mut current_zone_id = None::<String>;
-    let mut wake_sample = None::<WakeSample>;
     let (provider_events_tx, mut provider_events_rx) = mpsc::channel(16);
     let mut stt_turns = Vec::<SttTurn>::new();
     let mut pending_fallback = None::<(Vec<u8>, Option<String>)>;
@@ -331,17 +327,6 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                 };
                 match message {
                     Message::Binary(pcm) => {
-                        if let Some(sample) = wake_sample.take() {
-                            if pcm.len() == sample.bytes {
-                                if let Err(error) = store_wake_sample(&sample.label, &pcm) {
-                                    tracing::warn!(%error, "Kizz wake training sample was not stored");
-                                }
-                            } else {
-                                tracing::warn!(expected = sample.bytes, actual = pcm.len(),
-                                    "Kizz wake training sample length mismatch");
-                            }
-                            continue;
-                        }
                         utterance.extend_from_slice(&pcm);
                         if utterance.len() > MAX_UTTERANCE_BYTES {
                             let excess = utterance.len() - MAX_UTTERANCE_BYTES;
@@ -396,7 +381,6 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                                 providers = stt_turns.len(),
                                 "Kizz voice turn received device context");
                         }
-                        Some(ClientEvent::WakeSample(sample)) => wake_sample = Some(sample),
                         Some(ClientEvent::Commit) if turn_completed => {
                             tracing::info!("Ignored device fallback commit after Flux completed the turn");
                         }
@@ -521,14 +505,7 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
 #[derive(Debug, PartialEq)]
 enum ClientEvent {
     Start { zone_id: Option<String> },
-    WakeSample(WakeSample),
     Commit,
-}
-
-#[derive(Debug, PartialEq)]
-struct WakeSample {
-    label: String,
-    bytes: usize,
 }
 
 fn parse_client_event(message: &str) -> Option<ClientEvent> {
@@ -541,41 +518,9 @@ fn parse_client_event(message: &str) -> Option<ClientEvent> {
                 .filter(|zone_id| !zone_id.is_empty())
                 .map(str::to_owned),
         }),
-        "wake_sample" => {
-            let label = event.get("label")?.as_str()?;
-            let bytes = usize::try_from(event.get("bytes")?.as_u64()?).ok()?;
-            if label != "hiphi_kizz" || bytes == 0 || bytes > MAX_WAKE_SAMPLE_BYTES {
-                return None;
-            }
-            Some(ClientEvent::WakeSample(WakeSample {
-                label: label.to_owned(),
-                bytes,
-            }))
-        }
         "commit" => Some(ClientEvent::Commit),
         _ => None,
     }
-}
-
-fn store_wake_sample(label: &str, pcm: &[u8]) -> Result<(), String> {
-    let Some(root) = std::env::var_os("KIZZ_WAKE_TRAINING_DIR") else {
-        return Ok(());
-    };
-    let destination = Path::new(&root).join("positive").join(label);
-    std::fs::create_dir_all(&destination).map_err(|error| error.to_string())?;
-    let mut sample = tempfile::Builder::new()
-        .prefix("device-")
-        .suffix(".wav")
-        .tempfile_in(&destination)
-        .map_err(|error| error.to_string())?;
-    write_wav(&mut sample, pcm).map_err(|error| error.to_string())?;
-    let path = sample
-        .into_temp_path()
-        .keep()
-        .map_err(|error| error.to_string())?;
-    tracing::info!(path = %path.display(), bytes = pcm.len(),
-        "Stored Kizz wake training sample");
-    Ok(())
 }
 
 async fn start_provider_turn(
@@ -1549,24 +1494,6 @@ fn normalize_codex_result(text: &str) -> Result<Value, String> {
     Ok(result)
 }
 
-fn write_wav(file: &mut tempfile::NamedTempFile, pcm: &[u8]) -> std::io::Result<()> {
-    let data_len = pcm.len() as u32;
-    file.write_all(b"RIFF")?;
-    file.write_all(&(36 + data_len).to_le_bytes())?;
-    file.write_all(b"WAVEfmt ")?;
-    file.write_all(&16u32.to_le_bytes())?;
-    file.write_all(&1u16.to_le_bytes())?;
-    file.write_all(&1u16.to_le_bytes())?;
-    file.write_all(&SAMPLE_RATE.to_le_bytes())?;
-    file.write_all(&(SAMPLE_RATE * 2).to_le_bytes())?;
-    file.write_all(&2u16.to_le_bytes())?;
-    file.write_all(&16u16.to_le_bytes())?;
-    file.write_all(b"data")?;
-    file.write_all(&data_len.to_le_bytes())?;
-    file.write_all(pcm)?;
-    file.flush()
-}
-
 async fn send_event(socket: &mut WebSocket, event: Value) -> Result<(), axum::Error> {
     socket.send(Message::Text(event.to_string().into())).await
 }
@@ -1781,13 +1708,10 @@ mod tests {
     }
 
     #[test]
-    fn wake_training_sample_is_bounded_and_exactly_labeled() {
+    fn production_voice_rejects_training_audio() {
         assert_eq!(
             parse_client_event(r#"{"type":"wake_sample","label":"hiphi_kizz","bytes":64000}"#),
-            Some(ClientEvent::WakeSample(WakeSample {
-                label: "hiphi_kizz".to_string(),
-                bytes: 64_000,
-            }))
+            None
         );
         assert_eq!(
             parse_client_event(r#"{"type":"wake_sample","label":"other","bytes":64000}"#),

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -253,6 +253,15 @@ fn deepgram_closed_event(
     }
 }
 
+async fn emit_provider_event(events: &mpsc::Sender<DeepgramEvent>, event: DeepgramEvent) -> bool {
+    if events.send(event).await.is_err() {
+        tracing::debug!("Kizz STT provider event receiver dropped");
+        false
+    } else {
+        true
+    }
+}
+
 struct SttTurn {
     provider: SttProvider,
     input: mpsc::Sender<SttInput>,
@@ -334,7 +343,13 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                             utterance.drain(..excess);
                         }
                         for turn in &stt_turns {
-                            let _ = turn.send_audio(pcm.to_vec()).await;
+                            if let Err(error) = turn.send_audio(pcm.to_vec()).await {
+                                tracing::debug!(
+                                    provider = turn.provider.name(),
+                                    %error,
+                                    "Kizz STT provider stopped accepting audio"
+                                );
+                            }
                         }
                     }
                     Message::Text(message) => match parse_client_event(&message) {
@@ -387,8 +402,10 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                                     }
                                 }
                             }
-                            if stt_turns.is_empty() {
-                                let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"I could not connect to speech recognition. Please try again."})).await;
+                            if stt_turns.is_empty()
+                                && send_event(&mut socket, json!({"type":"state","state":"clarify","message":"I could not connect to speech recognition. Please try again."})).await.is_err()
+                            {
+                                break;
                             }
                             tracing::info!(zone_id = current_zone_id.as_deref().unwrap_or("unknown"),
                                 providers = stt_turns.len(),
@@ -405,20 +422,34 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                             let zone_id = current_zone_id.take();
                             tracing::info!(bytes = committed.len(), "Kizz fallback utterance committed");
                             if committed.len() < MIN_UTTERANCE_BYTES {
-                                let _ = send_event(&mut socket,
-                                    json!({"type":"state","state":"clarify","message":"I did not hear enough yet."})).await;
+                                if send_event(&mut socket,
+                                    json!({"type":"state","state":"clarify","message":"I did not hear enough yet."})).await.is_err() {
+                                    break;
+                                }
                                 continue;
                             }
-                            let _ = send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
+                            if send_event(&mut socket, json!({"type":"state","state":"thinking"})).await.is_err() {
+                                break;
+                            }
                             if !stt_turns.is_empty() {
                                 pending_fallback = Some((committed, zone_id));
-                                for turn in &stt_turns { let _ = turn.close().await; }
+                                for turn in &stt_turns {
+                                    if let Err(error) = turn.close().await {
+                                        tracing::debug!(
+                                            provider = turn.provider.name(),
+                                            %error,
+                                            "Kizz STT provider stopped before finalization"
+                                        );
+                                    }
+                                }
                                 tracing::info!("Streaming STT finalization requested by device fallback");
                                 continue;
                             }
                             turn_completed = true;
                             tracing::warn!("No streaming speech recognizer was available for the Kizz turn");
-                            let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await;
+                            if send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await.is_err() {
+                                break;
+                            }
                         }
                         None => tracing::warn!(%message, "Ignored unknown Kizz voice event"),
                     },
@@ -459,17 +490,31 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                     DeepgramEvent::EndOfTurn { transcript, confidence } if !turn_completed => {
                         finished_stt += 1;
                         turn_completed = true;
-                        for turn in &stt_turns { let _ = turn.close().await; }
+                        for turn in &stt_turns {
+                            if let Err(error) = turn.close().await {
+                                tracing::debug!(
+                                    provider = turn.provider.name(),
+                                    %error,
+                                    "Kizz STT provider stopped before competitor finalization"
+                                );
+                            }
+                        }
                         let (committed, zone_id) = pending_fallback.take()
                             .unwrap_or_else(|| (std::mem::take(&mut utterance), current_zone_id.take()));
                         tracing::info!(%transcript, confidence, provider = provider.name(), bytes = committed.len(), latency_ms,
                             "Streaming STT ended Kizz voice turn");
-                        let _ = send_event(&mut socket, json!({"type":"endpoint","reason":format!("{}_end_of_turn", provider.name()),"confidence":confidence})).await;
+                        if send_event(&mut socket, json!({"type":"endpoint","reason":format!("{}_end_of_turn", provider.name()),"confidence":confidence})).await.is_err() {
+                            break;
+                        }
                         // Surface the recognition result immediately. The device can
                         // show what it heard while the Codex/MCP turn is running.
-                        let _ = send_event(&mut socket,
-                            json!({"type":"transcript","text":transcript})).await;
-                        let _ = send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
+                        if send_event(&mut socket,
+                            json!({"type":"transcript","text":transcript})).await.is_err() {
+                            break;
+                        }
+                        if send_event(&mut socket, json!({"type":"state","state":"thinking"})).await.is_err() {
+                            break;
+                        }
                         let context = current_voice_context(&state, zone_id.as_deref()).await;
                         tracing::info!(
                             zone_id = context.zone_id.as_deref().unwrap_or("unknown"),
@@ -486,7 +531,9 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                                 json!({"type":"state","state":"clarify","message":"I lost that thought. Please try once more."})
                             }
                         };
-                        let _ = send_event(&mut socket, result).await;
+                        if send_event(&mut socket, result).await.is_err() {
+                            break;
+                        }
                     }
                     DeepgramEvent::EndOfTurn { transcript, confidence } => {
                         finished_stt += 1;
@@ -503,7 +550,9 @@ async fn run_session(mut socket: WebSocket, state: AppState) {
                             pending_fallback.take();
                             tracing::warn!(provider = provider.name(), %error, "Streaming STT finalization failed");
                             turn_completed = true;
-                            let _ = send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await;
+                            if send_event(&mut socket, json!({"type":"state","state":"clarify","message":"Speech recognition is unavailable. Please try once more."})).await.is_err() {
+                                break;
+                            }
                         } else {
                             tracing::warn!(provider = provider.name(), %error, "Streaming STT stream failed; awaiting another provider or device fallback endpoint");
                         }
@@ -677,7 +726,14 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                                 let remainder = pending.split_off(DEEPGRAM_AUDIO_CHUNK_BYTES);
                                 let chunk = std::mem::replace(&mut pending, remainder);
                                 if let Err(error) = output.send(DgMessage::Binary(chunk)).await {
-                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(error.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                     return;
                                 }
                             }
@@ -687,13 +743,27 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                             if !pending.is_empty() {
                                 if let Err(error) = output.send(DgMessage::Binary(
                                     std::mem::take(&mut pending))).await {
-                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(error.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                     return;
                                 }
                             }
                             if let Err(error) = output.send(DgMessage::Text(
                                 json!({"type":"CloseStream"}).to_string())).await {
-                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                if !emit_provider_event(
+                                    &events,
+                                    DeepgramEvent::Failed(error.to_string()),
+                                )
+                                .await
+                                {
+                                    return;
+                                }
                                 return;
                             }
                             close_deadline = Some(tokio::time::Instant::now() + Duration::from_secs(3));
@@ -702,18 +772,32 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                 }
                 message = input.next() => {
                     let Some(message) = message else {
-                        let _ = events.send(deepgram_closed_event(
-                            !input_open,
-                            latest_transcript.take(),
-                            latest_confidence,
-                        )).await;
+                        if !emit_provider_event(
+                            &events,
+                            deepgram_closed_event(
+                                !input_open,
+                                latest_transcript.take(),
+                                latest_confidence,
+                            ),
+                        )
+                        .await
+                        {
+                            return;
+                        }
                         return;
                     };
                     match message {
                         Ok(DgMessage::Text(text)) => {
                             let Ok(event) = serde_json::from_str::<Value>(&text) else { continue };
                             if event.get("type").and_then(Value::as_str) == Some("Error") {
-                                let _ = events.send(DeepgramEvent::Failed(event.to_string())).await;
+                                if !emit_provider_event(
+                                    &events,
+                                    DeepgramEvent::Failed(event.to_string()),
+                                )
+                                .await
+                                {
+                                    return;
+                                }
                                 return;
                             }
                             if event.get("type").and_then(Value::as_str) == Some("TurnInfo") {
@@ -732,13 +816,26 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                                 let confidence = event.get("end_of_turn_confidence")
                                     .and_then(Value::as_f64);
                                 if transcript.is_empty() {
-                                    let _ = events.send(DeepgramEvent::Failed(
-                                        "Deepgram ended an empty turn".to_string())).await;
-                                } else {
-                                    let _ = events.send(DeepgramEvent::EndOfTurn {
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(
+                                            "Deepgram ended an empty turn".to_string(),
+                                        ),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
+                                } else if !emit_provider_event(
+                                    &events,
+                                    DeepgramEvent::EndOfTurn {
                                         transcript,
                                         confidence,
-                                    }).await;
+                                    },
+                                )
+                                .await
+                                {
+                                    return;
                                 }
                                 return;
                             }
@@ -748,21 +845,41 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                                     .and_then(Value::as_str).unwrap_or("").trim();
                                 if !transcript.is_empty() {
                                     first_partial_sent = true;
-                                    let _ = events.send(DeepgramEvent::PartialTranscript(
-                                        transcript.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::PartialTranscript(transcript.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                 }
                             }
                         }
                         Ok(DgMessage::Close(_)) => {
-                            let _ = events.send(deepgram_closed_event(
-                                !input_open,
-                                latest_transcript.take(),
-                                latest_confidence,
-                            )).await;
+                            if !emit_provider_event(
+                                &events,
+                                deepgram_closed_event(
+                                    !input_open,
+                                    latest_transcript.take(),
+                                    latest_confidence,
+                                ),
+                            )
+                            .await
+                            {
+                                return;
+                            }
                             return;
                         }
                         Err(error) => {
-                            let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                            if !emit_provider_event(
+                                &events,
+                                DeepgramEvent::Failed(error.to_string()),
+                            )
+                            .await
+                            {
+                                return;
+                            }
                             return;
                         }
                         _ => {}
@@ -771,8 +888,14 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                 _ = tokio::time::sleep_until(close_deadline.unwrap_or_else(||
                     tokio::time::Instant::now() + Duration::from_secs(86_400))),
                     if close_deadline.is_some() => {
-                    let _ = events.send(DeepgramEvent::Failed(
-                        "Deepgram finalization timed out".to_string())).await;
+                    if !emit_provider_event(
+                        &events,
+                        DeepgramEvent::Failed("Deepgram finalization timed out".to_string()),
+                    )
+                    .await
+                    {
+                        return;
+                    }
                     return;
                 }
             }
@@ -895,7 +1018,14 @@ async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                 audio_bytes_sent += chunk.len();
                                 if let Err(error) = output.send(DgMessage::Text(
                                     elevenlabs_audio_message(&chunk, false))).await {
-                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(error.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                     return;
                                 }
                             }
@@ -906,7 +1036,14 @@ async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                 audio_bytes_sent += pending_audio.len();
                                 if let Err(error) = output.send(DgMessage::Text(
                                     elevenlabs_audio_message(&std::mem::take(&mut pending_audio), false))).await {
-                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(error.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                     return;
                                 }
                             }
@@ -915,7 +1052,14 @@ async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                 let chunk_bytes = padding_bytes.min(ELEVENLABS_AUDIO_CHUNK_BYTES);
                                 if let Err(error) = output.send(DgMessage::Text(
                                     elevenlabs_audio_message(&vec![0; chunk_bytes], false))).await {
-                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(error.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                     return;
                                 }
                                 padding_bytes -= chunk_bytes;
@@ -923,7 +1067,14 @@ async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                             // This matches the official SDK's manual commit wire message.
                             if let Err(error) = output.send(DgMessage::Text(
                                 elevenlabs_audio_message(&[], true))).await {
-                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                if !emit_provider_event(
+                                    &events,
+                                    DeepgramEvent::Failed(error.to_string()),
+                                )
+                                .await
+                                {
+                                    return;
+                                }
                                 return;
                             }
                             close_deadline = Some(tokio::time::Instant::now() + Duration::from_secs(5));
@@ -932,8 +1083,14 @@ async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                 }
                 message = input.next() => {
                     let Some(message) = message else {
-                        let _ = events.send(DeepgramEvent::Failed(
-                            "ElevenLabs closed the stream".to_string())).await;
+                        if !emit_provider_event(
+                            &events,
+                            DeepgramEvent::Failed("ElevenLabs closed the stream".to_string()),
+                        )
+                        .await
+                        {
+                            return;
+                        }
                         return;
                     };
                     match message {
@@ -943,22 +1100,39 @@ async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                     DeepgramEvent::PartialTranscript(_) if first_partial_sent => {}
                                     DeepgramEvent::PartialTranscript(_) => {
                                         first_partial_sent = true;
-                                        let _ = events.send(event).await;
+                                        if !emit_provider_event(&events, event).await {
+                                            return;
+                                        }
                                     }
                                     _ => {
-                                        let _ = events.send(event).await;
+                                        if !emit_provider_event(&events, event).await {
+                                            return;
+                                        }
                                         return;
                                     }
                                 }
                             }
                         }
                         Ok(DgMessage::Close(_)) => {
-                            let _ = events.send(DeepgramEvent::Failed(
-                                "ElevenLabs closed the stream".to_string())).await;
+                            if !emit_provider_event(
+                                &events,
+                                DeepgramEvent::Failed("ElevenLabs closed the stream".to_string()),
+                            )
+                            .await
+                            {
+                                return;
+                            }
                             return;
                         }
                         Err(error) => {
-                            let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                            if !emit_provider_event(
+                                &events,
+                                DeepgramEvent::Failed(error.to_string()),
+                            )
+                            .await
+                            {
+                                return;
+                            }
                             return;
                         }
                         _ => {}
@@ -967,8 +1141,14 @@ async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                 _ = tokio::time::sleep_until(close_deadline.unwrap_or_else(||
                     tokio::time::Instant::now() + Duration::from_secs(86_400))),
                     if close_deadline.is_some() => {
-                    let _ = events.send(DeepgramEvent::Failed(
-                        "ElevenLabs finalization timed out".to_string())).await;
+                    if !emit_provider_event(
+                        &events,
+                        DeepgramEvent::Failed("ElevenLabs finalization timed out".to_string()),
+                    )
+                    .await
+                    {
+                        return;
+                    }
                     return;
                 }
             }
@@ -1025,7 +1205,14 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                 let remainder = pending_audio.split_off(AUDIO_CHUNK_BYTES);
                                 let chunk = std::mem::replace(&mut pending_audio, remainder);
                                 if let Err(error) = output.send(DgMessage::Binary(chunk)).await {
-                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(error.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                     return;
                                 }
                             }
@@ -1041,7 +1228,14 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                 }
                                 if let Err(error) = output.send(DgMessage::Binary(
                                     std::mem::take(&mut pending_audio))).await {
-                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(error.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                     return;
                                 }
                             }
@@ -1049,7 +1243,14 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                             // closes the session and can discard an in-flight turn.
                             if let Err(error) = output.send(DgMessage::Text(
                                 json!({"type":"ForceEndpoint"}).to_string())).await {
-                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                if !emit_provider_event(
+                                    &events,
+                                    DeepgramEvent::Failed(error.to_string()),
+                                )
+                                .await
+                                {
+                                    return;
+                                }
                                 return;
                             }
                             match tokio::time::timeout(Duration::from_secs(5), async {
@@ -1065,7 +1266,14 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                                     return Err("AssemblyAI ended an empty turn".to_string());
                                                 }
                                                 let confidence = event.get("end_of_turn_confidence").and_then(Value::as_f64);
-                                                let _ = events.send(DeepgramEvent::EndOfTurn { transcript, confidence }).await;
+                                                if !emit_provider_event(
+                                                    &events,
+                                                    DeepgramEvent::EndOfTurn { transcript, confidence },
+                                                )
+                                                .await
+                                                {
+                                                    return Err("Kizz provider event receiver dropped".to_string());
+                                                }
                                                 return Ok(());
                                             }
                                             if event.get("type").and_then(Value::as_str) == Some("Error") {
@@ -1080,8 +1288,23 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                 Err("AssemblyAI closed the stream".to_string())
                             }).await {
                                 Ok(Ok(())) => {}
-                                Ok(Err(error)) => { let _ = events.send(DeepgramEvent::Failed(error)).await; }
-                                Err(_) => { let _ = events.send(DeepgramEvent::Failed("AssemblyAI finalization timed out".to_string())).await; }
+                                Ok(Err(error)) => {
+                                    if !emit_provider_event(&events, DeepgramEvent::Failed(error)).await {
+                                        return;
+                                    }
+                                }
+                                Err(_) => {
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(
+                                            "AssemblyAI finalization timed out".to_string(),
+                                        ),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
+                                }
                             }
                             return;
                         }
@@ -1089,24 +1312,54 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                 }
                 message = input.next() => {
                     let Some(message) = message else {
-                        let _ = events.send(DeepgramEvent::Failed("AssemblyAI closed the stream".to_string())).await;
+                        if !emit_provider_event(
+                            &events,
+                            DeepgramEvent::Failed("AssemblyAI closed the stream".to_string()),
+                        )
+                        .await
+                        {
+                            return;
+                        }
                         return;
                     };
                     match message {
                         Ok(DgMessage::Text(text)) => {
                             let Ok(event) = serde_json::from_str::<Value>(&text) else { continue };
                             if event.get("type").and_then(Value::as_str) == Some("Error") {
-                                let _ = events.send(DeepgramEvent::Failed(event.to_string())).await;
+                                if !emit_provider_event(
+                                    &events,
+                                    DeepgramEvent::Failed(event.to_string()),
+                                )
+                                .await
+                                {
+                                    return;
+                                }
                                 return;
                             }
                             if event.get("type").and_then(Value::as_str) == Some("Turn") &&
                                 event.get("end_of_turn").and_then(Value::as_bool) == Some(true) {
                                 let transcript = event.get("transcript").and_then(Value::as_str).unwrap_or("").trim().to_string();
                                 if transcript.is_empty() {
-                                    let _ = events.send(DeepgramEvent::Failed("AssemblyAI ended an empty turn".to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::Failed(
+                                            "AssemblyAI ended an empty turn".to_string(),
+                                        ),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                 } else {
                                     let confidence = event.get("end_of_turn_confidence").and_then(Value::as_f64);
-                                    let _ = events.send(DeepgramEvent::EndOfTurn { transcript, confidence }).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::EndOfTurn { transcript, confidence },
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                 }
                                 return;
                             }
@@ -1116,17 +1369,37 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                     .and_then(Value::as_str).unwrap_or("").trim();
                                 if !transcript.is_empty() {
                                     first_partial_sent = true;
-                                    let _ = events.send(DeepgramEvent::PartialTranscript(
-                                        transcript.to_string())).await;
+                                    if !emit_provider_event(
+                                        &events,
+                                        DeepgramEvent::PartialTranscript(transcript.to_string()),
+                                    )
+                                    .await
+                                    {
+                                        return;
+                                    }
                                 }
                             }
                         }
                         Ok(DgMessage::Close(_)) => {
-                            let _ = events.send(DeepgramEvent::Failed("AssemblyAI closed the stream".to_string())).await;
+                            if !emit_provider_event(
+                                &events,
+                                DeepgramEvent::Failed("AssemblyAI closed the stream".to_string()),
+                            )
+                            .await
+                            {
+                                return;
+                            }
                             return;
                         }
                         Err(error) => {
-                            let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                            if !emit_provider_event(
+                                &events,
+                                DeepgramEvent::Failed(error.to_string()),
+                            )
+                            .await
+                            {
+                                return;
+                            }
                             return;
                         }
                         _ => {}

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -5,10 +5,12 @@
 //! hands the transcript to a persistent Codex App Server thread whose only
 //! music capability is UHC's MCP server. Kizz owns the response character.
 
+use crate::api::AppState;
 use axum::extract::ws::{Message, WebSocket};
-use axum::extract::WebSocketUpgrade;
+use axum::extract::{State, WebSocketUpgrade};
 use axum::http::StatusCode;
 use axum::response::Response;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -16,6 +18,7 @@ use std::collections::VecDeque;
 use std::io::Write;
 use std::path::Path;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
@@ -32,15 +35,33 @@ const MIN_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize / 2;
 const CODEX_START_TIMEOUT: Duration = Duration::from_secs(20);
 const CODEX_TURN_TIMEOUT: Duration = Duration::from_secs(30);
 const DEEPGRAM_AUDIO_CHUNK_BYTES: usize = 16_000 * 2 * 80 / 1000;
+const ELEVENLABS_AUDIO_CHUNK_BYTES: usize = 16_000 * 2 * 100 / 1000;
+const ELEVENLABS_MIN_AUDIO_BYTES: usize = 16_000 * 2 * 21 / 10;
 
 static CODEX_AGENT: OnceLock<Mutex<Option<CodexVoiceAgent>>> = OnceLock::new();
 static RUNTIME: OnceLock<VoiceRuntime> = OnceLock::new();
+static NEXT_STT_TURN_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+struct VoiceTurnContext {
+    zone_id: Option<String>,
+    zone_name: Option<String>,
+    now_playing: Option<VoiceNowPlayingContext>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct VoiceNowPlayingContext {
+    title: String,
+    artist: String,
+    album: String,
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum SttProvider {
     Deepgram,
     Assemblyai,
+    Elevenlabs,
 }
 
 impl SttProvider {
@@ -48,6 +69,7 @@ impl SttProvider {
         match value.to_ascii_lowercase().as_str() {
             "deepgram" => Some(Self::Deepgram),
             "assemblyai" | "assembly" => Some(Self::Assemblyai),
+            "elevenlabs" | "eleven" => Some(Self::Elevenlabs),
             _ => None,
         }
     }
@@ -55,8 +77,46 @@ impl SttProvider {
         match self {
             Self::Deepgram => "deepgram",
             Self::Assemblyai => "assemblyai",
+            Self::Elevenlabs => "elevenlabs",
         }
     }
+}
+
+fn providers_for(primary: SttProvider) -> [SttProvider; 3] {
+    match primary {
+        SttProvider::Deepgram => [
+            SttProvider::Deepgram,
+            SttProvider::Assemblyai,
+            SttProvider::Elevenlabs,
+        ],
+        SttProvider::Assemblyai => [
+            SttProvider::Assemblyai,
+            SttProvider::Elevenlabs,
+            SttProvider::Deepgram,
+        ],
+        SttProvider::Elevenlabs => [
+            SttProvider::Elevenlabs,
+            SttProvider::Assemblyai,
+            SttProvider::Deepgram,
+        ],
+    }
+}
+
+fn stt_model_name(provider: SttProvider) -> String {
+    match provider {
+        SttProvider::Deepgram => "flux-general-en".to_string(),
+        SttProvider::Assemblyai => "u3-rt-pro".to_string(),
+        SttProvider::Elevenlabs => std::env::var("ELEVENLABS_STT_MODEL")
+            .unwrap_or_else(|_| "scribe_v2_realtime".to_string()),
+    }
+}
+
+fn all_active_providers_finished(
+    has_pending_device_commit: bool,
+    finished: usize,
+    active: usize,
+) -> bool {
+    has_pending_device_commit && active > 0 && finished >= active
 }
 
 struct VoiceRuntime {
@@ -76,6 +136,7 @@ struct VoiceReliability {
 #[derive(Serialize)]
 struct VoiceTurnRecord {
     timestamp: u64,
+    turn_id: u64,
     provider: &'static str,
     outcome: &'static str,
     latency_ms: Option<u64>,
@@ -100,6 +161,7 @@ fn runtime() -> &'static VoiceRuntime {
 }
 
 async fn record_turn(
+    turn_id: u64,
     provider: SttProvider,
     outcome: &'static str,
     latency_ms: Option<u64>,
@@ -112,10 +174,11 @@ async fn record_turn(
             reliability.attempts += 1;
             reliability.connected += 1;
         }
-        "failed" => {
+        "connection_failed" => {
             reliability.attempts += 1;
             reliability.failed += 1;
         }
+        "failed" => reliability.failed += 1,
         "completed" => reliability.completed += 1,
         _ => {}
     }
@@ -124,12 +187,13 @@ async fn record_turn(
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0),
+        turn_id,
         provider: provider.name(),
         outcome,
         latency_ms,
         detail,
     });
-    while reliability.recent.len() > 50 {
+    while reliability.recent.len() > 200 {
         reliability.recent.pop_front();
     }
 }
@@ -145,7 +209,7 @@ pub async fn provider_post(
     let Some(provider) = SttProvider::parse(&request.provider) else {
         return Err((
             StatusCode::BAD_REQUEST,
-            axum::Json(json!({"error":"provider must be deepgram or assemblyai"})),
+            axum::Json(json!({"error":"provider must be deepgram, assemblyai, or elevenlabs"})),
         ));
     };
     *runtime().provider.write().await = provider;
@@ -165,11 +229,26 @@ pub async fn reliability_get() -> axum::Json<Value> {
 
 #[derive(Debug)]
 enum DeepgramEvent {
+    PartialTranscript(String),
     EndOfTurn {
         transcript: String,
         confidence: Option<f64>,
     },
     Failed(String),
+}
+
+fn deepgram_closed_event(
+    close_was_requested: bool,
+    transcript: Option<String>,
+    confidence: Option<f64>,
+) -> DeepgramEvent {
+    match (close_was_requested, transcript) {
+        (true, Some(transcript)) if !transcript.trim().is_empty() => DeepgramEvent::EndOfTurn {
+            transcript,
+            confidence,
+        },
+        _ => DeepgramEvent::Failed("Deepgram closed the stream".to_string()),
+    }
 }
 
 struct SttTurn {
@@ -183,8 +262,10 @@ enum SttInput {
 }
 
 struct ProviderEvent {
+    turn_id: u64,
     provider: SttProvider,
     event: DeepgramEvent,
+    latency_ms: u64,
 }
 
 impl SttTurn {
@@ -203,8 +284,8 @@ impl SttTurn {
     }
 }
 
-pub async fn voice_upgrade(upgrade: WebSocketUpgrade) -> Response {
-    upgrade.on_upgrade(run_session)
+pub async fn voice_upgrade(State(state): State<AppState>, upgrade: WebSocketUpgrade) -> Response {
+    upgrade.on_upgrade(move |socket| run_session(socket, state))
 }
 
 /// Start the persistent audio agent after the HTTP listener is live, so the
@@ -222,7 +303,7 @@ pub async fn prewarm() {
     }
 }
 
-async fn run_session(mut socket: WebSocket) {
+async fn run_session(mut socket: WebSocket, state: AppState) {
     tracing::info!("Kizz voice session opened");
     let mut utterance = Vec::<u8>::new();
     let mut current_zone_id = None::<String>;
@@ -231,8 +312,8 @@ async fn run_session(mut socket: WebSocket) {
     let mut stt_turns = Vec::<SttTurn>::new();
     let mut pending_fallback = None::<(Vec<u8>, Option<String>)>;
     let mut turn_completed = false;
-    let mut turn_started = None::<Instant>;
-    let mut failed_stt = 0usize;
+    let mut active_turn_id = 0u64;
+    let mut finished_stt = 0usize;
     loop {
         tokio::select! {
             incoming = socket.recv() => {
@@ -273,22 +354,33 @@ async fn run_session(mut socket: WebSocket) {
                             turn_completed = false;
                             pending_fallback = None;
                             let selected_provider = *runtime().provider.read().await;
-                            turn_started = Some(Instant::now());
+                            active_turn_id = NEXT_STT_TURN_ID.fetch_add(1, Ordering::Relaxed);
+                            let turn_id = active_turn_id;
                             stt_turns.clear();
-                            failed_stt = 0;
-                            let providers = if selected_provider == SttProvider::Deepgram { vec![SttProvider::Deepgram, SttProvider::Assemblyai] } else { vec![SttProvider::Assemblyai, SttProvider::Deepgram] };
-                            let connect_started = Instant::now();
-                            let first = start_provider_turn(providers[0], provider_events_tx.clone());
-                            let second = start_provider_turn(providers[1], provider_events_tx.clone());
-                            let (first_result, second_result) = tokio::join!(first, second);
-                            for (provider, result) in [(providers[0], first_result), (providers[1], second_result)] {
+                            finished_stt = 0;
+                            let providers = providers_for(selected_provider);
+                            let connections = providers.into_iter().map(|provider| {
+                                let events = provider_events_tx.clone();
+                                async move {
+                                    let started = Instant::now();
+                                    let result = start_provider_turn(turn_id, provider, events).await;
+                                    (provider, result, started.elapsed().as_millis() as u64)
+                                }
+                            });
+                            for (provider, result, connect_latency_ms) in futures::future::join_all(connections).await {
                                 match result {
                                     Ok(turn) => {
-                                        record_turn(provider, "connected", Some(connect_started.elapsed().as_millis() as u64), None).await;
+                                        record_turn(
+                                            turn_id,
+                                            provider,
+                                            "connected",
+                                            Some(connect_latency_ms),
+                                            Some(stt_model_name(provider)),
+                                        ).await;
                                         stt_turns.push(turn);
                                     }
                                     Err(error) => {
-                                        record_turn(provider, "failed", Some(connect_started.elapsed().as_millis() as u64), Some(error.clone())).await;
+                                        record_turn(turn_id, provider, "connection_failed", Some(connect_latency_ms), Some(error.clone())).await;
                                         tracing::warn!(provider = provider.name(), %error, "streaming speech recognition unavailable");
                                     }
                                 }
@@ -340,16 +432,36 @@ async fn run_session(mut socket: WebSocket) {
                 }
             }
             event = provider_events_rx.recv() => {
-                let Some(ProviderEvent { provider, event }) = event else { continue };
+                let Some(ProviderEvent { turn_id, provider, event, latency_ms }) = event else { continue };
+                if turn_id != active_turn_id {
+                    tracing::info!(turn_id, active_turn_id, provider = provider.name(),
+                        "Ignored a late STT result from an earlier Kizz turn");
+                    continue;
+                }
                 match event {
+                    DeepgramEvent::PartialTranscript(transcript) => {
+                        tracing::info!(%transcript, provider = provider.name(),
+                            latency_ms,
+                            "Streaming STT produced its first partial transcript");
+                    }
+                    DeepgramEvent::EndOfTurn { transcript, confidence }
+                        if provider == SttProvider::Deepgram && !turn_completed => {
+                        finished_stt += 1;
+                        // Flux is useful as a timing/reference signal, but its
+                        // endpoint is too eager for Kizz's conversational audio.
+                        // Keep the observation in the reliability ledger and
+                        // let AssemblyAI or the device-side VAD commit the turn.
+                        tracing::info!(%transcript, confidence, provider = provider.name(),
+                            latency_ms,
+                            "Ignored Deepgram Flux endpoint for Kizz; retaining timing telemetry");
+                    }
                     DeepgramEvent::EndOfTurn { transcript, confidence } if !turn_completed => {
+                        finished_stt += 1;
                         turn_completed = true;
                         for turn in &stt_turns { let _ = turn.close().await; }
                         let (committed, zone_id) = pending_fallback.take()
                             .unwrap_or_else(|| (std::mem::take(&mut utterance), current_zone_id.take()));
-                        let latency_ms = turn_started.map(|started| started.elapsed().as_millis() as u64);
-                        record_turn(provider, "completed", latency_ms, Some(transcript.clone())).await;
-                        tracing::info!(%transcript, confidence, provider = provider.name(), bytes = committed.len(), latency_ms = latency_ms.unwrap_or(0),
+                        tracing::info!(%transcript, confidence, provider = provider.name(), bytes = committed.len(), latency_ms,
                             "Streaming STT ended Kizz voice turn");
                         let _ = send_event(&mut socket, json!({"type":"endpoint","reason":format!("{}_end_of_turn", provider.name()),"confidence":confidence})).await;
                         // Surface the recognition result immediately. The device can
@@ -357,7 +469,16 @@ async fn run_session(mut socket: WebSocket) {
                         let _ = send_event(&mut socket,
                             json!({"type":"transcript","text":transcript})).await;
                         let _ = send_event(&mut socket, json!({"type":"state","state":"thinking"})).await;
-                        let result = match codex_transcript_request(&transcript, zone_id.as_deref()).await {
+                        let context = current_voice_context(&state, zone_id.as_deref()).await;
+                        tracing::info!(
+                            zone_id = context.zone_id.as_deref().unwrap_or("unknown"),
+                            zone_name = context.zone_name.as_deref().unwrap_or("unknown"),
+                            title = context.now_playing.as_ref().map(|track| track.title.as_str()).unwrap_or(""),
+                            artist = context.now_playing.as_ref().map(|track| track.artist.as_str()).unwrap_or(""),
+                            album = context.now_playing.as_ref().map(|track| track.album.as_str()).unwrap_or(""),
+                            "Kizz Codex turn received current playback context"
+                        );
+                        let result = match codex_transcript_request(&transcript, &context).await {
                             Ok(result) => result,
                             Err(error) => {
                                 tracing::warn!(%error, "Kizz Codex voice turn failed");
@@ -367,13 +488,17 @@ async fn run_session(mut socket: WebSocket) {
                         let _ = send_event(&mut socket, result).await;
                     }
                     DeepgramEvent::EndOfTurn { transcript, confidence } => {
-                        let latency_ms = turn_started.map(|started| started.elapsed().as_millis() as u64);
-                        record_turn(provider, "completed", latency_ms, Some(format!("{} (confidence={:?})", transcript, confidence))).await;
+                        finished_stt += 1;
+                        tracing::info!(%transcript, confidence, provider = provider.name(), latency_ms,
+                            "Streaming STT competitor completed after the winning transcript");
                     }
                     DeepgramEvent::Failed(error) => {
-                        failed_stt += 1;
-                        record_turn(provider, "failed", None, Some(error.clone())).await;
-                        if pending_fallback.is_some() && failed_stt >= stt_turns.len() {
+                        finished_stt += 1;
+                        if all_active_providers_finished(
+                            pending_fallback.is_some(),
+                            finished_stt,
+                            stt_turns.len(),
+                        ) {
                             pending_fallback.take();
                             tracing::warn!(provider = provider.name(), %error, "Streaming STT finalization failed");
                             turn_completed = true;
@@ -450,15 +575,63 @@ fn store_wake_sample(label: &str, pcm: &[u8]) -> Result<(), String> {
 }
 
 async fn start_provider_turn(
+    turn_id: u64,
     provider: SttProvider,
     events: mpsc::Sender<ProviderEvent>,
 ) -> Result<SttTurn, String> {
     let (inner_tx, mut inner_rx) = mpsc::channel(8);
     let forward = events.clone();
+    let started = Instant::now();
     tokio::spawn(async move {
         while let Some(event) = inner_rx.recv().await {
+            let latency_ms = started.elapsed().as_millis() as u64;
+            match &event {
+                DeepgramEvent::PartialTranscript(transcript) => {
+                    record_turn(
+                        turn_id,
+                        provider,
+                        "first_partial",
+                        Some(latency_ms),
+                        Some(transcript.clone()),
+                    )
+                    .await;
+                }
+                DeepgramEvent::EndOfTurn {
+                    transcript,
+                    confidence,
+                } => {
+                    let outcome = if provider == SttProvider::Deepgram {
+                        "endpoint_hint"
+                    } else {
+                        "completed"
+                    };
+                    record_turn(
+                        turn_id,
+                        provider,
+                        outcome,
+                        Some(latency_ms),
+                        Some(format!("{} (confidence={:?})", transcript, confidence)),
+                    )
+                    .await;
+                }
+                DeepgramEvent::Failed(error) => {
+                    record_turn(
+                        turn_id,
+                        provider,
+                        "failed",
+                        Some(latency_ms),
+                        Some(error.clone()),
+                    )
+                    .await;
+                }
+            }
             if forward
-                .send(ProviderEvent { provider, event })
+                .send(ProviderEvent {
+                    turn_id,
+                    provider,
+                    event,
+                    latency_ms,
+                })
                 .await
                 .is_err()
             {
@@ -478,6 +651,7 @@ async fn start_stt_turn(
     match provider {
         SttProvider::Assemblyai => start_assemblyai_turn(events).await,
         SttProvider::Deepgram => start_deepgram_turn(events).await,
+        SttProvider::Elevenlabs => start_elevenlabs_turn(events).await,
     }
 }
 
@@ -528,6 +702,9 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
         let mut pending = Vec::<u8>::with_capacity(DEEPGRAM_AUDIO_CHUNK_BYTES * 2);
         let mut close_deadline = None::<tokio::time::Instant>;
         let mut input_open = true;
+        let mut first_partial_sent = false;
+        let mut latest_transcript = None::<String>;
+        let mut latest_confidence = None::<f64>;
         loop {
             tokio::select! {
                 command = input_rx.recv(), if input_open => {
@@ -563,8 +740,11 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                 }
                 message = input.next() => {
                     let Some(message) = message else {
-                        let _ = events.send(DeepgramEvent::Failed(
-                            "Deepgram closed the stream".to_string())).await;
+                        let _ = events.send(deepgram_closed_event(
+                            !input_open,
+                            latest_transcript.take(),
+                            latest_confidence,
+                        )).await;
                         return;
                     };
                     match message {
@@ -573,6 +753,15 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                             if event.get("type").and_then(Value::as_str) == Some("Error") {
                                 let _ = events.send(DeepgramEvent::Failed(event.to_string())).await;
                                 return;
+                            }
+                            if event.get("type").and_then(Value::as_str) == Some("TurnInfo") {
+                                let transcript = event.get("transcript")
+                                    .and_then(Value::as_str).unwrap_or("").trim();
+                                if !transcript.is_empty() {
+                                    latest_transcript = Some(transcript.to_string());
+                                }
+                                latest_confidence = event.get("end_of_turn_confidence")
+                                    .and_then(Value::as_f64).or(latest_confidence);
                             }
                             if event.get("type").and_then(Value::as_str) == Some("TurnInfo") &&
                                 event.get("event").and_then(Value::as_str) == Some("EndOfTurn") {
@@ -591,10 +780,23 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
                                 }
                                 return;
                             }
+                            if !first_partial_sent &&
+                                event.get("type").and_then(Value::as_str) == Some("TurnInfo") {
+                                let transcript = event.get("transcript")
+                                    .and_then(Value::as_str).unwrap_or("").trim();
+                                if !transcript.is_empty() {
+                                    first_partial_sent = true;
+                                    let _ = events.send(DeepgramEvent::PartialTranscript(
+                                        transcript.to_string())).await;
+                                }
+                            }
                         }
                         Ok(DgMessage::Close(_)) => {
-                            let _ = events.send(DeepgramEvent::Failed(
-                                "Deepgram closed the stream".to_string())).await;
+                            let _ = events.send(deepgram_closed_event(
+                                !input_open,
+                                latest_transcript.take(),
+                                latest_confidence,
+                            )).await;
                             return;
                         }
                         Err(error) => {
@@ -616,6 +818,202 @@ async fn start_deepgram_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttT
     });
     Ok(SttTurn {
         provider: SttProvider::Deepgram,
+        input: input_tx,
+    })
+}
+
+fn elevenlabs_audio_message(pcm: &[u8], commit: bool) -> String {
+    json!({
+        "message_type": "input_audio_chunk",
+        "audio_base_64": BASE64_STANDARD.encode(pcm),
+        "commit": commit,
+        "sample_rate": SAMPLE_RATE,
+    })
+    .to_string()
+}
+
+fn elevenlabs_padding_bytes(audio_bytes_sent: usize) -> usize {
+    ELEVENLABS_MIN_AUDIO_BYTES.saturating_sub(audio_bytes_sent)
+}
+
+fn parse_elevenlabs_event(text: &str) -> Option<DeepgramEvent> {
+    let event = serde_json::from_str::<Value>(text).ok()?;
+    let message_type = event.get("message_type").and_then(Value::as_str)?;
+    match message_type {
+        "partial_transcript" => event
+            .get("text")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|transcript| !transcript.is_empty())
+            .map(|transcript| DeepgramEvent::PartialTranscript(transcript.to_string())),
+        "committed_transcript" => {
+            let transcript = event
+                .get("text")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if transcript.is_empty() {
+                Some(DeepgramEvent::Failed(
+                    "ElevenLabs committed an empty transcript".to_string(),
+                ))
+            } else {
+                Some(DeepgramEvent::EndOfTurn {
+                    transcript,
+                    confidence: None,
+                })
+            }
+        }
+        "auth_error"
+        | "quota_exceeded"
+        | "transcriber_error"
+        | "input_error"
+        | "invalid_request"
+        | "error"
+        | "commit_throttled"
+        | "unaccepted_terms"
+        | "rate_limited"
+        | "queue_overflow"
+        | "resource_exhausted"
+        | "session_time_limit_exceeded"
+        | "chunk_size_exceeded"
+        | "insufficient_audio_activity" => Some(DeepgramEvent::Failed(format!(
+            "ElevenLabs {message_type}: {}",
+            event.get("error").and_then(Value::as_str).unwrap_or(text)
+        ))),
+        _ => None,
+    }
+}
+
+async fn start_elevenlabs_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<SttTurn, String> {
+    let key = std::env::var("ELEVENLABS_API_KEY")
+        .or_else(|_| std::env::var("ELEVEN_LABS_API_KEY"))
+        .map_err(|_| {
+            "ELEVENLABS_API_KEY (or legacy ELEVEN_LABS_API_KEY) is not configured".to_string()
+        })?;
+    let model = stt_model_name(SttProvider::Elevenlabs);
+    let endpoint = std::env::var("ELEVENLABS_STT_URL")
+        .unwrap_or_else(|_| "wss://api.elevenlabs.io/v1/speech-to-text/realtime".to_string());
+    let uri = format!(
+        "{endpoint}?model_id={}&audio_format=pcm_16000&language_code=en&commit_strategy=manual",
+        urlencoding::encode(&model)
+    );
+    let mut request = uri
+        .into_client_request()
+        .map_err(|error| format!("invalid ElevenLabs URI: {error}"))?;
+    request.headers_mut().insert(
+        "xi-api-key",
+        key.parse()
+            .map_err(|error| format!("invalid ElevenLabs credential: {error}"))?,
+    );
+    let (socket, _) = timeout(
+        Duration::from_secs(5),
+        tokio_tungstenite::connect_async(request),
+    )
+    .await
+    .map_err(|_| "ElevenLabs connection timed out".to_string())?
+    .map_err(|error| format!("ElevenLabs connection failed: {error}"))?;
+    let (mut output, mut input) = socket.split();
+    let (input_tx, mut input_rx) = mpsc::channel::<SttInput>(64);
+    tokio::spawn(async move {
+        let mut pending_audio = Vec::<u8>::with_capacity(ELEVENLABS_AUDIO_CHUNK_BYTES * 2);
+        let mut first_partial_sent = false;
+        let mut audio_bytes_sent = 0usize;
+        let mut input_open = true;
+        let mut close_deadline = None::<tokio::time::Instant>;
+        loop {
+            tokio::select! {
+                command = input_rx.recv(), if input_open => {
+                    match command {
+                        Some(SttInput::Audio(audio)) => {
+                            pending_audio.extend_from_slice(&audio);
+                            while pending_audio.len() >= ELEVENLABS_AUDIO_CHUNK_BYTES {
+                                let remainder = pending_audio.split_off(ELEVENLABS_AUDIO_CHUNK_BYTES);
+                                let chunk = std::mem::replace(&mut pending_audio, remainder);
+                                audio_bytes_sent += chunk.len();
+                                if let Err(error) = output.send(DgMessage::Text(
+                                    elevenlabs_audio_message(&chunk, false))).await {
+                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    return;
+                                }
+                            }
+                        }
+                        Some(SttInput::Close) | None => {
+                            input_open = false;
+                            if !pending_audio.is_empty() {
+                                audio_bytes_sent += pending_audio.len();
+                                if let Err(error) = output.send(DgMessage::Text(
+                                    elevenlabs_audio_message(&std::mem::take(&mut pending_audio), false))).await {
+                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    return;
+                                }
+                            }
+                            let mut padding_bytes = elevenlabs_padding_bytes(audio_bytes_sent);
+                            while padding_bytes > 0 {
+                                let chunk_bytes = padding_bytes.min(ELEVENLABS_AUDIO_CHUNK_BYTES);
+                                if let Err(error) = output.send(DgMessage::Text(
+                                    elevenlabs_audio_message(&vec![0; chunk_bytes], false))).await {
+                                    let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                    return;
+                                }
+                                padding_bytes -= chunk_bytes;
+                            }
+                            // This matches the official SDK's manual commit wire message.
+                            if let Err(error) = output.send(DgMessage::Text(
+                                elevenlabs_audio_message(&[], true))).await {
+                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                return;
+                            }
+                            close_deadline = Some(tokio::time::Instant::now() + Duration::from_secs(5));
+                        }
+                    }
+                }
+                message = input.next() => {
+                    let Some(message) = message else {
+                        let _ = events.send(DeepgramEvent::Failed(
+                            "ElevenLabs closed the stream".to_string())).await;
+                        return;
+                    };
+                    match message {
+                        Ok(DgMessage::Text(text)) => {
+                            if let Some(event) = parse_elevenlabs_event(&text) {
+                                match event {
+                                    DeepgramEvent::PartialTranscript(_) if first_partial_sent => {}
+                                    DeepgramEvent::PartialTranscript(_) => {
+                                        first_partial_sent = true;
+                                        let _ = events.send(event).await;
+                                    }
+                                    _ => {
+                                        let _ = events.send(event).await;
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        Ok(DgMessage::Close(_)) => {
+                            let _ = events.send(DeepgramEvent::Failed(
+                                "ElevenLabs closed the stream".to_string())).await;
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+                _ = tokio::time::sleep_until(close_deadline.unwrap_or_else(||
+                    tokio::time::Instant::now() + Duration::from_secs(86_400))),
+                    if close_deadline.is_some() => {
+                    let _ = events.send(DeepgramEvent::Failed(
+                        "ElevenLabs finalization timed out".to_string())).await;
+                    return;
+                }
+            }
+        }
+    });
+    Ok(SttTurn {
+        provider: SttProvider::Elevenlabs,
         input: input_tx,
     })
 }
@@ -654,6 +1052,7 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
         const MIN_AUDIO_BYTES: usize = 16_000 * 2 * 50 / 1000;
         const AUDIO_CHUNK_BYTES: usize = 16_000 * 2 * 80 / 1000;
         let mut pending_audio = Vec::<u8>::with_capacity(AUDIO_CHUNK_BYTES * 2);
+        let mut first_partial_sent = false;
         loop {
             tokio::select! {
                 command = input_rx.recv() => {
@@ -671,14 +1070,9 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                         }
                         Some(SttInput::Close) | None => {
                             // Kizz's device-side VAD has already decided that this
-                            // utterance is complete. AssemblyAI's ForceEndpoint
-                            // flushes the final Turn; Terminate only closes the
-                            // session and can discard an in-flight final turn.
-                            if let Err(error) = output.send(DgMessage::Text(
-                                json!({"type":"ForceEndpoint"}).to_string())).await {
-                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
-                                return;
-                            }
+                            // utterance is complete. Send the final buffered audio
+                            // before ForceEndpoint; flushing first can make
+                            // AssemblyAI finalize an empty/incomplete turn.
                             if !pending_audio.is_empty() {
                                 if pending_audio.len() < MIN_AUDIO_BYTES {
                                     pending_audio.resize(MIN_AUDIO_BYTES, 0);
@@ -688,6 +1082,13 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                     let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
                                     return;
                                 }
+                            }
+                            // ForceEndpoint flushes the final Turn; Terminate only
+                            // closes the session and can discard an in-flight turn.
+                            if let Err(error) = output.send(DgMessage::Text(
+                                json!({"type":"ForceEndpoint"}).to_string())).await {
+                                let _ = events.send(DeepgramEvent::Failed(error.to_string())).await;
+                                return;
                             }
                             match tokio::time::timeout(Duration::from_secs(5), async {
                                 while let Some(message) = input.next().await {
@@ -747,6 +1148,16 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
                                 }
                                 return;
                             }
+                            if !first_partial_sent &&
+                                event.get("type").and_then(Value::as_str) == Some("Turn") {
+                                let transcript = event.get("transcript")
+                                    .and_then(Value::as_str).unwrap_or("").trim();
+                                if !transcript.is_empty() {
+                                    first_partial_sent = true;
+                                    let _ = events.send(DeepgramEvent::PartialTranscript(
+                                        transcript.to_string())).await;
+                                }
+                            }
                         }
                         Ok(DgMessage::Close(_)) => {
                             let _ = events.send(DeepgramEvent::Failed("AssemblyAI closed the stream".to_string())).await;
@@ -770,7 +1181,7 @@ async fn start_assemblyai_turn(events: mpsc::Sender<DeepgramEvent>) -> Result<St
 
 async fn codex_transcript_request(
     transcript: &str,
-    current_zone_id: Option<&str>,
+    context: &VoiceTurnContext,
 ) -> Result<Value, String> {
     let agent = CODEX_AGENT.get_or_init(|| Mutex::new(None));
     let mut _conversation_guard = agent.lock().await;
@@ -785,7 +1196,7 @@ async fn codex_transcript_request(
     let first = _conversation_guard
         .as_mut()
         .ok_or("Codex voice agent was not initialized")?
-        .turn(transcript, current_zone_id);
+        .turn(transcript, context);
     let first = timeout(CODEX_TURN_TIMEOUT, first)
         .await
         .map_err(|_| "Codex voice turn timed out".to_string())?;
@@ -801,14 +1212,43 @@ async fn codex_transcript_request(
     let mut restarted = timeout(CODEX_START_TIMEOUT, CodexVoiceAgent::start())
         .await
         .map_err(|_| "Codex App Server restart timed out".to_string())??;
-    let result = timeout(
-        CODEX_TURN_TIMEOUT,
-        restarted.turn(transcript, current_zone_id),
-    )
-    .await
-    .map_err(|_| "Codex voice turn timed out after restart".to_string())?;
+    let result = timeout(CODEX_TURN_TIMEOUT, restarted.turn(transcript, context))
+        .await
+        .map_err(|_| "Codex voice turn timed out after restart".to_string())?;
     *_conversation_guard = Some(restarted);
     result
+}
+
+async fn current_voice_context(
+    state: &AppState,
+    current_zone_id: Option<&str>,
+) -> VoiceTurnContext {
+    let Some(zone_id) = current_zone_id else {
+        return VoiceTurnContext::default();
+    };
+    let Some(zone) = state.aggregator.get_zone(zone_id).await else {
+        return VoiceTurnContext {
+            zone_id: Some(zone_id.to_string()),
+            ..VoiceTurnContext::default()
+        };
+    };
+    VoiceTurnContext {
+        zone_id: Some(zone.zone_id),
+        zone_name: Some(zone.zone_name),
+        now_playing: zone.now_playing.map(|track| VoiceNowPlayingContext {
+            title: track.title,
+            artist: track.artist,
+            album: track.album,
+        }),
+    }
+}
+
+fn build_codex_input(transcript: &str, context: &VoiceTurnContext) -> Result<String, String> {
+    let context = serde_json::to_string(context)
+        .map_err(|error| format!("Kizz device context could not be serialized: {error}"))?;
+    Ok(format!(
+        "Local speech recognition heard: {transcript}\nCurrent device context: {context}"
+    ))
 }
 
 struct CodexVoiceAgent {
@@ -905,15 +1345,8 @@ impl CodexVoiceAgent {
     async fn turn(
         &mut self,
         transcript: &str,
-        current_zone_id: Option<&str>,
+        context: &VoiceTurnContext,
     ) -> Result<Value, String> {
-        let zone_context = current_zone_id
-            .map(|zone_id| {
-                format!(
-                    "\nKizz's currently selected zone id is: {zone_id}. Use it as the default only when the listener did not name a room."
-                )
-            })
-            .unwrap_or_default();
         let request_id = self
             .request(json!({
                 "method":"turn/start",
@@ -921,7 +1354,7 @@ impl CodexVoiceAgent {
                     "threadId": self.thread_id,
                     "input": [{
                         "type":"text",
-                        "text": format!("Local speech recognition heard: {transcript}{zone_context}")
+                        "text": build_codex_input(transcript, context)?
                     }],
                     "effort": "low",
                     "outputSchema": kizz_result_schema()
@@ -1066,9 +1499,10 @@ ordinary speech-recognition errors.
 Use only the unified-hifi-control MCP for music state and music actions. Never
 use shell, filesystem, web, code editing, or any other tool. Inspect live zones
 and content when needed. Resolve natural room references and conversational
-follow-ups from this persistent thread. When a current zone id is supplied, use
-that zone by default if the listener omitted a room. An explicitly spoken room
-always overrides device context. For a clear request, perform it and
+follow-ups from this persistent thread. Each turn includes current device context
+with the selected zone and its title, artist, and album when something is playing.
+Use the selected zone by default if the listener omitted a room. An explicitly
+spoken room always overrides device context. For a clear request, perform it and
 report success only when the MCP result confirms it. If the intended content or
 zone is genuinely ambiguous, do not guess or act; ask one short clarification.
 
@@ -1136,6 +1570,160 @@ async fn send_event(socket: &mut WebSocket, event: Value) -> Result<(), axum::Er
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_primary_runs_all_three_realtime_providers() {
+        assert_eq!(
+            providers_for(SttProvider::Deepgram),
+            [
+                SttProvider::Deepgram,
+                SttProvider::Assemblyai,
+                SttProvider::Elevenlabs,
+            ]
+        );
+        assert_eq!(
+            providers_for(SttProvider::Elevenlabs),
+            [
+                SttProvider::Elevenlabs,
+                SttProvider::Assemblyai,
+                SttProvider::Deepgram,
+            ]
+        );
+        assert_eq!(stt_model_name(SttProvider::Deepgram), "flux-general-en");
+        assert_eq!(stt_model_name(SttProvider::Assemblyai), "u3-rt-pro");
+    }
+
+    #[test]
+    fn elevenlabs_committed_transcript_is_actionable() {
+        let event = parse_elevenlabs_event(
+            r#"{"message_type":"committed_transcript","text":"play Prince"}"#,
+        )
+        .expect("committed transcript event");
+
+        match event {
+            DeepgramEvent::EndOfTurn {
+                transcript,
+                confidence,
+            } => {
+                assert_eq!(transcript, "play Prince");
+                assert_eq!(confidence, None);
+            }
+            DeepgramEvent::PartialTranscript(transcript) => {
+                panic!("committed event parsed as partial: {transcript}")
+            }
+            DeepgramEvent::Failed(error) => panic!("unexpected failure: {error}"),
+        }
+    }
+
+    #[test]
+    fn elevenlabs_partial_and_final_events_do_not_commit_a_turn() {
+        assert!(matches!(
+            parse_elevenlabs_event(
+                r#"{"message_type":"partial_transcript","text":"play Pri"}"#
+            ),
+            Some(DeepgramEvent::PartialTranscript(transcript)) if transcript == "play Pri"
+        ));
+        assert!(parse_elevenlabs_event(
+            r#"{"message_type":"final_transcript","text":"play Prince"}"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn elevenlabs_service_errors_fail_the_provider() {
+        let event = parse_elevenlabs_event(
+            r#"{"message_type":"quota_exceeded","error":"quota exhausted"}"#,
+        )
+        .expect("error event");
+
+        assert!(matches!(
+            event,
+            DeepgramEvent::Failed(error) if error.contains("quota_exceeded") && error.contains("quota exhausted")
+        ));
+    }
+
+    #[test]
+    fn elevenlabs_manual_commit_uses_the_official_empty_audio_message() {
+        let message: Value = serde_json::from_str(&elevenlabs_audio_message(&[], true))
+            .expect("manual commit message");
+
+        assert_eq!(message["message_type"], "input_audio_chunk");
+        assert_eq!(message["audio_base_64"], "");
+        assert_eq!(message["commit"], true);
+        assert_eq!(message["sample_rate"], 16_000);
+    }
+
+    #[test]
+    fn elevenlabs_short_commands_are_padded_to_its_processing_minimum() {
+        assert_eq!(elevenlabs_padding_bytes(54_272), 12_928);
+        assert_eq!(elevenlabs_padding_bytes(64_000), 3_200);
+        assert_eq!(elevenlabs_padding_bytes(67_200), 0);
+        assert_eq!(elevenlabs_padding_bytes(80_000), 0);
+    }
+
+    #[test]
+    fn device_commit_recovers_after_every_provider_finishes_without_a_winner() {
+        assert!(!all_active_providers_finished(true, 2, 3));
+        assert!(all_active_providers_finished(true, 3, 3));
+        assert!(!all_active_providers_finished(false, 3, 3));
+    }
+
+    #[test]
+    fn deepgram_close_retains_its_last_update_for_comparison_only() {
+        let event = deepgram_closed_event(
+            true,
+            Some("What is playing right now?".to_string()),
+            Some(0.82),
+        );
+
+        assert!(matches!(
+            event,
+            DeepgramEvent::EndOfTurn { transcript, confidence }
+                if transcript == "What is playing right now?" && confidence == Some(0.82)
+        ));
+        assert!(matches!(
+            deepgram_closed_event(false, Some("stale".to_string()), None),
+            DeepgramEvent::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn codex_input_includes_selected_zone_and_now_playing_context() {
+        let context = VoiceTurnContext {
+            zone_id: Some("roon:kitchen".to_string()),
+            zone_name: Some("Kitchen".to_string()),
+            now_playing: Some(VoiceNowPlayingContext {
+                title: "Water No Get Enemy".to_string(),
+                artist: "Fela Kuti".to_string(),
+                album: "Expensive Shit".to_string(),
+            }),
+        };
+
+        let input = build_codex_input("turn it up", &context).expect("valid context");
+
+        assert!(input.contains("Local speech recognition heard: turn it up"));
+        assert!(input.contains(
+            r#""zone_id":"roon:kitchen","zone_name":"Kitchen","now_playing":{"title":"Water No Get Enemy","artist":"Fela Kuti","album":"Expensive Shit"}"#
+        ));
+    }
+
+    #[test]
+    fn codex_input_marks_an_idle_selected_zone_without_stale_track_metadata() {
+        let context = VoiceTurnContext {
+            zone_id: Some("roon:kitchen".to_string()),
+            zone_name: Some("Kitchen".to_string()),
+            now_playing: None,
+        };
+
+        let input = build_codex_input("play Prince", &context).expect("valid context");
+
+        assert!(
+            input.contains(r#""zone_id":"roon:kitchen","zone_name":"Kitchen","now_playing":null"#)
+        );
+        assert!(!input.contains("title"));
+        assert!(!input.contains("artist"));
+        assert!(!input.contains("album"));
+    }
 
     #[test]
     fn codex_success_becomes_a_kizz_state_event() {

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -21,6 +21,7 @@ use tokio::time::{timeout, Duration};
 
 const SAMPLE_RATE: u32 = 16_000;
 const MAX_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize * 2 * 14;
+const MAX_WAKE_SAMPLE_BYTES: usize = SAMPLE_RATE as usize * 2 * 3;
 const MIN_UTTERANCE_BYTES: usize = SAMPLE_RATE as usize / 2;
 const CODEX_START_TIMEOUT: Duration = Duration::from_secs(20);
 const CODEX_TURN_TIMEOUT: Duration = Duration::from_secs(30);
@@ -51,6 +52,7 @@ async fn run_session(mut socket: WebSocket) {
     tracing::info!("Kizz voice session opened");
     let mut utterance = Vec::<u8>::new();
     let mut current_zone_id = None::<String>;
+    let mut wake_sample = None::<WakeSample>;
     while let Some(incoming) = socket.recv().await {
         let message = match incoming {
             Ok(message) => message,
@@ -61,6 +63,20 @@ async fn run_session(mut socket: WebSocket) {
         };
         match message {
             Message::Binary(pcm) => {
+                if let Some(sample) = wake_sample.take() {
+                    if pcm.len() == sample.bytes {
+                        if let Err(error) = store_wake_sample(&sample.label, &pcm) {
+                            tracing::warn!(%error, "Kizz wake training sample was not stored");
+                        }
+                    } else {
+                        tracing::warn!(
+                            expected = sample.bytes,
+                            actual = pcm.len(),
+                            "Kizz wake training sample length mismatch"
+                        );
+                    }
+                    continue;
+                }
                 utterance.extend_from_slice(&pcm);
                 if utterance.len() > MAX_UTTERANCE_BYTES {
                     let excess = utterance.len() - MAX_UTTERANCE_BYTES;
@@ -75,6 +91,9 @@ async fn run_session(mut socket: WebSocket) {
                         zone_id = current_zone_id.as_deref().unwrap_or("unknown"),
                         "Kizz voice turn received device context"
                     );
+                }
+                Some(ClientEvent::WakeSample(sample)) => {
+                    wake_sample = Some(sample);
                 }
                 Some(ClientEvent::Commit) => {
                     let committed = std::mem::take(&mut utterance);
@@ -123,7 +142,14 @@ async fn run_session(mut socket: WebSocket) {
 #[derive(Debug, PartialEq)]
 enum ClientEvent {
     Start { zone_id: Option<String> },
+    WakeSample(WakeSample),
     Commit,
+}
+
+#[derive(Debug, PartialEq)]
+struct WakeSample {
+    label: String,
+    bytes: usize,
 }
 
 fn parse_client_event(message: &str) -> Option<ClientEvent> {
@@ -136,9 +162,41 @@ fn parse_client_event(message: &str) -> Option<ClientEvent> {
                 .filter(|zone_id| !zone_id.is_empty())
                 .map(str::to_owned),
         }),
+        "wake_sample" => {
+            let label = event.get("label")?.as_str()?;
+            let bytes = usize::try_from(event.get("bytes")?.as_u64()?).ok()?;
+            if label != "hiphi_kizz" || bytes == 0 || bytes > MAX_WAKE_SAMPLE_BYTES {
+                return None;
+            }
+            Some(ClientEvent::WakeSample(WakeSample {
+                label: label.to_owned(),
+                bytes,
+            }))
+        }
         "commit" => Some(ClientEvent::Commit),
         _ => None,
     }
+}
+
+fn store_wake_sample(label: &str, pcm: &[u8]) -> Result<(), String> {
+    let Some(root) = std::env::var_os("KIZZ_WAKE_TRAINING_DIR") else {
+        return Ok(());
+    };
+    let destination = Path::new(&root).join("positive").join(label);
+    std::fs::create_dir_all(&destination).map_err(|error| error.to_string())?;
+    let mut sample = tempfile::Builder::new()
+        .prefix("device-")
+        .suffix(".wav")
+        .tempfile_in(&destination)
+        .map_err(|error| error.to_string())?;
+    write_wav(&mut sample, pcm).map_err(|error| error.to_string())?;
+    let path = sample
+        .into_temp_path()
+        .keep()
+        .map_err(|error| error.to_string())?;
+    tracing::info!(path = %path.display(), bytes = pcm.len(),
+        "Stored Kizz wake training sample");
+    Ok(())
 }
 
 async fn codex_request(pcm: &[u8], current_zone_id: Option<&str>) -> Result<Value, String> {
@@ -641,6 +699,25 @@ mod tests {
             Some(ClientEvent::Commit)
         );
         assert_eq!(parse_client_event(r#"{"message":"start"}"#), None);
+    }
+
+    #[test]
+    fn wake_training_sample_is_bounded_and_exactly_labeled() {
+        assert_eq!(
+            parse_client_event(r#"{"type":"wake_sample","label":"hiphi_kizz","bytes":64000}"#),
+            Some(ClientEvent::WakeSample(WakeSample {
+                label: "hiphi_kizz".to_string(),
+                bytes: 64_000,
+            }))
+        );
+        assert_eq!(
+            parse_client_event(r#"{"type":"wake_sample","label":"other","bytes":64000}"#),
+            None
+        );
+        assert_eq!(
+            parse_client_event(r#"{"type":"wake_sample","label":"hiphi_kizz","bytes":999999}"#),
+            None
+        );
     }
 
     #[test]

--- a/tests/await_in_lock_lint.rs
+++ b/tests/await_in_lock_lint.rs
@@ -268,6 +268,14 @@ const ALLOWLIST: &[(&str, &str, &str)] = &[
         "_lifecycle_guard",
         "HQPlayer manager lifecycle mutations must be serialized",
     ),
+    // Codex App Server is a line-oriented request/response conversation over one stdio pair.
+    // A complete voice turn, including one restart retry, must remain exclusive so another
+    // listener cannot consume its responses or interleave commands into the same thread.
+    (
+        "voice.rs",
+        "_conversation_guard",
+        "Kizz App Server conversations must be linearized",
+    ),
 ];
 
 fn is_allowed(file: &str, guard: &str) -> bool {

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -58,6 +58,7 @@ GET /roon/zones
 GET /status
 GET /upnp/status
 GET /upnp/zones
+GET /voice/v1
 GET /zones
 POST /api/settings
 POST /control

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -58,6 +58,8 @@ GET /roon/zones
 GET /status
 GET /upnp/status
 GET /upnp/zones
+GET /voice/provider
+GET /voice/reliability
 GET /voice/v1
 GET /zones
 POST /api/settings
@@ -86,3 +88,4 @@ POST /roon/play
 POST /roon/play_item
 POST /roon/volume
 POST /upnp/control
+POST /voice/provider


### PR DESCRIPTION
Closes #504.

## What changed

- Adds the LAN WebSocket voice gateway from Kizz to UHC, with Codex App Server and UHC MCP handling music requests.
- Runs each 16 kHz utterance concurrently through Deepgram Flux, AssemblyAI u3-rt-pro, and ElevenLabs Scribe v2 Realtime.
- Uses the first actionable AssemblyAI or ElevenLabs committed transcript. Deepgram remains a telemetry-only endpoint signal.
- Records per-turn model, connection time, first-partial time, final transcript, endpoint time, failures, and late competitor results without allowing a stale result to execute a later turn.
- Uses Kizz device-side VAD as the authoritative commit.
- Sends selected-zone and now-playing context to the Codex turn.
- Enforces the music-domain boundary in that same Codex turn: the structured response classifies the transcript as `command`, `non_command`, or `uncertain`; Codex may call UHC MCP only for `command`, and UHC converts either other result to `I can't let you do that Dave`.
- Does not add a second LLM classifier call.
- Handles provider-channel, provider-finalization, and device-WebSocket send failures explicitly instead of ignoring them.
- Adds a single-instance voice launch script and removes local Whisper from the path.

## Verification

Current head: `5b57e28a8fddfd894291b61548d2e8e36ab48a9e`

- `cargo test --lib`: 353 passed.
- Full `cargo test`: passed, including integration and doc tests.
- `cargo test --test ignored_send_lint`: 6 passed.
- `cargo clippy --lib -- -D warnings`: passed.
- `cargo fmt --check`: passed.
- `bash -n scripts/run_kizz_voice.sh`: passed.
- `GET http://127.0.0.1:8088/voice/reliability` was reachable on the launcher port and returned current provider telemetry.
- Controlled 16 kHz replay: all three providers transcribed “What is playing right now?” correctly; ElevenLabs won the actionable race.
- Physical Kizz accepted a real music command and declined non-music false-wake transcripts through the single-turn gate.

## Remaining human gate

The API contract includes `GET/POST /voice/provider` and `GET /voice/reliability`. CI requires the maintainer-applied `api-change-approved` label; agents are prohibited from applying it. The PR stays draft.