### PR TITLE
fix: bump roon-api to eliminate 100Hz SOOD polling at idle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "roon-api"
 version = "0.3.1"
-source = "git+https://github.com/open-horizon-labs/rust-roon-api.git?branch=ohc%2Fmain#06dd807f2b9c09274cc679710e9175d97ca09adf"
+source = "git+https://github.com/open-horizon-labs/rust-roon-api.git?branch=ohc%2Fmain#8eb9c52ec7c42b7ea361158241cb7faa607c08f4"
 dependencies = [
  "futures-util",
  "if-addrs 0.13.4",


### PR DESCRIPTION
## Problem

A user report of unified-hifi-control sitting at ~20% of one core at idle (even with other adapters off) traced to the vendored roon-api's SOOD discovery task: it polled every UDP socket with `try_recv_from` + a 10ms sleep — 100 wakeups/sec with `1 + 2N` recv syscalls each (N = non-loopback IPv4 interfaces), forever. The Roon adapter is on by default, so every install pays this. A dev instance on an M-series Mac accrued ~4% average CPU over 17 days from this alone; on RPi 3 / Atom QNAP hardware 20% is the expected magnitude.

## Change

Bumps the `roon-api` pin to pick up [open-horizon-labs/rust-roon-api#2](https://github.com/open-horizon-labs/rust-roon-api/pull/2) (merged, `8eb9c52`):
- SOOD receive task awaits `recv_from` via `select_all` — wakes only on actual datagrams.
- The SOOD channel reader breaks on channel close instead of spinning at 100% CPU.
- `Message::new` no longer panics on short/non-UTF8 datagrams (previously any LAN host could crash the daemon with one UDP packet to port 9003).

Cargo.lock-only change; no UHC source touched.

## Validation

- All Roon-related tests pass (48 across suites) against the new pin.
- Live run on v3: real Roon core discovered, extension registered, zones published; process idles at 0.0% CPU over 90s sampling.

## Follow-up (not in this PR)

roon-api still maps 10s of websocket silence to `CoreEvent::Lost`, which UHC answers with a full adapter restart — potential idle reconnect churn, tracked separately; needs a keepalive design and live-core validation.