### PR TITLE
LMS adapter: implement sync groups via CLI sync commands

### DIFF
--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -58,7 +58,8 @@ use tracing::{debug, info, warn};
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::lms_discovery::discover_lms_servers;
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::adapters::Startable;
 use crate::bus::runtime::{
@@ -85,6 +86,33 @@ const LMS_MUTE_PREF: &str = "mute";
 /// MCP and aggregator use prefixed IDs (e.g., "lms:00:11:22:33:44:55"), but LMS API expects bare IDs.
 fn strip_lms_prefix(id: &str) -> &str {
     id.strip_prefix("lms:").unwrap_or(id)
+}
+
+/// Require a properly-prefixed LMS zone id and return its bare player id.
+///
+/// Unlike Music Assistant's ids, LMS player ids are MAC addresses and
+/// legitimately contain colons, so (unlike `musicassistant_player_id`) this
+/// does not reject a remainder containing `:`.
+fn lms_player_id(zone_id: &str, parameter: &str) -> Result<String> {
+    zone_id
+        .strip_prefix("lms:")
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("{parameter} must be an LMS zone id"))
+}
+
+/// [`lms_player_id`] over a list, rejecting duplicates the same way the
+/// Music Assistant multiroom contract does.
+fn lms_player_ids(zone_ids: &[String], parameter: &str) -> Result<Vec<String>> {
+    let mut ids = Vec::with_capacity(zone_ids.len());
+    for zone_id in zone_ids {
+        let id = lms_player_id(zone_id, parameter)?;
+        if ids.contains(&id) {
+            return Err(anyhow!("{parameter} must not contain duplicate zones"));
+        }
+        ids.push(id);
+    }
+    Ok(ids)
 }
 
 /// Read an integer that LMS may emit as either a JSON number or a JSON string.
@@ -1243,6 +1271,148 @@ impl LmsAdapter {
     pub async fn get_player_status(&self, player_id: &str) -> Result<LmsPlayer> {
         let player_id = strip_lms_prefix(player_id);
         self.rpc.get_player_status(player_id).await
+    }
+
+    // -------------------------------------------------------------------------
+    // Sync groups (#510): LMS's native Squeezebox multi-room, wired to the
+    // multiroom_status / multiroom_set_members / multiroom_ungroup contract
+    // the Music Assistant adapter already implements
+    // (`src/adapters/musicassistant.rs`).
+    //
+    // LMS sync is peer-based -- a group is just a set of players playing the
+    // same stream in lockstep, with no server-side concept of a leader. The
+    // contract, however, is leader/member shaped. This adapter resolves that
+    // mismatch by treating "join the leader's group" literally: every add
+    // is sent as `<leader> sync <member>`. Verified live against Lyrion 9.1.2
+    // (issue #403's investigation): the **addressed** player in a `sync`
+    // command becomes/stays the sync master, and the **argument** player
+    // adopts the addressed player's queue, repeat and shuffle -- destroying
+    // its own. Addressing the leader therefore keeps the leader's queue
+    // intact and makes the member fall in behind it, exactly the semantics
+    // `multiroom_set_members`'s `leader_zone_id` implies. Removal is
+    // leader-independent: `<member> sync -` unsyncs that one player from
+    // whatever group it is currently in.
+    //
+    // Because there is no server-side leader, `multiroom_status` cannot
+    // recover *which* player was originally addressed -- only current group
+    // membership via `syncgroups ?`. This adapter picks the first id LMS
+    // reports for each group as that group's leader for display purposes.
+    // That is a stable-but-arbitrary UHC convention, not an LMS fact.
+
+    /// Read every active LMS sync group from `syncgroups ?` as a raw member
+    /// list (no leader/member split yet). Groups of fewer than two players
+    /// are not sync groups and are dropped.
+    async fn read_sync_groups(&self) -> Result<Vec<Vec<String>>> {
+        let result = self
+            .rpc
+            .execute(None, vec![json!("syncgroups"), json!("?")])
+            .await?;
+        let groups_loop = result
+            .get("syncgroups_loop")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        Ok(groups_loop
+            .iter()
+            .filter_map(|group| group.get("sync_members").and_then(Value::as_str))
+            .map(|members| {
+                members
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|members| members.len() >= 2)
+            .collect())
+    }
+
+    /// Report every active LMS sync group in the multiroom contract's shape.
+    ///
+    /// `can_set_members` is always `true`: unlike Music Assistant's per-leader
+    /// `SET_MEMBERS` feature flag, every LMS player accepts `sync`
+    /// unconditionally, so there is no per-group capability to check.
+    pub async fn multiroom_status(&self) -> Result<Value> {
+        let groups = self.read_sync_groups().await?;
+        let groups = groups
+            .into_iter()
+            .filter_map(|members| {
+                let (leader, rest) = members.split_first()?;
+                Some(json!({
+                    "leader_zone_id": PrefixedZoneId::lms(leader).to_string(),
+                    "member_zone_ids": rest
+                        .iter()
+                        .map(|id| PrefixedZoneId::lms(id).to_string())
+                        .collect::<Vec<_>>(),
+                    "can_set_members": true,
+                }))
+            })
+            .collect::<Vec<_>>();
+        Ok(json!({ "groups": groups }))
+    }
+
+    /// Sync `add_zone_ids` into `leader_zone_id`'s group and unsync
+    /// `remove_zone_ids`, then return the refreshed `multiroom_status`.
+    pub async fn set_group_members(
+        &self,
+        leader_zone_id: &str,
+        add_zone_ids: &[String],
+        remove_zone_ids: &[String],
+    ) -> Result<Value> {
+        if add_zone_ids.is_empty() && remove_zone_ids.is_empty() {
+            return Err(anyhow!("LMS group membership needs at least one member"));
+        }
+        let leader_id = lms_player_id(leader_zone_id, "leader_zone_id")?;
+        let add_ids = lms_player_ids(add_zone_ids, "member_zone_ids_to_add")?;
+        let remove_ids = lms_player_ids(remove_zone_ids, "member_zone_ids_to_remove")?;
+        let players = self.rpc.get_players().await?;
+        let player_exists = |id: &str| players.iter().any(|player| player.playerid == id);
+        if !player_exists(&leader_id) {
+            return Err(anyhow!("LMS group leader was not found"));
+        }
+        for player_id in add_ids.iter().chain(remove_ids.iter()) {
+            if player_id == &leader_id {
+                return Err(anyhow!(
+                    "LMS group leader cannot be its own member input"
+                ));
+            }
+            if !player_exists(player_id) {
+                return Err(anyhow!("LMS group member was not found"));
+            }
+        }
+        for member_id in &add_ids {
+            self.rpc
+                .execute(Some(&leader_id), vec![json!("sync"), json!(member_id)])
+                .await?;
+        }
+        for member_id in &remove_ids {
+            self.rpc
+                .execute(Some(member_id), vec![json!("sync"), json!("-")])
+                .await?;
+        }
+        self.multiroom_status().await
+    }
+
+    /// Unsync each of `member_zone_ids` via its own `sync -`, independent of
+    /// which group (if any) it currently belongs to, then return the
+    /// refreshed `multiroom_status`.
+    pub async fn ungroup_members(&self, member_zone_ids: &[String]) -> Result<Value> {
+        let member_ids = lms_player_ids(member_zone_ids, "member_zone_ids")?;
+        if member_ids.is_empty() {
+            return Err(anyhow!("LMS ungroup needs at least one member"));
+        }
+        let players = self.rpc.get_players().await?;
+        for member_id in &member_ids {
+            if !players.iter().any(|player| player.playerid == *member_id) {
+                return Err(anyhow!("LMS group member was not found"));
+            }
+        }
+        for member_id in &member_ids {
+            self.rpc
+                .execute(Some(member_id), vec![json!("sync"), json!("-")])
+                .await?;
+        }
+        self.multiroom_status().await
     }
 
     /// Start polling for player updates (internal - use Startable trait)
@@ -3082,6 +3252,74 @@ async fn run_lms_command_endpoint(
                 // deadline; the command may have applied even though LMS did not serve readback.
                 tracing::warn!(%error, command_id = command_id.get(), "LMS native write accepted but coherent player readback failed");
             }
+        }
+    }
+}
+
+/// Content-library surface (#510): only the multiroom sync-group operations
+/// are implemented here. LMS's own search/play surfaces are reached through
+/// their dedicated paths (`LmsAdapter::search`, `LmsAdapter::control`, ...);
+/// this trait is what lets the provider-neutral MCP registry
+/// (`AdapterRegistry::library_content`) dispatch `multiroom_status`,
+/// `multiroom_set_members` and `multiroom_ungroup` to LMS the same way it
+/// already dispatches them to Music Assistant
+/// (`src/adapters/musicassistant.rs`).
+#[async_trait]
+impl LibraryAdapter for LmsAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow!(
+            "LMS search is not implemented via the generic content-library surface (see #396/#402)"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow!(
+            "LMS play-by-uri is not implemented via the generic content-library surface (see #396)"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        match operation {
+            "multiroom_status" => self.multiroom_status().await,
+            "multiroom_set_members" => {
+                let leader = params
+                    .get("leader_zone_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("LMS group operation requires leader_zone_id"))?;
+                let add = params
+                    .get("member_zone_ids_to_add")
+                    .or_else(|| params.get("member_zone_ids"))
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow!("LMS group operation requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                let remove = params
+                    .get("member_zone_ids_to_remove")
+                    .and_then(Value::as_array)
+                    .map(|members| {
+                        members
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                self.set_group_members(leader, &add, &remove).await
+            }
+            "multiroom_ungroup" => {
+                let members = params
+                    .get("member_zone_ids")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow!("LMS ungroup requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                self.ungroup_members(&members).await
+            }
+            _ => Err(anyhow!("LMS content operation `{operation}` is not supported")),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,6 +502,14 @@ mod server {
             .adapter_registry
             .register_library("spotify", spotify.clone())
             .await;
+        // LMS's transport commands keep going through the dedicated `state.lms`
+        // field/routes; this registration only exposes the provider-neutral
+        // content-library surface (#510's multiroom sync-group operations) via
+        // `AdapterRegistry::library_content("lms", ...)`.
+        state
+            .adapter_registry
+            .register_library("lms", state.lms.clone())
+            .await;
         state.provider_auth.attach_spotify(spotify.clone()).await;
         state
             .provider_auth

--- a/tests/adapter_integration.rs
+++ b/tests/adapter_integration.rs
@@ -780,4 +780,186 @@ mod mock_server_tests {
         adapter.stop().await;
         mock.stop().await;
     }
+
+    // -------------------------------------------------------------------------
+    // LMS sync groups (#510): multiroom_status / set_group_members /
+    // ungroup_members over the mock server's `sync` / `syncgroups ?` support.
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_status_reports_no_groups_before_syncing() {
+        let mock = MockLmsServer::start().await;
+        mock.add_player("aa:bb:cc:dd:ee:ff", "Living Room").await;
+        mock.add_player("11:22:33:44:55:66", "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+
+        let status = adapter.multiroom_status().await.unwrap();
+        assert_eq!(
+            status["groups"].as_array().unwrap().len(),
+            0,
+            "no players are synced yet"
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_set_members_syncs_member_into_leaders_group() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        let member = "11:22:33:44:55:66";
+        mock.add_player(leader, "Living Room").await;
+        mock.add_player(member, "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+        mock.clear_commands().await;
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let member_zone = PrefixedZoneId::lms(member).to_string();
+        let result = adapter
+            .set_group_members(&leader_zone, &[member_zone.clone()], &[])
+            .await
+            .expect("set_group_members should succeed");
+
+        let groups = result["groups"].as_array().expect("groups array");
+        assert_eq!(groups.len(), 1, "one group after syncing one member");
+        assert_eq!(groups[0]["leader_zone_id"], serde_json::json!(leader_zone));
+        assert_eq!(groups[0]["member_zone_ids"], serde_json::json!([member_zone]));
+        assert_eq!(groups[0]["can_set_members"], serde_json::json!(true));
+
+        // The leader is addressed, the member is the argument -- verified live
+        // (#403) to make the *addressed* player the sync master and keep its
+        // queue, which is why the leader (not the member) issues the command.
+        let leader_commands = mock.write_commands(leader).await;
+        assert!(
+            leader_commands.contains(&vec!["sync".to_string(), member.to_string()]),
+            "expected `sync {member}` addressed to the leader, got {leader_commands:?}"
+        );
+
+        assert_eq!(
+            mock.sync_groups().await,
+            vec![vec![leader.to_string(), member.to_string()]]
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_ungroup_unsyncs_member() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        let member = "11:22:33:44:55:66";
+        mock.add_player(leader, "Living Room").await;
+        mock.add_player(member, "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let member_zone = PrefixedZoneId::lms(member).to_string();
+        adapter
+            .set_group_members(&leader_zone, &[member_zone.clone()], &[])
+            .await
+            .expect("initial sync should succeed");
+        mock.clear_commands().await;
+
+        let result = adapter
+            .ungroup_members(&[member_zone])
+            .await
+            .expect("ungroup_members should succeed");
+        assert_eq!(
+            result["groups"].as_array().unwrap().len(),
+            0,
+            "the group dissolves once its only member leaves"
+        );
+
+        let member_commands = mock.write_commands(member).await;
+        assert_eq!(
+            member_commands,
+            vec![vec!["sync".to_string(), "-".to_string()]],
+            "the member is addressed directly to unsync itself"
+        );
+
+        assert!(
+            mock.sync_groups().await.is_empty(),
+            "server-side group state must also be gone"
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_set_members_rejects_unknown_player_before_any_sync_call() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        mock.add_player(leader, "Living Room").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+        mock.clear_commands().await;
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let unknown_zone = PrefixedZoneId::lms("00:00:00:00:00:00").to_string();
+        let result = adapter
+            .set_group_members(&leader_zone, &[unknown_zone], &[])
+            .await;
+        assert!(
+            result.is_err(),
+            "an unknown member must be refused, not synced"
+        );
+        assert!(
+            mock.write_commands(leader).await.is_empty(),
+            "no sync command should reach LMS once validation fails"
+        );
+        assert!(mock.sync_groups().await.is_empty());
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
 }

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -99,6 +99,15 @@ struct MockLmsState {
     /// `playlistcontrol` call. Keyed by [`LmsSearchResultType`]-shaped kind:
     /// `"album"`, `"artist"`, `"track"`.
     library: HashMap<&'static str, Vec<MockLibraryItem>>,
+    /// Active sync groups (#510). Each inner `Vec` is one group's full
+    /// membership, first-added player first -- mirroring what real LMS's
+    /// `syncgroups ?` reports (a flat member list with no leader marker).
+    /// This is a simplified peer model, not a full replica of LMS's
+    /// undocumented internal master-election-on-leave behavior: `sync -`
+    /// dissolves the whole group rather than promoting a new master, which is
+    /// enough to exercise the adapter's join/leave/status calls without
+    /// claiming to model LMS's internals exactly.
+    sync_groups: Vec<Vec<String>>,
 }
 
 /// Mock LMS Server
@@ -115,6 +124,7 @@ impl MockLmsServer {
             players: HashMap::new(),
             commands: Vec::new(),
             library: HashMap::new(),
+            sync_groups: Vec::new(),
         }));
 
         let app = Router::new()
@@ -232,10 +242,53 @@ impl MockLmsServer {
             .collect()
     }
 
+    /// Current sync groups, each as its full member id list (#510). Lets a
+    /// test assert on server-side membership directly, independent of how
+    /// the adapter reports it.
+    pub async fn sync_groups(&self) -> Vec<Vec<String>> {
+        self.state.read().await.sync_groups.clone()
+    }
+
     /// Stop the mock server
     pub async fn stop(self) {
         self.handle.abort();
     }
+}
+
+/// Join `member` into `master`'s sync group (#510).
+///
+/// Mirrors the live-verified behavior (issue #403): the *addressed* player
+/// (`master`) becomes/stays the sync master, and `member` joins its group.
+/// `member` is first removed from any group it was previously in.
+fn mock_sync_join(state: &mut MockLmsState, master: &str, member: &str) {
+    mock_sync_remove(state, member);
+    if let Some(group) = state
+        .sync_groups
+        .iter_mut()
+        .find(|group| group.first().map(String::as_str) == Some(master))
+    {
+        if !group.iter().any(|id| id == member) {
+            group.push(member.to_string());
+        }
+        return;
+    }
+    // `master` was not already a group's first (leader) entry. If it was a
+    // member of some other group, leaving that group first keeps this model
+    // consistent with "the addressed player becomes master".
+    mock_sync_remove(state, master);
+    state
+        .sync_groups
+        .push(vec![master.to_string(), member.to_string()]);
+}
+
+/// Remove `player` from whatever sync group it currently belongs to, if any.
+/// A group left with fewer than two members is no longer a sync group and is
+/// dropped entirely.
+fn mock_sync_remove(state: &mut MockLmsState, player: &str) {
+    for group in state.sync_groups.iter_mut() {
+        group.retain(|id| id != player);
+    }
+    state.sync_groups.retain(|group| group.len() >= 2);
 }
 
 /// JSON-RPC request format
@@ -378,6 +431,21 @@ async fn handle_jsonrpc(
                 result: json!({}),
             }));
         }
+        // `<playerid> sync <otherplayerid>` joins a group; `<playerid> sync -`
+        // leaves whatever group it is in (#510).
+        "sync" if commands.get(1).is_some() => {
+            let target = commands.get(1).and_then(Value::as_str).unwrap_or("");
+            let mut state = state.write().await;
+            if target == "-" {
+                mock_sync_remove(&mut state, player_id);
+            } else {
+                mock_sync_join(&mut state, player_id, target);
+            }
+            return Ok(Json(JsonRpcResponse {
+                id: request.id,
+                result: json!({}),
+            }));
+        }
         _ => {}
     }
 
@@ -436,6 +504,36 @@ async fn handle_jsonrpc(
         "mixer" => {
             // Volume control - return empty success
             json!({})
+        }
+        // Server-scoped `syncgroups ?` (#510): one entry per active group,
+        // with the full membership as a comma-joined id list, matching the
+        // `sync_members`/`sync_member_names` shape verified live against
+        // Lyrion 9.1.2 (issue #403's investigation).
+        "syncgroups" => {
+            let syncgroups_loop: Vec<Value> = state
+                .sync_groups
+                .iter()
+                .map(|group| {
+                    let names: Vec<String> = group
+                        .iter()
+                        .map(|id| {
+                            state
+                                .players
+                                .get(id)
+                                .map(|p| p.name.clone())
+                                .unwrap_or_default()
+                        })
+                        .collect();
+                    json!({
+                        "sync_members": group.join(","),
+                        "sync_member_names": names.join(","),
+                    })
+                })
+                .collect();
+            json!({
+                "count": syncgroups_loop.len(),
+                "syncgroups_loop": syncgroups_loop
+            })
         }
         "playlist" => {
             // Playlist control (next/prev) - return empty success


### PR DESCRIPTION
Closes #510

## Base branch

Based on `feat/issue-462-streaming-adapters`, not `v3`: the multiroom MCP contract (`multiroom_set_members`/`multiroom_ungroup`/`multiroom_status`, implemented by `src/adapters/musicassistant.rs`) exists only on this branch today. Same rationale as PR #511.

## Summary

Wires the LMS adapter to the existing multiroom content-library contract using LMS's native Squeezebox `sync`/`syncgroups ?` CLI commands (`src/adapters/lms.rs`, `execute` around line 412 before this change).

- **`multiroom_set_members`**: syncs each added member into the leader's group via `<leader> sync <member>`, and unsyncs each removed member via `<member> sync -`.
- **`multiroom_ungroup`**: unsyncs each named member via `<member> sync -`.
- **`multiroom_status`**: reads `syncgroups ?` and reports each group's current membership.

**Leader mapping (per the issue's note):** LMS sync groups are peer-based — a group is just a set of players playing in lockstep, with no server-side leader concept. This adapter maps the contract's leader/member shape onto LMS by always addressing the *leader* in the `sync` command sent for each added member. Live-verified behavior recorded in #403's investigation: the **addressed** player in a `sync` command becomes/stays the sync master, and the **argument** player adopts the addressed player's queue (destroying its own). Addressing the leader therefore keeps the leader's queue and playback intact and makes the member fall in behind it — exactly what `leader_zone_id` implies. For `multiroom_status`, since LMS reports flat group membership with no leader marker, this adapter treats the *first id LMS returns* for each group as that group's leader. This is a stable-but-arbitrary UHC display convention, not an LMS fact, and is documented as such at the implementation site.

**Zone snapshots / disconnect composition:** group membership is never cached locally — every `multiroom_status` call re-reads `syncgroups ?` live. A player that disconnects (composing with #461's zone-removal handling) simply stops appearing in the next `syncgroups ?` read; there is no local group cache that could strand stale state.

**Wiring:** `LmsAdapter` now implements `LibraryAdapter` (`src/adapters/traits.rs`), registered under the `"lms"` prefix (`src/main.rs`) so `AdapterRegistry::library_content("lms", ...)` reaches it — the same registry mechanism Music Assistant's grouping already uses. Only the three multiroom operations are implemented; `search`/`play_uri` return an honest "not implemented via this surface" refusal, since LMS's own search/play paths are unrelated existing code (`LmsAdapter::search`, `LmsAdapter::control`).

## Deliberate scope decision (please read)

The `hifi_zone_group` MCP tool (`src/mcp/tools/groups.rs`) and the `MultiroomSync` capability routing (`src/mcp/capabilities.rs`'s `routed()`, line ~363) remain Music-Assistant-only in this PR. I looked at generalizing both and decided against it here, for two reasons:

1. The issue's acceptance criteria are scoped to the **adapter** (`multiroom_set_members`/`ungroup`/`status` behavior, zone-snapshot composition, mock-server test coverage) — not to the MCP tool surface.
2. `hifi_zone_group`'s `status` action takes no zone id today (single-provider assumption). Generalizing it to route by provider requires a design decision (e.g., an explicit `provider` argument, or aggregating across providers) that would also touch the locked `tests/mcp_contract.rs` capability-probe fixture (`every_supported_capability_reaches_that_providers_own_adapter`, which asserts an exact proved-cell count) and `AGENTS.md`'s generated capability matrix. That felt like separate, larger scope than this issue asked for.

The adapter/registry contract this PR wires up (`AdapterRegistry::library_content("lms", ...)`) is the same one that tool would call once generalized, so this PR is a clean prerequisite for that follow-up rather than a dead end.

## Local verification

Environment notes per repo conventions: `make css` run first; `cargo`/`rustc` from rustup's `1.97.1` toolchain put ahead of Homebrew's on `PATH`; this is a stacked/feature-branch PR so **CI does not run** — verified entirely locally.

```
cargo test                       # 424 unrelated-crate tests + full binary test suite: all pass
                                  # except tests/web_fullstack_runner_contract.rs::runner_builds_matching_assets_before_it_starts_the_server,
                                  # which fails identically on origin/feat/issue-462-streaming-adapters before this change (confirmed via git stash) —
                                  # a pre-existing dx/wasm build environment issue, unrelated to this PR.
cargo clippy -- -D warnings       # clean
```

New coverage in `tests/adapter_integration.rs` (`mock_server_tests`), against `tests/mock_servers/lms.rs` (extended with `sync`/`syncgroups ?` support per the issue's acceptance criteria):

- `lms_multiroom_status_reports_no_groups_before_syncing`
- `lms_multiroom_set_members_syncs_member_into_leaders_group` (asserts the exact `sync <member>` command is addressed to the leader)
- `lms_multiroom_ungroup_unsyncs_member` (asserts `sync -` is addressed to the member)
- `lms_multiroom_set_members_rejects_unknown_player_before_any_sync_call`

`sg review` could not run in this sandbox (superego CLI's LLM call failed with an expired OAuth session, an environment limitation) — the diff was reviewed manually instead.

## Deviations from acceptance criteria

None on the adapter-level criteria. See "Deliberate scope decision" above for the one surface (MCP tool wiring) intentionally left for follow-up work, with the reasoning stated.