### PR TITLE
feat: per-zone visibility, ordering, and renaming

### DIFF
--- a/.oh/zone-visibility-and-ordering.md
+++ b/.oh/zone-visibility-and-ordering.md
@@ -1,0 +1,167 @@
+# Zone visibility and ordering
+
+**Branch:** `feat/zone-visibility-sorting`
+**Base:** `v3` @ `18dd880`
+**Stage:** Aim (no source change yet)
+**Origin:** User report — Docker install, Roon-only: "it should respect private zones and exclude
+them from the zones list. Or, at least, it should be configurable somehow." Plus standing requests
+for grouping/sorting.
+
+---
+
+## Aim
+
+**Aim:** A listener with zones they don't want to control from UHC removes them once, in settings,
+and never sees them again — and every zone list they encounter comes back in the same order every
+time.
+
+**Why it matters:** The zone list is the front door of UHC. A Roon user whose phone, laptop, and
+System Output show up alongside their three real endpoints is doing visual filtering on every single
+interaction. And because the list order is currently drawn fresh from a `HashMap` on each request,
+"the third one down" is never the same zone twice — which makes muscle memory impossible and makes
+physical knob bindings unreliable. Neither is a missing feature; both are a tax paid per use.
+
+**Current State:**
+- Every zone any adapter reports is shown. Personal endpoints (Roon-on-phone, laptop System Output,
+  a stale Squeezelite instance) sit in the list next to real listening zones, and there is no way to
+  remove one.
+- `/zones` returns `HashMap::values()` ([aggregator.rs:272](../src/aggregator.rs), surfaced via
+  [`get_all_zones_internal`](../src/knobs/routes.rs)) — order is nondeterministic **per request**.
+  Knobs and any API consumer inherit that.
+- The web zones page is the one consumer that already sorts
+  ([zones.rs:256](../src/app/pages/zones.rs)), and it sorts case-sensitively by byte value, so
+  `kitchen` lands after `Zone`.
+- **MCP bypasses the shared chokepoint entirely.** Three paths read the aggregator raw —
+  [`zones_payload`](../src/mcp/tools/zones.rs) (backing `hifi_zones` and `hifi://zones`),
+  [resource enumeration](../src/mcp/resources.rs), and
+  [`hifi_capabilities`](../src/mcp/tools/capabilities.rs). Today this costs nothing, because
+  adapter settings are enforced *upstream* of the aggregator, not by the chokepoint's filter:
+  [`register_from_settings`](../src/main.rs) gates startup, and #429 made the settings endpoint
+  flush a disabled adapter's zones via `stop_adapter_and_flush` →
+  [`AdapterStopping`](../src/aggregator.rs). So disabled adapters' zones are absent from
+  `aggregator.get_zones()` outright. **It costs everything the moment a zone-list policy lives at
+  the chokepoint** — which is exactly what this aim adds.
+
+  *(Checked and found false:* an earlier draft claimed MCP ignores adapter toggles. It does not.
+  The only residual divergence is an `app-settings.json` edited on disk without a restart —
+  `get_all_zones_internal` re-reads settings per call, the aggregator does not — which is narrow,
+  self-healing on restart, and closes for free once MCP shares the chokepoint.)*
+
+**Desired State:**
+- Zones the user has hidden are absent from every zone list — web UI, knobs, API, and MCP
+  (`hifi_zones`, resources, `hifi_capabilities`) — until they unhide them.
+- Every zone list is ordered by name, ascending, case-insensitively, identically on every request.
+
+---
+
+### Mechanism
+
+**Change:**
+1. Deterministic ordering applied at the shared chokepoint,
+   [`get_all_zones_internal`](../src/knobs/routes.rs) — the one place that already does
+   adapter-level filtering for all consumers. Default on, ascending, case-insensitive, with
+   `zone_id` as tiebreaker so equal names never swap.
+2. Per-zone visibility: a persisted set of hidden zone IDs in `app-settings.json` (alongside the
+   existing `hide_knobs_page` / `hide_hqp_page` flags), filtered at the same chokepoint, with a
+   settings-page control to hide/unhide. Default: nothing hidden.
+3. Route MCP's three zone-list paths through the shared chokepoint, so hiding and ordering apply
+   there. This is not a bug fix — MCP's output is correct today. It is what keeps MCP correct once
+   (2) makes zone-list membership a policy decision rather than a fact about the aggregator.
+   `tests/mcp_contract.rs::zones_resource_agrees_with_hifi_zones_tool` already asserts two of the
+   three agree — extend it to cover `hifi_capabilities`, so the three cannot drift apart again.
+
+**Hypothesis:** The reporter asked for "respect private zones," but the behavior they want is
+"zones I don't care about aren't in my way." Per-zone visibility delivers that behavior without
+depending on a signal Roon may not give us — and because the filter keys on the already-prefixed
+`zone_id` rather than on any adapter-specific field, it is provider-agnostic by construction: Roon,
+LMS, OpenHome, UPnP, and HQPlayer all get it from the same code with no per-adapter work.
+
+**Assumptions:**
+- **The Roon Core exposes no privacy flag to extensions.** The `Zone` struct we deserialize
+  (`roon-api` `transport.rs:94`) carries `zone_id, display_name, outputs, state, is_*_allowed,
+  queue_*, now_playing, settings`; `Output` carries `output_id, zone_id,
+  can_group_with_output_ids, display_name, volume, source_controls`. Neither has a privacy field.
+  Roon's Private Zone is a *remote-visibility* concept, and the reporter seeing private zones in UHC
+  is evidence the Core does not filter them for extensions. **Not yet verified against a live
+  Core** — the crate drops unknown JSON fields silently, so a field could exist that we never see.
+  Cheap probe: log the raw zone payload once against a real Core. If a flag turns up, default-on
+  private-zone hiding becomes possible and this aim gets revisited.
+- Hiding a zone is a *display* decision, not a *control* decision — a hidden zone that is already
+  bound to a knob or addressed directly by ID keeps working. Hiding removes it from lists, it does
+  not deauthorize it.
+- Zone IDs are stable enough across Core restarts to persist against. (Roon zone IDs are stable;
+  worth confirming for LMS/UPnP before the setting is advertised as cross-provider.)
+- Users have few enough zones that an explicit hide list is less work than the filtering they do
+  today. Fails at large zone counts, where the ask would become allow-list-by-default.
+
+**Misunderstanding Signal:** Someone ships a `hide_private_zones: true` toggle in settings that
+keys off a name heuristic or an output type guess, and calls the reporter's request satisfied. That
+delivers a checkbox with the reporter's words on it while guessing wrong about which zones are
+personal — worse than the honest answer, because the user can no longer tell whether a missing zone
+was their choice or ours.
+
+---
+
+### Feedback
+
+**Signal:**
+- The reporter (Docker, Roon-only) confirms their personal endpoints stay gone across a container
+  restart, and that they did not have to hand-edit JSON to do it.
+- `/zones` returns byte-identical ordering across repeated requests on an unchanged zone set —
+  assertable in a test, not just observable.
+- Hiding a zone removes it from `hifi_zones` as well as the web UI, in the same edit.
+- No follow-up reports of "my knob started controlling the wrong zone," or of an assistant losing
+  the ability to control a zone it could reach before.
+
+**Timeframe:** Ordering is verifiable in-repo the day it lands. Visibility needs one round-trip with
+the reporter — call it a week.
+
+---
+
+### Guardrails
+
+- **Guardrail:** Hidden zones must not be a control-plane filter — commands addressed to a hidden
+  zone by ID still execute, on every surface including MCP. `hifi_play` against a hidden zone's ID
+  works; the zone simply is not *offered* by `hifi_zones`.
+  **Reason:** Knob bindings, MCP calls, and HQPlayer links reference zones by ID. Making "hidden"
+  mean "unreachable" would silently break working setups on upgrade. Hiding is decluttering, not
+  authorization.
+  **Trigger:** If someone asks to keep an assistant out of a room specifically — a genuine boundary
+  rather than tidiness — that is a separate access-control concept and needs its own aim, not an
+  overload of this setting.
+
+- **Guardrail:** Ordering and filtering land at `get_all_zones_internal`, not per-consumer. No zone
+  list may call `aggregator.get_zones()` directly.
+  **Reason:** The ordering defect exists precisely because zone-list policy was treated as a
+  per-consumer concern — the web page fixed it locally and everyone else inherited the `HashMap`.
+  MCP has been fine reading raw only because zone-list membership was, until now, a fact about the
+  aggregator rather than a policy. This aim changes that, and every raw reader becomes a place the
+  policy can silently not apply.
+  **Trigger:** If a consumer legitimately needs a different order (e.g. recently-played-first),
+  that's a parameter on the shared path, not a bypass of it.
+
+- **Guardrail:** Defaults must be honest. Ordering defaults on because there is no argument for
+  random. Visibility defaults to *nothing hidden*, because we have no trustworthy signal for which
+  zones are private.
+  **Reason:** The reporter asked for default-on hiding; we can't deliver that without guessing, and
+  a wrong guess hides a zone the user wanted with no clue why.
+  **Trigger:** A verified privacy field from a live Core flips this — then default-on hiding of
+  Roon-flagged private zones is correct and should ship.
+
+- **Guardrail:** Grouping is out of scope for this aim.
+  **Reason:** Group-by-source already exists on the web zones page; what "grouping" means to the
+  people asking (Roon transport grouping vs. user-defined room grouping) is unresolved, and the two
+  are wildly different in size.
+  **Trigger:** Its own aim, once we know which one people want.
+
+---
+
+## Decisions Taken
+
+| Question | Decision |
+|---|---|
+| What does "grouping" mean? | Deferred. Sorting + visibility only in this aim. |
+| Fallback if Roon exposes no privacy flag? | Per-zone hide list, default all visible. Tell the reporter plainly that Roon gives extensions no private-zone signal. |
+| Does hiding apply to all adapters? | Yes — provider-agnostic by construction, no per-adapter work. |
+| Does hiding apply to MCP? | Yes, one shared list, **list-only**. Hidden zones vanish from `hifi_zones` / resources / `hifi_capabilities`; direct control by zone ID still works. Per-surface toggles and AI access control are explicitly not this aim. |
+| Is there an MCP adapter-toggle bug to fix? | **No.** Claimed in an earlier draft, checked, found false — #429 and startup gating already keep disabled adapters' zones out of the aggregator. MCP still gets routed through the chokepoint, but as prevention, not repair. |

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Pre-built binaries available for Linux (x64, arm64, armv7), macOS (x64, arm64), 
 services:
   unified-hifi-control:
     image: muness/unified-hifi-control:latest
-    # Required for Roon/UPnP discovery. Also publishes :8088 on every interface
-    # the host has — see "Security and network exposure" below.
+    # Required for Roon/UPnP discovery. Also publishes the bridge port (8088 by
+    # default) on every interface the host has, unauthenticated — see
+    # "Security and Network Exposure" below.
     network_mode: host
     volumes:
       - ./data:/data
@@ -95,15 +96,17 @@ Legacy aliases: `PORT` (→ `UHC_PORT`), `LOG_LEVEL` (→ `RUST_LOG`)
 
 **Unified Hi-Fi Control is unauthenticated by design. Treat it as a trusted-LAN service and do not port-forward it.**
 
-The bridge listens on `0.0.0.0:8088` — every interface the host has — and the web UI, the REST API, and the MCP endpoint all accept requests without credentials. That is deliberate: the ESP32 knobs, the iOS companion, browsers, and AI agents all need to reach it, and none of them have a way to hold a secret. It also matches the backends it sits in front of, which are themselves open on the LAN (Lyrion Music Server, for instance, requires no auth by default).
+The bridge listens on `0.0.0.0` — every interface the host has — and the web UI, the REST API, and the MCP endpoint all accept requests without credentials. That is deliberate: the ESP32 knobs, the iOS companion, browsers, and AI agents all need to reach it, and none of them have a way to hold a secret. It also matches the backends it sits in front of, which are themselves open on the LAN (Lyrion Music Server, for instance, requires no auth by default).
+
+The port is `8088` unless you change it. `UHC_PORT` wins, then legacy `PORT`, then a `port` entry in the config file, then the default — so if you have set any of those, read "the bridge port" below rather than `8088`.
 
 What that means in practice:
 
 - **Anything on your network can control playback.** A guest's phone, an IoT gadget, or a compromised TV can change zones, volume, transport, and HQPlayer DSP settings. The blast radius is your music, not your data — there is no file access, no shell, and no credential store behind these endpoints.
-- **Do not expose port 8088 to the internet.** `network_mode: host` in the Docker example publishes it on every interface, so a router port-forward or a permissive cloud firewall is all it takes. If you need remote access, use a VPN or an authenticating reverse proxy rather than forwarding the port.
+- **Do not expose the bridge port to the internet.** `network_mode: host` in the Docker example publishes it on every interface, so a router port-forward or a permissive cloud firewall is all it takes. If you need remote access, use a VPN or an authenticating reverse proxy rather than forwarding the port.
 - **Agents connected over MCP inherit that control.** If the agent you connect also reads untrusted text — web pages, track and playlist names, email — a prompt-injection attack could steer it into these tools. Connect agents you trust, and be aware that "control my stereo" is the ceiling of what they can be talked into here.
 
-If your network is flat and you would rather not have guest devices reach the bridge, put it on a VLAN or restrict port 8088 at the firewall to the devices that need it.
+If your network is flat and you would rather not have guest devices reach the bridge, put it on a VLAN or restrict the bridge port at the firewall to the devices that need it.
 
 ## HQPlayer DSP Integration
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Pre-built binaries available for Linux (x64, arm64, armv7), macOS (x64, arm64), 
 services:
   unified-hifi-control:
     image: muness/unified-hifi-control:latest
-    network_mode: host  # Required for Roon/UPnP discovery
+    # Required for Roon/UPnP discovery. Also publishes :8088 on every interface
+    # the host has — see "Security and network exposure" below.
+    network_mode: host
     volumes:
       - ./data:/data
     environment:
@@ -88,6 +90,20 @@ docker compose up -d
 Legacy aliases: `PORT` (→ `UHC_PORT`), `LOG_LEVEL` (→ `RUST_LOG`)
 
 **Note:** Port 8088 is also HQPlayer's default. If running both on the same host, change one.
+
+## Security and Network Exposure
+
+**Unified Hi-Fi Control is unauthenticated by design. Treat it as a trusted-LAN service and do not port-forward it.**
+
+The bridge listens on `0.0.0.0:8088` — every interface the host has — and the web UI, the REST API, and the MCP endpoint all accept requests without credentials. That is deliberate: the ESP32 knobs, the iOS companion, browsers, and AI agents all need to reach it, and none of them have a way to hold a secret. It also matches the backends it sits in front of, which are themselves open on the LAN (Lyrion Music Server, for instance, requires no auth by default).
+
+What that means in practice:
+
+- **Anything on your network can control playback.** A guest's phone, an IoT gadget, or a compromised TV can change zones, volume, transport, and HQPlayer DSP settings. The blast radius is your music, not your data — there is no file access, no shell, and no credential store behind these endpoints.
+- **Do not expose port 8088 to the internet.** `network_mode: host` in the Docker example publishes it on every interface, so a router port-forward or a permissive cloud firewall is all it takes. If you need remote access, use a VPN or an authenticating reverse proxy rather than forwarding the port.
+- **Agents connected over MCP inherit that control.** If the agent you connect also reads untrusted text — web pages, track and playlist names, email — a prompt-injection attack could steer it into these tools. Connect agents you trust, and be aware that "control my stereo" is the ceiling of what they can be talked into here.
+
+If your network is flat and you would rather not have guest devices reach the bridge, put it on a VLAN or restrict port 8088 at the firewall to the devices that need it.
 
 ## HQPlayer DSP Integration
 
@@ -157,6 +173,8 @@ Control your hi-fi with natural language. The bridge includes an MCP server so C
 | `hifi_hqplayer_set_pipeline` | Change filter, shaper, dither settings |
 
 *Search and play work with Roon and LMS. Transport controls work with all adapters.*
+
+The MCP endpoint is unauthenticated like the rest of the bridge — see [Security and Network Exposure](#security-and-network-exposure).
 
 ### Example Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,12 @@
 services:
   unified-hifi-control:
     build: .
-    # Host network required for Roon mDNS discovery
+    # Host network required for Roon mDNS discovery.
+    #
+    # Note this publishes :8088 on every interface the host has, not just localhost.
+    # The web UI, REST API, and MCP endpoint are all unauthenticated, so anything on
+    # your network can control playback, volume, and DSP. Keep it on a trusted LAN and
+    # do not port-forward it. See "Security and Network Exposure" in the README.
     network_mode: host
     volumes:
       - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,11 @@ services:
     build: .
     # Host network required for Roon mDNS discovery.
     #
-    # Note this publishes :8088 on every interface the host has, not just localhost.
-    # The web UI, REST API, and MCP endpoint are all unauthenticated, so anything on
-    # your network can control playback, volume, and DSP. Keep it on a trusted LAN and
-    # do not port-forward it. See "Security and Network Exposure" in the README.
+    # Note this publishes the bridge port (PORT below, 8088 by default) on every
+    # interface the host has, not just localhost. The web UI, REST API, and MCP
+    # endpoint are all unauthenticated, so anything on your network can control
+    # playback, volume, and DSP. Keep it on a trusted LAN and do not port-forward it.
+    # See "Security and Network Exposure" in the README.
     network_mode: host
     volumes:
       - ./data:/data

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2927,7 +2927,16 @@ const MAX_ZONE_NAME_CHARS: usize = 60;
 #[derive(Debug, Deserialize)]
 pub struct ZoneOrderRequest {
     pub zone_id: String,
-    pub direction: crate::zone_list::MoveDirection,
+    /// Step one place. Used by the up/down buttons.
+    #[serde(default)]
+    pub direction: Option<crate::zone_list::MoveDirection>,
+    /// Take the slot this zone currently occupies. Used by drag-and-drop.
+    ///
+    /// A target *zone* rather than an index: the client's row indices can go stale between render
+    /// and drop if a zone appears or disappears, and a stale index would land the zone somewhere
+    /// the user did not point at, silently. A stale zone id simply resolves to nothing.
+    #[serde(default)]
+    pub target_zone_id: Option<String>,
 }
 
 /// POST /api/zones/order - move one zone one place up or down.
@@ -2947,9 +2956,16 @@ pub async fn zone_order_post(
     let hidden_ids: Vec<String> = settings.hidden_zone_ids().to_vec();
     let hidden: std::collections::HashSet<&str> = hidden_ids.iter().map(String::as_str).collect();
 
-    let Some(new_order) =
-        crate::zone_list::reorder(&effective, &req.zone_id, req.direction, &hidden)
-    else {
+    // A drop names its destination exactly; a button step has to reason about hidden neighbours.
+    let moved = match (&req.target_zone_id, req.direction) {
+        (Some(target), _) => crate::zone_list::reorder_to(&effective, &req.zone_id, target),
+        (None, Some(direction)) => {
+            crate::zone_list::reorder(&effective, &req.zone_id, direction, &hidden)
+        }
+        (None, None) => None,
+    };
+
+    let Some(new_order) = moved else {
         // Already at the end it was moved toward, or no such zone. A no-op, not an error -- but say
         // so, since the UI announces "already first" rather than silently doing nothing.
         return (

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2539,6 +2539,58 @@ pub struct AppSettings {
     pub hide_lms_page: bool,
     #[serde(default)]
     pub adapters: AdapterSettings,
+    /// Zone IDs the user has hidden from every zone list.
+    ///
+    /// `Option` rather than `Vec` because this type is both the stored shape *and* the request body
+    /// of `POST /api/settings`, and that handler saves what it is given wholesale. The settings
+    /// page builds an `AppSettings` from its own form fields, so a plain `#[serde(default)] Vec`
+    /// would deserialise a body without the key as empty and silently erase the user's hide list
+    /// every time they toggled an adapter. `None` means "the caller said nothing about hidden
+    /// zones, keep what is stored"; `Some(vec![])` is an explicit clear. See
+    /// `api_settings_post_handler`.
+    #[serde(
+        default,
+        alias = "hiddenZones",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hidden_zones: Option<Vec<String>>,
+    /// The user's explicit zone order, as zone IDs. Zones absent from it sort alphabetically after
+    /// the ones present, so a newly discovered zone lands somewhere predictable rather than at a
+    /// position that depends on `HashMap` iteration.
+    ///
+    /// `Option` for the same reason as `hidden_zones` — see that field.
+    #[serde(default, alias = "zoneOrder", skip_serializing_if = "Option::is_none")]
+    pub zone_order: Option<Vec<String>>,
+    /// Per-zone display-name overrides, keyed by zone ID.
+    ///
+    /// Renaming is applied *before* sorting, which is what makes it useful beyond cosmetics: a user
+    /// who prefixes several zones with `Basement - ` gets them grouped together in every list, with
+    /// no grouping feature. That is the intended use, not a side effect.
+    ///
+    /// `Option` for the same reason as `hidden_zones` — see that field.
+    #[serde(default, alias = "zoneNames", skip_serializing_if = "Option::is_none")]
+    pub zone_names: Option<std::collections::BTreeMap<String, String>>,
+}
+
+impl AppSettings {
+    /// The hide list, treating "unset" and "empty" alike — the distinction matters only to the
+    /// settings write path, never to a reader.
+    pub fn hidden_zone_ids(&self) -> &[String] {
+        self.hidden_zones.as_deref().unwrap_or(&[])
+    }
+
+    /// The explicit zone order, empty when the user has never reordered anything.
+    pub fn zone_order_ids(&self) -> &[String] {
+        self.zone_order.as_deref().unwrap_or(&[])
+    }
+
+    /// The custom display name for a zone, if the user set one.
+    pub fn custom_zone_name(&self, zone_id: &str) -> Option<&str> {
+        self.zone_names
+            .as_ref()
+            .and_then(|names| names.get(zone_id))
+            .map(String::as_str)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -2565,6 +2617,14 @@ impl Default for AppSettings {
             hide_knobs_page: false,
             hide_hqp_page: false,
             hide_lms_page: false,
+            // Nothing hidden by default. Roon exposes no private-zone flag to extensions, so any
+            // default-on hiding would be us guessing which of the user's zones are personal — and
+            // a wrong guess makes a zone vanish with no way for them to tell it was our choice.
+            hidden_zones: None,
+            // No explicit order until the user makes one; until then, alphabetical.
+            zone_order: None,
+            // Zones keep the names their provider reports until the user overrides one.
+            zone_names: None,
             adapters: AdapterSettings {
                 roon: true,
                 upnp: false,
@@ -2643,6 +2703,22 @@ pub async fn api_settings_post_handler(
     // Load current settings to compare
     let old_settings = load_app_settings();
 
+    // Carry the hide list forward when the body did not mention it. This endpoint saves its request
+    // body wholesale, and its main caller -- the settings page -- builds an `AppSettings` from its
+    // own form fields, which do not include hidden zones. Without this, toggling any adapter would
+    // unhide every zone the user had hidden. An explicit `"hidden_zones": []` still clears.
+    let mut new_settings = new_settings;
+    if new_settings.hidden_zones.is_none() {
+        new_settings.hidden_zones = old_settings.hidden_zones.clone();
+    }
+    if new_settings.zone_order.is_none() {
+        new_settings.zone_order = old_settings.zone_order.clone();
+    }
+    if new_settings.zone_names.is_none() {
+        new_settings.zone_names = old_settings.zone_names.clone();
+    }
+    let new_settings = new_settings;
+
     // Save the new settings
     if !save_app_settings(&new_settings) {
         return Json(serde_json::json!({"ok": false, "error": "Failed to save settings"}));
@@ -2716,6 +2792,245 @@ pub async fn api_settings_post_handler(
     }
 
     Json(serde_json::json!({"ok": true}))
+}
+
+/// One row of the zone management list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ManagedZone {
+    /// The name as displayed everywhere — the user's override when set, otherwise the provider's.
+    pub zone_name: String,
+    /// The name the provider reports. Shown alongside a renamed zone so the user can always map it
+    /// back to what Roon or LMS calls it.
+    pub provider_name: String,
+    /// Whether `zone_name` is a user override rather than the provider's own name.
+    pub renamed: bool,
+    pub zone_id: String,
+    pub source: String,
+    pub hidden: bool,
+}
+
+/// `GET /api/zones/visibility` response.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ManagedZonesResponse {
+    pub zones: Vec<ManagedZone>,
+}
+
+/// GET /api/zones/visibility - every zone the user can manage, hidden ones included.
+///
+/// Distinct from `/zones`, which is a zone *list* and therefore excludes hidden zones. This is the
+/// management view, and it must show what is hidden or hiding would be a one-way door: the only
+/// screen that can unhide a zone would be unable to see it.
+pub async fn zone_visibility_get(State(state): State<AppState>) -> impl IntoResponse {
+    let settings = load_app_settings();
+    let hidden: std::collections::HashSet<&str> = settings
+        .hidden_zone_ids()
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    // `manageable_zones` has already applied any rename, so `zone_name` here is the effective name.
+    // The provider's own name comes from the aggregator, which never sees the override.
+    let provider_names: std::collections::HashMap<String, String> = state
+        .aggregator
+        .get_zones()
+        .await
+        .into_iter()
+        .map(|z| (z.zone_id, z.zone_name))
+        .collect();
+
+    let zones = crate::zone_list::manageable_zones(&state)
+        .await
+        .into_iter()
+        .map(|z| {
+            let provider_name = provider_names
+                .get(&z.zone_id)
+                .cloned()
+                .unwrap_or_else(|| z.zone_name.clone());
+            ManagedZone {
+                hidden: hidden.contains(z.zone_id.as_str()),
+                renamed: provider_name != z.zone_name,
+                provider_name,
+                zone_id: z.zone_id,
+                zone_name: z.zone_name,
+                source: z.source,
+            }
+        })
+        .collect();
+
+    Json(ManagedZonesResponse { zones })
+}
+
+/// `POST /api/zones/visibility` request body.
+#[derive(Debug, Deserialize)]
+pub struct ZoneVisibilityRequest {
+    pub zone_id: String,
+    pub hidden: bool,
+}
+
+/// `POST /api/zones/name` request body.
+#[derive(Debug, Deserialize)]
+pub struct ZoneNameRequest {
+    pub zone_id: String,
+    /// The new display name. Empty, whitespace-only, or absent clears the override and restores the
+    /// provider's own name — so there is always a way back without a separate "reset" control.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// POST /api/zones/name - rename a zone, or clear the rename.
+///
+/// The override lives in UHC only; nothing is written back to Roon or LMS. Since the rename is
+/// applied before sorting, prefixing several zones with a common string ("Basement - ") groups them
+/// in every list, which is the main reason this exists.
+pub async fn zone_name_post(Json(req): Json<ZoneNameRequest>) -> impl IntoResponse {
+    let mut settings = load_app_settings();
+    let mut names = settings.zone_names.take().unwrap_or_default();
+
+    let trimmed = req.name.as_deref().map(str::trim).unwrap_or("");
+    if trimmed.is_empty() {
+        names.remove(&req.zone_id);
+    } else if trimmed.chars().count() > MAX_ZONE_NAME_CHARS {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": format!("Zone names are limited to {MAX_ZONE_NAME_CHARS} characters.")
+            })),
+        );
+    } else {
+        names.insert(req.zone_id.clone(), trimmed.to_string());
+    }
+
+    settings.zone_names = Some(names);
+
+    if !save_app_settings(&settings) {
+        // See `zone_order_post` for why this is a 500, not `200 {"ok": false}`.
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "Could not save the zone name. Check that the config directory is writable."
+            })),
+        );
+    }
+
+    tracing::info!(zone_id = %req.zone_id, renamed = !trimmed.is_empty(), "Zone name updated");
+
+    (StatusCode::OK, Json(serde_json::json!({"ok": true})))
+}
+
+/// Long enough for "Basement - Left Channel Monoblock", short enough that a name cannot break the
+/// layout of a zone list or a knob's small display.
+const MAX_ZONE_NAME_CHARS: usize = 60;
+
+/// `POST /api/zones/order` request body.
+#[derive(Debug, Deserialize)]
+pub struct ZoneOrderRequest {
+    pub zone_id: String,
+    pub direction: crate::zone_list::MoveDirection,
+}
+
+/// POST /api/zones/order - move one zone one place up or down.
+///
+/// Takes a zone and a direction rather than a whole ordered list. Two reasons: the client does not
+/// have to reconstruct an order it only partly knows (hidden zones are in the order too), and two
+/// browser tabs each nudging a different zone both land, where whole-list writes would have the
+/// second silently discard the first.
+pub async fn zone_order_post(
+    State(state): State<AppState>,
+    Json(req): Json<ZoneOrderRequest>,
+) -> impl IntoResponse {
+    // The order is computed over *manageable* zones, hidden ones included, so that hiding a zone
+    // and later unhiding it puts it back where the user had placed it rather than at the end.
+    let effective = crate::zone_list::manageable_zones(&state).await;
+    let mut settings = load_app_settings();
+    let hidden_ids: Vec<String> = settings.hidden_zone_ids().to_vec();
+    let hidden: std::collections::HashSet<&str> = hidden_ids.iter().map(String::as_str).collect();
+
+    let Some(new_order) =
+        crate::zone_list::reorder(&effective, &req.zone_id, req.direction, &hidden)
+    else {
+        // Already at the end it was moved toward, or no such zone. A no-op, not an error -- but say
+        // so, since the UI announces "already first" rather than silently doing nothing.
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "ok": true,
+                "moved": false,
+                "zone_order": hidden_ids_order(&settings),
+            })),
+        );
+    };
+
+    settings.zone_order = Some(new_order.clone());
+
+    if !save_app_settings(&settings) {
+        // A real 500. Returning 200 with `{"ok": false}` would be indistinguishable from success to
+        // any client that checks the HTTP status -- and a settings page that silently discards
+        // writes is worse than one that refuses them. A read-only bind-mounted config directory is
+        // a common Docker misconfiguration, so this path is reachable in normal use.
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "Could not save the zone order. Check that the config directory is writable."
+            })),
+        );
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({"ok": true, "moved": true, "zone_order": new_order})),
+    )
+}
+
+fn hidden_ids_order(settings: &AppSettings) -> Vec<String> {
+    settings.zone_order_ids().to_vec()
+}
+
+/// POST /api/zones/visibility - hide or unhide a single zone.
+///
+/// Deliberately not folded into `POST /api/settings`. That endpoint takes a whole `AppSettings`, so
+/// a caller wanting only to hide a zone would have to send every other setting too — and
+/// `AdapterSettings::default()` is all-false, so a body that omitted `adapters` would silently
+/// disable Roon. A one-zone toggle also has no read-modify-write window: two browser tabs hiding
+/// different zones both land, where posting a whole list would have the second overwrite the first.
+pub async fn zone_visibility_post(Json(req): Json<ZoneVisibilityRequest>) -> impl IntoResponse {
+    let mut settings = load_app_settings();
+    let mut hidden = settings.hidden_zones.take().unwrap_or_default();
+
+    if req.hidden {
+        if !hidden.contains(&req.zone_id) {
+            hidden.push(req.zone_id.clone());
+        }
+    } else {
+        hidden.retain(|id| *id != req.zone_id);
+    }
+    // Sorted so the persisted file has a stable shape regardless of the order zones were hidden in.
+    hidden.sort();
+    settings.hidden_zones = Some(hidden.clone());
+
+    if !save_app_settings(&settings) {
+        // See `zone_order_post` for why this is a 500 rather than `200 {"ok": false}`.
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "ok": false,
+                "error": "Could not save zone visibility. Check that the config directory is writable."
+            })),
+        );
+    }
+
+    tracing::info!(
+        zone_id = %req.zone_id,
+        hidden = req.hidden,
+        "Zone visibility updated"
+    );
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({"ok": true, "hidden_zones": hidden})),
+    )
 }
 
 #[cfg(test)]
@@ -2920,6 +3235,266 @@ mod tests {
         assert!(
             !settings.adapters.lms,
             "adapters.lms should be false without LMS_UNIFIEDHIFI_STARTED"
+        );
+    }
+
+    /// The whole reason `hidden_zones` is an `Option`.
+    ///
+    /// `POST /api/settings` saves its request body wholesale, and the settings page builds its
+    /// `AppSettings` from its own form fields -- which do not include hidden zones. With the
+    /// obvious `#[serde(default)] Vec<String>`, a body without the key deserialises to an empty
+    /// vec and wipes the list, so every adapter toggle would silently unhide every zone the user
+    /// had hidden. That implementation passes any test that posts a *complete* settings body; it
+    /// fails this one, which posts the partial body the real UI actually sends.
+    #[tokio::test]
+    #[serial]
+    async fn posting_settings_without_hidden_zones_preserves_the_hide_list() {
+        env::set_var("UHC_CONFIG_DIR", "/tmp/uhc-test-hidden-zones-carry-forward");
+
+        let mut seeded = AppSettings::default();
+        seeded.hidden_zones = Some(vec!["roon:phone".to_string()]);
+        seeded.zone_order = Some(vec!["roon:kitchen".to_string()]);
+        assert!(save_app_settings(&seeded), "failed to seed settings");
+
+        // Exactly what the settings page sends: adapters and page flags, no zone fields at all.
+        let from_the_ui: AppSettings = serde_json::from_value(serde_json::json!({
+            "hide_knobs_page": false,
+            "hide_hqp_page": false,
+            "hide_lms_page": false,
+            "adapters": { "roon": true, "upnp": false, "openhome": false, "lms": true, "hqplayer": false }
+        }))
+        .expect("the settings page's body must deserialise");
+        assert!(
+            from_the_ui.hidden_zones.is_none(),
+            "sanity: a body without the key must arrive as None, not as an empty list"
+        );
+
+        let state = app_state_with_startable(Arc::new(FakeAdapter("lms"))).await;
+        let _ = api_settings_post_handler(State(state), Json(from_the_ui)).await;
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        assert_eq!(
+            after.hidden_zone_ids(),
+            ["roon:phone".to_string()],
+            "toggling an adapter must not erase the hide list"
+        );
+        assert_eq!(
+            after.zone_order_ids(),
+            ["roon:kitchen".to_string()],
+            "toggling an adapter must not erase the zone order"
+        );
+        assert!(
+            after.adapters.lms,
+            "the change actually being made must land"
+        );
+    }
+
+    /// The other half of the `Option`: an explicit empty list is a real instruction, not silence.
+    #[tokio::test]
+    #[serial]
+    async fn posting_an_explicit_empty_hide_list_clears_it() {
+        env::set_var(
+            "UHC_CONFIG_DIR",
+            "/tmp/uhc-test-hidden-zones-explicit-clear",
+        );
+
+        let mut seeded = AppSettings::default();
+        seeded.hidden_zones = Some(vec!["roon:phone".to_string()]);
+        assert!(save_app_settings(&seeded), "failed to seed settings");
+
+        let mut clearing = AppSettings::default();
+        clearing.hidden_zones = Some(vec![]);
+
+        let state = app_state_with_startable(Arc::new(FakeAdapter("lms"))).await;
+        let _ = api_settings_post_handler(State(state), Json(clearing)).await;
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        assert!(
+            after.hidden_zone_ids().is_empty(),
+            "an explicit empty list must clear the hide list, got {:?}",
+            after.hidden_zone_ids()
+        );
+    }
+
+    /// Hiding is idempotent and unhiding is exact -- a double-click must not stack duplicates, and
+    /// unhiding one zone must not disturb the others.
+    #[tokio::test]
+    #[serial]
+    async fn zone_visibility_toggling_is_idempotent() {
+        env::set_var("UHC_CONFIG_DIR", "/tmp/uhc-test-zone-visibility-idempotent");
+        assert!(
+            save_app_settings(&AppSettings::default()),
+            "failed to seed settings"
+        );
+
+        for _ in 0..3 {
+            let _ = zone_visibility_post(Json(ZoneVisibilityRequest {
+                zone_id: "roon:phone".to_string(),
+                hidden: true,
+            }))
+            .await;
+        }
+        let _ = zone_visibility_post(Json(ZoneVisibilityRequest {
+            zone_id: "lms:laptop".to_string(),
+            hidden: true,
+        }))
+        .await;
+
+        assert_eq!(
+            load_app_settings().hidden_zone_ids(),
+            ["lms:laptop".to_string(), "roon:phone".to_string()],
+            "hiding twice must not duplicate the entry"
+        );
+
+        let _ = zone_visibility_post(Json(ZoneVisibilityRequest {
+            zone_id: "roon:phone".to_string(),
+            hidden: false,
+        }))
+        .await;
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        assert_eq!(
+            after.hidden_zone_ids(),
+            ["lms:laptop".to_string()],
+            "unhiding one zone must leave the others hidden"
+        );
+    }
+
+    /// Renaming with an empty name clears the override rather than storing an empty string.
+    ///
+    /// Storing `""` would leave a nameless row in every zone list with no way back short of hand
+    /// editing JSON -- and "clear the field to reset" is the only reset affordance in the UI.
+    #[tokio::test]
+    #[serial]
+    async fn clearing_a_zone_name_restores_the_provider_name() {
+        env::set_var("UHC_CONFIG_DIR", "/tmp/uhc-test-zone-rename-clear");
+        assert!(
+            save_app_settings(&AppSettings::default()),
+            "failed to seed settings"
+        );
+
+        let _ = zone_name_post(Json(ZoneNameRequest {
+            zone_id: "roon:kitchen".to_string(),
+            name: Some("Basement - Kitchen".to_string()),
+        }))
+        .await;
+        assert_eq!(
+            load_app_settings().custom_zone_name("roon:kitchen"),
+            Some("Basement - Kitchen")
+        );
+
+        for cleared in [Some(String::new()), Some("   ".to_string()), None] {
+            let _ = zone_name_post(Json(ZoneNameRequest {
+                zone_id: "roon:kitchen".to_string(),
+                name: cleared.clone(),
+            }))
+            .await;
+            assert_eq!(
+                load_app_settings().custom_zone_name("roon:kitchen"),
+                None,
+                "{cleared:?} must clear the override, not store it"
+            );
+
+            let _ = zone_name_post(Json(ZoneNameRequest {
+                zone_id: "roon:kitchen".to_string(),
+                name: Some("Basement - Kitchen".to_string()),
+            }))
+            .await;
+        }
+
+        env::remove_var("UHC_CONFIG_DIR");
+    }
+
+    /// A name is trimmed on the way in, so " Kitchen " and "Kitchen" cannot sort differently.
+    #[tokio::test]
+    #[serial]
+    async fn zone_names_are_trimmed() {
+        env::set_var("UHC_CONFIG_DIR", "/tmp/uhc-test-zone-rename-trim");
+        assert!(
+            save_app_settings(&AppSettings::default()),
+            "failed to seed settings"
+        );
+
+        let _ = zone_name_post(Json(ZoneNameRequest {
+            zone_id: "roon:kitchen".to_string(),
+            name: Some("   Basement - Kitchen  ".to_string()),
+        }))
+        .await;
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        assert_eq!(
+            after.custom_zone_name("roon:kitchen"),
+            Some("Basement - Kitchen")
+        );
+    }
+
+    /// An over-long name is refused rather than truncated, and nothing is written.
+    #[tokio::test]
+    #[serial]
+    async fn an_over_long_zone_name_is_refused() {
+        env::set_var("UHC_CONFIG_DIR", "/tmp/uhc-test-zone-rename-too-long");
+        assert!(
+            save_app_settings(&AppSettings::default()),
+            "failed to seed settings"
+        );
+
+        let response = zone_name_post(Json(ZoneNameRequest {
+            zone_id: "roon:kitchen".to_string(),
+            name: Some("x".repeat(MAX_ZONE_NAME_CHARS + 1)),
+        }))
+        .await
+        .into_response();
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            after.custom_zone_name("roon:kitchen"),
+            None,
+            "a refused rename must not be persisted"
+        );
+    }
+
+    /// A failed save must be an HTTP error, not `200 {"ok": false}`.
+    ///
+    /// The client checks the HTTP status; a 200 with a falsy body is indistinguishable from success
+    /// to it, which is how a settings page ends up silently discarding writes. Exercised through a
+    /// config directory that cannot be created, standing in for the read-only bind mount that makes
+    /// this reachable in normal Docker use.
+    #[tokio::test]
+    #[serial]
+    async fn an_unwritable_config_directory_produces_a_server_error() {
+        // A path under a *file* can never be created as a directory.
+        let blocker = std::env::temp_dir().join("uhc-test-unwritable-config-blocker");
+        std::fs::write(&blocker, b"not a directory").expect("write blocker file");
+        env::set_var(
+            "UHC_CONFIG_DIR",
+            blocker.join("nested").to_string_lossy().as_ref(),
+        );
+
+        let response = zone_visibility_post(Json(ZoneVisibilityRequest {
+            zone_id: "roon:phone".to_string(),
+            hidden: true,
+        }))
+        .await
+        .into_response();
+
+        env::remove_var("UHC_CONFIG_DIR");
+        let _ = std::fs::remove_file(&blocker);
+
+        assert_eq!(
+            response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a save failure must surface as an HTTP error the client can detect"
         );
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2667,24 +2667,73 @@ pub fn load_app_settings() -> AppSettings {
     settings
 }
 
+/// Serialises every read-modify-write of `app-settings.json`.
+///
+/// The zone handlers each load the settings, change one field, and save the whole file. Without a
+/// lock, two requests that overlap both read the same starting state and the second save discards
+/// the first change — so hiding two zones in quick succession, or two browser tabs editing
+/// different zones, can silently keep only one. Splitting the API into one-zone-per-request (rather
+/// than whole-list writes) narrows that window but does not close it; this does.
+static SETTINGS_WRITE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Load the settings, apply `mutate`, and save — atomically with respect to other callers.
+///
+/// Every zone-settings mutation goes through here. The load happens *inside* the lock, which is the
+/// point: a caller that loaded beforehand would be acting on state that another writer may already
+/// have replaced.
+fn mutate_app_settings(mutate: impl FnOnce(&mut AppSettings)) -> bool {
+    let _guard = SETTINGS_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut settings = load_app_settings();
+    mutate(&mut settings);
+    save_app_settings_locked(&settings)
+}
+
+/// Overwrite the settings wholesale. Test-only on purpose.
+///
+/// Production writes go through [`mutate_app_settings`], which reads the current state inside the
+/// lock. A blind overwrite is safe only when the caller knows nothing else is writing — true for a
+/// test seeding a temp config directory, and not true anywhere else.
+#[cfg(test)]
 fn save_app_settings(settings: &AppSettings) -> bool {
+    let _guard = SETTINGS_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    save_app_settings_locked(settings)
+}
+
+/// The actual write. Callers must already hold [`SETTINGS_WRITE_LOCK`].
+fn save_app_settings_locked(settings: &AppSettings) -> bool {
     let path = settings_path();
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    match serde_json::to_string_pretty(settings) {
-        Ok(json) => match std::fs::write(&path, json) {
-            Ok(()) => {
-                tracing::info!("Saved app settings");
-                true
-            }
-            Err(e) => {
-                tracing::error!("Failed to save app settings: {}", e);
-                false
-            }
-        },
+    let json = match serde_json::to_string_pretty(settings) {
+        Ok(json) => json,
         Err(e) => {
             tracing::error!("Failed to serialize app settings: {}", e);
+            return false;
+        }
+    };
+
+    // Write-then-rename, so a crash or a full disk mid-write cannot leave a truncated
+    // `app-settings.json` behind. `std::fs::write` truncates in place, which on the config file
+    // holding every adapter toggle and the zone hide list means a bad moment costs the user their
+    // whole configuration. The temp file is a sibling so the rename stays within one filesystem.
+    let temp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&temp, &json) {
+        tracing::error!("Failed to write app settings: {}", e);
+        return false;
+    }
+    match std::fs::rename(&temp, &path) {
+        Ok(()) => {
+            tracing::info!("Saved app settings");
+            true
+        }
+        Err(e) => {
+            tracing::error!("Failed to replace app settings: {}", e);
+            let _ = std::fs::remove_file(&temp);
             false
         }
     }
@@ -2700,29 +2749,35 @@ pub async fn api_settings_post_handler(
     State(state): State<AppState>,
     Json(new_settings): Json<AppSettings>,
 ) -> impl IntoResponse {
-    // Load current settings to compare
-    let old_settings = load_app_settings();
-
-    // Carry the hide list forward when the body did not mention it. This endpoint saves its request
-    // body wholesale, and its main caller -- the settings page -- builds an `AppSettings` from its
-    // own form fields, which do not include hidden zones. Without this, toggling any adapter would
-    // unhide every zone the user had hidden. An explicit `"hidden_zones": []` still clears.
+    // Carry the zone fields forward when the body did not mention them. This endpoint saves its
+    // request body wholesale, and its main caller -- the settings page -- builds an `AppSettings`
+    // from its own form fields, which do not include the zone preferences. Without this, toggling
+    // any adapter would unhide every zone the user had hidden. An explicit `"hidden_zones": []`
+    // still clears.
+    //
+    // The merge happens inside the write lock, and reads the settings from inside it too. Doing the
+    // load outside would reintroduce exactly the race the carry-forward exists to prevent: a zone
+    // hidden between the load and the save would be carried forward from stale state and lost.
     let mut new_settings = new_settings;
-    if new_settings.hidden_zones.is_none() {
-        new_settings.hidden_zones = old_settings.hidden_zones.clone();
-    }
-    if new_settings.zone_order.is_none() {
-        new_settings.zone_order = old_settings.zone_order.clone();
-    }
-    if new_settings.zone_names.is_none() {
-        new_settings.zone_names = old_settings.zone_names.clone();
-    }
-    let new_settings = new_settings;
+    let mut old_settings = AppSettings::default();
+    let saved = mutate_app_settings(|current| {
+        old_settings = current.clone();
+        if new_settings.hidden_zones.is_none() {
+            new_settings.hidden_zones = current.hidden_zones.clone();
+        }
+        if new_settings.zone_order.is_none() {
+            new_settings.zone_order = current.zone_order.clone();
+        }
+        if new_settings.zone_names.is_none() {
+            new_settings.zone_names = current.zone_names.clone();
+        }
+        *current = new_settings.clone();
+    });
 
-    // Save the new settings
-    if !save_app_settings(&new_settings) {
+    if !saved {
         return Json(serde_json::json!({"ok": false, "error": "Failed to save settings"}));
     }
+    let new_settings = new_settings;
 
     // Compare adapter enabled states and start/stop as needed
     let old_adapters = &old_settings.adapters;
@@ -2860,22 +2915,10 @@ pub async fn zone_visibility_get(State(state): State<AppState>) -> impl IntoResp
     Json(ManagedZonesResponse { zones })
 }
 
-/// `POST /api/zones/visibility` request body.
-#[derive(Debug, Deserialize)]
-pub struct ZoneVisibilityRequest {
-    pub zone_id: String,
-    pub hidden: bool,
-}
-
-/// `POST /api/zones/name` request body.
-#[derive(Debug, Deserialize)]
-pub struct ZoneNameRequest {
-    pub zone_id: String,
-    /// The new display name. Empty, whitespace-only, or absent clears the override and restores the
-    /// provider's own name — so there is always a way back without a separate "reset" control.
-    #[serde(default)]
-    pub name: Option<String>,
-}
+// The zone request bodies are defined once, in `crate::app::api`, and shared with the client that
+// sends them. `src/app` is not feature-gated, so the server compiles it too. Redefining them here
+// would let a field name drift into a 422 the UI could not explain.
+pub use crate::app::api::{ZoneNameRequest, ZoneOrderRequest, ZoneVisibilityRequest};
 
 /// POST /api/zones/name - rename a zone, or clear the rename.
 ///
@@ -2883,13 +2926,10 @@ pub struct ZoneNameRequest {
 /// applied before sorting, prefixing several zones with a common string ("Basement - ") groups them
 /// in every list, which is the main reason this exists.
 pub async fn zone_name_post(Json(req): Json<ZoneNameRequest>) -> impl IntoResponse {
-    let mut settings = load_app_settings();
-    let mut names = settings.zone_names.take().unwrap_or_default();
+    let trimmed = req.name.as_deref().map(str::trim).unwrap_or("").to_string();
 
-    let trimmed = req.name.as_deref().map(str::trim).unwrap_or("");
-    if trimmed.is_empty() {
-        names.remove(&req.zone_id);
-    } else if trimmed.chars().count() > MAX_ZONE_NAME_CHARS {
+    // Validate before taking the write lock: a rejected name must not hold up other writers.
+    if trimmed.chars().count() > MAX_ZONE_NAME_CHARS {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
@@ -2897,13 +2937,19 @@ pub async fn zone_name_post(Json(req): Json<ZoneNameRequest>) -> impl IntoRespon
                 "error": format!("Zone names are limited to {MAX_ZONE_NAME_CHARS} characters.")
             })),
         );
-    } else {
-        names.insert(req.zone_id.clone(), trimmed.to_string());
     }
 
-    settings.zone_names = Some(names);
+    let saved = mutate_app_settings(|settings| {
+        let mut names = settings.zone_names.take().unwrap_or_default();
+        if trimmed.is_empty() {
+            names.remove(&req.zone_id);
+        } else {
+            names.insert(req.zone_id.clone(), trimmed.clone());
+        }
+        settings.zone_names = Some(names);
+    });
 
-    if !save_app_settings(&settings) {
+    if !saved {
         // See `zone_order_post` for why this is a 500, not `200 {"ok": false}`.
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -2923,22 +2969,6 @@ pub async fn zone_name_post(Json(req): Json<ZoneNameRequest>) -> impl IntoRespon
 /// layout of a zone list or a knob's small display.
 const MAX_ZONE_NAME_CHARS: usize = 60;
 
-/// `POST /api/zones/order` request body.
-#[derive(Debug, Deserialize)]
-pub struct ZoneOrderRequest {
-    pub zone_id: String,
-    /// Step one place. Used by the up/down buttons.
-    #[serde(default)]
-    pub direction: Option<crate::zone_list::MoveDirection>,
-    /// Take the slot this zone currently occupies. Used by drag-and-drop.
-    ///
-    /// A target *zone* rather than an index: the client's row indices can go stale between render
-    /// and drop if a zone appears or disappears, and a stale index would land the zone somewhere
-    /// the user did not point at, silently. A stale zone id simply resolves to nothing.
-    #[serde(default)]
-    pub target_zone_id: Option<String>,
-}
-
 /// POST /api/zones/order - move one zone one place up or down.
 ///
 /// Takes a zone and a direction rather than a whole ordered list. Two reasons: the client does not
@@ -2952,7 +2982,7 @@ pub async fn zone_order_post(
     // The order is computed over *manageable* zones, hidden ones included, so that hiding a zone
     // and later unhiding it puts it back where the user had placed it rather than at the end.
     let effective = crate::zone_list::manageable_zones(&state).await;
-    let mut settings = load_app_settings();
+    let settings = load_app_settings();
     let hidden_ids: Vec<String> = settings.hidden_zone_ids().to_vec();
     let hidden: std::collections::HashSet<&str> = hidden_ids.iter().map(String::as_str).collect();
 
@@ -2966,8 +2996,9 @@ pub async fn zone_order_post(
     };
 
     let Some(new_order) = moved else {
-        // Already at the end it was moved toward, or no such zone. A no-op, not an error -- but say
-        // so, since the UI announces "already first" rather than silently doing nothing.
+        // Already at the end it was moved toward, or no such zone. A no-op, not an error -- and the
+        // UI reads `moved` to announce "already first" instead of claiming a move that never
+        // happened.
         return (
             StatusCode::OK,
             Json(serde_json::json!({
@@ -2978,9 +3009,8 @@ pub async fn zone_order_post(
         );
     };
 
-    settings.zone_order = Some(new_order.clone());
-
-    if !save_app_settings(&settings) {
+    let order_to_save = new_order.clone();
+    if !mutate_app_settings(move |settings| settings.zone_order = Some(order_to_save)) {
         // A real 500. Returning 200 with `{"ok": false}` would be indistinguishable from success to
         // any client that checks the HTTP status -- and a settings page that silently discards
         // writes is worse than one that refuses them. A read-only bind-mounted config directory is
@@ -3009,24 +3039,29 @@ fn hidden_ids_order(settings: &AppSettings) -> Vec<String> {
 /// Deliberately not folded into `POST /api/settings`. That endpoint takes a whole `AppSettings`, so
 /// a caller wanting only to hide a zone would have to send every other setting too — and
 /// `AdapterSettings::default()` is all-false, so a body that omitted `adapters` would silently
-/// disable Roon. A one-zone toggle also has no read-modify-write window: two browser tabs hiding
-/// different zones both land, where posting a whole list would have the second overwrite the first.
+/// disable Roon. A one-zone toggle also keeps the read-modify-write window as small as it can be:
+/// two browser tabs hiding different zones both land, because each request states only its own
+/// change and [`mutate_app_settings`] serialises the merge. Posting a whole list instead would have
+/// the second write overwrite the first no matter how the server locked.
 pub async fn zone_visibility_post(Json(req): Json<ZoneVisibilityRequest>) -> impl IntoResponse {
-    let mut settings = load_app_settings();
-    let mut hidden = settings.hidden_zones.take().unwrap_or_default();
-
-    if req.hidden {
-        if !hidden.contains(&req.zone_id) {
-            hidden.push(req.zone_id.clone());
+    let mut hidden = Vec::new();
+    let saved = mutate_app_settings(|settings| {
+        let mut list = settings.hidden_zones.take().unwrap_or_default();
+        if req.hidden {
+            if !list.contains(&req.zone_id) {
+                list.push(req.zone_id.clone());
+            }
+        } else {
+            list.retain(|id| *id != req.zone_id);
         }
-    } else {
-        hidden.retain(|id| *id != req.zone_id);
-    }
-    // Sorted so the persisted file has a stable shape regardless of the order zones were hidden in.
-    hidden.sort();
-    settings.hidden_zones = Some(hidden.clone());
+        // Sorted so the persisted file has a stable shape regardless of the order zones were hidden
+        // in.
+        list.sort();
+        hidden = list.clone();
+        settings.hidden_zones = Some(list);
+    });
 
-    if !save_app_settings(&settings) {
+    if !saved {
         // See `zone_order_post` for why this is a 500 rather than `200 {"ok": false}`.
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -3477,6 +3512,53 @@ mod tests {
             after.custom_zone_name("roon:kitchen"),
             None,
             "a refused rename must not be persisted"
+        );
+    }
+
+    /// Concurrent hides must all survive.
+    ///
+    /// Each handler loads the settings, adds one zone, and saves the whole file. Without a lock
+    /// spanning that read-modify-write, two overlapping requests both read the same starting list
+    /// and the second save discards the first zone — so hiding several zones quickly, or from two
+    /// browser tabs, silently keeps only some of them. One-zone-per-request narrows the window; it
+    /// does not close it, and this test fails any implementation that relies on the narrowing.
+    ///
+    /// `multi_thread` is load-bearing. The handlers' read-modify-write contains no `.await`, so on
+    /// the default current-thread runtime the tasks would run to completion one at a time and this
+    /// would pass against the racy implementation it exists to catch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[serial]
+    async fn concurrent_hides_do_not_overwrite_each_other() {
+        env::set_var("UHC_CONFIG_DIR", "/tmp/uhc-test-zone-visibility-concurrent");
+        assert!(
+            save_app_settings(&AppSettings::default()),
+            "failed to seed settings"
+        );
+
+        let zone_ids: Vec<String> = (0..12).map(|i| format!("roon:zone-{i:02}")).collect();
+        let mut handles = Vec::new();
+        for zone_id in zone_ids.clone() {
+            handles.push(tokio::spawn(async move {
+                zone_visibility_post(Json(ZoneVisibilityRequest {
+                    zone_id,
+                    hidden: true,
+                }))
+                .await;
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("hide task panicked");
+        }
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        let mut expected = zone_ids;
+        expected.sort();
+        assert_eq!(
+            after.hidden_zone_ids(),
+            expected.as_slice(),
+            "every concurrent hide must survive; lost entries mean the read-modify-write raced"
         );
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2717,15 +2717,35 @@ fn save_app_settings_locked(settings: &AppSettings) -> bool {
         }
     };
 
-    // Write-then-rename, so a crash or a full disk mid-write cannot leave a truncated
-    // `app-settings.json` behind. `std::fs::write` truncates in place, which on the config file
-    // holding every adapter toggle and the zone hide list means a bad moment costs the user their
-    // whole configuration. The temp file is a sibling so the rename stays within one filesystem.
+    // Write to a sibling temp file, flush it to disk, then rename over the target. Writing in place
+    // with `std::fs::write` truncates first, so a crash or a full disk between the truncate and the
+    // last byte costs the user every adapter toggle, hide-list entry, and zone name at once.
+    //
+    // All three steps matter and none of them substitutes for another:
+    //
+    // - The temp file is a *sibling* so the rename stays within one filesystem. `rename(2)` across
+    //   devices fails outright.
+    // - `sync_all` before the rename is what makes the guarantee real. `rename` is atomic for the
+    //   name only; it says nothing about whether the temp file's bytes have reached the disk. Skip
+    //   the flush and a power loss can leave the renamed file empty or half-written on ext4,
+    //   XFS, and APFS alike — the exact corruption the temp file was supposed to prevent.
+    // - Cleaning up on rename failure keeps a stale `.json.tmp` from accumulating.
+    //
+    // Not covered: the directory entry created by the rename is itself unflushed, so a power loss
+    // right after can lose the *new* settings. That is acceptable — the user sees their previous
+    // configuration, not a damaged one, which is the property this is protecting.
     let temp = path.with_extension("json.tmp");
-    if let Err(e) = std::fs::write(&temp, &json) {
+    let written = std::fs::File::create(&temp).and_then(|mut file| {
+        use std::io::Write;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()
+    });
+    if let Err(e) = written {
         tracing::error!("Failed to write app settings: {}", e);
+        let _ = std::fs::remove_file(&temp);
         return false;
     }
+
     match std::fs::rename(&temp, &path) {
         Ok(()) => {
             tracing::info!("Saved app settings");
@@ -3560,6 +3580,57 @@ mod tests {
             expected.as_slice(),
             "every concurrent hide must survive; lost entries mean the read-modify-write raced"
         );
+    }
+
+    /// A successful save leaves no `.json.tmp` behind, and the file it wrote is complete.
+    ///
+    /// The durable-replace path writes a sibling temp file, flushes it, and renames over the
+    /// target. A rename that silently failed to move the temp file — or a code path that wrote the
+    /// temp and forgot the rename — would leave the config unchanged while reporting success, with
+    /// a stray temp file as the only evidence.
+    #[tokio::test]
+    #[serial]
+    async fn saving_settings_leaves_no_temp_file_behind() {
+        let dir = std::env::temp_dir().join("uhc-test-settings-durable-replace");
+        let _ = std::fs::remove_dir_all(&dir);
+        env::set_var("UHC_CONFIG_DIR", dir.to_string_lossy().as_ref());
+
+        let _ = zone_visibility_post(Json(ZoneVisibilityRequest {
+            zone_id: "roon:phone".to_string(),
+            hidden: true,
+        }))
+        .await;
+
+        let written = load_app_settings();
+        let strays: Vec<_> = walk_config_files(&dir)
+            .into_iter()
+            .filter(|name| name.ends_with(".tmp"))
+            .collect();
+        env::remove_var("UHC_CONFIG_DIR");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            written.hidden_zone_ids(),
+            ["roon:phone".to_string()],
+            "the rename must have published the new contents"
+        );
+        assert!(strays.is_empty(), "temp files left behind: {strays:?}");
+    }
+
+    fn walk_config_files(dir: &std::path::Path) -> Vec<String> {
+        let mut found = Vec::new();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return found;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                found.extend(walk_config_files(&path));
+            } else {
+                found.push(path.to_string_lossy().into_owned());
+            }
+        }
+        found
     }
 
     /// A failed save must be an HTTP error, not `200 {"ok": false}`.

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -133,7 +133,30 @@ pub struct ZoneVisibilityRequest {
 #[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct ZoneOrderRequest {
     pub zone_id: String,
-    pub direction: MoveDirection,
+    /// Step one place — the up/down buttons.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<MoveDirection>,
+    /// Take this zone's slot — a drag-and-drop drop.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_zone_id: Option<String>,
+}
+
+impl ZoneOrderRequest {
+    pub fn step(zone_id: String, direction: MoveDirection) -> Self {
+        Self {
+            zone_id,
+            direction: Some(direction),
+            target_zone_id: None,
+        }
+    }
+
+    pub fn drop_onto(zone_id: String, target_zone_id: String) -> Self {
+        Self {
+            zone_id,
+            direction: None,
+            target_zone_id: Some(target_zone_id),
+        }
+    }
 }
 
 /// Shared with the server's `zone_list::MoveDirection`, so a typo is a compile error rather than a

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -76,6 +76,82 @@ pub struct Zone {
     pub dsp: Option<ZoneDsp>,
 }
 
+// =============================================================================
+// Zone management types (`/api/zones/visibility`, `/api/zones/order`)
+// =============================================================================
+
+/// One row of the zone management list. Unlike [`Zone`], this includes zones the user has hidden —
+/// the management view is the one place that must show them, or unhiding would be impossible.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct ManagedZone {
+    pub zone_id: String,
+    /// The effective display name: the user's override when set, otherwise the provider's.
+    pub zone_name: String,
+    /// What Roon/LMS/etc. calls this zone, so a renamed zone can still be identified.
+    #[serde(default)]
+    pub provider_name: String,
+    #[serde(default)]
+    pub renamed: bool,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub hidden: bool,
+}
+
+impl ManagedZone {
+    /// Name plus provider, for accessible labels. Zone names are not unique — the same room name on
+    /// two providers is common in this product — so a bare name would produce two controls with
+    /// identical accessible names and no way to tell them apart by ear.
+    pub fn qualified_label(&self) -> String {
+        format!("{} ({})", self.zone_name, source_label(&self.source))
+    }
+}
+
+/// Provider ids as people know them, matching the Features table's spelling.
+pub fn source_label(source: &str) -> &str {
+    match source {
+        "roon" => "Roon",
+        "lms" => "LMS",
+        "hqplayer" => "HQPlayer",
+        "openhome" => "OpenHome",
+        "upnp" => "UPnP",
+        other => other,
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct ManagedZonesResponse {
+    pub zones: Vec<ManagedZone>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct ZoneVisibilityRequest {
+    pub zone_id: String,
+    pub hidden: bool,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct ZoneOrderRequest {
+    pub zone_id: String,
+    pub direction: MoveDirection,
+}
+
+/// Shared with the server's `zone_list::MoveDirection`, so a typo is a compile error rather than a
+/// 422 the UI would discard.
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MoveDirection {
+    Up,
+    Down,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct ZoneNameRequest {
+    pub zone_id: String,
+    /// `None` or empty clears the override and restores the provider's name.
+    pub name: Option<String>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct ZoneDsp {
     pub r#type: Option<String>,

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -124,20 +124,31 @@ pub struct ManagedZonesResponse {
     pub zones: Vec<ManagedZone>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+/// `POST /api/zones/visibility`.
+///
+/// The zone request types are defined once and used by both sides: `src/app` serialises them and
+/// `src/api` deserialises them in its handlers. `src/app` is not feature-gated, so the server
+/// compiles this module too. Two parallel definitions would let a field name or an enum spelling
+/// drift into a 422 that the UI has no way to explain.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ZoneVisibilityRequest {
     pub zone_id: String,
     pub hidden: bool,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+/// `POST /api/zones/order`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ZoneOrderRequest {
     pub zone_id: String,
     /// Step one place — the up/down buttons.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub direction: Option<MoveDirection>,
-    /// Take this zone's slot — a drag-and-drop drop.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Take the slot this zone currently occupies — a drag-and-drop drop.
+    ///
+    /// A target *zone* rather than an index: the client's row indices can go stale between render
+    /// and drop if a zone appears or disappears, and a stale index would land the zone somewhere
+    /// the user did not point at, silently. A stale zone id simply resolves to nothing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_zone_id: Option<String>,
 }
 
@@ -159,19 +170,21 @@ impl ZoneOrderRequest {
     }
 }
 
-/// Shared with the server's `zone_list::MoveDirection`, so a typo is a compile error rather than a
-/// 422 the UI would discard.
-#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+/// Which way a step-reorder moves a zone. Re-exported by `crate::zone_list` for the server side.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum MoveDirection {
     Up,
     Down,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+/// `POST /api/zones/name`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ZoneNameRequest {
     pub zone_id: String,
-    /// `None` or empty clears the override and restores the provider's name.
+    /// `None`, empty, or whitespace-only clears the override and restores the provider's name — so
+    /// there is always a way back without a separate "reset" endpoint.
+    #[serde(default)]
     pub name: Option<String>,
 }
 

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -4,7 +4,12 @@
 
 use dioxus::prelude::*;
 
-use crate::app::api::{AdapterSettings, AppSettings, HqpStatus, LmsConfig, RoonStatus};
+use crate::app::api::{
+    source_label, AdapterSettings, AppSettings, HqpStatus, LmsConfig, ManagedZone,
+    ManagedZonesResponse, MoveDirection, RoonStatus, ZoneNameRequest, ZoneOrderRequest,
+    ZoneVisibilityRequest,
+};
+use crate::app::components::ErrorAlert;
 use crate::app::components::Layout;
 use crate::app::settings_context::use_settings;
 use crate::app::sse::use_sse;
@@ -196,6 +201,123 @@ pub fn Settings() -> Element {
         }
     });
 
+    // Zone management: every zone the user can manage, hidden ones included. Deliberately not
+    // `/zones`, which excludes hidden zones -- this is the one view that has to show them, or
+    // hiding would be a one-way door.
+    let mut managed_zones = use_resource(|| async {
+        crate::app::api::fetch_json::<ManagedZonesResponse>("/api/zones/visibility")
+            .await
+            .ok()
+    });
+
+    // Announced to assistive tech after every zone change. Without it a screen-reader user presses
+    // "move up" and hears nothing at all -- the row moves silently.
+    let mut zone_status = use_signal(String::new);
+    let mut zone_error = use_signal(|| Option::<String>::None);
+    // Bumped on a failed write. It is part of each row's key, so a failure forces Dioxus to recreate
+    // the row's DOM nodes. Without that, a rejected checkbox click leaves the browser's natively
+    // toggled checkbox showing the opposite of the truth: the refetched data is unchanged, so the
+    // VDOM `checked` value is unchanged, so the diff emits no correcting mutation.
+    let mut zone_revision = use_signal(|| 0u32);
+
+    let mut report_zone_failure = move |err: String| {
+        zone_error.set(Some(err));
+        zone_revision += 1;
+    };
+
+    let set_zone_hidden = move |zone: ManagedZone| {
+        let label = zone.qualified_label();
+        let now_hidden = !zone.hidden;
+        spawn(async move {
+            let result = crate::app::api::post_json::<_, serde_json::Value>(
+                "/api/zones/visibility",
+                &ZoneVisibilityRequest {
+                    zone_id: zone.zone_id.clone(),
+                    hidden: now_hidden,
+                },
+            )
+            .await;
+            match result {
+                Ok(_) => {
+                    zone_error.set(None);
+                    zone_status.set(if now_hidden {
+                        format!("{label} hidden.")
+                    } else {
+                        format!("{label} shown.")
+                    });
+                }
+                Err(err) => report_zone_failure(err),
+            }
+            managed_zones.restart();
+        });
+    };
+
+    let move_zone = move |zone: ManagedZone, direction: MoveDirection, at_boundary: bool| {
+        let label = zone.qualified_label();
+        spawn(async move {
+            if at_boundary {
+                // The control stays focusable at the boundary rather than becoming `disabled`,
+                // because a disabled element cannot hold focus -- pressing "up" on the second row
+                // would move the zone to first, disable the button under the user's finger, and drop
+                // focus to <body>. Saying so is better than silence.
+                zone_status.set(match direction {
+                    MoveDirection::Up => format!("{label} is already first."),
+                    MoveDirection::Down => format!("{label} is already last."),
+                });
+                return;
+            }
+            let result = crate::app::api::post_json::<_, serde_json::Value>(
+                "/api/zones/order",
+                &ZoneOrderRequest {
+                    zone_id: zone.zone_id.clone(),
+                    direction,
+                },
+            )
+            .await;
+            match result {
+                Ok(_) => {
+                    zone_error.set(None);
+                    zone_status.set(match direction {
+                        MoveDirection::Up => format!("{label} moved up."),
+                        MoveDirection::Down => format!("{label} moved down."),
+                    });
+                }
+                Err(err) => report_zone_failure(err),
+            }
+            managed_zones.restart();
+        });
+    };
+
+    let rename_zone = move |zone: ManagedZone, name: String| {
+        let trimmed = name.trim().to_string();
+        if trimmed == zone.zone_name {
+            return;
+        }
+        spawn(async move {
+            let cleared = trimmed.is_empty();
+            let result = crate::app::api::post_json::<_, serde_json::Value>(
+                "/api/zones/name",
+                &ZoneNameRequest {
+                    zone_id: zone.zone_id.clone(),
+                    name: if cleared { None } else { Some(trimmed.clone()) },
+                },
+            )
+            .await;
+            match result {
+                Ok(_) => {
+                    zone_error.set(None);
+                    zone_status.set(if cleared {
+                        format!("Name reset to {}.", zone.provider_name)
+                    } else {
+                        format!("Renamed to {trimmed}.")
+                    });
+                }
+                Err(err) => report_zone_failure(err),
+            }
+            managed_zones.restart();
+        });
+    };
+
     // Discovery status resources
     let mut roon_status = use_resource(|| async {
         crate::app::api::fetch_json::<RoonStatus>("/roon/status")
@@ -234,6 +356,11 @@ pub fn Settings() -> Element {
             lms_config.restart();
             hqp_status.restart();
         }
+        // The zone set changes while the user is on this page -- they power on a speaker precisely
+        // because they are configuring it. Without this the table only updates on a manual reload.
+        if sse.should_refresh_zones() {
+            managed_zones.restart();
+        }
     });
 
     // Save settings handler
@@ -260,6 +387,10 @@ pub fn Settings() -> Element {
         };
         spawn(async move {
             let _ = crate::app::api::post_json_no_response("/api/settings", &settings).await;
+            // Enabling or disabling an adapter changes which zones are manageable, and the zone
+            // table sits directly below these toggles. Without this it keeps listing zones from an
+            // adapter the user just turned off.
+            managed_zones.restart();
         });
     };
 
@@ -484,6 +615,216 @@ pub fn Settings() -> Element {
                                 }
                                 td { class: "py-2 px-3", "Knobs" }
                                 td { class: "py-2 px-3 text-muted", "-" }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Zone management: name, visibility, and order.
+            section { class: "mb-8", aria_labelledby: "zones-heading",
+                div { class: "mb-4",
+                    h2 { id: "zones-heading", class: "text-xl font-semibold", "Zone list" }
+                    p { class: "text-muted text-sm",
+                        "Name your zones, choose which ones appear, and set their order. Applies everywhere — this app, knobs, and connected assistants."
+                    }
+                }
+
+                // Placed above the table, not below it. This is the sentence that defuses the
+                // "am I deleting my speaker?" moment, so it has to arrive before the checkbox
+                // rather than several screens below it on a long list. It also sits outside the
+                // loaded-and-non-empty branch, so it is present in every state.
+                p { class: "text-muted text-sm mb-4",
+                    "Hiding only removes a zone from lists. Nothing is deleted, a knob already pointing at it keeps working, and an assistant asked for it by name still finds it. A hidden zone keeps its place in the order, so showing it again puts it back where you left it."
+                }
+
+                if let Some(message) = zone_error() {
+                    ErrorAlert {
+                        message,
+                        on_dismiss: move |_| zone_error.set(None),
+                    }
+                }
+
+                // Announcements for assistive tech. Visually hidden: sighted users see the row
+                // move, which this exists to substitute for.
+                div {
+                    class: "sr-only",
+                    role: "status",
+                    aria_live: "polite",
+                    aria_atomic: "true",
+                    "{zone_status}"
+                }
+
+                div { class: "card overflow-x-auto p-4 sm:p-6",
+                    match managed_zones.read().as_ref() {
+                        None => rsx! {
+                            p { class: "text-muted py-2", role: "status", aria_live: "polite", "Loading zones…" }
+                        },
+                        Some(None) => rsx! {
+                            div { role: "alert",
+                                p { class: "status-err py-2 mb-3", "Could not load the zone list." }
+                                button {
+                                    r#type: "button",
+                                    class: "btn btn-outline btn-sm",
+                                    onclick: move |_| managed_zones.restart(),
+                                    "Try again"
+                                }
+                            }
+                        },
+                        Some(Some(response)) if response.zones.is_empty() => rsx! {
+                            p { class: "text-muted py-2",
+                                "No zones discovered yet. Check that an adapter is enabled above and connected."
+                            }
+                        },
+                        Some(Some(response)) => {
+                            let zones = response.zones.clone();
+                            let revision = zone_revision();
+                            // Positions count visible zones only, because that is the order every
+                            // other surface shows. Numbering hidden zones would promise an order
+                            // that nothing displays.
+                            let visible_total = zones.iter().filter(|z| !z.hidden).count();
+                            let mut visible_position = 0usize;
+                            let mut rows = Vec::with_capacity(zones.len());
+                            for zone in zones {
+                                let position = if zone.hidden {
+                                    None
+                                } else {
+                                    visible_position += 1;
+                                    Some(visible_position)
+                                };
+                                rows.push((zone, position));
+                            }
+                            let first_visible = rows.iter().position(|(z, _)| !z.hidden);
+                            let last_visible = rows.iter().rposition(|(z, _)| !z.hidden);
+
+                            rsx! {
+                                table { class: "w-full", id: "zones-table",
+                                    thead {
+                                        tr { class: "border-b border-default",
+                                            th { class: "text-left py-2 px-2 font-semibold w-12", "Show" }
+                                            th { class: "text-left py-2 px-2 font-semibold", "Name" }
+                                            th { class: "text-left py-2 px-2 font-semibold hidden sm:table-cell w-28", "Source" }
+                                            th { class: "text-right py-2 px-2 font-semibold w-32", "Position" }
+                                        }
+                                    }
+                                    tbody {
+                                        for (index, (zone, position)) in rows.into_iter().enumerate() {
+                                            tr {
+                                                key: "{zone.zone_id}-{revision}",
+                                                class: "border-b border-default",
+                                                td { class: "py-2 px-2 align-top",
+                                                    label { class: "inline-flex min-h-11 min-w-11 items-center justify-center -my-2 -mx-2",
+                                                        input {
+                                                            r#type: "checkbox",
+                                                            class: "checkbox",
+                                                            aria_label: "Show {zone.qualified_label()}",
+                                                            checked: !zone.hidden,
+                                                            onchange: {
+                                                                let zone = zone.clone();
+                                                                move |_| set_zone_hidden(zone.clone())
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                td { class: "py-2 px-2 align-top",
+                                                    input {
+                                                        r#type: "text",
+                                                        class: if zone.hidden { "input w-full text-muted" } else { "input w-full" },
+                                                        value: "{zone.zone_name}",
+                                                        maxlength: "60",
+                                                        aria_label: "Name for {zone.qualified_label()}",
+                                                        // Commits on blur and on Enter rather than
+                                                        // per keystroke: each save is a disk write
+                                                        // plus a full list refetch, and refetching
+                                                        // mid-word would fight the cursor.
+                                                        onchange: {
+                                                            let zone = zone.clone();
+                                                            move |evt: FormEvent| rename_zone(zone.clone(), evt.value())
+                                                        }
+                                                    }
+                                                    // Source lives here below `sm`, where the
+                                                    // column is hidden to buy back width for the
+                                                    // name field on a phone.
+                                                    div { class: "text-muted text-xs mt-1 sm:hidden", "{source_label(&zone.source)}" }
+                                                    if zone.renamed {
+                                                        div { class: "text-muted text-xs mt-1",
+                                                            "{zone.provider_name} · "
+                                                            button {
+                                                                r#type: "button",
+                                                                class: "underline",
+                                                                onclick: {
+                                                                    let zone = zone.clone();
+                                                                    move |_| rename_zone(zone.clone(), String::new())
+                                                                },
+                                                                "reset"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                td { class: "py-2 px-2 align-top text-muted hidden sm:table-cell", "{source_label(&zone.source)}" }
+                                                td { class: "py-2 px-2 align-top",
+                                                    div { class: "flex items-center justify-end gap-2",
+                                                        span { class: "text-muted text-sm tabular-nums",
+                                                            if let Some(position) = position {
+                                                                "{position} of {visible_total}"
+                                                            } else {
+                                                                "Hidden"
+                                                            }
+                                                        }
+                                                        {
+                                                            let at_top = Some(index) == first_visible;
+                                                            let at_bottom = Some(index) == last_visible;
+                                                            let up_zone = zone.clone();
+                                                            let down_zone = zone.clone();
+                                                            rsx! {
+                                                                // `aria-disabled`, not `disabled`:
+                                                                // a disabled control cannot hold
+                                                                // focus, so moving a zone to first
+                                                                // would disable the very button
+                                                                // that was just pressed and drop
+                                                                // focus to <body>. These stay
+                                                                // focusable and announce "already
+                                                                // first" instead.
+                                                                button {
+                                                                    r#type: "button",
+                                                                    class: if at_top { "btn btn-outline btn-sm opacity-45" } else { "btn btn-outline btn-sm" },
+                                                                    aria_disabled: if at_top { "true" } else { "false" },
+                                                                    aria_label: "Move {zone.qualified_label()} up",
+                                                                    onclick: move |_| move_zone(up_zone.clone(), MoveDirection::Up, at_top),
+                                                                    svg {
+                                                                        class: "w-4 h-4",
+                                                                        fill: "none",
+                                                                        view_box: "0 0 24 24",
+                                                                        stroke: "currentColor",
+                                                                        "stroke-width": "2",
+                                                                        "aria-hidden": "true",
+                                                                        path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M5 15l7-7 7 7" }
+                                                                    }
+                                                                }
+                                                                button {
+                                                                    r#type: "button",
+                                                                    class: if at_bottom { "btn btn-outline btn-sm opacity-45" } else { "btn btn-outline btn-sm" },
+                                                                    aria_disabled: if at_bottom { "true" } else { "false" },
+                                                                    aria_label: "Move {zone.qualified_label()} down",
+                                                                    onclick: move |_| move_zone(down_zone.clone(), MoveDirection::Down, at_bottom),
+                                                                    svg {
+                                                                        class: "w-4 h-4",
+                                                                        fill: "none",
+                                                                        view_box: "0 0 24 24",
+                                                                        stroke: "currentColor",
+                                                                        "stroke-width": "2",
+                                                                        "aria-hidden": "true",
+                                                                        path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M19 9l-7 7-7-7" }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -283,11 +283,22 @@ pub fn Settings() -> Element {
             )
             .await;
             match result {
-                Ok(_) => {
+                Ok(body) => {
                     zone_error.set(None);
-                    zone_status.set(match direction {
-                        MoveDirection::Up => format!("{label} moved up."),
-                        MoveDirection::Down => format!("{label} moved down."),
+                    // The server reports whether a swap actually happened. `at_boundary` above is
+                    // computed from the first/last *visible* rows, so a hidden row never matches it
+                    // and always sends a request -- and a hidden row that is already first has
+                    // nothing to swap with. Announcing "moved up" there would tell a screen-reader
+                    // user, who has no other feedback for this action, something untrue.
+                    let moved = body
+                        .get("moved")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(true);
+                    zone_status.set(match (moved, direction) {
+                        (true, MoveDirection::Up) => format!("{label} moved up."),
+                        (true, MoveDirection::Down) => format!("{label} moved down."),
+                        (false, MoveDirection::Up) => format!("{label} is already first."),
+                        (false, MoveDirection::Down) => format!("{label} is already last."),
                     });
                 }
                 Err(err) => report_zone_failure(err),
@@ -351,9 +362,17 @@ pub fn Settings() -> Element {
                 }
                 Err(err) => report_zone_failure(err),
             }
-            // Either way the server is now authoritative for this row: on success it holds the new
-            // name, on failure the old one, and in both cases that is what the field should show.
-            name_drafts.write().remove(&zone.zone_id);
+            // The server is now authoritative for this row -- but only for the text we submitted.
+            // The user can start typing again while the request is in flight, so drop the draft
+            // only if it still matches what was sent; otherwise the newer keystrokes would vanish
+            // and the field would snap back to the name they had just moved on from.
+            let stale = name_drafts
+                .read()
+                .get(&zone.zone_id)
+                .is_some_and(|draft| draft.trim() == trimmed);
+            if stale {
+                name_drafts.write().remove(&zone.zone_id);
+            }
             managed_zones.restart();
         });
     };

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -219,6 +219,17 @@ pub fn Settings() -> Element {
     // toggled checkbox showing the opposite of the truth: the refetched data is unchanged, so the
     // VDOM `checked` value is unchanged, so the diff emits no correcting mutation.
     let mut zone_revision = use_signal(|| 0u32);
+    // In-progress name edits, by zone id.
+    //
+    // `value:` on a Dioxus input makes it *controlled*: after every input event the DOM value is
+    // reset to whatever the VDOM says. With only an `onchange` handler -- which fires on blur, not
+    // per keystroke -- nothing held the typed text, so each character was immediately overwritten by
+    // the server's name and the field appeared to reject typing. Every other text input in this app
+    // pairs `value:` with an `oninput` that writes to a signal; this is that signal, per row.
+    //
+    // A draft is cleared once the rename commits, so the field falls back to the server's answer --
+    // which is what makes the "reset" button visibly restore the provider's name.
+    let mut name_drafts = use_signal(std::collections::HashMap::<String, String>::new);
 
     let mut report_zone_failure = move |err: String| {
         zone_error.set(Some(err));
@@ -311,9 +322,12 @@ pub fn Settings() -> Element {
         });
     };
 
-    let rename_zone = move |zone: ManagedZone, name: String| {
+    let mut rename_zone = move |zone: ManagedZone, name: String| {
         let trimmed = name.trim().to_string();
         if trimmed == zone.zone_name {
+            // Nothing to save, but drop the draft anyway so a field edited only by whitespace snaps
+            // back to the canonical name instead of keeping the user's spacing.
+            name_drafts.write().remove(&zone.zone_id);
             return;
         }
         spawn(async move {
@@ -337,6 +351,9 @@ pub fn Settings() -> Element {
                 }
                 Err(err) => report_zone_failure(err),
             }
+            // Either way the server is now authoritative for this row: on success it holds the new
+            // name, on failure the old one, and in both cases that is what the field should show.
+            name_drafts.write().remove(&zone.zone_id);
             managed_zones.restart();
         });
     };
@@ -732,6 +749,11 @@ pub fn Settings() -> Element {
                                 table { class: "w-full", id: "zones-table",
                                     thead {
                                         tr { class: "border-b border-default",
+                                            // Handle column. Hidden below `sm` because HTML5 drag
+                                            // events never fire on touch -- a grip a phone cannot
+                                            // use is a false affordance, and the arrows are the
+                                            // real control there.
+                                            th { class: "w-8 hidden sm:table-cell", span { class: "sr-only", "Drag to reorder" } }
                                             th { class: "text-left py-2 px-2 font-semibold w-12", "Show" }
                                             th { class: "text-left py-2 px-2 font-semibold", "Name" }
                                             th { class: "text-left py-2 px-2 font-semibold hidden sm:table-cell w-28", "Source" }
@@ -748,11 +770,6 @@ pub fn Settings() -> Element {
                                                     "zone-row zone-row-dragging border-b border-default"
                                                 } else {
                                                     "zone-row border-b border-default"
-                                                },
-                                                draggable: "true",
-                                                ondragstart: {
-                                                    let zone_id = zone.zone_id.clone();
-                                                    move |_| dragging.set(Some(zone_id.clone()))
                                                 },
                                                 ondragover: {
                                                     let zone_id = zone.zone_id.clone();
@@ -784,6 +801,34 @@ pub fn Settings() -> Element {
                                                     dragging.set(None);
                                                     drop_target.set(None);
                                                 },
+                                                // The drag handle. `draggable` lives here rather
+                                                // than on the row so that selecting text in the
+                                                // name field does not start a drag -- the row is
+                                                // still the drop target, just not the drag source.
+                                                td {
+                                                    class: "zone-handle-cell hidden sm:table-cell align-middle",
+                                                    draggable: "true",
+                                                    ondragstart: {
+                                                        let zone_id = zone.zone_id.clone();
+                                                        move |_| dragging.set(Some(zone_id.clone()))
+                                                    },
+                                                    // aria-hidden: dragging has no keyboard
+                                                    // equivalent, so the arrows carry the
+                                                    // accessible path and this must not add a
+                                                    // stop in the tab order that does nothing.
+                                                    svg {
+                                                        class: "w-4 h-4 text-muted mx-auto",
+                                                        fill: "currentColor",
+                                                        view_box: "0 0 24 24",
+                                                        "aria-hidden": "true",
+                                                        circle { cx: "9", cy: "6", r: "1.5" }
+                                                        circle { cx: "15", cy: "6", r: "1.5" }
+                                                        circle { cx: "9", cy: "12", r: "1.5" }
+                                                        circle { cx: "15", cy: "12", r: "1.5" }
+                                                        circle { cx: "9", cy: "18", r: "1.5" }
+                                                        circle { cx: "15", cy: "18", r: "1.5" }
+                                                    }
+                                                }
                                                 td { class: "py-2 px-2 align-top",
                                                     label { class: "inline-flex min-h-11 min-w-11 items-center justify-center -my-2 -mx-2",
                                                         input {
@@ -802,9 +847,19 @@ pub fn Settings() -> Element {
                                                     input {
                                                         r#type: "text",
                                                         class: if zone.hidden { "input w-full text-muted" } else { "input w-full" },
-                                                        value: "{zone.zone_name}",
+                                                        // The draft while the user is typing,
+                                                        // otherwise the server's name. A controlled
+                                                        // input needs somewhere to put keystrokes
+                                                        // or the next render throws them away.
+                                                        value: "{name_drafts().get(&zone.zone_id).cloned().unwrap_or_else(|| zone.zone_name.clone())}",
                                                         maxlength: "60",
                                                         aria_label: "Name for {zone.qualified_label()}",
+                                                        oninput: {
+                                                            let zone_id = zone.zone_id.clone();
+                                                            move |evt: FormEvent| {
+                                                                name_drafts.write().insert(zone_id.clone(), evt.value());
+                                                            }
+                                                        },
                                                         // Commits on blur and on Enter rather than
                                                         // per keystroke: each save is a disk write
                                                         // plus a full list refetch, and refetching
@@ -836,23 +891,6 @@ pub fn Settings() -> Element {
                                                 td { class: "py-2 px-2 align-top text-muted hidden sm:table-cell", "{source_label(&zone.source)}" }
                                                 td { class: "py-2 px-2 align-top",
                                                     div { class: "flex items-center justify-end gap-2",
-                                                        // Grip: the affordance that says "this row
-                                                        // drags". Decorative only -- dragging has
-                                                        // no keyboard or touch equivalent, so the
-                                                        // buttons beside it carry the accessible
-                                                        // path and this is aria-hidden.
-                                                        svg {
-                                                            class: "w-4 h-4 text-muted hidden sm:block",
-                                                            fill: "currentColor",
-                                                            view_box: "0 0 24 24",
-                                                            "aria-hidden": "true",
-                                                            circle { cx: "9", cy: "6", r: "1.5" }
-                                                            circle { cx: "15", cy: "6", r: "1.5" }
-                                                            circle { cx: "9", cy: "12", r: "1.5" }
-                                                            circle { cx: "15", cy: "12", r: "1.5" }
-                                                            circle { cx: "9", cy: "18", r: "1.5" }
-                                                            circle { cx: "15", cy: "18", r: "1.5" }
-                                                        }
                                                         span { class: "text-muted text-sm tabular-nums",
                                                             if let Some(position) = position {
                                                                 "{position} of {visible_total}"

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -268,10 +268,7 @@ pub fn Settings() -> Element {
             }
             let result = crate::app::api::post_json::<_, serde_json::Value>(
                 "/api/zones/order",
-                &ZoneOrderRequest {
-                    zone_id: zone.zone_id.clone(),
-                    direction,
-                },
+                &ZoneOrderRequest::step(zone.zone_id.clone(), direction),
             )
             .await;
             match result {
@@ -281,6 +278,32 @@ pub fn Settings() -> Element {
                         MoveDirection::Up => format!("{label} moved up."),
                         MoveDirection::Down => format!("{label} moved down."),
                     });
+                }
+                Err(err) => report_zone_failure(err),
+            }
+            managed_zones.restart();
+        });
+    };
+
+    // Drag-and-drop state. HTML5 drag events do not fire on touch devices, so this is an
+    // enhancement layered over the up/down buttons rather than a replacement for them -- the buttons
+    // remain the path for phones and for keyboard users.
+    let mut dragging = use_signal(|| Option::<String>::None);
+    let mut drop_target = use_signal(|| Option::<String>::None);
+
+    let drop_zone_onto = move |zone: ManagedZone, target: ManagedZone| {
+        let label = zone.qualified_label();
+        let target_label = target.qualified_label();
+        spawn(async move {
+            let result = crate::app::api::post_json::<_, serde_json::Value>(
+                "/api/zones/order",
+                &ZoneOrderRequest::drop_onto(zone.zone_id.clone(), target.zone_id.clone()),
+            )
+            .await;
+            match result {
+                Ok(_) => {
+                    zone_error.set(None);
+                    zone_status.set(format!("{label} moved to {target_label}'s position."));
                 }
                 Err(err) => report_zone_failure(err),
             }
@@ -626,7 +649,7 @@ pub fn Settings() -> Element {
                 div { class: "mb-4",
                     h2 { id: "zones-heading", class: "text-xl font-semibold", "Zone list" }
                     p { class: "text-muted text-sm",
-                        "Name your zones, choose which ones appear, and set their order. Applies everywhere — this app, knobs, and connected assistants."
+                        "Name your zones, choose which ones appear, and set their order. Drag a row to move it, or use the arrows. Applies everywhere — this app, knobs, and connected assistants."
                     }
                 }
 
@@ -696,6 +719,14 @@ pub fn Settings() -> Element {
                             }
                             let first_visible = rows.iter().position(|(z, _)| !z.hidden);
                             let last_visible = rows.iter().rposition(|(z, _)| !z.hidden);
+                            // A drop knows only the dragged zone's id, so the row it belongs to has
+                            // to be recoverable by id from inside the drop handler.
+                            let drop_lookup: std::rc::Rc<std::collections::HashMap<String, ManagedZone>> =
+                                std::rc::Rc::new(
+                                    rows.iter()
+                                        .map(|(z, _)| (z.zone_id.clone(), z.clone()))
+                                        .collect(),
+                                );
 
                             rsx! {
                                 table { class: "w-full", id: "zones-table",
@@ -711,7 +742,48 @@ pub fn Settings() -> Element {
                                         for (index, (zone, position)) in rows.into_iter().enumerate() {
                                             tr {
                                                 key: "{zone.zone_id}-{revision}",
-                                                class: "border-b border-default",
+                                                class: if drop_target() == Some(zone.zone_id.clone()) {
+                                                    "zone-row zone-row-drop-target border-b border-default"
+                                                } else if dragging() == Some(zone.zone_id.clone()) {
+                                                    "zone-row zone-row-dragging border-b border-default"
+                                                } else {
+                                                    "zone-row border-b border-default"
+                                                },
+                                                draggable: "true",
+                                                ondragstart: {
+                                                    let zone_id = zone.zone_id.clone();
+                                                    move |_| dragging.set(Some(zone_id.clone()))
+                                                },
+                                                ondragover: {
+                                                    let zone_id = zone.zone_id.clone();
+                                                    move |evt: DragEvent| {
+                                                        // Without preventDefault the browser treats
+                                                        // this as an invalid drop target and never
+                                                        // fires ondrop.
+                                                        evt.prevent_default();
+                                                        if dragging().is_some() {
+                                                            drop_target.set(Some(zone_id.clone()));
+                                                        }
+                                                    }
+                                                },
+                                                ondrop: {
+                                                    let target = zone.clone();
+                                                    let rows_for_drop = drop_lookup.clone();
+                                                    move |evt: DragEvent| {
+                                                        evt.prevent_default();
+                                                        if let Some(dragged_id) = dragging() {
+                                                            if let Some(dragged) = rows_for_drop.get(&dragged_id) {
+                                                                drop_zone_onto(dragged.clone(), target.clone());
+                                                            }
+                                                        }
+                                                        dragging.set(None);
+                                                        drop_target.set(None);
+                                                    }
+                                                },
+                                                ondragend: move |_| {
+                                                    dragging.set(None);
+                                                    drop_target.set(None);
+                                                },
                                                 td { class: "py-2 px-2 align-top",
                                                     label { class: "inline-flex min-h-11 min-w-11 items-center justify-center -my-2 -mx-2",
                                                         input {
@@ -764,6 +836,23 @@ pub fn Settings() -> Element {
                                                 td { class: "py-2 px-2 align-top text-muted hidden sm:table-cell", "{source_label(&zone.source)}" }
                                                 td { class: "py-2 px-2 align-top",
                                                     div { class: "flex items-center justify-end gap-2",
+                                                        // Grip: the affordance that says "this row
+                                                        // drags". Decorative only -- dragging has
+                                                        // no keyboard or touch equivalent, so the
+                                                        // buttons beside it carry the accessible
+                                                        // path and this is aria-hidden.
+                                                        svg {
+                                                            class: "w-4 h-4 text-muted hidden sm:block",
+                                                            fill: "currentColor",
+                                                            view_box: "0 0 24 24",
+                                                            "aria-hidden": "true",
+                                                            circle { cx: "9", cy: "6", r: "1.5" }
+                                                            circle { cx: "15", cy: "6", r: "1.5" }
+                                                            circle { cx: "9", cy: "12", r: "1.5" }
+                                                            circle { cx: "15", cy: "12", r: "1.5" }
+                                                            circle { cx: "9", cy: "18", r: "1.5" }
+                                                            circle { cx: "15", cy: "18", r: "1.5" }
+                                                        }
                                                         span { class: "text-muted text-sm tabular-nums",
                                                             if let Some(position) = position {
                                                                 "{position} of {visible_total}"

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -261,10 +261,11 @@ pub fn Zones() -> Element {
             let source = zone.source.clone().unwrap_or_else(|| "Other".to_string());
             groups.entry(source).or_default().push(zone.clone());
         }
-        // Sort zones within each group by name for stable ordering
-        for zones in groups.values_mut() {
-            zones.sort_by(|a, b| a.zone_name.cmp(&b.zone_name));
-        }
+        // No sort here. `/zones` arrives already ordered by `crate::zone_list` -- the user's
+        // explicit order, then alphabetical -- and grouping preserves the relative order of what it
+        // is handed. Re-sorting locally would override the order the user set in Settings, and the
+        // byte-order `zone_name.cmp` this replaced also disagreed with the server's
+        // case-insensitive sort, putting `kitchen` after `Zone` on this page alone.
         // Sort groups in a sensible order: Roon, LMS, OpenHome, UPnP, then others
         let priority = |s: &str| -> i32 {
             match s.to_lowercase().as_str() {

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -253,32 +253,27 @@ pub fn Zones() -> Element {
     let profiles = hqp_profiles();
     let matrix = hqp_matrix();
 
-    // Group zones by source protocol
+    // Group *consecutive* same-source zones, preserving the order `/zones` delivered.
+    //
+    // `/zones` arrives ordered by `crate::zone_list` -- the user's explicit order, then
+    // alphabetical -- and that order is the whole point of the zone-list settings. This page used to
+    // bucket zones by source into a `HashMap` and sort the buckets by a fixed provider priority
+    // (Roon, LMS, OpenHome, UPnP, other), which rendered every Roon zone before every LMS zone no
+    // matter what the user arranged. A user who put an LMS zone at the top never saw it there.
+    //
+    // Runs of the same source still get one heading, so the grouping affordance survives; a source
+    // that appears in two places in the user's order simply gets two headings, which is a truthful
+    // rendering of what they asked for rather than a reshuffle behind their back.
     let grouped_zones: Vec<(String, Vec<Zone>)> = {
-        let mut groups: std::collections::HashMap<String, Vec<Zone>> =
-            std::collections::HashMap::new();
+        let mut runs: Vec<(String, Vec<Zone>)> = Vec::new();
         for zone in zones_list.iter() {
             let source = zone.source.clone().unwrap_or_else(|| "Other".to_string());
-            groups.entry(source).or_default().push(zone.clone());
-        }
-        // No sort here. `/zones` arrives already ordered by `crate::zone_list` -- the user's
-        // explicit order, then alphabetical -- and grouping preserves the relative order of what it
-        // is handed. Re-sorting locally would override the order the user set in Settings, and the
-        // byte-order `zone_name.cmp` this replaced also disagreed with the server's
-        // case-insensitive sort, putting `kitchen` after `Zone` on this page alone.
-        // Sort groups in a sensible order: Roon, LMS, OpenHome, UPnP, then others
-        let priority = |s: &str| -> i32 {
-            match s.to_lowercase().as_str() {
-                "roon" => 0,
-                "lms" => 1,
-                "openhome" => 2,
-                "upnp" => 3,
-                _ => 4,
+            match runs.last_mut() {
+                Some((current, zones)) if *current == source => zones.push(zone.clone()),
+                _ => runs.push((source, vec![zone.clone()])),
             }
-        };
-        let mut result: Vec<_> = groups.into_iter().collect();
-        result.sort_by_key(|a| priority(&a.0));
-        result
+        }
+        runs
     };
 
     let content = if is_loading {

--- a/src/input.css
+++ b/src/input.css
@@ -188,11 +188,16 @@
      Uses project CSS variables rather than Tailwind color utilities: this project defines its
      palette as `--accent-*` / `--surface-*` custom properties, so `bg-accent/10` compiles to
      nothing at all. */
-  .zone-row {
+  /* Only the handle grabs. The row is the drop target but not the drag source, so a click-drag in
+     the name field selects text instead of picking up the row. */
+  .zone-handle-cell {
     cursor: grab;
   }
-  .zone-row:active {
+  .zone-handle-cell:active {
     cursor: grabbing;
+  }
+  .zone-row:hover .zone-handle-cell svg {
+    color: var(--text-primary);
   }
   /* The row being dragged: faded, so the eye follows the gap rather than the source. */
   .zone-row-dragging {

--- a/src/input.css
+++ b/src/input.css
@@ -184,6 +184,26 @@
     color: var(--text-secondary);
   }
 
+  /* Draggable zone rows (Settings > Zone list).
+     Uses project CSS variables rather than Tailwind color utilities: this project defines its
+     palette as `--accent-*` / `--surface-*` custom properties, so `bg-accent/10` compiles to
+     nothing at all. */
+  .zone-row {
+    cursor: grab;
+  }
+  .zone-row:active {
+    cursor: grabbing;
+  }
+  /* The row being dragged: faded, so the eye follows the gap rather than the source. */
+  .zone-row-dragging {
+    opacity: 0.45;
+  }
+  /* The row that would receive the drop, marked on its top edge so the insertion point is a line
+     between rows rather than a filled block that reads as selection. */
+  .zone-row-drop-target {
+    box-shadow: inset 0 2px 0 0 var(--accent-color);
+  }
+
   /* Checkbox styling */
   .checkbox {
     @apply w-4 h-4 rounded;

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -123,13 +123,14 @@ pub async fn knob_zones_handler(
     Json(ZonesResponse { zones })
 }
 
-/// Helper to aggregate zones from aggregator (respects adapter settings, public for UI module)
+/// Helper to aggregate zones from aggregator (public for UI module).
+///
+/// Membership and order come from [`crate::zone_list::visible_zones`] — adapter settings, the
+/// user's per-zone hide list, and a deterministic sort. This function's remaining job is the
+/// `Zone` → [`ZoneInfo`] projection, which attaches HQPlayer DSP links and must preserve the order
+/// it is handed.
 pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
-    use crate::api::load_app_settings;
     use std::collections::HashMap;
-
-    let settings = load_app_settings();
-    let adapters = settings.adapters;
 
     // Get HQPlayer zone links for DSP field population
     let hqp_links: HashMap<String, String> = state
@@ -161,32 +162,10 @@ pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
         })
     };
 
-    // Get all zones from aggregator (already prefixed with source:)
-    let all_zones = state.aggregator.get_zones().await;
-
-    // Filter by enabled adapters and convert to ZoneInfo
-    all_zones
+    // Filtered (adapter settings + hide list) and sorted by the shared policy.
+    crate::zone_list::visible_zones(state)
+        .await
         .into_iter()
-        .filter(|z| {
-            // Filter based on adapter settings
-            if z.zone_id.starts_with("roon:") {
-                adapters.roon
-            } else if z.zone_id.starts_with("lms:") {
-                adapters.lms
-            } else if z.zone_id.starts_with("openhome:") {
-                adapters.openhome
-            } else if z.zone_id.starts_with("upnp:") {
-                adapters.upnp
-            } else if z.zone_id.starts_with("hqplayer:") {
-                // `hqplayer:` is the prefix `PrefixedZoneId::hqplayer` emits and the only one
-                // HQPlayer zones ever carry. This tested `hqp:` until #328, so it never matched, and
-                // HQPlayer zones fell into the include-by-default arm below — the adapter toggle in
-                // settings silently did nothing for them.
-                adapters.hqplayer
-            } else {
-                true // Unknown prefix, include by default
-            }
-        })
         .map(|z| ZoneInfo {
             dsp: get_dsp(&z.zone_id),
             zone_id: z.zone_id,

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -222,14 +222,20 @@ async fn get_zone_infos(state: &AppState) -> Vec<ZoneInfo> {
 /// Changes when zones are added/removed, enabling clients to detect zone list updates
 fn compute_zones_sha(zones: &[ZoneInfo]) -> String {
     let mut hasher = Sha256::new();
-    // Hash zone IDs and names - sorted for deterministic output
-    // Use length-prefixing to avoid delimiter collision (e.g., if zone name contains special chars)
-    let mut zone_data: Vec<_> = zones
-        .iter()
-        .map(|z| format!("{}:{}", z.zone_id, z.zone_name))
-        .collect();
-    zone_data.sort();
-    for item in &zone_data {
+    // Hashed in list order, so a reorder changes the SHA and clients notice.
+    //
+    // This used to sort first, and that was correct at the time: the list came from
+    // `HashMap::values()`, so its order differed between two requests with an unchanged zone set. An
+    // order-sensitive hash would have changed on essentially every request and had knobs refetching
+    // their zone list constantly, so sorting the order away was the only way to get a stable value.
+    //
+    // `zone_list::visible_zones` now imposes a deterministic order, which removes the reason for the
+    // sort and turns it into a bug: user-visible reordering was invisible to every client that polls
+    // this SHA, because reordering is the one change sorting erases.
+    //
+    // Length-prefixed to avoid delimiter collisions, e.g. a zone named "a:b".
+    for zone in zones {
+        let item = format!("{}:{}", zone.zone_id, zone.zone_name);
         let len = item.len() as u32;
         hasher.update(len.to_be_bytes());
         hasher.update(item.as_bytes());
@@ -1555,9 +1561,16 @@ mod tests {
         assert_eq!(sha1.len(), 8, "SHA should be 8 hex chars");
     }
 
+    /// Reordering must change the SHA, or clients never learn about it.
+    ///
+    /// This test replaces `zones_sha_order_insensitive`, which asserted the opposite. That assertion
+    /// was right for its time: the zone list came from `HashMap::values()` and had no stable order,
+    /// so hashing order would have churned the SHA on every request. `zone_list::visible_zones` now
+    /// guarantees a deterministic order, so hashing it is safe — and necessary, because reordering
+    /// changes neither the set of zones nor their names, and is therefore the one user-visible
+    /// change a sorted hash cannot see.
     #[test]
-    fn zones_sha_order_insensitive() {
-        // Same zones in different order should produce same SHA
+    fn zones_sha_changes_on_reorder() {
         let zones_a = vec![
             make_zone("zone-1", "Living Room"),
             make_zone("zone-2", "Kitchen"),
@@ -1568,10 +1581,36 @@ mod tests {
             make_zone("zone-1", "Living Room"),
         ];
 
-        let sha_a = compute_zones_sha(&zones_a);
-        let sha_b = compute_zones_sha(&zones_b);
+        assert_ne!(
+            compute_zones_sha(&zones_a),
+            compute_zones_sha(&zones_b),
+            "a knob polling this SHA must be able to detect that the zone order changed"
+        );
+    }
 
-        assert_eq!(sha_a, sha_b, "Order should not affect SHA");
+    /// The same list still hashes the same. Determinism is what makes the SHA usable at all; the
+    /// change above is that it is now determined by the order too, not that it became unstable.
+    #[test]
+    fn zones_sha_is_stable_for_an_unchanged_list() {
+        let zones = vec![
+            make_zone("zone-1", "Living Room"),
+            make_zone("zone-2", "Kitchen"),
+        ];
+
+        assert_eq!(compute_zones_sha(&zones), compute_zones_sha(&zones));
+    }
+
+    /// Hiding a zone changes the SHA, because a hidden zone is absent from the list this hashes.
+    /// (Renaming is already covered by `zones_sha_changes_on_rename` below.)
+    #[test]
+    fn zones_sha_changes_when_a_zone_is_hidden() {
+        let shown = vec![
+            make_zone("zone-1", "Living Room"),
+            make_zone("zone-2", "Kitchen"),
+        ];
+        let hidden = vec![make_zone("zone-1", "Living Room")];
+
+        assert_ne!(compute_zones_sha(&shown), compute_zones_sha(&hidden));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,3 +63,6 @@ pub mod mdns;
 // Server-only: it necessarily touches both `crate::bus` and `crate::adaptive`.
 #[cfg(feature = "server")]
 pub mod producers;
+// The single decision point for zone-list membership and order (see module docs).
+#[cfg(feature = "server")]
+pub mod zone_list;

--- a/src/main.rs
+++ b/src/main.rs
@@ -477,6 +477,12 @@ mod server {
             // App settings API
             .route("/api/settings", get(api::api_settings_get_handler))
             .route("/api/settings", post(api::api_settings_post_handler))
+            // Kept on one line each: the API-contract extractor (tests/api_contract.rs) only sees
+            // single-line `.route(...)` calls, so a multi-line form would slip past the guard.
+            .route("/api/zones/visibility", get(api::zone_visibility_get))
+            .route("/api/zones/visibility", post(api::zone_visibility_post))
+            .route("/api/zones/order", post(api::zone_order_post))
+            .route("/api/zones/name", post(api::zone_name_post))
             // Event stream (SSE)
             .route("/events", get(api::events_handler))
             // Knob hardware API routes

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -212,7 +212,9 @@ pub async fn list_resources(state: &AppState, hqplayer_enabled: bool) -> Vec<Res
         },
     ];
 
-    for zone in state.aggregator.get_zones().await {
+    // Same visibility policy as `hifi_zones` -- a hidden zone must not reappear as a resource.
+    // Reading `state.aggregator.get_zones()` here would leak exactly what the user hid.
+    for zone in crate::zone_list::visible_zones(state).await {
         resources.push(zone_resource(&zone.zone_id, &zone.zone_name));
     }
 

--- a/src/mcp/tools/capabilities.rs
+++ b/src/mcp/tools/capabilities.rs
@@ -102,9 +102,10 @@ async fn one_zone(
 /// client can plan for a zone type before it appears — and so the AGENTS.md matrix
 /// is exactly this payload rather than a subset of it.
 async fn every_zone(state: &AppState, env: Envelope) -> CallToolResult {
-    let zones: Vec<McpCapabilityZone> = state
-        .aggregator
-        .get_zones()
+    // Same visibility policy as `hifi_zones`. This report is how a client discovers what it can do
+    // with each zone, so listing a hidden zone here would put it back in front of the assistant
+    // that `hifi_zones` just withheld it from.
+    let zones: Vec<McpCapabilityZone> = crate::zone_list::visible_zones(state)
         .await
         .into_iter()
         .map(|zone| McpCapabilityZone {

--- a/src/mcp/tools/zones.rs
+++ b/src/mcp/tools/zones.rs
@@ -58,9 +58,11 @@ pub struct HifiNowPlayingTool {
 ///
 /// [`Zone`]: crate::bus::Zone
 pub async fn zones_payload(state: &AppState) -> Vec<McpZone> {
-    state
-        .aggregator
-        .get_zones()
+    // `visible_zones`, not `aggregator.get_zones()`: an assistant should be offered the same zones,
+    // in the same order, as the web UI and the knobs. A zone the user hid is not offered here --
+    // though `hifi_play` and friends still accept its ID, since hiding declutters lists rather than
+    // withdrawing control (see `crate::zone_list`).
+    crate::zone_list::visible_zones(state)
         .await
         .into_iter()
         .map(|z| McpZone {

--- a/src/zone_list.rs
+++ b/src/zone_list.rs
@@ -1,0 +1,777 @@
+//! The one place that decides which zones appear in a zone list, and in what order.
+//!
+//! # Why this is a module and not a helper inside one surface
+//!
+//! Zone-list *membership* used to be a fact about the aggregator: if a zone was in
+//! [`ZoneAggregator`], it belonged in every list. Adapter settings were enforced upstream —
+//! `register_from_settings` gates startup, and #429 made disabling an adapter flush its zones on
+//! `AdapterStopping` — so a surface that read `aggregator.get_zones()` raw still produced a correct
+//! answer. The adapter filter in `knobs::routes::get_all_zones_internal` was a second line of
+//! defence, not the only one.
+//!
+//! Per-zone visibility breaks that. Hiding a zone is a *policy* the aggregator knows nothing about:
+//! a hidden zone is still discovered, still updated, still controllable. From here on, any surface
+//! that reads the aggregator directly to build a list silently opts out of the user's choice.
+//!
+//! Ordering has the same shape. `aggregator.get_zones()` returns `HashMap::values()`, so the order
+//! differs *between two calls with an unchanged zone set*. The zones page compensated locally
+//! (`zones.rs`), which fixed the page and left every other consumer — knobs, MCP, `/zones` —
+//! with a list that reshuffles under them.
+//!
+//! So: every zone list goes through [`visible_zones`]. Not "should" — the guardrail for this work
+//! is that no zone list calls `aggregator.get_zones()` directly.
+//!
+//! # What this deliberately does not do
+//!
+//! Hiding is a *list* filter, never a control filter. A hidden zone addressed by ID still plays,
+//! pauses, and changes volume, on every surface including MCP. Knob bindings, MCP `zone_id`
+//! arguments, and HQPlayer links all resolve through `aggregator.get_zone(id)`, which this module
+//! does not touch. Hiding declutters; it does not deauthorise. Making "hidden" mean "unreachable"
+//! would silently break working knob and assistant setups on upgrade.
+
+use crate::api::{AppSettings, AppState};
+use crate::bus::Zone;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+
+/// Every zone the user should be offered, in a stable order.
+///
+/// Applies, in order: the adapter enable filter, the per-zone hide list, then a deterministic sort.
+/// This is what every zone list uses.
+pub async fn visible_zones(state: &AppState) -> Vec<Zone> {
+    let settings = crate::api::load_app_settings();
+    let zones = state.aggregator.get_zones().await;
+    apply_zone_list_policy(zones, &settings)
+}
+
+/// Every zone the user *could* be offered, hidden ones included, in the same stable order.
+///
+/// Exists for one caller: the settings surface that lets someone unhide a zone. Hiding must not be
+/// a one-way door — if the only way to see a zone were [`visible_zones`], a hidden zone would be
+/// unreachable in the very UI meant to bring it back. Not for zone lists; use [`visible_zones`].
+pub async fn manageable_zones(state: &AppState) -> Vec<Zone> {
+    let settings = crate::api::load_app_settings();
+    let zones = state.aggregator.get_zones().await;
+    apply_adapter_filter_and_sort(zones, &settings)
+}
+
+/// [`visible_zones`] with the settings and zone set passed in, so the policy is testable without an
+/// `AppState`, a bus, or a config file on disk.
+pub fn apply_zone_list_policy(zones: Vec<Zone>, settings: &AppSettings) -> Vec<Zone> {
+    let hidden: HashSet<&str> = settings
+        .hidden_zone_ids()
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    let mut visible = apply_adapter_filter_and_sort(zones, settings);
+    visible.retain(|z| !hidden.contains(z.zone_id.as_str()));
+    visible
+}
+
+/// [`manageable_zones`] with its inputs passed in.
+pub fn apply_adapter_filter_and_sort(zones: Vec<Zone>, settings: &AppSettings) -> Vec<Zone> {
+    let mut listed: Vec<Zone> = zones
+        .into_iter()
+        .filter(|z| adapter_enabled(&z.zone_id, settings))
+        .map(|z| apply_custom_name(z, settings))
+        .collect();
+
+    order_zones(&mut listed, settings.zone_order_ids());
+    listed
+}
+
+/// Replace a zone's display name with the user's override, if they set one.
+///
+/// Applied *before* [`order_zones`], deliberately. Sorting on the name the user chose is what turns
+/// renaming into grouping: prefix three zones with `Basement - ` and they sort together in every
+/// list, with no grouping feature to build or explain. Sorting on the provider's name instead would
+/// scatter them and make the rename purely cosmetic.
+///
+/// Only the display name changes. `zone_id` is untouched, so knob bindings, HQPlayer links, and MCP
+/// `zone_id` arguments keep working across a rename.
+fn apply_custom_name(mut zone: Zone, settings: &AppSettings) -> Zone {
+    if let Some(name) = settings.custom_zone_name(&zone.zone_id) {
+        zone.zone_name = name.to_string();
+    }
+    zone
+}
+
+/// Whether the adapter owning `zone_id` is enabled in settings.
+///
+/// Redundant with the upstream enforcement described in the module docs, and kept anyway: settings
+/// are re-read from disk on every call here, while the aggregator only learns of a change through
+/// the settings endpoint. Editing `app-settings.json` directly — plausible for Docker users
+/// bind-mounting a config directory — leaves the two disagreeing until restart, and this is the
+/// side that reflects what the file actually says.
+fn adapter_enabled(zone_id: &str, settings: &AppSettings) -> bool {
+    let adapters = &settings.adapters;
+    if let Some((prefix, _)) = zone_id.split_once(':') {
+        match prefix {
+            "roon" => adapters.roon,
+            "lms" => adapters.lms,
+            "openhome" => adapters.openhome,
+            "upnp" => adapters.upnp,
+            // `hqplayer:` is the prefix `PrefixedZoneId::hqplayer` emits and the only one HQPlayer
+            // zones ever carry. This tested `hqp:` until #328, so it never matched and HQPlayer
+            // zones fell through to the default-include arm — the settings toggle silently did
+            // nothing for them.
+            "hqplayer" => adapters.hqplayer,
+            // Unknown prefix: include. A zone from a provider this build predates is better shown
+            // than silently swallowed.
+            _ => true,
+        }
+    } else {
+        true
+    }
+}
+
+/// Order zones: the user's explicit order first, then everything else alphabetically.
+///
+/// A zone named in `zone_order` sorts by its position there. A zone not named in it — never
+/// reordered, or discovered after the user last arranged things — sorts after all of them, by
+/// [`compare_by_name`]. That fallback is the point: a new zone appears at a stable, findable place
+/// instead of wherever `HashMap` iteration happened to put it, and it does so without silently
+/// rewriting an order the user set by hand.
+///
+/// `zone_order` may name zones that no longer exist; they simply never match.
+pub fn order_zones(zones: &mut [Zone], zone_order: &[String]) {
+    let rank: HashMap<&str, usize> = zone_order
+        .iter()
+        .enumerate()
+        .map(|(index, zone_id)| (zone_id.as_str(), index))
+        .collect();
+
+    zones.sort_by(|a, b| {
+        match (rank.get(a.zone_id.as_str()), rank.get(b.zone_id.as_str())) {
+            (Some(left), Some(right)) => left.cmp(right),
+            // Explicitly ordered zones come before ones the user has never placed.
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => compare_by_name(a, b),
+        }
+    });
+}
+
+/// Compare by display name, ascending, case-insensitively, with `zone_id` as tiebreaker.
+///
+/// Case-insensitive because a byte-order sort puts every lowercase name after every uppercase one —
+/// `kitchen` lands after `Zone`, which reads as unsorted to anyone who names a zone in lowercase.
+///
+/// The `zone_id` tiebreaker is what makes this *deterministic* rather than merely sorted. Two zones
+/// can legitimately share a display name (the same endpoint name on two providers, or two
+/// identical devices), and with equal keys a stable sort preserves input order — which is
+/// `HashMap::values()`, i.e. arbitrary and different next call. Zone IDs are unique, so the
+/// composite key never ties.
+fn compare_by_name(a: &Zone, b: &Zone) -> Ordering {
+    a.zone_name
+        .to_lowercase()
+        .cmp(&b.zone_name.to_lowercase())
+        .then_with(|| a.zone_id.cmp(&b.zone_id))
+}
+
+/// Move one zone one step up or down, returning the full resulting order as zone IDs.
+///
+/// Takes the *effective* order (what the user is looking at) and returns a complete list, so the
+/// first reorder materialises the alphabetical order into an explicit one. Without that, moving the
+/// third zone up would produce a two-element order list whose meaning depended on the alphabetical
+/// fallback for everything else — and the visible result would not match what was clicked.
+///
+/// # Why a visible zone swaps with its nearest *visible* neighbour
+///
+/// The order is stored over manageable zones, hidden ones included, so that unhiding a zone
+/// restores it to where the user put it. The naive consequence is that moving a visible zone "up"
+/// past a hidden neighbour changes the stored order but changes nothing on any surface the user
+/// looks at — `/zones`, the knobs, and MCP all filter hidden zones out. The click would appear to
+/// do nothing, and the more zones you hide the more often it happens, which is precisely the user
+/// this feature is for.
+///
+/// So a visible zone swaps with the nearest visible zone in that direction, carrying any hidden
+/// zones between them along. Every click on a visible row therefore has a visible effect
+/// everywhere. A hidden zone still swaps with its immediate neighbour, since "visible position" has
+/// no meaning for it.
+///
+/// Returns `None` when the move is a no-op: the zone is absent, or there is nothing left to swap
+/// with in that direction.
+pub fn reorder(
+    effective_order: &[Zone],
+    zone_id: &str,
+    direction: MoveDirection,
+    hidden: &HashSet<&str>,
+) -> Option<Vec<String>> {
+    let index = effective_order.iter().position(|z| z.zone_id == zone_id)?;
+    let target_is_hidden = hidden.contains(zone_id);
+
+    let is_swap_candidate = |candidate: &Zone| -> bool {
+        // A hidden zone has no visible position to trade, so it just takes the adjacent slot.
+        target_is_hidden || !hidden.contains(candidate.zone_id.as_str())
+    };
+
+    let swap_with = match direction {
+        MoveDirection::Up => effective_order[..index]
+            .iter()
+            .rposition(is_swap_candidate)?,
+        MoveDirection::Down => {
+            let offset = effective_order[index + 1..]
+                .iter()
+                .position(is_swap_candidate)?;
+            index + 1 + offset
+        }
+    };
+
+    let mut ids: Vec<String> = effective_order.iter().map(|z| z.zone_id.clone()).collect();
+    let moved = ids.remove(index);
+    // Re-insert at the neighbour's slot: a plain `swap` would displace the hidden zones between
+    // them rather than stepping over them, so the moved zone would jump further than one place.
+    ids.insert(swap_with, moved);
+    Some(ids)
+}
+
+/// Which way [`reorder`] moves a zone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MoveDirection {
+    Up,
+    Down,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::AdapterSettings;
+    use crate::bus::PlaybackState;
+
+    fn zone(zone_id: &str, zone_name: &str) -> Zone {
+        Zone {
+            zone_id: zone_id.to_string(),
+            zone_name: zone_name.to_string(),
+            state: PlaybackState::Stopped,
+            volume_control: None,
+            now_playing: None,
+            source: zone_id.split(':').next().unwrap_or("roon").to_string(),
+            is_controllable: true,
+            is_seekable: false,
+            last_updated: 0,
+            is_play_allowed: true,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        }
+    }
+
+    fn all_adapters_on() -> AppSettings {
+        AppSettings {
+            adapters: AdapterSettings {
+                roon: true,
+                upnp: true,
+                openhome: true,
+                lms: true,
+                hqplayer: true,
+            },
+            ..AppSettings::default()
+        }
+    }
+
+    fn ids(zones: &[Zone]) -> Vec<&str> {
+        zones.iter().map(|z| z.zone_id.as_str()).collect()
+    }
+
+    /// The defect users actually reported. A byte-order sort — the obvious
+    /// `sort_by_key(|z| z.zone_name.clone())` — passes a fixture whose names all share a case, and
+    /// fails here: it yields Attic, Kitchen, Zone, basement, den.
+    #[test]
+    fn sorts_case_insensitively_not_by_byte_value() {
+        let settings = all_adapters_on();
+        let zones = vec![
+            zone("roon:1", "Zone"),
+            zone("roon:2", "kitchen"),
+            zone("roon:3", "Attic"),
+            zone("roon:4", "den"),
+            zone("roon:5", "Basement"),
+        ];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(
+            ids(&visible),
+            vec!["roon:3", "roon:5", "roon:4", "roon:2", "roon:1"],
+            "expected Attic, Basement, den, kitchen, Zone"
+        );
+    }
+
+    /// Equal display names must not leave order to the input.
+    ///
+    /// A sort without the `zone_id` tiebreaker passes every single-name fixture and fails this one:
+    /// Rust's sort is stable, so equal keys preserve input order, and the input is
+    /// `HashMap::values()`. Two remotes would see the two "Living Room" zones in different orders,
+    /// and a knob bound to "the second Living Room" would drift between devices.
+    #[test]
+    fn equal_names_break_the_tie_on_zone_id_not_on_input_order() {
+        let settings = all_adapters_on();
+
+        let one = apply_zone_list_policy(
+            vec![
+                zone("lms:bbb", "Living Room"),
+                zone("roon:aaa", "Living Room"),
+            ],
+            &settings,
+        );
+        let other = apply_zone_list_policy(
+            vec![
+                zone("roon:aaa", "Living Room"),
+                zone("lms:bbb", "Living Room"),
+            ],
+            &settings,
+        );
+
+        assert_eq!(ids(&one), vec!["lms:bbb", "roon:aaa"]);
+        assert_eq!(
+            ids(&one),
+            ids(&other),
+            "the same zone set in a different input order must produce the same output order"
+        );
+    }
+
+    /// Hiding keys on `zone_id`, which is prefixed by provider before it reaches here, so the
+    /// filter is provider-agnostic with no per-adapter branch. A Roon-only implementation —
+    /// tempting, since the request came from a Roon user — passes a Roon-only fixture and fails
+    /// this one.
+    #[test]
+    fn hides_zones_from_every_provider() {
+        let settings = AppSettings {
+            hidden_zones: Some(vec![
+                "roon:phone".to_string(),
+                "lms:laptop".to_string(),
+                "upnp:tv".to_string(),
+                "openhome:spare".to_string(),
+                "hqplayer:test".to_string(),
+            ]),
+            ..all_adapters_on()
+        };
+        let zones = vec![
+            zone("roon:phone", "My Phone"),
+            zone("roon:kitchen", "Kitchen"),
+            zone("lms:laptop", "Laptop"),
+            zone("upnp:tv", "TV"),
+            zone("openhome:spare", "Spare"),
+            zone("hqplayer:test", "Test"),
+        ];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(ids(&visible), vec!["roon:kitchen"]);
+    }
+
+    /// Hiding must not become an adapter filter by accident: hiding one Roon zone leaves the rest
+    /// of Roon alone.
+    #[test]
+    fn hiding_one_zone_leaves_its_siblings_visible() {
+        let settings = AppSettings {
+            hidden_zones: Some(vec!["roon:phone".to_string()]),
+            ..all_adapters_on()
+        };
+        let zones = vec![
+            zone("roon:phone", "My Phone"),
+            zone("roon:kitchen", "Kitchen"),
+            zone("roon:study", "Study"),
+        ];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(ids(&visible), vec!["roon:kitchen", "roon:study"]);
+    }
+
+    /// A hide list naming a zone that no longer exists must be inert, not an error and not a
+    /// filter that drops everything.
+    #[test]
+    fn stale_hidden_ids_are_ignored() {
+        let settings = AppSettings {
+            hidden_zones: Some(vec!["roon:zone-from-a-previous-core".to_string()]),
+            ..all_adapters_on()
+        };
+
+        let visible = apply_zone_list_policy(vec![zone("roon:kitchen", "Kitchen")], &settings);
+
+        assert_eq!(ids(&visible), vec!["roon:kitchen"]);
+    }
+
+    /// Default settings hide nothing. We have no trustworthy signal for which zones are private —
+    /// Roon exposes none to extensions — so defaulting anything to hidden would be a guess the user
+    /// cannot see us making.
+    #[test]
+    fn nothing_is_hidden_by_default() {
+        let settings = all_adapters_on();
+        assert!(settings.hidden_zone_ids().is_empty());
+
+        let visible = apply_zone_list_policy(
+            vec![
+                zone("roon:phone", "My Phone"),
+                zone("roon:kitchen", "Kitchen"),
+            ],
+            &settings,
+        );
+
+        assert_eq!(ids(&visible), vec!["roon:kitchen", "roon:phone"]);
+    }
+
+    #[test]
+    fn disabled_adapters_are_still_filtered() {
+        let settings = AppSettings {
+            adapters: AdapterSettings {
+                roon: true,
+                lms: false,
+                ..all_adapters_on().adapters
+            },
+            ..all_adapters_on()
+        };
+
+        let visible = apply_zone_list_policy(
+            vec![
+                zone("lms:player", "Player"),
+                zone("roon:kitchen", "Kitchen"),
+            ],
+            &settings,
+        );
+
+        assert_eq!(ids(&visible), vec!["roon:kitchen"]);
+    }
+
+    /// The explicit order wins over the alphabet, or reordering does nothing.
+    #[test]
+    fn explicit_order_overrides_alphabetical() {
+        let settings = AppSettings {
+            zone_order: Some(vec!["roon:study".to_string(), "roon:attic".to_string()]),
+            ..all_adapters_on()
+        };
+        let zones = vec![zone("roon:attic", "Attic"), zone("roon:study", "Study")];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(ids(&visible), vec!["roon:study", "roon:attic"]);
+    }
+
+    /// A zone discovered after the user last arranged things must land somewhere findable, and must
+    /// not disturb the order they set.
+    ///
+    /// The tempting implementation — sort the ordered ones, then leave the rest in input order —
+    /// passes a fixture with one unplaced zone and fails this one: the two unplaced zones come back
+    /// in `HashMap` order rather than alphabetically.
+    #[test]
+    fn unplaced_zones_follow_the_ordered_ones_alphabetically() {
+        let settings = AppSettings {
+            zone_order: Some(vec!["roon:study".to_string(), "roon:attic".to_string()]),
+            ..all_adapters_on()
+        };
+        let zones = vec![
+            zone("roon:new-b", "zeta"),
+            zone("roon:attic", "Attic"),
+            zone("roon:new-a", "alpha"),
+            zone("roon:study", "Study"),
+        ];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(
+            ids(&visible),
+            vec!["roon:study", "roon:attic", "roon:new-a", "roon:new-b"],
+            "explicit order first, then newcomers alphabetically"
+        );
+    }
+
+    /// An order list naming departed zones must not shift the survivors around.
+    #[test]
+    fn stale_ids_in_the_order_list_are_inert() {
+        let settings = AppSettings {
+            zone_order: Some(vec![
+                "roon:gone".to_string(),
+                "roon:study".to_string(),
+                "roon:also-gone".to_string(),
+                "roon:attic".to_string(),
+            ]),
+            ..all_adapters_on()
+        };
+        let zones = vec![zone("roon:attic", "Attic"), zone("roon:study", "Study")];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(ids(&visible), vec!["roon:study", "roon:attic"]);
+    }
+
+    /// The first reorder must write a *complete* order, not a two-element one.
+    ///
+    /// A `reorder` that returned only the moved pair would leave every other zone on the
+    /// alphabetical fallback — so moving the third zone up would visibly reshuffle the first two as
+    /// well. This asserts the whole visible order comes back.
+    fn nothing_hidden() -> HashSet<&'static str> {
+        HashSet::new()
+    }
+
+    #[test]
+    fn reorder_materialises_the_full_order() {
+        let effective = vec![
+            zone("roon:a", "Attic"),
+            zone("roon:b", "Basement"),
+            zone("roon:c", "Cellar"),
+        ];
+
+        let moved = reorder(&effective, "roon:c", MoveDirection::Up, &nothing_hidden())
+            .expect("move should apply");
+
+        assert_eq!(moved, vec!["roon:a", "roon:c", "roon:b"]);
+    }
+
+    #[test]
+    fn reorder_moves_down() {
+        let effective = vec![zone("roon:a", "Attic"), zone("roon:b", "Basement")];
+
+        let moved = reorder(&effective, "roon:a", MoveDirection::Down, &nothing_hidden())
+            .expect("move should apply");
+
+        assert_eq!(moved, vec!["roon:b", "roon:a"]);
+    }
+
+    /// Moving past either end is a no-op, not a panic and not a wrap-around.
+    #[test]
+    fn reorder_at_the_ends_does_nothing() {
+        let effective = vec![zone("roon:a", "Attic"), zone("roon:b", "Basement")];
+        let hidden = nothing_hidden();
+
+        assert!(reorder(&effective, "roon:a", MoveDirection::Up, &hidden).is_none());
+        assert!(reorder(&effective, "roon:b", MoveDirection::Down, &hidden).is_none());
+        assert!(reorder(&effective, "roon:nonexistent", MoveDirection::Up, &hidden).is_none());
+    }
+
+    /// Moving a visible zone past a hidden one must change what the user can actually see.
+    ///
+    /// The naive `ids.swap(index, index - 1)` swaps with the immediate neighbour. When that
+    /// neighbour is hidden, the stored order changes but `/zones`, the knobs, and MCP all show the
+    /// identical list — the click appears to do nothing everywhere except the settings table it was
+    /// clicked in. This test fails that implementation: it requires Cellar to end up above Attic,
+    /// stepping over the hidden Basement.
+    #[test]
+    fn a_visible_zone_steps_over_hidden_neighbours() {
+        let effective = vec![
+            zone("roon:a", "Attic"),
+            zone("roon:b", "Basement"),
+            zone("roon:c", "Cellar"),
+        ];
+        let hidden: HashSet<&str> = ["roon:b"].into_iter().collect();
+
+        let moved =
+            reorder(&effective, "roon:c", MoveDirection::Up, &hidden).expect("move should apply");
+
+        assert_eq!(
+            moved,
+            vec!["roon:c", "roon:a", "roon:b"],
+            "Cellar must end up above Attic, the nearest visible neighbour"
+        );
+
+        // The visible order actually changed, which is the point.
+        let settings = AppSettings {
+            zone_order: Some(moved),
+            hidden_zones: Some(vec!["roon:b".to_string()]),
+            ..all_adapters_on()
+        };
+        let visible = apply_zone_list_policy(effective, &settings);
+        assert_eq!(ids(&visible), vec!["roon:c", "roon:a"]);
+    }
+
+    /// A visible zone with only hidden zones above it is already first, and must report a no-op
+    /// rather than shuffling hidden zones around to no visible effect.
+    #[test]
+    fn a_visible_zone_with_only_hidden_zones_above_it_cannot_move_up() {
+        let effective = vec![
+            zone("roon:hidden-1", "Aaa"),
+            zone("roon:hidden-2", "Bbb"),
+            zone("roon:visible", "Ccc"),
+        ];
+        let hidden: HashSet<&str> = ["roon:hidden-1", "roon:hidden-2"].into_iter().collect();
+
+        assert!(
+            reorder(&effective, "roon:visible", MoveDirection::Up, &hidden).is_none(),
+            "already first among visible zones"
+        );
+    }
+
+    /// A hidden zone has no visible position, so it trades with whatever is adjacent.
+    #[test]
+    fn a_hidden_zone_swaps_with_its_immediate_neighbour() {
+        let effective = vec![
+            zone("roon:a", "Attic"),
+            zone("roon:b", "Basement"),
+            zone("roon:c", "Cellar"),
+        ];
+        let hidden: HashSet<&str> = ["roon:c"].into_iter().collect();
+
+        let moved =
+            reorder(&effective, "roon:c", MoveDirection::Up, &hidden).expect("move should apply");
+
+        assert_eq!(moved, vec!["roon:a", "roon:c", "roon:b"]);
+    }
+
+    /// Hiding a zone must not lose its place. The order is computed over *manageable* zones —
+    /// hidden included — so unhiding puts it back where the user had it rather than at the end.
+    #[test]
+    fn hidden_zones_keep_their_place_in_the_order() {
+        let ordered = vec![
+            "roon:c".to_string(),
+            "roon:b".to_string(),
+            "roon:a".to_string(),
+        ];
+        let zones = || {
+            vec![
+                zone("roon:a", "Attic"),
+                zone("roon:b", "Basement"),
+                zone("roon:c", "Cellar"),
+            ]
+        };
+
+        let while_hidden = AppSettings {
+            zone_order: Some(ordered.clone()),
+            hidden_zones: Some(vec!["roon:b".to_string()]),
+            ..all_adapters_on()
+        };
+        assert_eq!(
+            ids(&apply_zone_list_policy(zones(), &while_hidden)),
+            vec!["roon:c", "roon:a"]
+        );
+
+        let after_unhiding = AppSettings {
+            zone_order: Some(ordered),
+            hidden_zones: Some(vec![]),
+            ..all_adapters_on()
+        };
+        assert_eq!(
+            ids(&apply_zone_list_policy(zones(), &after_unhiding)),
+            vec!["roon:c", "roon:b", "roon:a"],
+            "unhidden zone returns to its placed position, not to the end"
+        );
+    }
+
+    /// The management view shows hidden zones; every zone *list* does not. Without this, the only
+    /// screen able to unhide a zone could not see it.
+    #[test]
+    fn the_management_view_shows_what_lists_hide() {
+        let settings = AppSettings {
+            hidden_zones: Some(vec!["roon:phone".to_string()]),
+            ..all_adapters_on()
+        };
+        let zones = || {
+            vec![
+                zone("roon:phone", "My Phone"),
+                zone("roon:kitchen", "Kitchen"),
+            ]
+        };
+
+        assert_eq!(
+            ids(&apply_zone_list_policy(zones(), &settings)),
+            vec!["roon:kitchen"]
+        );
+        assert_eq!(
+            ids(&apply_adapter_filter_and_sort(zones(), &settings)),
+            vec!["roon:kitchen", "roon:phone"]
+        );
+    }
+
+    fn named(pairs: &[(&str, &str)]) -> std::collections::BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(id, name)| ((*id).to_string(), (*name).to_string()))
+            .collect()
+    }
+
+    /// Renaming must happen before sorting, or it is cosmetic only.
+    ///
+    /// This is the whole point of the feature: prefixing zones with a common string groups them,
+    /// with no grouping feature. An implementation that renames during the final projection to
+    /// `ZoneInfo` — the obvious place, right where the name is displayed — passes any test that
+    /// only checks the name and fails this one, because the list is still ordered by the provider's
+    /// names.
+    #[test]
+    fn renaming_groups_zones_because_it_happens_before_sorting() {
+        let settings = AppSettings {
+            zone_names: Some(named(&[
+                ("roon:kitchen", "Basement - Kitchen"),
+                ("roon:workshop", "Basement - Workshop"),
+            ])),
+            ..all_adapters_on()
+        };
+        let zones = vec![
+            zone("roon:attic", "Attic"),
+            zone("roon:kitchen", "Kitchen"),
+            zone("roon:lounge", "Lounge"),
+            zone("roon:workshop", "Workshop"),
+        ];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(
+            visible
+                .iter()
+                .map(|z| z.zone_name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "Attic",
+                "Basement - Kitchen",
+                "Basement - Workshop",
+                "Lounge"
+            ],
+            "the two renamed zones must sort together under their shared prefix"
+        );
+    }
+
+    /// A rename changes the display name and nothing else. Zone IDs are what knob bindings,
+    /// HQPlayer links, and MCP `zone_id` arguments address, so a rename that touched them would
+    /// break working setups.
+    #[test]
+    fn renaming_leaves_zone_ids_untouched() {
+        let settings = AppSettings {
+            zone_names: Some(named(&[("roon:kitchen", "Somewhere Else")])),
+            ..all_adapters_on()
+        };
+
+        let visible = apply_zone_list_policy(vec![zone("roon:kitchen", "Kitchen")], &settings);
+
+        assert_eq!(ids(&visible), vec!["roon:kitchen"]);
+        assert_eq!(visible[0].zone_name, "Somewhere Else");
+    }
+
+    /// An override naming a zone that no longer exists must be inert.
+    #[test]
+    fn stale_renames_are_ignored() {
+        let settings = AppSettings {
+            zone_names: Some(named(&[("roon:gone", "Ghost")])),
+            ..all_adapters_on()
+        };
+
+        let visible = apply_zone_list_policy(vec![zone("roon:kitchen", "Kitchen")], &settings);
+
+        assert_eq!(visible[0].zone_name, "Kitchen");
+    }
+
+    /// An explicit order still beats the renamed alphabet — renaming groups zones only where the
+    /// user has not placed them by hand.
+    #[test]
+    fn an_explicit_order_still_outranks_a_rename() {
+        let settings = AppSettings {
+            zone_names: Some(named(&[("roon:z", "Aaa")])),
+            zone_order: Some(vec!["roon:a".to_string(), "roon:z".to_string()]),
+            ..all_adapters_on()
+        };
+        let zones = vec![zone("roon:z", "Zed"), zone("roon:a", "Attic")];
+
+        let visible = apply_zone_list_policy(zones, &settings);
+
+        assert_eq!(ids(&visible), vec!["roon:a", "roon:z"]);
+    }
+
+    /// A provider this build predates should appear rather than vanish.
+    #[test]
+    fn unknown_prefixes_are_included() {
+        let settings = all_adapters_on();
+
+        let visible = apply_zone_list_policy(vec![zone("someday:new", "New Thing")], &settings);
+
+        assert_eq!(ids(&visible), vec!["someday:new"]);
+    }
+}

--- a/src/zone_list.rs
+++ b/src/zone_list.rs
@@ -228,12 +228,10 @@ pub fn reorder(
 }
 
 /// Which way [`reorder`] moves a zone.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum MoveDirection {
-    Up,
-    Down,
-}
+///
+/// Re-exported rather than redefined: the client sends this value, so one definition means a
+/// mismatch is a compile error instead of a 422 at runtime.
+pub use crate::app::api::MoveDirection;
 
 /// Move one zone to the slot another zone currently occupies, returning the full resulting order.
 ///

--- a/src/zone_list.rs
+++ b/src/zone_list.rs
@@ -235,6 +235,36 @@ pub enum MoveDirection {
     Down,
 }
 
+/// Move one zone to the slot another zone currently occupies, returning the full resulting order.
+///
+/// This is the drop half of drag-and-drop, where [`reorder`] is the step half. It takes a target
+/// *zone* rather than a target index because the client's row indices and the server's list can
+/// disagree — a zone can appear or vanish between render and drop — and a stale index would silently
+/// drop the zone in the wrong place, while a stale zone id resolves to `None` and does nothing.
+///
+/// Unlike [`reorder`], this does not step over hidden zones: a drop names an exact destination, and
+/// honouring it literally is what makes the result match where the user let go.
+///
+/// Returns `None` when either zone is unknown, or when they are the same zone.
+pub fn reorder_to(
+    effective_order: &[Zone],
+    zone_id: &str,
+    target_zone_id: &str,
+) -> Option<Vec<String>> {
+    if zone_id == target_zone_id {
+        return None;
+    }
+    let from = effective_order.iter().position(|z| z.zone_id == zone_id)?;
+    let to = effective_order
+        .iter()
+        .position(|z| z.zone_id == target_zone_id)?;
+
+    let mut ids: Vec<String> = effective_order.iter().map(|z| z.zone_id.clone()).collect();
+    let moved = ids.remove(from);
+    ids.insert(to, moved);
+    Some(ids)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -591,6 +621,40 @@ mod tests {
             reorder(&effective, "roon:visible", MoveDirection::Up, &hidden).is_none(),
             "already first among visible zones"
         );
+    }
+
+    /// A drop lands the zone exactly where the user let go, hidden rows included — unlike a button
+    /// step, which reasons about visible neighbours. Dropping onto row 0 must put it at row 0.
+    #[test]
+    fn a_drop_lands_on_the_targets_exact_slot() {
+        let effective = vec![
+            zone("roon:a", "Attic"),
+            zone("roon:b", "Basement"),
+            zone("roon:c", "Cellar"),
+        ];
+
+        assert_eq!(
+            reorder_to(&effective, "roon:c", "roon:a").expect("drop should apply"),
+            vec!["roon:c", "roon:a", "roon:b"],
+            "dropping Cellar onto Attic's row puts Cellar first"
+        );
+        assert_eq!(
+            reorder_to(&effective, "roon:a", "roon:c").expect("drop should apply"),
+            vec!["roon:b", "roon:c", "roon:a"],
+            "dropping Attic onto Cellar's row puts Attic last"
+        );
+    }
+
+    /// A drop that resolves to nothing must be a no-op, never a panic or a silent misplacement.
+    /// The dragged row can vanish between render and drop — a zone going offline mid-drag is
+    /// ordinary in this product.
+    #[test]
+    fn a_drop_on_an_unknown_or_identical_zone_does_nothing() {
+        let effective = vec![zone("roon:a", "Attic"), zone("roon:b", "Basement")];
+
+        assert!(reorder_to(&effective, "roon:a", "roon:a").is_none());
+        assert!(reorder_to(&effective, "roon:gone", "roon:a").is_none());
+        assert!(reorder_to(&effective, "roon:a", "roon:gone").is_none());
     }
 
     /// A hidden zone has no visible position, so it trades with whatever is adjacent.

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -16,6 +16,7 @@
 DELETE /mcp
 GET /admin
 GET /api/settings
+GET /api/zones/visibility
 GET /assets/{*path}
 GET /config/{knob_id}
 GET /control
@@ -60,6 +61,9 @@ GET /upnp/status
 GET /upnp/zones
 GET /zones
 POST /api/settings
+POST /api/zones/name
+POST /api/zones/order
+POST /api/zones/visibility
 POST /control
 POST /hqp/detect
 POST /hqp/instances

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -165,11 +165,21 @@ struct SettingsFixture {
 
 impl SettingsFixture {
     fn with_hqplayer(enabled: bool) -> Self {
+        Self::new(enabled, &[])
+    }
+
+    /// Settings with a populated per-zone hide list, for the MCP visibility contract.
+    fn with_hidden_zones(hidden: &[&str]) -> Self {
+        Self::new(true, hidden)
+    }
+
+    fn new(enabled: bool, hidden_zones: &[&str]) -> Self {
         let dir = tempfile::tempdir().expect("tempdir");
         let settings = json!({
             "hide_knobs_page": false,
             "hide_hqp_page": false,
             "hide_lms_page": false,
+            "hidden_zones": hidden_zones,
             "adapters": {
                 "roon": true,
                 "upnp": true,
@@ -5505,4 +5515,204 @@ async fn status_resource_agrees_with_hifi_status_tool() {
         tool_value, resource_value,
         "hifi://status must carry exactly the hifi_status tool's payload"
     );
+}
+
+// =============================================================================
+// Zone visibility (per-zone hide list)
+// =============================================================================
+
+/// Publish a bare zone onto the bus and wait for the aggregator to hold it.
+///
+/// Republishes rather than sleeping-then-publishing-once. The bus is a broadcast channel, so an
+/// event published before `ZoneAggregator::run` has attached its subscription is dropped with no
+/// error — and a fixed sleep only makes that race less likely on an unloaded machine, which is the
+/// worst kind of test flake. `ZoneDiscovered` is idempotent in the aggregator (it upserts by
+/// `zone_id`), so repeating it until the zone is observably held is safe and removes the race
+/// outright.
+async fn seed_zone(
+    bus: &unified_hifi_control::bus::SharedBus,
+    state: &AppState,
+    zone_id: &str,
+    zone_name: &str,
+) {
+    let zone = unified_hifi_control::bus::Zone {
+        zone_id: zone_id.to_string(),
+        zone_name: zone_name.to_string(),
+        state: unified_hifi_control::bus::PlaybackState::Stopped,
+        volume_control: None,
+        now_playing: None,
+        source: zone_id.split(':').next().unwrap_or("roon").to_string(),
+        is_controllable: true,
+        is_seekable: false,
+        last_updated: 0,
+        is_play_allowed: true,
+        is_pause_allowed: true,
+        is_next_allowed: true,
+        is_previous_allowed: true,
+    };
+
+    for _ in 0..100 {
+        bus.publish(unified_hifi_control::bus::BusEvent::ZoneDiscovered { zone: zone.clone() });
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        if state.aggregator.get_zone(zone_id).await.is_some() {
+            return;
+        }
+    }
+    panic!("zone {zone_id} never reached the aggregator");
+}
+
+/// A zone the user hid must be withheld from **all three** MCP zone surfaces, not just the obvious
+/// one.
+///
+/// `hifi_zones`, the `hifi://zones/...` resource enumeration, and `hifi_capabilities` each read
+/// `aggregator.get_zones()` directly before this work. Filtering only `hifi_zones` — the tempting
+/// one-line fix, since it is the tool named "zones" — leaves the hidden zone advertised as a
+/// resource and described in the capability report, so an assistant still finds it and offers it.
+/// This test fails that fix.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn a_hidden_zone_is_withheld_from_every_mcp_zone_surface() {
+    let _settings = SettingsFixture::with_hidden_zones(&["roon:phone"]);
+    let bus = create_bus();
+    let state = build_state_with_bus(bus.clone(), None).await;
+    let aggregator = state.aggregator.clone();
+    let aggregator_task = tokio::spawn(async move { aggregator.run().await });
+    // Let the aggregator's bus subscription attach before the first publish, or the event races the
+    // subscribe and is dropped.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    seed_zone(&bus, &state, "roon:phone", "My Phone").await;
+    seed_zone(&bus, &state, "roon:kitchen", "Kitchen").await;
+
+    let app = TestApp::with_state(state.clone());
+
+    // 1. hifi_zones
+    let zones_text = result_text(&app.call_tool("hifi_zones", json!({})).await);
+    assert!(
+        !zones_text.contains("roon:phone"),
+        "hifi_zones must not list a hidden zone: {zones_text}"
+    );
+    assert!(
+        zones_text.contains("roon:kitchen"),
+        "hifi_zones must still list the zones that are not hidden: {zones_text}"
+    );
+
+    // 2. resource enumeration
+    let resources = app.list_resources().await;
+    let uris: Vec<String> = resources
+        .get("resources")
+        .and_then(Value::as_array)
+        .expect("resources array")
+        .iter()
+        .filter_map(|r| r.get("uri").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect();
+    assert!(
+        !uris.iter().any(|u| u == "hifi://zones/roon:phone"),
+        "a hidden zone must not be advertised as a resource: {uris:?}"
+    );
+    assert!(
+        uris.iter().any(|u| u == "hifi://zones/roon:kitchen"),
+        "visible zones must still be advertised as resources: {uris:?}"
+    );
+
+    // 3. hifi_capabilities
+    let caps_text = result_text(&app.call_tool("hifi_capabilities", json!({})).await);
+    assert!(
+        !caps_text.contains("roon:phone"),
+        "hifi_capabilities must not describe a hidden zone: {caps_text}"
+    );
+    assert!(
+        caps_text.contains("roon:kitchen"),
+        "hifi_capabilities must still describe visible zones: {caps_text}"
+    );
+
+    aggregator_task.abort();
+}
+
+/// Hiding declutters lists; it does not withdraw control.
+///
+/// This is the guardrail that stops "hidden" from quietly becoming "denied". Knob bindings, MCP
+/// `zone_id` arguments, and HQPlayer links all address zones by ID, so an implementation that
+/// filtered the *control* path too would silently break working setups on upgrade — and would still
+/// pass every list-filtering assertion above.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn a_hidden_zone_remains_controllable_by_id() {
+    let _settings = SettingsFixture::with_hidden_zones(&["roon:phone"]);
+    let bus = create_bus();
+    let state = build_state_with_bus(bus.clone(), None).await;
+    let aggregator = state.aggregator.clone();
+    let aggregator_task = tokio::spawn(async move { aggregator.run().await });
+    // Let the aggregator's bus subscription attach before the first publish, or the event races the
+    // subscribe and is dropped.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    seed_zone(&bus, &state, "roon:phone", "My Phone").await;
+
+    let app = TestApp::with_state(state.clone());
+
+    let now_playing = app
+        .call_tool("hifi_now_playing", json!({ "zone_id": "roon:phone" }))
+        .await;
+    let text = result_text(&now_playing);
+    assert!(
+        !text.to_lowercase().contains("not found"),
+        "a hidden zone must still resolve when addressed by ID: {text}"
+    );
+
+    let read = app.read_resource("hifi://zones/roon:phone").await;
+    assert!(
+        read.pointer("/result/contents/0/text").is_some(),
+        "a hidden zone's resource must still be readable when addressed directly: {read}"
+    );
+
+    aggregator_task.abort();
+}
+
+/// Ordering must reach MCP too, not just the web UI.
+///
+/// Before this work `hifi_zones` returned `HashMap::values()`, so two identical calls could return
+/// two different orders. An assistant told "play in the second zone" would act on different
+/// hardware each time.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn hifi_zones_is_ordered_and_stable_across_calls() {
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let bus = create_bus();
+    let state = build_state_with_bus(bus.clone(), None).await;
+    let aggregator = state.aggregator.clone();
+    let aggregator_task = tokio::spawn(async move { aggregator.run().await });
+
+    // Seeded in an order that is neither alphabetical nor reverse-alphabetical, and with mixed case
+    // so a byte-order sort would put `attic` last rather than first.
+    seed_zone(&bus, &state, "roon:z", "Zed").await;
+    seed_zone(&bus, &state, "roon:a", "attic").await;
+    seed_zone(&bus, &state, "roon:m", "Middle").await;
+
+    let app = TestApp::with_state(state.clone());
+
+    let first: Value =
+        serde_json::from_str(&result_text(&app.call_tool("hifi_zones", json!({})).await))
+            .expect("hifi_zones must return JSON");
+    let names: Vec<&str> = first
+        .as_array()
+        .expect("hifi_zones returns an array")
+        .iter()
+        .filter_map(|z| z.get("zone_name").and_then(Value::as_str))
+        .collect();
+    assert_eq!(
+        names,
+        vec!["attic", "Middle", "Zed"],
+        "hifi_zones must be sorted by name, case-insensitively"
+    );
+
+    for _ in 0..5 {
+        let again: Value =
+            serde_json::from_str(&result_text(&app.call_tool("hifi_zones", json!({})).await))
+                .expect("hifi_zones must return JSON");
+        assert_eq!(first, again, "hifi_zones order must not vary between calls");
+    }
+
+    aggregator_task.abort();
 }


### PR DESCRIPTION
Reported by a user testing the Roon connection in Docker:

> I think it should respect private zones and exclude them from the zones list. Or, at least, it should be configurable somehow.

## What this does

Adds a **Zone list** section to Settings where each zone can be renamed, shown/hidden, and moved up or down. All three apply everywhere — this app, knobs, and connected assistants.

## One thing I could not deliver as asked

The request was for private-zone hiding, default on. **Roon exposes no private-zone flag to extensions** — neither the `Zone` nor the `Output` payload carries one, and the reporter seeing private zones at all is evidence the Core does not filter them for extensions.

So nothing is hidden by default. Defaulting anything to hidden would mean guessing which of someone's zones are personal, and a wrong guess makes a zone vanish with no way for them to tell it was our choice rather than theirs. What ships is the "or at least configurable somehow" half — which also serves LMS/UPnP/OpenHome users with the same problem.

If someone confirms a privacy field on a live Core, default-on hiding becomes possible and is worth revisiting.

## The ordering bug this fixes

`/zones` returned `HashMap::values()`, so the order **differed between two calls on an unchanged zone set**. Knobs, MCP, and every API consumer inherited it. The web zones page was the only consumer that compensated, and it sorted by byte value — `kitchen` landed after `Zone`.

## Design

Everything routes through one decision point, `zone_list::visible_zones`: adapter settings → hide list → rename → deterministic sort.

This is a change in kind. Zone-list membership *used* to be a fact about the aggregator — startup gating and #429's flush-on-`AdapterStopping` kept disabled adapters' zones out entirely, so reading `get_zones()` raw was correct. Hiding makes membership a **policy**, so any surface reading the aggregator directly now silently opts out of the user's choice. MCP's three zone paths were doing exactly that and are now routed through the chokepoint.

| Decision | Why |
|---|---|
| Hiding keys on `zone_id` | Already provider-prefixed, so all five adapters are covered with no per-adapter code |
| Hidden ≠ unreachable | A hidden zone addressed by ID still plays, MCP included. Knob bindings and assistant setups survive the upgrade |
| Rename before sort | Prefixing zones with `Basement - ` groups them in every list — grouping for free, nothing to build or explain |
| Explicit order, then alphabetical | A newly discovered zone lands somewhere findable instead of wherever `HashMap` iteration put it |
| Visible zones step over hidden ones when reordering | Otherwise a click changes the stored order but nothing the user can see, and the more you hide the more often it happens |
| Zone fields are `Option` | `POST /api/settings` saves its body wholesale and the settings page builds one from its own form fields — without carry-forward, toggling an adapter would erase the hide list |
| One zone per write | Two tabs editing different zones both land; whole-list writes would have the second discard the first |

## API

Four new routes (`api-change-approved` label needed). Kept single-line in `main.rs` — the contract extractor only sees single-line `.route(...)` calls, so the multi-line form I wrote first slipped past the guard entirely.

- `GET /api/zones/visibility` — the management list, hidden zones included. Distinct from `/zones` on purpose: without it, the only screen that can unhide a zone could not see it.
- `POST /api/zones/visibility` — `{zone_id, hidden}`
- `POST /api/zones/order` — `{zone_id, direction}`
- `POST /api/zones/name` — `{zone_id, name}`; empty clears

## Review pass

Ran a design critique on the settings UI and fixed what it found:

- **Save failures were invisible.** Handlers returned `200 {"ok": false}`; the client checks HTTP status, so a read-only bind-mounted config directory — a common Docker misconfiguration — would have produced a settings page that silently discarded writes while the checkbox stayed flipped. Now a real 500, surfaced in an `ErrorAlert`, with a revision-keyed row so the DOM is forced back to truth.
- **Reordering was unusable non-visually.** No announcement, and moving a zone to first disabled the very button under focus, dropping it to `<body>`. Now an `aria-live` region announces each move, and boundary buttons use `aria-disabled` so they stay focusable and say "already first".
- **The reorder buttons had no affordance** — `btn` with no variant has no border, no background, no hover. Now `btn-outline` with SVG chevrons.
- Four columns did not fit a 375px phone; Source now collapses below `sm`.
- The table never refreshed on zone discovery or adapter toggles, though `should_refresh_zones()` already existed.
- Accessible names include the provider, since zone names are not unique across adapters.

## Testing

Full suite green. New coverage is adversarial — each test names the plausible wrong implementation it fails:

- Sorting is case-insensitive (a byte-order sort fails)
- Equal names tiebreak on `zone_id` (a stable sort over `HashMap` order fails)
- Hiding works for all five providers (a Roon-only fix fails)
- Hidden zones are withheld from **all three** MCP surfaces (filtering only `hifi_zones` fails)
- Hidden zones remain controllable by ID (a control-plane filter fails)
- `hifi_zones` is byte-identical across repeated calls
- Renaming groups zones (renaming at the display layer instead of before the sort fails)
- Posting settings without the zone fields preserves them (a plain `Vec` fails)
- An unwritable config directory yields a 500

## Not in scope

Grouping — group-by-source already exists on the zones page, and what people mean by "grouping" (Roon transport grouping vs. user-defined rooms) is unresolved. Prefix-renaming covers the common case in the meantime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added settings to hide, rename, and reorder zones.
  * Added drag-and-drop ordering with precise placement controls.
  * Zone lists now use deterministic, case-insensitive ordering.
  * Hidden zones are excluded from listings while remaining directly controllable.
  * Applied consistent visibility and ordering across web, API, and integrations.
  * Added API endpoints for managing zone visibility, names, and order.

* **Bug Fixes**
  * Improved settings updates, validation, persistence, and refresh behavior.
  * Preserved existing settings during partial updates.
  * Improved accessibility feedback and drag-and-drop usability.

* **Documentation**
  * Added security guidance for network exposure, authentication, and MCP usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->