### PR TITLE
Roon adapter: implement zone grouping via group_outputs/ungroup_outputs

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -14,6 +14,7 @@ use roon_api::{
     CoreEvent, Info, Parsed, RoonApi, RoonApiError, Services, Svc,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -25,7 +26,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::bus::{
     runtime::{
@@ -172,6 +174,35 @@ pub(crate) fn is_ungrounded_grouping(item: &BrowseItem) -> bool {
 /// MCP and aggregator use prefixed IDs (e.g., "roon:zone_123"), but Roon API expects bare IDs.
 fn strip_roon_prefix(id: &str) -> &str {
     id.strip_prefix("roon:").unwrap_or(id)
+}
+
+/// Require a properly-prefixed Roon zone id and return its bare id.
+///
+/// Unlike [`strip_roon_prefix`] (used by the pre-existing transport paths,
+/// which tolerate a bare id for backward compatibility), the multiroom
+/// grouping surface (#509) is new and follows the stricter validation the
+/// Music Assistant and LMS adapters already apply to their own multiroom
+/// parameters (`musicassistant_player_id`, `lms_player_id`).
+fn roon_zone_id(zone_id: &str, parameter: &str) -> Result<String> {
+    zone_id
+        .strip_prefix("roon:")
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("{parameter} must be a Roon zone id"))
+}
+
+/// [`roon_zone_id`] over a list, rejecting duplicates the same way the
+/// Music Assistant and LMS multiroom contracts do.
+fn roon_zone_ids(zone_ids: &[String], parameter: &str) -> Result<Vec<String>> {
+    let mut ids = Vec::with_capacity(zone_ids.len());
+    for zone_id in zone_ids {
+        let id = roon_zone_id(zone_id, parameter)?;
+        if ids.contains(&id) {
+            return Err(anyhow::anyhow!("{parameter} must not contain duplicate zones"));
+        }
+        ids.push(id);
+    }
+    Ok(ids)
 }
 
 /// Pending image request - stores the oneshot sender to deliver the result
@@ -630,6 +661,14 @@ pub struct Output {
     pub output_id: String,
     pub display_name: String,
     pub volume: Option<VolumeInfo>,
+    /// Output ids this output can be grouped with, straight from the Core
+    /// (`transport::Output::can_group_with_output_ids`). Roon only groups
+    /// outputs that share a streaming protocol (RAAT with RAAT, AirPlay with
+    /// AirPlay, etc); this is the Core's own compatibility list, so grouping
+    /// (#509) refuses upfront against it instead of guessing at protocol
+    /// names the wire format never exposes.
+    #[serde(default)]
+    pub can_group_with_output_ids: Vec<String>,
 }
 
 /// Volume information
@@ -1372,6 +1411,213 @@ impl RoonAdapter {
         };
         transport.mute(&output_id, &how).await;
         Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiroom grouping (#509): `Transport::group_outputs` / `ungroup_outputs`
+    // wired to the `multiroom_status` / `multiroom_set_members` /
+    // `multiroom_ungroup` contract the Music Assistant adapter already
+    // implements (`src/adapters/musicassistant.rs`).
+    //
+    // Roon groups *outputs*, not zones. Grouping merges every named zone's
+    // outputs into a single zone; the Core keeps the leader's zone_id and
+    // retires the other zones (their outputs move under the leader's
+    // zone_id in the next zone update). This adapter resolves each zone
+    // argument to one representative output -- the same first-output
+    // resolution `change_volume` (above) already uses for multi-output
+    // zones -- and lets the ordinary zone-event pipeline in `run()`
+    // (`Parsed::Zones` / `Parsed::ZonesRemoved`, already unconditional for
+    // every zone change) publish the resulting `ZoneUpdated` /
+    // `ZoneRemoved` bus events. No special-case bus code is needed for
+    // grouping: from the bus's perspective a merge is just an ordinary zone
+    // update plus zone removal.
+    //
+    // Because member zone ids do not survive a merge, this adapter reports
+    // (and accepts back) *outputs* as members once a group exists: for a
+    // zone with more than one output, `multiroom_status` treats the first
+    // output as the "leader" and the rest as members, addressed as
+    // `roon:<output_id>` rather than a zone id. That is a stable-but-
+    // arbitrary UHC display convention (mirroring the same call LMS's
+    // adapter documents for its own leaderless sync groups), not a Roon
+    // fact: `resolve_roon_output` accepts either a live zone id or a bare
+    // output id, so a caller can always name a group member whether or not
+    // it currently has its own zone.
+
+    /// Resolve `id` (bare, no "roon:" prefix) to one Roon output: either the
+    /// first output of a zone with this id, or -- for a member of an
+    /// existing group, whose original zone id was retired by the merge --
+    /// the output with this id directly.
+    async fn resolve_roon_output(&self, id: &str) -> Result<Output> {
+        let state = self.state.read().await;
+        if let Some(zone) = state.zones.get(id) {
+            return zone
+                .outputs
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Zone has no outputs: {id}"));
+        }
+        state
+            .zones
+            .values()
+            .find_map(|zone| zone.outputs.iter().find(|o| o.output_id == id).cloned())
+            .ok_or_else(|| anyhow::anyhow!("Roon zone or output was not found: {id}"))
+    }
+
+    /// Report every Roon zone with more than one output as a group.
+    ///
+    /// `can_set_members` is always `true`: every Roon output accepts
+    /// `group_outputs`/`ungroup_outputs` unconditionally, so there is no
+    /// per-group capability to check (unlike Music Assistant's per-leader
+    /// `SET_MEMBERS` feature flag).
+    pub async fn multiroom_status(&self) -> Result<Value> {
+        let state = self.state.read().await;
+        let groups: Vec<Value> = state
+            .zones
+            .values()
+            .filter(|zone| zone.outputs.len() > 1)
+            .filter_map(|zone| {
+                let (_leader_output, member_outputs) = zone.outputs.split_first()?;
+                Some(json!({
+                    "leader_zone_id": PrefixedZoneId::roon(&zone.zone_id).to_string(),
+                    "member_zone_ids": member_outputs
+                        .iter()
+                        .map(|o| PrefixedZoneId::roon(&o.output_id).to_string())
+                        .collect::<Vec<_>>(),
+                    "can_set_members": true,
+                }))
+            })
+            .collect();
+        Ok(json!({ "groups": groups }))
+    }
+
+    /// Group `add_zone_ids` (and any current members of `leader_zone_id`'s
+    /// group) together via `group_outputs`, and ungroup `remove_zone_ids` via
+    /// `ungroup_outputs`, then return the current `multiroom_status`.
+    ///
+    /// Roon confirms grouping asynchronously through the ordinary zone
+    /// subscription rather than a synchronous RPC reply (the same is true of
+    /// `change_volume`/`mute`/`control` above), so -- unlike the Music
+    /// Assistant and LMS adapters, whose underlying protocols are
+    /// request/response -- the status returned here is a snapshot of
+    /// current knowledge, not a guaranteed post-condition. Callers that need
+    /// the authoritative outcome should watch the zone bus, exactly as they
+    /// already must for every other Roon transport command.
+    pub async fn set_group_members(
+        &self,
+        leader_zone_id: &str,
+        add_zone_ids: &[String],
+        remove_zone_ids: &[String],
+    ) -> Result<Value> {
+        if add_zone_ids.is_empty() && remove_zone_ids.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Roon group membership needs at least one member"
+            ));
+        }
+        let leader_id = roon_zone_id(leader_zone_id, "leader_zone_id")?;
+        let add_ids = roon_zone_ids(add_zone_ids, "member_zone_ids_to_add")?;
+        let remove_ids = roon_zone_ids(remove_zone_ids, "member_zone_ids_to_remove")?;
+        for id in add_ids.iter().chain(remove_ids.iter()) {
+            if id == &leader_id {
+                return Err(anyhow::anyhow!(
+                    "Roon group leader cannot be its own member input"
+                ));
+            }
+        }
+
+        let leader_output = self
+            .resolve_roon_output(&leader_id)
+            .await
+            .map_err(|_| anyhow::anyhow!("Roon group leader was not found"))?;
+        let mut add_outputs = Vec::with_capacity(add_ids.len());
+        for id in &add_ids {
+            add_outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+        let mut remove_outputs = Vec::with_capacity(remove_ids.len());
+        for id in &remove_ids {
+            remove_outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+
+        // Roon only groups outputs that share a streaming protocol. The Core
+        // does not expose a queryable protocol name, but `can_group_with_output_ids`
+        // *is* the Core's own compatibility list for the leader's output, so a
+        // mismatch here is refused cleanly instead of being sent to the Core
+        // to fail (or be silently ignored) in some undocumented way.
+        for output in &add_outputs {
+            if !leader_output
+                .can_group_with_output_ids
+                .iter()
+                .any(|id| id == &output.output_id)
+            {
+                return Err(anyhow::anyhow!(
+                    "Cannot group '{}' with '{}': they do not share a compatible streaming protocol",
+                    output.display_name,
+                    leader_output.display_name
+                ));
+            }
+        }
+
+        let transport = {
+            let state = self.state.read().await;
+            state
+                .transport
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Not connected to Roon"))?
+        };
+
+        if !add_outputs.is_empty() {
+            let mut output_ids: Vec<&str> = vec![leader_output.output_id.as_str()];
+            output_ids.extend(add_outputs.iter().map(|o| o.output_id.as_str()));
+            transport.group_outputs(output_ids).await;
+        }
+        for output in &remove_outputs {
+            transport
+                .ungroup_outputs(vec![output.output_id.as_str()])
+                .await;
+        }
+
+        self.multiroom_status().await
+    }
+
+    /// Ungroup each of `member_zone_ids` via `ungroup_outputs`, then return
+    /// the current `multiroom_status`. See [`Self::set_group_members`] for
+    /// why the returned status is a snapshot rather than a guaranteed
+    /// post-condition.
+    pub async fn ungroup_members(&self, member_zone_ids: &[String]) -> Result<Value> {
+        let member_ids = roon_zone_ids(member_zone_ids, "member_zone_ids")?;
+        if member_ids.is_empty() {
+            return Err(anyhow::anyhow!("Roon ungroup needs at least one member"));
+        }
+        let mut outputs = Vec::with_capacity(member_ids.len());
+        for id in &member_ids {
+            outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+
+        let transport = {
+            let state = self.state.read().await;
+            state
+                .transport
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Not connected to Roon"))?
+        };
+        for output in &outputs {
+            transport
+                .ungroup_outputs(vec![output.output_id.as_str()])
+                .await;
+        }
+
+        self.multiroom_status().await
     }
 
     /// Get album art image
@@ -2268,6 +2514,76 @@ impl RoonAdapter {
     }
 }
 
+/// Content-library surface (#509): only the multiroom grouping operations
+/// are implemented here. Roon's own search/play surfaces are reached
+/// through their dedicated paths (`RoonAdapter::search`, `RoonAdapter::play_item`,
+/// ...); this trait is what lets the provider-neutral MCP registry
+/// (`AdapterRegistry::library_content`) dispatch `multiroom_status`,
+/// `multiroom_set_members` and `multiroom_ungroup` to Roon the same way it
+/// already dispatches them to Music Assistant
+/// (`src/adapters/musicassistant.rs`).
+#[async_trait]
+impl LibraryAdapter for RoonAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow::anyhow!(
+            "Roon search is not implemented via the generic content-library surface (see #396/#402)"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow::anyhow!(
+            "Roon play-by-uri is not implemented via the generic content-library surface (see #396)"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        match operation {
+            "multiroom_status" => self.multiroom_status().await,
+            "multiroom_set_members" => {
+                let leader = params
+                    .get("leader_zone_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("Roon group operation requires leader_zone_id"))?;
+                let add = params
+                    .get("member_zone_ids_to_add")
+                    .or_else(|| params.get("member_zone_ids"))
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow::anyhow!("Roon group operation requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                let remove = params
+                    .get("member_zone_ids_to_remove")
+                    .and_then(Value::as_array)
+                    .map(|members| {
+                        members
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                self.set_group_members(leader, &add, &remove).await
+            }
+            "multiroom_ungroup" => {
+                let members = params
+                    .get("member_zone_ids")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow::anyhow!("Roon ungroup requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                self.ungroup_members(&members).await
+            }
+            _ => Err(anyhow::anyhow!(
+                "Roon content operation `{operation}` is not supported"
+            )),
+        }
+    }
+}
+
 #[async_trait]
 impl AdapterLogic for RoonAdapter {
     fn prefix(&self) -> &'static str {
@@ -2604,6 +2920,7 @@ fn convert_zone(roon_zone: &RoonZone) -> Zone {
                 is_muted: v.is_muted,
                 step: v.step,
             }),
+            can_group_with_output_ids: o.can_group_with_output_ids.clone(),
         })
         .collect();
 
@@ -3383,6 +3700,7 @@ mod tests {
                     is_muted: None,
                     step: None,
                 }),
+                can_group_with_output_ids: Vec::new(),
             }],
         }
     }
@@ -3448,6 +3766,7 @@ mod tests {
                 output_id: "output-no-vol".to_string(),
                 display_name: "No Volume Output".to_string(),
                 volume: None,
+                can_group_with_output_ids: Vec::new(),
             }],
         };
         let bus_zone = roon_zone_to_bus_zone(&zone);

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,6 +502,14 @@ mod server {
             .adapter_registry
             .register_library("spotify", spotify.clone())
             .await;
+        // Roon's transport commands keep going through the dedicated
+        // `state.roon` field/routes; this registration only exposes the
+        // provider-neutral content-library surface (#509's multiroom
+        // grouping operations) via `AdapterRegistry::library_content("roon", ...)`.
+        state
+            .adapter_registry
+            .register_library("roon", state.roon.clone())
+            .await;
         state.provider_auth.attach_spotify(spotify.clone()).await;
         state
             .provider_auth

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -562,6 +562,11 @@ struct CoreState {
     core_id: String,
     display_name: String,
     display_version: String,
+    /// The zone subscription's `(req_id, writer)`, captured when
+    /// `subscribe_zones` completes (#509). `group_outputs`/`ungroup_outputs`
+    /// push their effect on this same subscription, mirroring a real Core --
+    /// see the `SubscribeZones` handler for why it must be this req_id.
+    zone_push: Option<(usize, Writer)>,
 }
 
 // =============================================================================
@@ -611,6 +616,7 @@ impl FakeRoonCore {
             core_id: format!("fake-core-408-{}", addr.port()),
             display_name: "Fake Roon Core".to_string(),
             display_version: "2.0.408".to_string(),
+            zone_push: None,
         }));
         let root_title = library.root_title.clone();
 
@@ -951,6 +957,48 @@ pub fn default_zone(zone_id: &str, display_name: &str) -> Value {
     })
 }
 
+/// A single-output zone with an explicit output id and grouping
+/// compatibility list (issue #509), for tests that need several distinct
+/// zones whose outputs can (or deliberately cannot) be grouped together.
+/// `default_zone` above always derives `"{zone_id}_output"` and leaves
+/// `can_group_with_output_ids` empty, which cannot express either.
+pub fn zone_with_grouping(
+    zone_id: &str,
+    display_name: &str,
+    output_id: &str,
+    can_group_with_output_ids: &[&str],
+) -> Value {
+    json!({
+        "zone_id": zone_id,
+        "display_name": display_name,
+        "state": "stopped",
+        "is_next_allowed": true,
+        "is_previous_allowed": true,
+        "is_pause_allowed": false,
+        "is_play_allowed": true,
+        "is_seek_allowed": false,
+        "queue_items_remaining": 0,
+        "queue_time_remaining": 0,
+        "now_playing": null,
+        "settings": { "loop": "disabled", "shuffle": false, "auto_radio": false },
+        "outputs": [{
+            "output_id": output_id,
+            "zone_id": zone_id,
+            "can_group_with_output_ids": can_group_with_output_ids,
+            "display_name": display_name,
+            "source_controls": null,
+            "volume": {
+                "type": "number",
+                "min": 0.0,
+                "max": 100.0,
+                "value": 50.0,
+                "step": 1.0,
+                "is_muted": false
+            }
+        }]
+    })
+}
+
 // =============================================================================
 // MOO framing
 // =============================================================================
@@ -1186,6 +1234,14 @@ async fn handle_request(
         }
         RequestKind::SubscribeZones => {
             let body = json!({ "zones": core.read().await.zones.clone() });
+            // Remember this request id and connection so group_outputs /
+            // ungroup_outputs (#509) can push a later `CONTINUE Changed` on
+            // the same subscription -- exactly how a real Core reports the
+            // effect of grouping, per the fork's own `parse_msg`
+            // (`transport.rs:457-484`): it only recognises `zones_changed` /
+            // `zones_added` / `zones_removed` arriving on the *subscription's*
+            // `req_id`, not a fresh one.
+            core.write().await.zone_push = Some((req_id, writer.clone()));
             // FROM FORK: transport.rs:479 accepts name "Subscribed"; a
             // subscription stays open, hence CONTINUE.
             respond(
@@ -1203,6 +1259,8 @@ async fn handle_request(
         }
         RequestKind::Browse => handle_browse(req_id, &body, &core, &writer, &root_title).await,
         RequestKind::Load => handle_load(req_id, &body, &core, &writer).await,
+        RequestKind::GroupOutputs => handle_group_outputs(req_id, &body, &core, &writer).await,
+        RequestKind::UngroupOutputs => handle_ungroup_outputs(req_id, &body, &core, &writer).await,
         RequestKind::Unknown => {
             // Mirrors the fork's own reply to an unknown service (lib.rs:588-592).
             // FROM ROONLABS' PUBLISHED API: `InvalidRequest` with an `error` string
@@ -1232,6 +1290,8 @@ enum RequestKind {
     Browse,
     Load,
     Ping,
+    GroupOutputs,
+    UngroupOutputs,
     Unknown,
 }
 
@@ -1245,6 +1305,9 @@ impl RequestKind {
             "com.roonlabs.browse:1/browse" => Self::Browse,
             "com.roonlabs.browse:1/load" => Self::Load,
             "com.roonlabs.ping:1/ping" => Self::Ping,
+            // FROM FORK: transport.rs:334,343 -- both send only `output_ids`.
+            "com.roonlabs.transport:2/group_outputs" => Self::GroupOutputs,
+            "com.roonlabs.transport:2/ungroup_outputs" => Self::UngroupOutputs,
             _ => Self::Unknown,
         }
     }
@@ -1496,6 +1559,231 @@ async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>,
     // FROM FORK: browse.rs:93-98 LoadResult { items, offset, list } — all required.
     let body = json!({ "items": items, "offset": offset, "list": list });
     respond(core, writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+}
+
+// =============================================================================
+// Grouping: group_outputs / ungroup_outputs (issue #509)
+// =============================================================================
+//
+// FROM FORK: `transport.rs:334-350` sends only `{"output_ids": [...]}` and
+// reads no reply body at all -- `Transport::group_outputs`/`ungroup_outputs`
+// return the raw `Option<usize>` request id, not a parsed result. So the
+// client observes the *effect* of grouping only through the zone
+// subscription's `Changed` push, exactly like every other Roon transport
+// write in this fake (`control`, `mute`, `change_volume` get the same
+// body-less `COMPLETE Success`). This fake's own zone-merge/split semantics
+// below are a simplified model, not a documented Core behavior: real Roon's
+// exact index/ordering rules for a merged zone's `outputs` list are
+// unpublished. What is load-bearing is that a merge (a) keeps the leader's
+// zone_id, (b) unions the outputs, and (c) retires any source zone left with
+// none -- which is exactly what issue #509's acceptance criteria describe.
+
+async fn handle_group_outputs(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>, writer: &Writer) {
+    let output_ids = string_array(body, "output_ids");
+    respond(core, writer, "COMPLETE", "Success", req_id, None).await;
+
+    let (merge, push) = {
+        let mut state = core.write().await;
+        let merge = merge_zone_outputs(&mut state.zones, &output_ids);
+        (merge, state.zone_push.clone())
+    };
+    let Some((merged_zone, removed_zone_ids)) = merge else {
+        return;
+    };
+    if let Some((sub_req_id, sub_writer)) = push {
+        let mut change = json!({ "zones_changed": [merged_zone] });
+        if !removed_zone_ids.is_empty() {
+            change["zones_removed"] = json!(removed_zone_ids);
+        }
+        send(&sub_writer, "CONTINUE", "Changed", sub_req_id, Some(&change)).await;
+    }
+}
+
+async fn handle_ungroup_outputs(
+    req_id: usize,
+    body: &Value,
+    core: &Arc<RwLock<CoreState>>,
+    writer: &Writer,
+) {
+    let output_ids = string_array(body, "output_ids");
+    respond(core, writer, "COMPLETE", "Success", req_id, None).await;
+
+    let (changed, added, removed, push) = {
+        let mut state = core.write().await;
+        let (changed, added, removed) = split_zone_outputs(&mut state.zones, &output_ids);
+        (changed, added, removed, state.zone_push.clone())
+    };
+    if changed.is_empty() && added.is_empty() && removed.is_empty() {
+        return;
+    }
+    if let Some((sub_req_id, sub_writer)) = push {
+        let mut zones_changed = changed;
+        zones_changed.extend(added);
+        let mut change = json!({});
+        if !zones_changed.is_empty() {
+            change["zones_changed"] = json!(zones_changed);
+        }
+        if !removed.is_empty() {
+            change["zones_removed"] = json!(removed);
+        }
+        send(&sub_writer, "CONTINUE", "Changed", sub_req_id, Some(&change)).await;
+    }
+}
+
+fn string_array(body: &Value, field: &str) -> Vec<String> {
+    body.get(field)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The `(zone index, output index)` of the zone currently holding `output_id`.
+fn zone_output_index(zones: &[Value], output_id: &str) -> Option<(usize, usize)> {
+    zones.iter().enumerate().find_map(|(zi, zone)| {
+        let outs = zone.get("outputs")?.as_array()?;
+        let oi = outs
+            .iter()
+            .position(|o| o.get("output_id").and_then(Value::as_str) == Some(output_id))?;
+        Some((zi, oi))
+    })
+}
+
+/// Merge every output in `output_ids` into the zone holding the first id.
+/// Returns the merged zone's full JSON and the zone_ids of any source zones
+/// that lost their last output and were retired as a result. `None` when
+/// there was nothing to merge (the leader output was not found, or every
+/// other requested output already belongs to the leader's zone).
+fn merge_zone_outputs(zones: &mut Vec<Value>, output_ids: &[String]) -> Option<(Value, Vec<String>)> {
+    let leader_output_id = output_ids.first()?;
+    let (leader_zi, _) = zone_output_index(zones, leader_output_id)?;
+    let leader_zone_id = zones[leader_zi]["zone_id"].as_str()?.to_string();
+
+    let mut moved_from = Vec::new();
+    let mut moved_outputs = Vec::new();
+    for output_id in &output_ids[1..] {
+        let Some((zi, _)) = zone_output_index(zones, output_id) else {
+            continue;
+        };
+        if zi == leader_zi {
+            continue; // already part of the leader's zone
+        }
+        let outs = zones[zi]["outputs"].as_array_mut()?;
+        let Some(pos) = outs
+            .iter()
+            .position(|o| o["output_id"].as_str() == Some(output_id.as_str()))
+        else {
+            continue;
+        };
+        let mut out = outs.remove(pos);
+        out["zone_id"] = json!(leader_zone_id);
+        moved_from.push(zi);
+        moved_outputs.push(out);
+    }
+    if moved_outputs.is_empty() {
+        return None;
+    }
+
+    // Retire any source zone that lost its last output. Removing in
+    // descending index order keeps the remaining indices (including
+    // `leader_zi`, adjusted below) valid.
+    let mut emptied: Vec<usize> = moved_from;
+    emptied.sort_unstable();
+    emptied.dedup();
+    let mut removed_zone_ids = Vec::new();
+    let mut leader_zi = leader_zi;
+    for zi in emptied.into_iter().rev() {
+        if zones[zi]["outputs"]
+            .as_array()
+            .is_some_and(|outs| outs.is_empty())
+        {
+            removed_zone_ids.push(zones[zi]["zone_id"].as_str().unwrap_or_default().to_string());
+            zones.remove(zi);
+            if zi < leader_zi {
+                leader_zi -= 1;
+            }
+        }
+    }
+
+    let leader_outputs = zones[leader_zi]["outputs"].as_array_mut()?;
+    leader_outputs.extend(moved_outputs);
+
+    Some((zones[leader_zi].clone(), removed_zone_ids))
+}
+
+/// Pull every output in `output_ids` out of its current zone into its own
+/// standalone zone. Returns `(zones_changed, zones_added, zones_removed)`:
+/// a source zone that keeps at least one output after losing this one is
+/// `zones_changed`; a source zone left empty is retired into `zones_removed`.
+/// An output already alone in its zone is left untouched (not returned in
+/// any of the three).
+fn split_zone_outputs(
+    zones: &mut Vec<Value>,
+    output_ids: &[String],
+) -> (Vec<Value>, Vec<Value>, Vec<String>) {
+    let mut zones_changed = Vec::new();
+    let mut zones_added = Vec::new();
+    let mut zones_removed = Vec::new();
+
+    for output_id in output_ids {
+        let Some((zi, _)) = zone_output_index(zones, output_id) else {
+            continue;
+        };
+        let output_count = zones[zi]["outputs"].as_array().map_or(0, Vec::len);
+        if output_count <= 1 {
+            continue; // already standalone
+        }
+        let outs = zones[zi]["outputs"].as_array_mut().unwrap();
+        let pos = outs
+            .iter()
+            .position(|o| o["output_id"].as_str() == Some(output_id.as_str()))
+            .unwrap();
+        let mut out = outs.remove(pos);
+
+        let new_zone_id = format!("ungrouped-{output_id}");
+        out["zone_id"] = json!(new_zone_id);
+        let new_zone = standalone_zone_from_output(&new_zone_id, out);
+        zones.push(new_zone.clone());
+        zones_added.push(new_zone);
+
+        if zones[zi]["outputs"].as_array().unwrap().is_empty() {
+            zones_removed.push(zones[zi]["zone_id"].as_str().unwrap_or_default().to_string());
+        } else {
+            zones_changed.push(zones[zi].clone());
+        }
+    }
+    if !zones_removed.is_empty() {
+        zones.retain(|z| {
+            !zones_removed.contains(&z["zone_id"].as_str().unwrap_or_default().to_string())
+        });
+    }
+    (zones_changed, zones_added, zones_removed)
+}
+
+/// Build a minimal, fully-populated standalone zone (every field
+/// `roon_api`'s `transport::Zone` requires, same as [`default_zone`]) around
+/// one output that just left a group.
+fn standalone_zone_from_output(zone_id: &str, output: Value) -> Value {
+    json!({
+        "zone_id": zone_id,
+        "display_name": output["display_name"],
+        "state": "stopped",
+        "is_next_allowed": true,
+        "is_previous_allowed": true,
+        "is_pause_allowed": false,
+        "is_play_allowed": true,
+        "is_seek_allowed": false,
+        "queue_items_remaining": 0,
+        "queue_time_remaining": 0,
+        "now_playing": null,
+        "settings": { "loop": "disabled", "shuffle": false, "auto_radio": false },
+        "outputs": [output],
+    })
 }
 
 fn current_list(state: &CoreState, session_key: &str) -> Value {

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -30,7 +30,9 @@ mod mock_servers;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use mock_servers::roon_core::{album, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope};
+use mock_servers::roon_core::{
+    album, zone_with_grouping, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
+};
 use roon_api::browse::{BrowseOpts, LoadOpts};
 use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
 use unified_hifi_control::bus::create_bus;
@@ -1602,6 +1604,216 @@ async fn a_shared_session_key_is_one_level_stack_however_well_results_correlate(
         Some(&here.list.title),
         levels.last(),
         "a following load pages the level that landed last, whoever asked for it"
+    );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// Multiroom grouping: group_outputs / ungroup_outputs (issue #509)
+// =============================================================================
+//
+// Roon confirms grouping asynchronously through the ordinary zone
+// subscription (`RoonAdapter::set_group_members`'s own docs explain why), so
+// these tests poll `RoonAdapter::get_zones` rather than asserting on the
+// instant `set_group_members`/`ungroup_members` return.
+
+/// Poll `RoonAdapter::get_zones` until it reports exactly `expected` zones or
+/// a bound is hit, then return the last observation either way -- so a
+/// failing assertion downstream shows what actually arrived instead of just
+/// "timed out".
+async fn wait_for_zone_count(
+    adapter: &RoonAdapter,
+    expected: usize,
+) -> Vec<unified_hifi_control::adapters::roon::Zone> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let zones = adapter.get_zones().await;
+        if zones.len() == expected || Instant::now() >= deadline {
+            return zones;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn roon_multiroom_status_reports_no_groups_for_single_output_zones() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    // `connected()` only waits for Browse to register; the zone subscription
+    // it triggers as a side effect can still be in flight, so wait for both
+    // configured zones to have actually arrived before trusting the status
+    // below to mean anything.
+    wait_for_zone_count(&adapter, 2).await;
+
+    let status = adapter.multiroom_status().await.unwrap();
+    assert_eq!(
+        status["groups"].as_array().unwrap().len(),
+        0,
+        "no zone has more than one output yet"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_set_group_members_merges_outputs_into_one_zone() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    // See the status test above: wait for both zones before grouping them.
+    wait_for_zone_count(&adapter, 2).await;
+
+    adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await
+        .expect("set_group_members should succeed");
+
+    // Merging is confirmed asynchronously (the Core's `group_outputs` handler
+    // runs in its own spawned task, and the merge itself is only visible once
+    // its zone push round-trips back to the adapter), so wait for that before
+    // inspecting either the wire log or the adapter's own zone state.
+    let zones = wait_for_zone_count(&adapter, 1).await;
+    assert_eq!(
+        zones.len(),
+        1,
+        "the two zones merge into one once the Core's push arrives"
+    );
+
+    // The wire request the Core actually saw: `group_outputs` addressed by
+    // output id, leader first, exactly as `Transport::group_outputs`
+    // (`transport.rs:334-341`) sends it.
+    let group_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/group_outputs")
+        .collect();
+    assert_eq!(group_requests.len(), 1, "exactly one group_outputs call");
+    assert_eq!(
+        group_requests[0].body["output_ids"],
+        serde_json::json!(["output_a", "output_b"])
+    );
+    let merged = &zones[0];
+    assert_eq!(merged.zone_id, "zone_a", "the leader's zone_id survives");
+    let mut output_ids: Vec<&str> = merged.outputs.iter().map(|o| o.output_id.as_str()).collect();
+    output_ids.sort_unstable();
+    assert_eq!(output_ids, vec!["output_a", "output_b"]);
+
+    let status = adapter.multiroom_status().await.unwrap();
+    let groups = status["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 1, "the merged zone reports as one group");
+    assert_eq!(groups[0]["leader_zone_id"], serde_json::json!("roon:zone_a"));
+    assert_eq!(
+        groups[0]["member_zone_ids"],
+        serde_json::json!(["roon:output_b"]),
+        "member zone_a was retired, so the surviving member is named by output id"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_ungroup_members_splits_outputs_back_into_separate_zones() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    wait_for_zone_count(&adapter, 2).await;
+
+    adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await
+        .expect("initial grouping should succeed");
+    wait_for_zone_count(&adapter, 1).await;
+
+    adapter
+        .ungroup_members(&["roon:output_b".to_string()])
+        .await
+        .expect("ungroup_members should succeed");
+
+    // See the merge test above for why this waits before inspecting either
+    // the wire log or the adapter's own zone state.
+    let zones = wait_for_zone_count(&adapter, 2).await;
+    assert_eq!(
+        zones.len(),
+        2,
+        "output_b splits back into its own zone once the Core's push arrives"
+    );
+
+    let ungroup_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/ungroup_outputs")
+        .collect();
+    assert_eq!(ungroup_requests.len(), 1, "exactly one ungroup_outputs call");
+    assert_eq!(
+        ungroup_requests[0].body["output_ids"],
+        serde_json::json!(["output_b"])
+    );
+    assert!(
+        zones.iter().all(|z| z.outputs.len() == 1),
+        "each zone is single-output again: {zones:?}"
+    );
+
+    let status = adapter.multiroom_status().await.unwrap();
+    assert_eq!(
+        status["groups"].as_array().unwrap().len(),
+        0,
+        "no zone has more than one output after the split"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_set_group_members_refuses_mixed_protocol_outputs() {
+    let core = FakeRoonCore::start().await;
+    // Neither output lists the other as groupable -- e.g. one is RAAT and the
+    // other AirPlay. Real Roon Cores only group outputs that share a
+    // streaming protocol; `can_group_with_output_ids` is the Core's own
+    // compatibility list for exactly this.
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &[]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &[]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    wait_for_zone_count(&adapter, 2).await;
+
+    let result = adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await;
+
+    let error = result.expect_err("mixed-protocol grouping must be refused, not attempted");
+    let message = error.to_string();
+    assert!(
+        message.contains("protocol"),
+        "refusal should explain why, got: {message}"
+    );
+
+    let group_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/group_outputs")
+        .collect();
+    assert!(
+        group_requests.is_empty(),
+        "the incompatible request must never reach the Core: {group_requests:?}"
     );
 
     core.stop().await;

--- a/tests/volume_safety.rs
+++ b/tests/volume_safety.rs
@@ -22,6 +22,7 @@ fn db_output() -> Output {
             is_muted: Some(false),
             step: Some(1.0),
         }),
+        can_group_with_output_ids: Vec::new(),
     }
 }
 
@@ -71,6 +72,7 @@ fn pct_output() -> Output {
             is_muted: Some(false),
             step: Some(1.0),
         }),
+        can_group_with_output_ids: Vec::new(),
     }
 }
 
@@ -113,6 +115,7 @@ fn missing_volume_uses_safe_defaults() {
         output_id: "no-vol".to_string(),
         display_name: "No Volume".to_string(),
         volume: None,
+        can_group_with_output_ids: Vec::new(),
     };
     let (min, max) = get_volume_range(Some(&output));
     assert_eq!(min, 0.0);


### PR DESCRIPTION
Closes #509

## Base branch

Based on `feat/issue-462-streaming-adapters`, not `v3`: the multiroom MCP contract (`multiroom_set_members`/`multiroom_ungroup`/`multiroom_status`, implemented by `src/adapters/musicassistant.rs`) exists only on this branch today. Same rationale as PR #511/#513.

## Summary

Wires the Roon adapter to the existing multiroom content-library contract using the forked `roon-api` crate's `Transport::group_outputs`/`ungroup_outputs` (`open-horizon-labs/rust-roon-api@ohc/main`, `src/transport.rs:334,343`), mirroring the pattern PR #513 established for LMS sync groups.

- **`multiroom_set_members`**: resolves the leader zone and each added/removed zone to a representative output (the same first-output resolution `change_volume` already uses for multi-output zones, `src/adapters/roon.rs` around the volume path), then calls `group_outputs`/`ungroup_outputs` with those output ids.
- **`multiroom_ungroup`**: resolves each named member to its output and calls `ungroup_outputs`.
- **`multiroom_status`**: reports every zone with more than one output as a group.

**Roon groups outputs, not zones (per the issue's notes).** Grouping merges every named zone's outputs into one zone; the Core keeps the leader's `zone_id` and retires the other zones. Because a member's original zone id does not survive a merge, this adapter reports (and accepts back) group members addressed by **output id** (`roon:<output_id>`) once a group exists, rather than by their now-retired zone id — a stable-but-arbitrary UHC display convention (documented at `RoonAdapter::multiroom_status`), analogous to what LMS's own adapter does for its leaderless sync groups. `resolve_roon_output` accepts either a live zone id or a bare output id, so a caller can always name a member whether or not it currently has its own zone.

**Mixed-protocol refusal.** Roon Core only groups outputs sharing a streaming protocol (RAAT with RAAT, AirPlay with AirPlay, etc.), but the wire format exposes no queryable protocol name. Instead, each `transport::Output` carries `can_group_with_output_ids` — the Core's own compatibility list — which this PR threads through the adapter's local `Output` type (previously untracked) and checks *before* ever calling `group_outputs`, returning a clean, explanatory error (`"...they do not share a compatible streaming protocol"`) rather than sending an incompatible request to the Core.

**Bus zone coherence.** No special-case bus code was needed: the existing zone-event pipeline in `RoonAdapter::run()` (`Parsed::Zones` / `Parsed::ZonesRemoved`) already publishes `ZoneUpdated`/`ZoneRemoved` unconditionally for every zone change, so a grouping merge (an ordinary zone update plus a zone removal, from the wire's perspective) is handled correctly by construction.

**Async confirmation.** Unlike LMS/Music Assistant's request/response RPCs, Roon confirms grouping asynchronously through the ordinary zone subscription (the same is true of this adapter's pre-existing `change_volume`/`mute`/`control`). `set_group_members`/`ungroup_members` return the current `multiroom_status` snapshot rather than a guaranteed post-condition; this is documented at both methods.

**Wiring:** `RoonAdapter` now implements `LibraryAdapter` (`src/adapters/traits.rs`), registered under the `"roon"` prefix (`src/main.rs`) so `AdapterRegistry::library_content("roon", ...)` reaches it — the same registry mechanism Music Assistant's and (pending) LMS's grouping use. Only the three multiroom operations are implemented; `search`/`play_uri` return an honest "not implemented via this surface" refusal, since Roon's own search/play paths are unrelated existing code.

## Deliberate scope decision (please read)

Per the issue and PR #513's precedent, the `hifi_zone_group` MCP tool (`src/mcp/tools/groups.rs`) and the `MultiroomSync` capability routing (`src/mcp/capabilities.rs`) remain Music-Assistant-only in this PR. That tool surface generalizing to route by provider is a deliberate follow-up outside this issue's scope (same reasoning PR #513 gave: it needs its own design decision plus locked-fixture/AGENTS.md updates). The adapter/registry contract this PR wires up (`AdapterRegistry::library_content("roon", ...)`) is the same one that tool would call once generalized.

## Test coverage

New coverage in `tests/roon_protocol.rs`, against `tests/mock_servers/roon_core.rs` (extended with `group_outputs`/`ungroup_outputs` support, a `zone_push` hook so the fake can push zone changes on the existing subscription the way a real Core does, and a `zone_with_grouping` zone builder that can express `can_group_with_output_ids`):

- `roon_multiroom_status_reports_no_groups_for_single_output_zones`
- `roon_set_group_members_merges_outputs_into_one_zone` (asserts the exact `group_outputs` wire call, the merged zone's shape, and the resulting `multiroom_status`)
- `roon_ungroup_members_splits_outputs_back_into_separate_zones`
- `roon_set_group_members_refuses_mixed_protocol_outputs` (asserts the refusal message and that the incompatible request never reaches the Core)

## Local verification

Environment notes per repo conventions: `make css` run first; `cargo`/`rustc` from rustup's `1.97.1` toolchain put ahead of Homebrew's on `PATH`; this is a stacked/feature-branch PR so **CI does not run** — verified entirely locally.

```
cargo test                       # 424 unrelated-crate tests + full binary test suite: all pass,
                                  # except two pre-existing, unrelated failures also present on
                                  # origin/feat/issue-462-streaming-adapters before this change
                                  # (confirmed via git stash):
                                  #   - web_fullstack_runner_contract::runner_builds_matching_assets_before_it_starts_the_server
                                  #     (pre-existing dx/wasm build environment issue, same one PR #513 documented)
                                  #   - roon_protocol::roon_core_completes_handshake, intermittently, under full
                                  #     `cargo test`'s cross-binary parallelism (a shared config-dir race in the
                                  #     test harness's isolate_config_dir helper, unrelated to this change; it
                                  #     passes reliably in isolation and when `roon_protocol` runs alone)
cargo clippy -- -D warnings      # clean
```

`sg review` (superego) is not available in this sandbox; the diff was reviewed manually instead, following PR #513's precedent.

## Deviations from acceptance criteria

None on the adapter-level criteria. See "Deliberate scope decision" above for the one surface (MCP tool wiring) intentionally left for follow-up work, with the reasoning stated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Roon multiroom audio grouping and ungrouping.
  * Added status reporting for grouped outputs.
  * Preserved compatibility information for supported output combinations.
  * Registered Roon content with the library system.

* **Bug Fixes**
  * Added validation to reject invalid, duplicate, or incompatible grouping requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->