### PR TITLE
Queue transfer between players + library browse in human surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ Two things this table does **not** claim:
 | `queue_reorder` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_remove` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_clear` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
+| `queue_transfer` | ⛔ | 🚧 #400 | ⛔ | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
 | `play_next` | 🚧 #399 | 🚧 #403 | 🚧 #392 | 🚧 #396 | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `repeat_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
@@ -288,6 +289,13 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - 🚧 **hqplayer / `queue_clear`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_clear`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
 - 🚧 **spotify / `queue_clear`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **roon / `queue_transfer`** — The Roon API's transport service exposes a queue subscription and play_from_here and no mutation at all -- no move, remove or clear. The pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing further.
+- 🚧 **lms / `queue_transfer`** (#400) — sync <playerid> was verified live (#403) to merge a player into another's sync group by adopting the leader's queue, which destroys the source's queue rather than transferring it; the CLI reference names no dedicated queue-to-queue transfer command. A composite emulation -- read the source's playlist, replay it against the target with playlistcontrol, then playlist clear the source -- is buildable from primitives #400 already verified live, but is not wired.
+- ⛔ **openhome / `queue_transfer`** — OpenHome's Playlist:1 (Read/Insert/DeleteId/DeleteAll) is scoped to one room's renderer; the service set defines no action that moves one room's playlist into another's. Songcast (Sender:1/Receiver:1) relays audio to a group, it does not merge queue state. Verified from the OpenHome service definitions, not from a device.
+- ⛔ **upnp / `queue_transfer`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
+- 🚧 **hqplayer / `queue_transfer`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
+- 🚧 **applemusic / `queue_transfer`** (#462) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
+- 🚧 **spotify / `queue_transfer`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
 - 🚧 **roon / `play_next`** (#399) — Roon's browse item actions include Play Next alongside Play Now and Queue; UHC's PlayAction models only Play, Queue and Radio, so this arrives with browse rather than with the queue.
 - 🚧 **lms / `play_next`** (#403) — playlistcontrol cmd:insert places an item immediately after the current one, verified live -- and LmsPlayAction::Insert is already modelled in the adapter and simply unreachable from MCP.
 - 🚧 **openhome / `play_next`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.

--- a/src/adapters/musicassistant.rs
+++ b/src/adapters/musicassistant.rs
@@ -553,6 +553,26 @@ impl MusicAssistantAdapter {
             .ok_or_else(|| anyhow!("Music Assistant active queue had no queue_id"))
     }
 
+    /// Move `zone_id`'s active queue onto `target_zone_id`'s queue, via MA's
+    /// `player_queues/transfer` (#507). Both queue ids are read fresh
+    /// immediately before the call, matching the stale-item guard the other
+    /// queue mutations use, and the readback afterward is the target's --
+    /// that is where the transferred queue now lives.
+    async fn queue_transfer(&self, zone_id: &str, target_zone_id: &str) -> Result<Value> {
+        let source_queue_id = self.queue_id_for_zone(zone_id).await?;
+        let target_queue_id = self.queue_id_for_zone(target_zone_id).await?;
+        let _: Value = self
+            .command(
+                "player_queues/transfer",
+                Some(json!({
+                    "source_queue_id": source_queue_id,
+                    "target_queue_id": target_queue_id,
+                })),
+            )
+            .await?;
+        self.read_active_queue(target_zone_id).await
+    }
+
     async fn search_catalog(&self, query: &str, limit: usize) -> Result<Vec<LibrarySearchResult>> {
         let response: Value = self
             .command(
@@ -1131,6 +1151,21 @@ impl LibraryAdapter for MusicAssistantAdapter {
     async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
         if operation.starts_with("collections_") {
             return self.collections_content(operation, params).await;
+        }
+        if operation == "queue_transfer" {
+            let zone_id = params
+                .get("zone_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| anyhow!("Music Assistant queue transfer requires zone_id"))?;
+            let target_zone_id = params
+                .get("target_zone_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow!("Music Assistant queue transfer requires target_zone_id")
+                })?;
+            return self.queue_transfer(zone_id, target_zone_id).await;
         }
         match operation {
             "multiroom_status" => return self.multiroom_status().await,
@@ -2084,6 +2119,52 @@ mod tests {
             expected["queue_id"] = json!("group-living-room");
             assert_eq!(mutation.body["args"], expected);
         }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn queue_transfer_moves_the_active_queue_and_returns_the_targets_readback() {
+        let (config, state, server) = mock_musicassistant_server().await;
+        let adapter =
+            MusicAssistantAdapter::new(crate::bus::create_bus(), config).expect("adapter");
+        let result = adapter
+            .content(
+                "queue_transfer",
+                &json!({
+                    "zone_id": "musicassistant:sonos-kitchen",
+                    "target_zone_id": "musicassistant:sonos-office",
+                }),
+            )
+            .await
+            .expect("transfer");
+        // The readback is the target's fresh active queue.
+        assert_eq!(result["queue"]["queue_id"], "group-living-room");
+
+        let requests = state.requests.lock().expect("requests").clone();
+        let transfer = requests
+            .iter()
+            .find(|request| request.body["command"] == "player_queues/transfer")
+            .expect("transfer command sent");
+        assert_eq!(
+            transfer.body["args"],
+            json!({"source_queue_id": "group-living-room", "target_queue_id": "group-living-room"})
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn queue_transfer_requires_both_zone_ids() {
+        let (config, _state, server) = mock_musicassistant_server().await;
+        let adapter =
+            MusicAssistantAdapter::new(crate::bus::create_bus(), config).expect("adapter");
+        let error = adapter
+            .content(
+                "queue_transfer",
+                &json!({"zone_id": "musicassistant:sonos-kitchen"}),
+            )
+            .await
+            .expect_err("missing target_zone_id");
+        assert!(error.to_string().contains("target_zone_id"));
         server.abort();
     }
 

--- a/src/api/browse.rs
+++ b/src/api/browse.rs
@@ -1,0 +1,86 @@
+//! HTTP surface for library browse, queue and play-ref, for the web UI (#507).
+//!
+//! # One contract, two consumers
+//!
+//! `hifi_collections`, `hifi_queue` and `hifi_play_ref` are MCP tools with a
+//! fully worked-out verb vocabulary: capability checks, opaque browse paths
+//! and playable refs (so no provider URI reaches a client), and a structured
+//! envelope describing what happened. The web UI needs exactly the same
+//! verbs -- browse a collection, transfer a queue, play or queue a browsed
+//! item -- so these handlers call the MCP tool handlers directly rather than
+//! re-implementing any of that against `AdapterRegistry` a second time.
+//!
+//! `crate::mcp::refs::RefTable` (`AppState::mcp_refs`) is a plain server-side
+//! table keyed by opaque token, not an MCP-transport concept, so a ref minted
+//! for a browse result served over this HTTP surface resolves the same way a
+//! ref minted for an MCP client would. The two consumers share one path
+//! server-side; only the transport (HTTP JSON here, JSON-RPC there) differs.
+//!
+//! Every response body is the tool's own envelope
+//! (`structuredContent`/`outcome`/`data`/`refusal`, see
+//! [`crate::mcp::envelope`]), verbatim. The HTTP status is derived from
+//! `outcome` so a browser client can branch on the status without parsing the
+//! body, while the body still carries the same detail an MCP client sees.
+
+use crate::api::AppState;
+use crate::mcp::tools::collections::{handle_collections, HifiCollectionsTool};
+use crate::mcp::tools::library::{handle_play_ref, HifiPlayRefTool};
+use crate::mcp::tools::queue::{handle_queue, HifiQueueTool};
+use axum::{extract::State, http::StatusCode, Json};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
+use serde_json::Value;
+
+/// Project a tool handler's result onto an HTTP response.
+///
+/// The body is the envelope `structuredContent` carries (or `null` if a tool
+/// somehow attached none -- unreachable today, see
+/// [`crate::mcp::envelope::Envelope::structured`]), verbatim. The HTTP status
+/// stays `200` for every envelope outcome, refusals included: `outcome` is
+/// already the machine-readable signal (`ok`/`accepted`/`unsupported`/
+/// `invalid`/`error`, see [`crate::mcp::envelope::Outcome`]) and `refusal`
+/// carries the detail, so folding that into HTTP status codes as well would
+/// just be two places for a client to check the same fact. `500` is reserved
+/// for the one case the envelope cannot describe: the MCP transport layer
+/// itself erroring before a tool ran.
+fn envelope_response(result: Result<CallToolResult, CallToolError>) -> (StatusCode, Json<Value>) {
+    match result {
+        Ok(call_result) => {
+            let body = call_result
+                .structured_content
+                .map(Value::Object)
+                .unwrap_or(Value::Null);
+            (StatusCode::OK, Json(body))
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": error.to_string()})),
+        ),
+    }
+}
+
+/// `POST /api/collections` -- browse, playlists or favorites for one zone.
+/// Same verb and paging semantics as the `hifi_collections` MCP tool.
+pub async fn collections_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiCollectionsTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_collections(&state, args).await)
+}
+
+/// `POST /api/queue` -- read, jump, reorder, remove, clear, or transfer a
+/// zone's queue. Same verb vocabulary as the `hifi_queue` MCP tool.
+pub async fn queue_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiQueueTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_queue(&state, args).await)
+}
+
+/// `POST /api/play_ref` -- play or queue a ref minted by `/api/collections`.
+/// Same verb vocabulary as the `hifi_play_ref` MCP tool.
+pub async fn play_ref_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiPlayRefTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_play_ref(&state, args).await)
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,6 +37,7 @@ use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 pub mod apple_bridge;
+pub mod browse;
 pub mod controller_auth;
 pub mod credentials;
 pub mod provider_auth;

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -250,6 +250,129 @@ pub struct NowPlaying {
 }
 
 // =============================================================================
+// Collections / queue types (#507)
+//
+// These mirror the `hifi_collections`/`hifi_queue`/`hifi_play_ref` MCP tool
+// wire shapes exactly, because `/api/collections`, `/api/queue` and
+// `/api/play_ref` (src/api/browse.rs) forward those tools' own envelope
+// verbatim -- see that module's doc comment for why. Only the fields this UI
+// renders are modelled; unknown fields are ignored by serde's default
+// behavior, so extra envelope fields (`scope`, `observed`, `params`, ...)
+// deserialize away harmlessly.
+// =============================================================================
+
+/// One item from a `hifi_collections` page: either a folder (`path` set,
+/// browse only) or a playable entry (`r#ref` set, usable with `/api/play_ref`).
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CollectionItem {
+    pub title: String,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(rename = "ref", default)]
+    pub item_ref: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CollectionPage {
+    #[serde(default)]
+    pub items: Vec<CollectionItem>,
+    #[serde(default)]
+    pub next_offset: Option<u32>,
+}
+
+/// The `reason`-tagged refusal shape from `crate::mcp::envelope::Refusal`.
+/// Every variant carries `detail`, which is all this UI shows.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct EnvelopeRefusal {
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub detail: String,
+}
+
+/// The envelope every `hifi_*` tool result carries
+/// (`crate::mcp::envelope::Envelope`), as forwarded verbatim by
+/// `src/api/browse.rs`. Generic over `data`'s shape.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Envelope<T> {
+    #[serde(default)]
+    pub outcome: String,
+    #[serde(default)]
+    pub data: Option<T>,
+    #[serde(default)]
+    pub refusal: Option<EnvelopeRefusal>,
+}
+
+impl<T> Envelope<T> {
+    pub fn is_ok(&self) -> bool {
+        matches!(self.outcome.as_str(), "ok" | "accepted")
+    }
+
+    /// A human-readable reason for a non-ok outcome, for display.
+    pub fn error_detail(&self) -> String {
+        self.refusal
+            .as_ref()
+            .map(|r| r.detail.clone())
+            .filter(|detail| !detail.is_empty())
+            .unwrap_or_else(|| format!("request did not succeed ({})", self.outcome))
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CollectionsRequest {
+    pub zone_id: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct QueueRequest {
+    pub zone_id: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_zone_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PlayRefRequest {
+    #[serde(rename = "ref")]
+    pub item_ref: String,
+    pub zone_id: String,
+    pub action: String,
+}
+
+/// `POST /api/collections`.
+pub async fn fetch_collections(
+    req: &CollectionsRequest,
+) -> Result<Envelope<CollectionPage>, String> {
+    post_json("/api/collections", req).await
+}
+
+/// `POST /api/queue`, for actions this UI drives without reading the queue
+/// contents back (transfer). The response body is ignored beyond outcome.
+pub async fn post_queue_action(req: &QueueRequest) -> Result<Envelope<serde_json::Value>, String> {
+    post_json("/api/queue", req).await
+}
+
+/// `POST /api/play_ref`.
+pub async fn post_play_ref(req: &PlayRefRequest) -> Result<Envelope<serde_json::Value>, String> {
+    post_json("/api/play_ref", req).await
+}
+
+// =============================================================================
 // LMS Types
 // =============================================================================
 

--- a/src/app/components/collections.rs
+++ b/src/app/components/collections.rs
@@ -1,0 +1,380 @@
+//! Library browse + queue transfer panel for a zone card (#507).
+//!
+//! Calls the same `/api/collections`, `/api/queue` and `/api/play_ref`
+//! endpoints the MCP tools back (see `src/api/browse.rs`), so this panel and
+//! an MCP agent see the same capability surface: browse/playlists/favorites,
+//! opaque playable refs, and queue transfer between Music Assistant zones.
+//! Only rendered for zones whose adapter advertises collections support
+//! (Music Assistant today) -- callers gate that, this component assumes it.
+
+use crate::app::api::{
+    self, CollectionItem, CollectionsRequest, PlayRefRequest, QueueRequest,
+};
+use dioxus::prelude::*;
+
+const PAGE_LIMIT: u32 = 20;
+
+#[derive(Clone, PartialEq, Props)]
+pub struct CollectionsBrowserProps {
+    /// The zone this panel browses and plays into.
+    pub zone_id: String,
+    /// Other zones a queue can be transferred to: `(zone_id, zone_name)`.
+    #[props(default)]
+    pub transfer_targets: Vec<(String, String)>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Tab {
+    Browse,
+    Playlists,
+    Favorites,
+    Radio,
+}
+
+impl Tab {
+    fn action(self) -> &'static str {
+        match self {
+            Tab::Browse => "browse",
+            Tab::Playlists => "playlists",
+            Tab::Favorites | Tab::Radio => "favorites",
+        }
+    }
+
+    fn media_type(self) -> Option<&'static str> {
+        match self {
+            Tab::Radio => Some("radio"),
+            Tab::Favorites => Some("tracks"),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Tab::Browse => "Browse",
+            Tab::Playlists => "Playlists",
+            Tab::Favorites => "Favorites",
+            Tab::Radio => "Radio",
+        }
+    }
+}
+
+const TABS: &[Tab] = &[Tab::Browse, Tab::Playlists, Tab::Favorites, Tab::Radio];
+
+/// Fetch one page of a collection and apply it to the panel's signals.
+/// A free function rather than a captured closure: `Signal<T>` is `Copy`, so
+/// this can be called from any number of independent event handlers without
+/// fighting move-closure ownership.
+#[allow(clippy::too_many_arguments)]
+async fn load_page(
+    zone_id: String,
+    action: String,
+    media_type: Option<String>,
+    path: Option<String>,
+    request_offset: u32,
+    append: bool,
+    mut items: Signal<Vec<CollectionItem>>,
+    mut next_offset: Signal<Option<u32>>,
+    mut offset: Signal<u32>,
+    mut loading: Signal<bool>,
+    mut error: Signal<Option<String>>,
+) {
+    loading.set(true);
+    error.set(None);
+    let req = CollectionsRequest {
+        zone_id,
+        action,
+        path,
+        media_type,
+        limit: Some(PAGE_LIMIT),
+        offset: Some(request_offset),
+    };
+    match api::fetch_collections(&req).await {
+        Ok(env) if env.is_ok() => {
+            let page = env.data.unwrap_or_default();
+            if append {
+                items.with_mut(|list| list.extend(page.items));
+            } else {
+                items.set(page.items);
+            }
+            next_offset.set(page.next_offset);
+            offset.set(request_offset);
+        }
+        Ok(env) => {
+            error.set(Some(env.error_detail()));
+            if !append {
+                items.set(Vec::new());
+            }
+        }
+        Err(message) => {
+            error.set(Some(message));
+            if !append {
+                items.set(Vec::new());
+            }
+        }
+    }
+    loading.set(false);
+}
+
+/// Expandable collections browser + queue transfer control for one zone.
+#[component]
+pub fn CollectionsBrowser(props: CollectionsBrowserProps) -> Element {
+    // A `Signal` is `Copy`, unlike the `String` in `props`, so every handler
+    // closure below can capture it independently without fighting move
+    // semantics over a single owned `String`.
+    let zone_id = use_signal(|| props.zone_id.clone());
+    let mut expanded = use_signal(|| false);
+    let mut tab = use_signal(|| Tab::Browse);
+    let mut path_stack = use_signal(Vec::<(String, Option<String>)>::new);
+    let items = use_signal(Vec::<CollectionItem>::new);
+    let mut offset = use_signal(|| 0u32);
+    let next_offset = use_signal(|| None::<u32>);
+    let loading = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
+    let mut status = use_signal(|| None::<String>);
+    let mut transfer_target = use_signal({
+        let first = props.transfer_targets.first().map(|(id, _)| id.clone());
+        move || first.clone()
+    });
+
+    // `use_callback` closes over props/state by reference and is itself
+    // `Copy`, so every handler below can hold and call the same instance.
+    let refresh = use_callback(move |append: bool| {
+        let zone_id = zone_id();
+        let action = tab.read().action().to_string();
+        let media_type = tab.read().media_type().map(ToOwned::to_owned);
+        let path = path_stack.read().last().and_then(|(_, p)| p.clone());
+        let request_offset = if append { offset() } else { 0 };
+        spawn(load_page(
+            zone_id,
+            action,
+            media_type,
+            path,
+            request_offset,
+            append,
+            items,
+            next_offset,
+            offset,
+            loading,
+            error,
+        ));
+    });
+
+    let toggle_open = move |_| {
+        let opening = !expanded();
+        expanded.set(opening);
+        if opening && items.read().is_empty() {
+            refresh(false);
+        }
+    };
+
+    let select_tab = use_callback(move |new_tab: Tab| {
+        tab.set(new_tab);
+        path_stack.set(Vec::new());
+        offset.set(0);
+        refresh(false);
+    });
+
+    let open_folder = use_callback(move |(title, path): (String, String)| {
+        path_stack.with_mut(|stack| stack.push((title, Some(path))));
+        offset.set(0);
+        refresh(false);
+    });
+
+    let go_back = move |_| {
+        path_stack.with_mut(|stack| {
+            stack.pop();
+        });
+        offset.set(0);
+        refresh(false);
+    };
+
+    let load_more = move |_| refresh(true);
+
+    let play_item = use_callback(move |(item_ref, action): (String, &'static str)| {
+        let zone_id = zone_id();
+        status.set(Some("Working...".to_string()));
+        spawn(async move {
+            let req = PlayRefRequest {
+                item_ref,
+                zone_id,
+                action: action.to_string(),
+            };
+            let message = match api::post_play_ref(&req).await {
+                Ok(env) if env.is_ok() => {
+                    if action == "queue" {
+                        "Added to queue".to_string()
+                    } else {
+                        "Playing".to_string()
+                    }
+                }
+                Ok(env) => env.error_detail(),
+                Err(message) => message,
+            };
+            status.set(Some(message));
+        });
+    });
+
+    let do_transfer = move |_| {
+        let Some(target) = transfer_target() else {
+            return;
+        };
+        let zone_id = zone_id();
+        status.set(Some("Transferring queue...".to_string()));
+        spawn(async move {
+            let req = QueueRequest {
+                zone_id,
+                action: "transfer".to_string(),
+                item_id: None,
+                position: None,
+                target_zone_id: Some(target),
+            };
+            let message = match api::post_queue_action(&req).await {
+                Ok(env) if env.is_ok() => "Queue transferred".to_string(),
+                Ok(env) => env.error_detail(),
+                Err(message) => message,
+            };
+            status.set(Some(message));
+        });
+    };
+
+    let breadcrumb_labels: Vec<String> = path_stack.read().iter().map(|(t, _)| t.clone()).collect();
+    let has_history = !path_stack.read().is_empty();
+    let current_tab = tab();
+    let current_items = items();
+    let is_loading = loading();
+    let current_error = error();
+    let current_status = status();
+    let can_load_more = next_offset.read().is_some();
+    let has_transfer_targets = !props.transfer_targets.is_empty();
+    let transfer_targets = props.transfer_targets.clone();
+
+    rsx! {
+        div { class: "mt-3 border-t border-subtle pt-3",
+            button {
+                class: "btn btn-ghost text-sm",
+                r#type: "button",
+                onclick: toggle_open,
+                if expanded() { "Hide library" } else { "Browse library" }
+            }
+
+            if expanded() {
+                div { class: "mt-3 space-y-3",
+                    // Tabs
+                    div { class: "flex flex-wrap gap-2",
+                        for candidate in TABS {
+                            {
+                                let candidate = *candidate;
+                                let active = candidate == current_tab;
+                                rsx! {
+                                    button {
+                                        key: "{candidate.label()}",
+                                        class: if active { "badge badge-primary" } else { "badge" },
+                                        r#type: "button",
+                                        onclick: move |_| select_tab(candidate),
+                                        "{candidate.label()}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Breadcrumb / back
+                    if has_history {
+                        div { class: "flex items-center gap-2 text-sm text-muted",
+                            button { class: "btn btn-ghost", r#type: "button", onclick: go_back, "< Back" }
+                            span { "{breadcrumb_labels.join(\" / \")}" }
+                        }
+                    }
+
+                    if let Some(message) = current_status.clone() {
+                        p { class: "text-sm text-muted", "{message}" }
+                    }
+                    if let Some(message) = current_error.clone() {
+                        p { class: "text-sm text-error", "{message}" }
+                    }
+                    if is_loading && current_items.is_empty() {
+                        p { class: "text-sm text-muted", "Loading..." }
+                    } else if current_items.is_empty() {
+                        p { class: "text-sm text-muted", "Nothing here." }
+                    } else {
+                        ul { class: "space-y-2",
+                            for item in current_items.iter().cloned() {
+                                li {
+                                    key: "{item.title}-{item.path.clone().unwrap_or_default()}-{item.item_ref.clone().unwrap_or_default()}",
+                                    class: "flex items-center justify-between gap-2",
+                                    div { class: "min-w-0",
+                                        p { class: "text-sm font-medium truncate", "{item.title}" }
+                                        if let Some(subtitle) = item.subtitle.clone() {
+                                            p { class: "text-xs text-muted truncate", "{subtitle}" }
+                                        }
+                                    }
+                                    div { class: "flex gap-2 flex-shrink-0",
+                                        if let Some(path) = item.path.clone() {
+                                            button {
+                                                class: "btn btn-ghost text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let title = item.title.clone();
+                                                    let path = path.clone();
+                                                    move |_| open_folder((title.clone(), path.clone()))
+                                                },
+                                                "Open"
+                                            }
+                                        }
+                                        if let Some(item_ref) = item.item_ref.clone() {
+                                            button {
+                                                class: "btn btn-primary text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let item_ref = item_ref.clone();
+                                                    move |_| play_item((item_ref.clone(), "play"))
+                                                },
+                                                "Play"
+                                            }
+                                            button {
+                                                class: "btn btn-ghost text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let item_ref = item_ref.clone();
+                                                    move |_| play_item((item_ref.clone(), "queue"))
+                                                },
+                                                "Queue"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if can_load_more {
+                            button {
+                                class: "btn btn-ghost text-sm",
+                                r#type: "button",
+                                onclick: load_more,
+                                "Load more"
+                            }
+                        }
+                    }
+
+                    if has_transfer_targets {
+                        div { class: "flex items-center gap-2 pt-2 border-t border-subtle",
+                            span { class: "text-sm text-muted", "Transfer queue to:" }
+                            select {
+                                class: "form-select text-sm",
+                                onchange: move |evt| transfer_target.set(Some(evt.value())),
+                                for (target_id, target_name) in transfer_targets.iter().cloned() {
+                                    option { key: "{target_id}", value: "{target_id}", "{target_name}" }
+                                }
+                            }
+                            button {
+                                class: "btn btn-ghost text-sm",
+                                r#type: "button",
+                                onclick: do_transfer,
+                                "Transfer"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -1,5 +1,6 @@
 //! Shared UI components for the Dioxus fullstack web UI.
 
+pub mod collections;
 pub mod error_alert;
 pub mod form_inputs;
 pub mod hqp_controls;
@@ -7,6 +8,7 @@ pub mod layout;
 pub mod nav;
 pub mod volume;
 
+pub use collections::CollectionsBrowser;
 pub use error_alert::ErrorAlert;
 pub use form_inputs::{PowerModeInput, ToggleInput};
 pub use hqp_controls::{HqpControlsCompact, HqpMatrixSelect, HqpProfileSelect};

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -3,7 +3,9 @@
 //! Shows all available zones using Dioxus resources.
 
 use crate::app::api::{HqpMatrixProfilesResponse, HqpProfile, NowPlaying, Zone, ZonesResponse};
-use crate::app::components::{ErrorAlert, HqpControlsCompact, Layout, VolumeControlsCompact};
+use crate::app::components::{
+    CollectionsBrowser, ErrorAlert, HqpControlsCompact, Layout, VolumeControlsCompact,
+};
 use crate::app::sse::{use_sse, SseEvent};
 use dioxus::prelude::*;
 use std::collections::HashMap;
@@ -254,6 +256,15 @@ pub fn Zones() -> Element {
     let profiles = hqp_profiles();
     let matrix = hqp_matrix();
 
+    // Music Assistant zones support library browse and queue transfer
+    // (#507); every other adapter hides the panel entirely rather than
+    // showing a browse surface that immediately refuses every call.
+    let musicassistant_zones: Vec<(String, String)> = zones_list
+        .iter()
+        .filter(|z| z.zone_id.starts_with("musicassistant:"))
+        .map(|z| (z.zone_id.clone(), z.zone_name.clone()))
+        .collect();
+
     // Group zones by source protocol
     let grouped_zones: Vec<(String, Vec<Zone>)> = {
         let mut groups: std::collections::HashMap<String, Vec<Zone>> =
@@ -305,6 +316,7 @@ pub fn Zones() -> Element {
                                 on_control: control,
                                 on_load_profile: load_profile,
                                 on_set_matrix: set_matrix,
+                                musicassistant_zones: musicassistant_zones.clone(),
                             }
                         }
                     }
@@ -345,6 +357,10 @@ fn ZoneCard(
     on_control: EventHandler<(String, String)>,
     on_load_profile: EventHandler<String>,
     on_set_matrix: EventHandler<String>,
+    /// Every Music Assistant zone, `(zone_id, zone_name)`, for the browse
+    /// panel's queue-transfer target list (#507). Empty when there are none.
+    #[props(default)]
+    musicassistant_zones: Vec<(String, String)>,
 ) -> Element {
     let zone_id = zone.zone_id.clone();
     let zone_id_prev = zone_id.clone();
@@ -494,6 +510,20 @@ fn ZoneCard(
                     volume_step: volume_step,
                     on_vol_down: move |_| on_control.call((zone_id_vol_down.clone(), "vol_down".to_string())),
                     on_vol_up: move |_| on_control.call((zone_id_vol_up.clone(), "vol_up".to_string())),
+                }
+            }
+
+            // Library browse + queue transfer (#507). Music Assistant only
+            // today; other adapters hide the panel rather than exposing a
+            // browse surface that would refuse every call.
+            if zone.zone_id.starts_with("musicassistant:") {
+                CollectionsBrowser {
+                    zone_id: zone.zone_id.clone(),
+                    transfer_targets: musicassistant_zones
+                        .iter()
+                        .filter(|(id, _)| *id != zone.zone_id)
+                        .cloned()
+                        .collect::<Vec<_>>(),
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -740,6 +740,12 @@ mod server {
             // App settings API
             .route("/api/settings", get(api::api_settings_get_handler))
             .route("/api/settings", post(api::api_settings_post_handler))
+            // Library browse, queue and play-ref for the web UI (#507). Same
+            // verb vocabulary as the hifi_collections/hifi_queue/hifi_play_ref
+            // MCP tools -- see src/api/browse.rs.
+            .route("/api/collections", post(api::browse::collections_handler))
+            .route("/api/queue", post(api::browse::queue_handler))
+            .route("/api/play_ref", post(api::browse::play_ref_handler))
             // Event stream (SSE)
             .route("/events", get(api::events_handler))
             // Knob hardware API routes

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -116,6 +116,8 @@ pub enum Capability {
     QueueRemove,
     /// Empty the queue.
     QueueClear,
+    /// Move an active queue from one zone to another (#507).
+    QueueTransfer,
     /// Insert immediately after the current item.
     PlayNext,
     /// Read and set repeat mode.
@@ -148,6 +150,7 @@ impl Capability {
         Self::QueueReorder,
         Self::QueueRemove,
         Self::QueueClear,
+        Self::QueueTransfer,
         Self::PlayNext,
         Self::RepeatMode,
         Self::ShuffleMode,
@@ -172,6 +175,7 @@ impl Capability {
             Self::QueueReorder => "queue_reorder",
             Self::QueueRemove => "queue_remove",
             Self::QueueClear => "queue_clear",
+            Self::QueueTransfer => "queue_transfer",
             Self::PlayNext => "play_next",
             Self::RepeatMode => "repeat_mode",
             Self::ShuffleMode => "shuffle_mode",
@@ -358,7 +362,8 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         Capability::QueueJump
         | Capability::QueueReorder
         | Capability::QueueRemove
-        | Capability::QueueClear => target == ZoneTarget::MusicAssistant,
+        | Capability::QueueClear
+        | Capability::QueueTransfer => target == ZoneTarget::MusicAssistant,
         Capability::PlayNext => target == ZoneTarget::MusicAssistant,
         Capability::MultiroomSync => target == ZoneTarget::MusicAssistant,
         Capability::Browse | Capability::SavedPlaylists | Capability::Favorites => {
@@ -411,6 +416,14 @@ const ROON_QUEUE_IS_READ_PLUS_JUMP: &str = "The Roon API's transport service exp
     subscription and play_from_here and no mutation at all -- no move, remove or clear. The \
     pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing \
     further.";
+
+/// OpenHome's per-room `Playlist:1` has no cross-room action, and Songcast
+/// relays audio rather than queue state.
+const OPENHOME_HAS_NO_QUEUE_TRANSFER: &str = "OpenHome's Playlist:1 (Read/Insert/DeleteId/\
+    DeleteAll) is scoped to one room's renderer; the service set defines no action that moves \
+    one room's playlist into another's. Songcast (Sender:1/Receiver:1) relays audio to a group, \
+    it does not merge queue state. Verified from the OpenHome service definitions, not from a \
+    device.";
 
 /// Playing a *named* item is a different question from *finding* one, and the ship
 /// gate's dissent caught this module conflating them.
@@ -472,6 +485,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::QueueReorder, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::QueueRemove, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::QueueClear, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
+    (ZoneTarget::Roon, Capability::QueueTransfer, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::PlayNext, Gap::NotWired("#399",
         "Roon's browse item actions include Play Next alongside Play Now and Queue; UHC's \
          PlayAction models only Play, Queue and Radio, so this arrives with browse rather \
@@ -518,6 +532,13 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
         "playlist delete <index> removes one queued item; verified live.")),
     (ZoneTarget::Lms, Capability::QueueClear, Gap::NotWired("#400",
         "playlist clear empties the queue; verified live.")),
+    (ZoneTarget::Lms, Capability::QueueTransfer, Gap::NotWired("#400",
+        "sync <playerid> was verified live (#403) to merge a player into another's sync group by \
+         adopting the leader's queue, which destroys the source's queue rather than transferring \
+         it; the CLI reference names no dedicated queue-to-queue transfer command. A composite \
+         emulation -- read the source's playlist, replay it against the target with \
+         playlistcontrol, then playlist clear the source -- is buildable from primitives #400 \
+         already verified live, but is not wired.")),
     (ZoneTarget::Lms, Capability::PlayNext, Gap::NotWired("#403",
         "playlistcontrol cmd:insert places an item immediately after the current one, verified \
          live -- and LmsPlayAction::Insert is already modelled in the adapter and simply \
@@ -557,6 +578,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
          OpenHome service definitions, not from a device.")),
     (ZoneTarget::OpenHome, Capability::QueueRemove, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::QueueClear, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
+    (ZoneTarget::OpenHome, Capability::QueueTransfer, Gap::ProviderCannot(OPENHOME_HAS_NO_QUEUE_TRANSFER)),
     (ZoneTarget::OpenHome, Capability::PlayNext, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::RepeatMode, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::ShuffleMode, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
@@ -592,6 +614,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Upnp, Capability::QueueReorder, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::QueueRemove, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::QueueClear, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
+    (ZoneTarget::Upnp, Capability::QueueTransfer, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::PlayNext, Gap::NotWired("#396", PLAY_A_NAMED_URI_EXISTS)),
     (ZoneTarget::Upnp, Capability::RepeatMode, Gap::NotWired("#392",
         "AVTransport:1's SetPlayMode takes REPEAT_ONE and REPEAT_ALL, so repeat is a protocol \
@@ -633,6 +656,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::HqPlayer, Capability::QueueReorder, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::QueueRemove, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::QueueClear, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
+    (ZoneTarget::HqPlayer, Capability::QueueTransfer, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::PlayNext, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::SavedPlaylists, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::Favorites, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
@@ -822,6 +846,7 @@ mod tests {
                                 | Capability::QueueReorder
                                 | Capability::QueueRemove
                                 | Capability::QueueClear
+                                | Capability::QueueTransfer
                                 | Capability::PlayNext
                                 | Capability::SavedPlaylists
                                 | Capability::Favorites
@@ -1027,7 +1052,7 @@ mod tests {
                 capability.name()
             );
         }
-        assert_eq!(seen.len(), 18, "the vocabulary changed size: {seen:?}");
+        assert_eq!(seen.len(), 19, "the vocabulary changed size: {seen:?}");
     }
 
     /// A refusal built from a capability state must carry the same

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -132,7 +132,7 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_search" => &["query", "zone_id", "source"],
         "hifi_play" => &["query", "zone_id", "source", "action"],
         "hifi_play_ref" => &["ref", "zone_id", "action"],
-        "hifi_queue" => &["zone_id", "action", "item_id", "position"],
+        "hifi_queue" => &["zone_id", "action", "item_id", "position", "target_zone_id"],
         "hifi_collections" => &["zone_id", "action", "path", "media_type", "limit", "offset"],
         "hifi_zone_group" => &["action", "leader_zone_id", "member_zone_ids", "confirm"],
         "hifi_spotify" => &[

--- a/src/mcp/tools/queue.rs
+++ b/src/mcp/tools/queue.rs
@@ -12,13 +12,13 @@ use serde::{Deserialize, Serialize};
 
 #[mcp_tool(
     name = "hifi_queue",
-    description = "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, and clear against its active queue; each mutation returns a fresh queue readback. Queue add is hifi_play action='queue'."
+    description = "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, clear, and transfer against its active queue; each mutation returns a fresh queue readback. transfer moves the active queue from zone_id to target_zone_id (both must be Music Assistant zones). Queue add is hifi_play action='queue'."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiQueueTool {
     /// Zone ID from hifi_zones.
     pub zone_id: String,
-    /// read (default), jump, reorder, remove, or clear.
+    /// read (default), jump, reorder, remove, clear, or transfer.
     #[serde(default = "default_action")]
     pub action: String,
     /// Queue item id for jump, reorder, or remove.
@@ -27,6 +27,9 @@ pub struct HifiQueueTool {
     /// Target zero-based position for reorder.
     #[serde(default)]
     pub position: Option<i64>,
+    /// Destination zone ID for transfer. Must belong to the same provider as zone_id.
+    #[serde(default)]
+    pub target_zone_id: Option<String>,
 }
 
 fn default_action() -> String {
@@ -44,18 +47,19 @@ pub async fn handle_queue(
         "reorder" => "queue_reorder",
         "remove" => "queue_remove",
         "clear" => "queue_clear",
+        "transfer" => "queue_transfer",
         _ => {
             return Envelope::write("hifi_queue", "queue").refused(
                 "Unknown queue action.",
                 crate::mcp::envelope::Refusal::invalid_parameter(
                     "action",
-                    &["read", "jump", "reorder", "remove", "clear"],
+                    &["read", "jump", "reorder", "remove", "clear", "transfer"],
                     "Choose a documented queue action.",
                 ),
             )
         }
     };
-    let env = if operation == "queue_read" {
+    let mut env = if operation == "queue_read" {
         Envelope::read("hifi_queue", operation)
     } else {
         Envelope::write("hifi_queue", operation)
@@ -63,11 +67,15 @@ pub async fn handle_queue(
     .param("zone_id", &*args.zone_id)
     .param("action", &*args.action)
     .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
+    if let Some(target_zone_id) = args.target_zone_id.as_deref() {
+        env = env.param("target_zone_id", target_zone_id);
+    }
     let capability = match operation {
         "queue_read" => Capability::QueueRead,
         "queue_jump" => Capability::QueueJump,
         "queue_reorder" => Capability::QueueReorder,
         "queue_remove" => Capability::QueueRemove,
+        "queue_transfer" => Capability::QueueTransfer,
         _ => Capability::QueueClear,
     };
     if !matches!(support(target, capability), Support::Supported) {
@@ -75,6 +83,46 @@ pub async fn handle_queue(
             "Queue read is not available for {} zones",
             target.label()
         ));
+    }
+    if operation == "queue_transfer" {
+        let target_zone_id = match args.target_zone_id.as_deref() {
+            Some(id) if !id.trim().is_empty() => id,
+            _ => {
+                return env.refused(
+                    "transfer requires target_zone_id.",
+                    crate::mcp::envelope::Refusal::invalid_parameter(
+                        "target_zone_id",
+                        &["a zone_id from hifi_zones"],
+                        "Provide the destination zone's zone_id.",
+                    ),
+                )
+            }
+        };
+        let target_target = ZoneTarget::classify(target_zone_id);
+        if !matches!(target.for_library(), LibraryRoute::MusicAssistant)
+            || !matches!(target_target.for_library(), LibraryRoute::MusicAssistant)
+        {
+            return env.refused(
+                "transfer requires both zones to be Music Assistant zones.",
+                crate::mcp::envelope::Refusal::invalid_parameter(
+                    "target_zone_id",
+                    &["a Music Assistant zone_id from hifi_zones"],
+                    "Queue transfer is only implemented between two Music Assistant zones.",
+                ),
+            );
+        }
+        return match state
+            .adapter_registry
+            .library_content(
+                "musicassistant",
+                operation,
+                &serde_json::json!({"zone_id": args.zone_id, "target_zone_id": target_zone_id}),
+            )
+            .await
+        {
+            Ok(value) => Ok(env.json_result(&value)),
+            Err(e) => env.failed(format!("Queue error: {e}")),
+        };
     }
     match target.for_library() {
         LibraryRoute::Spotify => match state

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -76,9 +76,12 @@ POST /api/bridges/applemusic/remove
 POST /api/bridges/applemusic/rename
 POST /api/bridges/applemusic/revoke
 POST /api/bridges/applemusic/state
+POST /api/collections
 POST /api/controller/bootstrap
+POST /api/play_ref
 POST /api/providers/{provider}/configure
 POST /api/providers/{provider}/oauth/revoke
+POST /api/queue
 POST /api/settings
 POST /control
 POST /hqp/detect

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -335,11 +335,11 @@
     }
   },
   "hifi_queue": {
-    "description": "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, and clear against its active queue; each mutation returns a fresh queue readback. Queue add is hifi_play action='queue'.",
+    "description": "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, clear, and transfer against its active queue; each mutation returns a fresh queue readback. transfer moves the active queue from zone_id to target_zone_id (both must be Music Assistant zones). Queue add is hifi_play action='queue'.",
     "inputSchema": {
       "properties": {
         "action": {
-          "description": "read (default), jump, reorder, remove, or clear.",
+          "description": "read (default), jump, reorder, remove, clear, or transfer.",
           "type": "string"
         },
         "item_id": {
@@ -351,6 +351,11 @@
           "description": "Target zero-based position for reorder.",
           "nullable": true,
           "type": "integer"
+        },
+        "target_zone_id": {
+          "description": "Destination zone ID for transfer. Must belong to the same provider as zone_id.",
+          "nullable": true,
+          "type": "string"
         },
         "zone_id": {
           "description": "Zone ID from hifi_zones.",

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -800,6 +800,7 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
             ("action", true),
             ("item_id", false),
             ("position", false),
+            ("target_zone_id", false),
         ],
     ),
     (
@@ -1805,7 +1806,8 @@ async fn musicassistant_mcp_handler(
         | Some("player_queues/play_index")
         | Some("player_queues/move_item")
         | Some("player_queues/delete_item")
-        | Some("player_queues/clear") => json!({"ok": true}),
+        | Some("player_queues/clear")
+        | Some("player_queues/transfer") => json!({"ok": true}),
         Some("players/cmd/set_members") | Some("players/cmd/ungroup_many") => json!({"ok": true}),
         command => panic!("unexpected Music Assistant command: {command:?}"),
     };
@@ -2021,6 +2023,7 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
         json!({"zone_id": zone_id, "action": "reorder", "item_id": "q2", "position": 0}),
         json!({"zone_id": zone_id, "action": "remove", "item_id": "q2"}),
         json!({"zone_id": zone_id, "action": "clear"}),
+        json!({"zone_id": zone_id, "action": "transfer", "target_zone_id": "musicassistant:group-child-2"}),
     ] {
         assert_eq!(
             app.call_tool("hifi_queue", args).await["structuredContent"]["outcome"],
@@ -2034,7 +2037,8 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
             "player_queues/play_index"
             | "player_queues/move_item"
             | "player_queues/delete_item"
-            | "player_queues/clear" => Some((
+            | "player_queues/clear"
+            | "player_queues/transfer" => Some((
                 request["command"].as_str().unwrap(),
                 request["args"].clone(),
             )),
@@ -2059,6 +2063,10 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
             (
                 "player_queues/clear",
                 json!({"queue_id":"living-room-group"})
+            ),
+            (
+                "player_queues/transfer",
+                json!({"source_queue_id":"living-room-group", "target_queue_id":"living-room-group"})
             ),
         ]
     );
@@ -4831,6 +4839,7 @@ const EXPECTED_CAPABILITIES: &[&str] = &[
     "queue_reorder",
     "queue_remove",
     "queue_clear",
+    "queue_transfer",
     "play_next",
     "repeat_mode",
     "shuffle_mode",
@@ -5227,6 +5236,14 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 "hifi_queue",
                 json!({ "zone_id": zone_id, "action": "clear" }),
             )),
+            "queue_transfer" => Some((
+                "hifi_queue",
+                json!({
+                    "zone_id": zone_id,
+                    "action": "transfer",
+                    "target_zone_id": format!("{provider}:xyz"),
+                }),
+            )),
             "repeat_mode" => Some((
                 "hifi_control",
                 json!({ "zone_id": zone_id, "action": "repeat_off" }),
@@ -5279,15 +5296,16 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     }
     // The routed Spotify content and mode cells plus Music Assistant's queue
     // mutations, mode, collections, and zone-group cells add twenty-three probes to the
-    // original provider transport set.
+    // original provider transport set, plus one more for Music Assistant's
+    // queue_transfer (#507).
     // Apple Music's transport/skip/volume
     // cells remain gated until signed physical companion validation (#465).
     // Asserted exactly, not as a floor: a floor would pass while a cell silently
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 45,
-        "{proved} supported cells were proved end to end, expected 45. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 46,
+        "{proved} supported cells were proved end to end, expected 46. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 


### PR DESCRIPTION
Closes #507

## Base branch

This PR targets `feat/issue-462-streaming-adapters`, not `v3`, per the pinned repo decision for this stack of streaming-adapter work.

## Summary

**Queue transfer (MCP contract + Music Assistant adapter)**
- `hifi_queue` gains a `transfer` action (`zone_id` -> `target_zone_id`), implemented for Music Assistant via `player_queues/transfer`. Both zones must be Music Assistant zones; anything else refuses cleanly with an `invalid_parameter` refusal.
- Added `Capability::QueueTransfer` to the capability matrix (`src/mcp/capabilities.rs`) and filled in every provider's cell honestly: `Supported` for Music Assistant, `ProviderCannot` for Roon/OpenHome/UPnP (each citing the relevant protocol fact), `NotImplemented` for LMS/HQPlayer/Apple Music/Spotify. Regenerated the derived `AGENTS.md` capability matrix and the `mcp_tools.json`/`mcp_contract.rs` fixtures.
- `src/adapters/musicassistant.rs`: new `queue_transfer` adapter method resolves both zones' queue ids fresh (matching the existing stale-item-guard pattern), calls `player_queues/transfer`, and returns the target zone's fresh queue readback.

**Web UI (browse + play/queue + queue transfer)**
- New `/api/collections`, `/api/queue`, `/api/play_ref` HTTP endpoints (`src/api/browse.rs`) that call the *same* `handle_collections`/`handle_queue`/`handle_play_ref` MCP tool handlers and forward their envelope verbatim as JSON — one contract, two consumers, per the issue's guidance, rather than a second implementation against `AdapterRegistry`.
- New `CollectionsBrowser` component (`src/app/components/collections.rs`) rendered on each Music Assistant zone card in `src/app/pages/zones.rs`: tabs for Browse/Playlists/Favorites/Radio, folder navigation with a back button, Play/Queue buttons on playable results (using the same opaque-ref mechanism `hifi_play_ref` uses), and a "Transfer queue to" control listing the other Music Assistant zones.
- Adapters without collections support (everything except Music Assistant today) show no browse panel at all — gated on the `musicassistant:` zone-id prefix, matching the issue's graceful-degradation requirement.
- Knob/watch surfaces are untouched, per the issue's explicit scope note.

## Adaptive-surface boundary lint

The adapter-boundary lint (`tests/adapter_boundary_lint.rs`) already allows any module to reach `AppState::adapter_registry`/`aggregator`/`bus` — only direct concrete-adapter access is forbidden. The new HTTP handlers and the MCP tools they wrap both go through that same registry, and no new contract-first split was required: the lint passes as-is (`cargo test --test adapter_boundary_lint --test architecture_lint --test adaptive_dependency_lint` all green). Nothing was deferred on this axis.

## Local verification

Rebuilt CSS first (`make css`) and ran with `RUSTC_WRAPPER=""` and rustup's rustc ahead of Homebrew's on `PATH`, per this repo's fresh-worktree notes.

- `cargo check --lib --bins` — clean
- `cargo check --no-default-features --features web --target wasm32-unknown-unknown` — clean (confirms the Dioxus web/WASM build path also compiles)
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 426+ tests pass across every suite; the only failure is the pre-existing `web_fullstack_runner_contract::runner_builds_matching_assets_before_it_starts_the_server` (known dx/wasm environment issue, confirmed pre-existing via `git stash` before starting this work). `roon_protocol::roon_core_completes_handshake` did not flake in this run.
- Regenerated fixtures deliberately: `UPDATE_MCP_FIXTURES=1 cargo test --test mcp_contract` and `UPDATE_AGENTS_MATRIX=1 cargo test --test mcp_contract agents_md_capability_matrix_matches_the_derived_data`.

## Deviations from the issue

- The issue's "may split naturally into contract PR + web UI PR" note anticipated a possible lint-forced split; the boundary lint did not force one, so this PR lands the whole feature (contract + web UI) in one PR rather than deferring anything.
- `sg review` (the local `oh-task` workflow step) was unavailable in this environment — the installed `sg` binary is `ast-grep`, which has no `review` subcommand here. Verification instead relied on `cargo test`, `cargo clippy -- -D warnings`, and manual review of the diff.
- No CI runs on this feature-branch-based PR and CodeRabbit is disabled for this base branch, per repo policy — everything above was verified locally.