### PR TITLE
feat(mcp): generalize hifi_zone_group routing across roon, lms, musicassistant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ Two things this table does **not** claim:
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `saved_playlists` | 🚧 #399 | 🚧 #403 | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
 | `favorites` | 🚧 #399 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
-| `multiroom_sync` | 🚧 #360 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
+| `multiroom_sync` | ✅ | ✅ | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
 
 ✅ supported · ⛔ the provider's protocol cannot do it · 🚧 the provider can, UHC has not wired it (issue that will)
 
@@ -317,8 +317,6 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - ⛔ **upnp / `favorites`** — AVTransport:1 and RenderingControl:1 store nothing; a MediaRenderer has no favourites. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `favorites`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `favorites`** (#482) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `multiroom_sync`** (#360) — the Roon API's transport service groups and ungroups outputs; UHC exposes no grouping on any surface.
-- 🚧 **lms / `multiroom_sync`** (#403) — sync <playerid>, sync -, sync ? and the server-scoped syncgroups ? all work; verified live. Joining is destructive to the target zone's queue, which is why #403 gates it behind confirmation.
 - 🚧 **openhome / `multiroom_sync`** (#392) — OpenHome's Sender:1 and Receiver:1 services are Songcast multiroom -- exactly this capability. UHC discovers neither. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `multiroom_sync`** — UPnP AV defines no synchronised-playback service; multiroom on UPnP renderers is vendor-specific and outside the two services UHC speaks. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `multiroom_sync`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -58,7 +58,8 @@ use tracing::{debug, info, warn};
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::lms_discovery::discover_lms_servers;
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::adapters::Startable;
 use crate::bus::runtime::{
@@ -85,6 +86,33 @@ const LMS_MUTE_PREF: &str = "mute";
 /// MCP and aggregator use prefixed IDs (e.g., "lms:00:11:22:33:44:55"), but LMS API expects bare IDs.
 fn strip_lms_prefix(id: &str) -> &str {
     id.strip_prefix("lms:").unwrap_or(id)
+}
+
+/// Require a properly-prefixed LMS zone id and return its bare player id.
+///
+/// Unlike Music Assistant's ids, LMS player ids are MAC addresses and
+/// legitimately contain colons, so (unlike `musicassistant_player_id`) this
+/// does not reject a remainder containing `:`.
+fn lms_player_id(zone_id: &str, parameter: &str) -> Result<String> {
+    zone_id
+        .strip_prefix("lms:")
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("{parameter} must be an LMS zone id"))
+}
+
+/// [`lms_player_id`] over a list, rejecting duplicates the same way the
+/// Music Assistant multiroom contract does.
+fn lms_player_ids(zone_ids: &[String], parameter: &str) -> Result<Vec<String>> {
+    let mut ids = Vec::with_capacity(zone_ids.len());
+    for zone_id in zone_ids {
+        let id = lms_player_id(zone_id, parameter)?;
+        if ids.contains(&id) {
+            return Err(anyhow!("{parameter} must not contain duplicate zones"));
+        }
+        ids.push(id);
+    }
+    Ok(ids)
 }
 
 /// Read an integer that LMS may emit as either a JSON number or a JSON string.
@@ -1243,6 +1271,148 @@ impl LmsAdapter {
     pub async fn get_player_status(&self, player_id: &str) -> Result<LmsPlayer> {
         let player_id = strip_lms_prefix(player_id);
         self.rpc.get_player_status(player_id).await
+    }
+
+    // -------------------------------------------------------------------------
+    // Sync groups (#510): LMS's native Squeezebox multi-room, wired to the
+    // multiroom_status / multiroom_set_members / multiroom_ungroup contract
+    // the Music Assistant adapter already implements
+    // (`src/adapters/musicassistant.rs`).
+    //
+    // LMS sync is peer-based -- a group is just a set of players playing the
+    // same stream in lockstep, with no server-side concept of a leader. The
+    // contract, however, is leader/member shaped. This adapter resolves that
+    // mismatch by treating "join the leader's group" literally: every add
+    // is sent as `<leader> sync <member>`. Verified live against Lyrion 9.1.2
+    // (issue #403's investigation): the **addressed** player in a `sync`
+    // command becomes/stays the sync master, and the **argument** player
+    // adopts the addressed player's queue, repeat and shuffle -- destroying
+    // its own. Addressing the leader therefore keeps the leader's queue
+    // intact and makes the member fall in behind it, exactly the semantics
+    // `multiroom_set_members`'s `leader_zone_id` implies. Removal is
+    // leader-independent: `<member> sync -` unsyncs that one player from
+    // whatever group it is currently in.
+    //
+    // Because there is no server-side leader, `multiroom_status` cannot
+    // recover *which* player was originally addressed -- only current group
+    // membership via `syncgroups ?`. This adapter picks the first id LMS
+    // reports for each group as that group's leader for display purposes.
+    // That is a stable-but-arbitrary UHC convention, not an LMS fact.
+
+    /// Read every active LMS sync group from `syncgroups ?` as a raw member
+    /// list (no leader/member split yet). Groups of fewer than two players
+    /// are not sync groups and are dropped.
+    async fn read_sync_groups(&self) -> Result<Vec<Vec<String>>> {
+        let result = self
+            .rpc
+            .execute(None, vec![json!("syncgroups"), json!("?")])
+            .await?;
+        let groups_loop = result
+            .get("syncgroups_loop")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        Ok(groups_loop
+            .iter()
+            .filter_map(|group| group.get("sync_members").and_then(Value::as_str))
+            .map(|members| {
+                members
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|members| members.len() >= 2)
+            .collect())
+    }
+
+    /// Report every active LMS sync group in the multiroom contract's shape.
+    ///
+    /// `can_set_members` is always `true`: unlike Music Assistant's per-leader
+    /// `SET_MEMBERS` feature flag, every LMS player accepts `sync`
+    /// unconditionally, so there is no per-group capability to check.
+    pub async fn multiroom_status(&self) -> Result<Value> {
+        let groups = self.read_sync_groups().await?;
+        let groups = groups
+            .into_iter()
+            .filter_map(|members| {
+                let (leader, rest) = members.split_first()?;
+                Some(json!({
+                    "leader_zone_id": PrefixedZoneId::lms(leader).to_string(),
+                    "member_zone_ids": rest
+                        .iter()
+                        .map(|id| PrefixedZoneId::lms(id).to_string())
+                        .collect::<Vec<_>>(),
+                    "can_set_members": true,
+                }))
+            })
+            .collect::<Vec<_>>();
+        Ok(json!({ "groups": groups }))
+    }
+
+    /// Sync `add_zone_ids` into `leader_zone_id`'s group and unsync
+    /// `remove_zone_ids`, then return the refreshed `multiroom_status`.
+    pub async fn set_group_members(
+        &self,
+        leader_zone_id: &str,
+        add_zone_ids: &[String],
+        remove_zone_ids: &[String],
+    ) -> Result<Value> {
+        if add_zone_ids.is_empty() && remove_zone_ids.is_empty() {
+            return Err(anyhow!("LMS group membership needs at least one member"));
+        }
+        let leader_id = lms_player_id(leader_zone_id, "leader_zone_id")?;
+        let add_ids = lms_player_ids(add_zone_ids, "member_zone_ids_to_add")?;
+        let remove_ids = lms_player_ids(remove_zone_ids, "member_zone_ids_to_remove")?;
+        let players = self.rpc.get_players().await?;
+        let player_exists = |id: &str| players.iter().any(|player| player.playerid == id);
+        if !player_exists(&leader_id) {
+            return Err(anyhow!("LMS group leader was not found"));
+        }
+        for player_id in add_ids.iter().chain(remove_ids.iter()) {
+            if player_id == &leader_id {
+                return Err(anyhow!(
+                    "LMS group leader cannot be its own member input"
+                ));
+            }
+            if !player_exists(player_id) {
+                return Err(anyhow!("LMS group member was not found"));
+            }
+        }
+        for member_id in &add_ids {
+            self.rpc
+                .execute(Some(&leader_id), vec![json!("sync"), json!(member_id)])
+                .await?;
+        }
+        for member_id in &remove_ids {
+            self.rpc
+                .execute(Some(member_id), vec![json!("sync"), json!("-")])
+                .await?;
+        }
+        self.multiroom_status().await
+    }
+
+    /// Unsync each of `member_zone_ids` via its own `sync -`, independent of
+    /// which group (if any) it currently belongs to, then return the
+    /// refreshed `multiroom_status`.
+    pub async fn ungroup_members(&self, member_zone_ids: &[String]) -> Result<Value> {
+        let member_ids = lms_player_ids(member_zone_ids, "member_zone_ids")?;
+        if member_ids.is_empty() {
+            return Err(anyhow!("LMS ungroup needs at least one member"));
+        }
+        let players = self.rpc.get_players().await?;
+        for member_id in &member_ids {
+            if !players.iter().any(|player| player.playerid == *member_id) {
+                return Err(anyhow!("LMS group member was not found"));
+            }
+        }
+        for member_id in &member_ids {
+            self.rpc
+                .execute(Some(member_id), vec![json!("sync"), json!("-")])
+                .await?;
+        }
+        self.multiroom_status().await
     }
 
     /// Start polling for player updates (internal - use Startable trait)
@@ -3082,6 +3252,74 @@ async fn run_lms_command_endpoint(
                 // deadline; the command may have applied even though LMS did not serve readback.
                 tracing::warn!(%error, command_id = command_id.get(), "LMS native write accepted but coherent player readback failed");
             }
+        }
+    }
+}
+
+/// Content-library surface (#510): only the multiroom sync-group operations
+/// are implemented here. LMS's own search/play surfaces are reached through
+/// their dedicated paths (`LmsAdapter::search`, `LmsAdapter::control`, ...);
+/// this trait is what lets the provider-neutral MCP registry
+/// (`AdapterRegistry::library_content`) dispatch `multiroom_status`,
+/// `multiroom_set_members` and `multiroom_ungroup` to LMS the same way it
+/// already dispatches them to Music Assistant
+/// (`src/adapters/musicassistant.rs`).
+#[async_trait]
+impl LibraryAdapter for LmsAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow!(
+            "LMS search is not implemented via the generic content-library surface (see #396/#402)"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow!(
+            "LMS play-by-uri is not implemented via the generic content-library surface (see #396)"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        match operation {
+            "multiroom_status" => self.multiroom_status().await,
+            "multiroom_set_members" => {
+                let leader = params
+                    .get("leader_zone_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("LMS group operation requires leader_zone_id"))?;
+                let add = params
+                    .get("member_zone_ids_to_add")
+                    .or_else(|| params.get("member_zone_ids"))
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow!("LMS group operation requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                let remove = params
+                    .get("member_zone_ids_to_remove")
+                    .and_then(Value::as_array)
+                    .map(|members| {
+                        members
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                self.set_group_members(leader, &add, &remove).await
+            }
+            "multiroom_ungroup" => {
+                let members = params
+                    .get("member_zone_ids")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow!("LMS ungroup requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                self.ungroup_members(&members).await
+            }
+            _ => Err(anyhow!("LMS content operation `{operation}` is not supported")),
         }
     }
 }

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -14,6 +14,7 @@ use roon_api::{
     CoreEvent, Info, Parsed, RoonApi, RoonApiError, Services, Svc,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -25,7 +26,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::bus::{
     runtime::{
@@ -172,6 +174,35 @@ pub(crate) fn is_ungrounded_grouping(item: &BrowseItem) -> bool {
 /// MCP and aggregator use prefixed IDs (e.g., "roon:zone_123"), but Roon API expects bare IDs.
 fn strip_roon_prefix(id: &str) -> &str {
     id.strip_prefix("roon:").unwrap_or(id)
+}
+
+/// Require a properly-prefixed Roon zone id and return its bare id.
+///
+/// Unlike [`strip_roon_prefix`] (used by the pre-existing transport paths,
+/// which tolerate a bare id for backward compatibility), the multiroom
+/// grouping surface (#509) is new and follows the stricter validation the
+/// Music Assistant and LMS adapters already apply to their own multiroom
+/// parameters (`musicassistant_player_id`, `lms_player_id`).
+fn roon_zone_id(zone_id: &str, parameter: &str) -> Result<String> {
+    zone_id
+        .strip_prefix("roon:")
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("{parameter} must be a Roon zone id"))
+}
+
+/// [`roon_zone_id`] over a list, rejecting duplicates the same way the
+/// Music Assistant and LMS multiroom contracts do.
+fn roon_zone_ids(zone_ids: &[String], parameter: &str) -> Result<Vec<String>> {
+    let mut ids = Vec::with_capacity(zone_ids.len());
+    for zone_id in zone_ids {
+        let id = roon_zone_id(zone_id, parameter)?;
+        if ids.contains(&id) {
+            return Err(anyhow::anyhow!("{parameter} must not contain duplicate zones"));
+        }
+        ids.push(id);
+    }
+    Ok(ids)
 }
 
 /// Pending image request - stores the oneshot sender to deliver the result
@@ -630,6 +661,14 @@ pub struct Output {
     pub output_id: String,
     pub display_name: String,
     pub volume: Option<VolumeInfo>,
+    /// Output ids this output can be grouped with, straight from the Core
+    /// (`transport::Output::can_group_with_output_ids`). Roon only groups
+    /// outputs that share a streaming protocol (RAAT with RAAT, AirPlay with
+    /// AirPlay, etc); this is the Core's own compatibility list, so grouping
+    /// (#509) refuses upfront against it instead of guessing at protocol
+    /// names the wire format never exposes.
+    #[serde(default)]
+    pub can_group_with_output_ids: Vec<String>,
 }
 
 /// Volume information
@@ -1372,6 +1411,213 @@ impl RoonAdapter {
         };
         transport.mute(&output_id, &how).await;
         Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiroom grouping (#509): `Transport::group_outputs` / `ungroup_outputs`
+    // wired to the `multiroom_status` / `multiroom_set_members` /
+    // `multiroom_ungroup` contract the Music Assistant adapter already
+    // implements (`src/adapters/musicassistant.rs`).
+    //
+    // Roon groups *outputs*, not zones. Grouping merges every named zone's
+    // outputs into a single zone; the Core keeps the leader's zone_id and
+    // retires the other zones (their outputs move under the leader's
+    // zone_id in the next zone update). This adapter resolves each zone
+    // argument to one representative output -- the same first-output
+    // resolution `change_volume` (above) already uses for multi-output
+    // zones -- and lets the ordinary zone-event pipeline in `run()`
+    // (`Parsed::Zones` / `Parsed::ZonesRemoved`, already unconditional for
+    // every zone change) publish the resulting `ZoneUpdated` /
+    // `ZoneRemoved` bus events. No special-case bus code is needed for
+    // grouping: from the bus's perspective a merge is just an ordinary zone
+    // update plus zone removal.
+    //
+    // Because member zone ids do not survive a merge, this adapter reports
+    // (and accepts back) *outputs* as members once a group exists: for a
+    // zone with more than one output, `multiroom_status` treats the first
+    // output as the "leader" and the rest as members, addressed as
+    // `roon:<output_id>` rather than a zone id. That is a stable-but-
+    // arbitrary UHC display convention (mirroring the same call LMS's
+    // adapter documents for its own leaderless sync groups), not a Roon
+    // fact: `resolve_roon_output` accepts either a live zone id or a bare
+    // output id, so a caller can always name a group member whether or not
+    // it currently has its own zone.
+
+    /// Resolve `id` (bare, no "roon:" prefix) to one Roon output: either the
+    /// first output of a zone with this id, or -- for a member of an
+    /// existing group, whose original zone id was retired by the merge --
+    /// the output with this id directly.
+    async fn resolve_roon_output(&self, id: &str) -> Result<Output> {
+        let state = self.state.read().await;
+        if let Some(zone) = state.zones.get(id) {
+            return zone
+                .outputs
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Zone has no outputs: {id}"));
+        }
+        state
+            .zones
+            .values()
+            .find_map(|zone| zone.outputs.iter().find(|o| o.output_id == id).cloned())
+            .ok_or_else(|| anyhow::anyhow!("Roon zone or output was not found: {id}"))
+    }
+
+    /// Report every Roon zone with more than one output as a group.
+    ///
+    /// `can_set_members` is always `true`: every Roon output accepts
+    /// `group_outputs`/`ungroup_outputs` unconditionally, so there is no
+    /// per-group capability to check (unlike Music Assistant's per-leader
+    /// `SET_MEMBERS` feature flag).
+    pub async fn multiroom_status(&self) -> Result<Value> {
+        let state = self.state.read().await;
+        let groups: Vec<Value> = state
+            .zones
+            .values()
+            .filter(|zone| zone.outputs.len() > 1)
+            .filter_map(|zone| {
+                let (_leader_output, member_outputs) = zone.outputs.split_first()?;
+                Some(json!({
+                    "leader_zone_id": PrefixedZoneId::roon(&zone.zone_id).to_string(),
+                    "member_zone_ids": member_outputs
+                        .iter()
+                        .map(|o| PrefixedZoneId::roon(&o.output_id).to_string())
+                        .collect::<Vec<_>>(),
+                    "can_set_members": true,
+                }))
+            })
+            .collect();
+        Ok(json!({ "groups": groups }))
+    }
+
+    /// Group `add_zone_ids` (and any current members of `leader_zone_id`'s
+    /// group) together via `group_outputs`, and ungroup `remove_zone_ids` via
+    /// `ungroup_outputs`, then return the current `multiroom_status`.
+    ///
+    /// Roon confirms grouping asynchronously through the ordinary zone
+    /// subscription rather than a synchronous RPC reply (the same is true of
+    /// `change_volume`/`mute`/`control` above), so -- unlike the Music
+    /// Assistant and LMS adapters, whose underlying protocols are
+    /// request/response -- the status returned here is a snapshot of
+    /// current knowledge, not a guaranteed post-condition. Callers that need
+    /// the authoritative outcome should watch the zone bus, exactly as they
+    /// already must for every other Roon transport command.
+    pub async fn set_group_members(
+        &self,
+        leader_zone_id: &str,
+        add_zone_ids: &[String],
+        remove_zone_ids: &[String],
+    ) -> Result<Value> {
+        if add_zone_ids.is_empty() && remove_zone_ids.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Roon group membership needs at least one member"
+            ));
+        }
+        let leader_id = roon_zone_id(leader_zone_id, "leader_zone_id")?;
+        let add_ids = roon_zone_ids(add_zone_ids, "member_zone_ids_to_add")?;
+        let remove_ids = roon_zone_ids(remove_zone_ids, "member_zone_ids_to_remove")?;
+        for id in add_ids.iter().chain(remove_ids.iter()) {
+            if id == &leader_id {
+                return Err(anyhow::anyhow!(
+                    "Roon group leader cannot be its own member input"
+                ));
+            }
+        }
+
+        let leader_output = self
+            .resolve_roon_output(&leader_id)
+            .await
+            .map_err(|_| anyhow::anyhow!("Roon group leader was not found"))?;
+        let mut add_outputs = Vec::with_capacity(add_ids.len());
+        for id in &add_ids {
+            add_outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+        let mut remove_outputs = Vec::with_capacity(remove_ids.len());
+        for id in &remove_ids {
+            remove_outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+
+        // Roon only groups outputs that share a streaming protocol. The Core
+        // does not expose a queryable protocol name, but `can_group_with_output_ids`
+        // *is* the Core's own compatibility list for the leader's output, so a
+        // mismatch here is refused cleanly instead of being sent to the Core
+        // to fail (or be silently ignored) in some undocumented way.
+        for output in &add_outputs {
+            if !leader_output
+                .can_group_with_output_ids
+                .iter()
+                .any(|id| id == &output.output_id)
+            {
+                return Err(anyhow::anyhow!(
+                    "Cannot group '{}' with '{}': they do not share a compatible streaming protocol",
+                    output.display_name,
+                    leader_output.display_name
+                ));
+            }
+        }
+
+        let transport = {
+            let state = self.state.read().await;
+            state
+                .transport
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Not connected to Roon"))?
+        };
+
+        if !add_outputs.is_empty() {
+            let mut output_ids: Vec<&str> = vec![leader_output.output_id.as_str()];
+            output_ids.extend(add_outputs.iter().map(|o| o.output_id.as_str()));
+            transport.group_outputs(output_ids).await;
+        }
+        for output in &remove_outputs {
+            transport
+                .ungroup_outputs(vec![output.output_id.as_str()])
+                .await;
+        }
+
+        self.multiroom_status().await
+    }
+
+    /// Ungroup each of `member_zone_ids` via `ungroup_outputs`, then return
+    /// the current `multiroom_status`. See [`Self::set_group_members`] for
+    /// why the returned status is a snapshot rather than a guaranteed
+    /// post-condition.
+    pub async fn ungroup_members(&self, member_zone_ids: &[String]) -> Result<Value> {
+        let member_ids = roon_zone_ids(member_zone_ids, "member_zone_ids")?;
+        if member_ids.is_empty() {
+            return Err(anyhow::anyhow!("Roon ungroup needs at least one member"));
+        }
+        let mut outputs = Vec::with_capacity(member_ids.len());
+        for id in &member_ids {
+            outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+
+        let transport = {
+            let state = self.state.read().await;
+            state
+                .transport
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Not connected to Roon"))?
+        };
+        for output in &outputs {
+            transport
+                .ungroup_outputs(vec![output.output_id.as_str()])
+                .await;
+        }
+
+        self.multiroom_status().await
     }
 
     /// Get album art image
@@ -2268,6 +2514,76 @@ impl RoonAdapter {
     }
 }
 
+/// Content-library surface (#509): only the multiroom grouping operations
+/// are implemented here. Roon's own search/play surfaces are reached
+/// through their dedicated paths (`RoonAdapter::search`, `RoonAdapter::play_item`,
+/// ...); this trait is what lets the provider-neutral MCP registry
+/// (`AdapterRegistry::library_content`) dispatch `multiroom_status`,
+/// `multiroom_set_members` and `multiroom_ungroup` to Roon the same way it
+/// already dispatches them to Music Assistant
+/// (`src/adapters/musicassistant.rs`).
+#[async_trait]
+impl LibraryAdapter for RoonAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow::anyhow!(
+            "Roon search is not implemented via the generic content-library surface (see #396/#402)"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow::anyhow!(
+            "Roon play-by-uri is not implemented via the generic content-library surface (see #396)"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        match operation {
+            "multiroom_status" => self.multiroom_status().await,
+            "multiroom_set_members" => {
+                let leader = params
+                    .get("leader_zone_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("Roon group operation requires leader_zone_id"))?;
+                let add = params
+                    .get("member_zone_ids_to_add")
+                    .or_else(|| params.get("member_zone_ids"))
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow::anyhow!("Roon group operation requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                let remove = params
+                    .get("member_zone_ids_to_remove")
+                    .and_then(Value::as_array)
+                    .map(|members| {
+                        members
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                self.set_group_members(leader, &add, &remove).await
+            }
+            "multiroom_ungroup" => {
+                let members = params
+                    .get("member_zone_ids")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow::anyhow!("Roon ungroup requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                self.ungroup_members(&members).await
+            }
+            _ => Err(anyhow::anyhow!(
+                "Roon content operation `{operation}` is not supported"
+            )),
+        }
+    }
+}
+
 #[async_trait]
 impl AdapterLogic for RoonAdapter {
     fn prefix(&self) -> &'static str {
@@ -2604,6 +2920,7 @@ fn convert_zone(roon_zone: &RoonZone) -> Zone {
                 is_muted: v.is_muted,
                 step: v.step,
             }),
+            can_group_with_output_ids: o.can_group_with_output_ids.clone(),
         })
         .collect();
 
@@ -3383,6 +3700,7 @@ mod tests {
                     is_muted: None,
                     step: None,
                 }),
+                can_group_with_output_ids: Vec::new(),
             }],
         }
     }
@@ -3448,6 +3766,7 @@ mod tests {
                 output_id: "output-no-vol".to_string(),
                 display_name: "No Volume Output".to_string(),
                 volume: None,
+                can_group_with_output_ids: Vec::new(),
             }],
         };
         let bus_zone = roon_zone_to_bus_zone(&zone);

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,6 +502,14 @@ mod server {
             .adapter_registry
             .register_library("spotify", spotify.clone())
             .await;
+        // Roon's transport commands keep going through the dedicated
+        // `state.roon` field/routes; this registration only exposes the
+        // provider-neutral content-library surface (#509's multiroom
+        // grouping operations) via `AdapterRegistry::library_content("roon", ...)`.
+        state
+            .adapter_registry
+            .register_library("roon", state.roon.clone())
+            .await;
         state.provider_auth.attach_spotify(spotify.clone()).await;
         state
             .provider_auth

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,6 +502,14 @@ mod server {
             .adapter_registry
             .register_library("spotify", spotify.clone())
             .await;
+        // LMS's transport commands keep going through the dedicated `state.lms`
+        // field/routes; this registration only exposes the provider-neutral
+        // content-library surface (#510's multiroom sync-group operations) via
+        // `AdapterRegistry::library_content("lms", ...)`.
+        state
+            .adapter_registry
+            .register_library("lms", state.lms.clone())
+            .await;
         state.provider_auth.attach_spotify(spotify.clone()).await;
         state
             .provider_auth

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -360,7 +360,15 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         | Capability::QueueRemove
         | Capability::QueueClear => target == ZoneTarget::MusicAssistant,
         Capability::PlayNext => target == ZoneTarget::MusicAssistant,
-        Capability::MultiroomSync => target == ZoneTarget::MusicAssistant,
+        // #517: LMS (#513) and Roon (#515) both implement the
+        // multiroom_status/multiroom_set_members/multiroom_ungroup contract at
+        // the adapter layer, exactly like Music Assistant. `hifi_zone_group`
+        // routes join/leave/status to whichever of the three owns the zone
+        // prefix (`src/mcp/tools/groups.rs`), so all three are routed here.
+        Capability::MultiroomSync => matches!(
+            target,
+            ZoneTarget::MusicAssistant | ZoneTarget::Roon | ZoneTarget::Lms
+        ),
         Capability::Browse | Capability::SavedPlaylists | Capability::Favorites => {
             matches!(target, ZoneTarget::Spotify | ZoneTarget::MusicAssistant)
         }
@@ -455,7 +463,8 @@ const HQPLAYER_CONTENT_UNVERIFIED: &str = "UHC's HQPlayer adapter speaks transpo
 #[rustfmt::skip]
 const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     // -------------------------------------------------------------------------
-    // Roon. Transport, volume, search and play-by-query are routed.
+    // Roon. Transport, volume, search, play-by-query and (since #517)
+    // multiroom_sync are routed.
     // -------------------------------------------------------------------------
     (ZoneTarget::Roon, Capability::PlayByRef, Gap::NotWired("#396",
         "RoonAdapter::browse/load/play_item exist and are exposed over HTTP; MCP mints no \
@@ -488,9 +497,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::Favorites, Gap::NotWired("#399",
         "Roon exposes My Favorites and tags as browse hierarchies, so this arrives with \
          browse.")),
-    (ZoneTarget::Roon, Capability::MultiroomSync, Gap::NotWired("#360",
-        "the Roon API's transport service groups and ungroups outputs; UHC exposes no \
-         grouping on any surface.")),
 
     // -------------------------------------------------------------------------
     // LMS. **Not one ProviderCannot** -- every gap here is UHC's, verified live
@@ -537,10 +543,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
         "favorites items / favorites playlist play / add / delete / exists all work; verified \
          live. Note LMS favorites have no durable id -- only a url -- so a ref must be minted \
          over the url.")),
-    (ZoneTarget::Lms, Capability::MultiroomSync, Gap::NotWired("#403",
-        "sync <playerid>, sync -, sync ? and the server-scoped syncgroups ? all work; verified \
-         live. Joining is destructive to the target zone's queue, which is why #403 gates it \
-         behind confirmation.")),
 
     // -------------------------------------------------------------------------
     // OpenHome. Transport, skip and (since #398) volume are routed.

--- a/src/mcp/tools/groups.rs
+++ b/src/mcp/tools/groups.rs
@@ -1,24 +1,125 @@
+//! `hifi_zone_group`: multiroom grouping, generalized across every adapter that
+//! implements the `multiroom_status` / `multiroom_set_members` /
+//! `multiroom_ungroup` contract (issue #517).
+//!
+//! # Three providers, one contract
+//!
+//! Music Assistant, Roon (#509/#515) and LMS (#510/#513) each implement the
+//! same three-operation content-library contract
+//! (`src/adapters/{musicassistant,roon,lms}.rs`, `impl LibraryAdapter for
+//! ...::content`). This module owns the provider-neutral routing that used to
+//! be hardwired to Music Assistant alone: `join`/`leave` resolve the owning
+//! adapter from the zone id's prefix via [`ZoneTarget`], exactly like every
+//! other MCP tool.
+//!
+//! # The `status` design decision
+//!
+//! Before #517, `status` took no zone id at all, which implicitly assumed a
+//! single grouping-capable provider. With three, that question has two honest
+//! answers and this tool supports both explicitly rather than picking one at
+//! the cost of the other:
+//!
+//! - **`zone_id` present**: scoped to that zone's provider, exactly like every
+//!   other zone-scoped tool infers its provider. Refused if the zone's prefix
+//!   names no multiroom-capable provider.
+//! - **`zone_id` absent**: aggregate every provider's groups into one
+//!   `groups` list, each entry tagged with its `provider`. A provider whose
+//!   call fails (not configured, not connected, ...) is reported in `errors`
+//!   rather than failing the whole read — one backend being unreachable must
+//!   not hide the other two's groups. `errors` is omitted entirely when every
+//!   provider answered.
+//!
+//! Aggregation is the default (no `zone_id`) because `status` is the one
+//! read-only action here and a client asking "what is grouped right now"
+//! almost always means "everywhere", not "guess which provider I meant". The
+//! explicit `zone_id` form exists for a client that already knows which
+//! provider it cares about and does not want to pay for the other two calls
+//! (or parse `errors` for a provider it does not use).
+//!
+//! # Two member-id conventions, tolerated not normalized
+//!
+//! `multiroom_status`'s `member_zone_ids` mean different things per adapter,
+//! and this tool passes them through verbatim rather than pretending they
+//! agree:
+//!
+//! - **Roon** merges outputs into one zone on grouping and retires the
+//!   member zones' own ids, so a member is reported (and must be addressed
+//!   again) as `roon:<output_id>`, not a zone id `hifi_zones` ever listed
+//!   independently once grouped.
+//! - **LMS** sync groups are leaderless — Squeezebox sync has no
+//!   server-side concept of "leader" — so `leader_zone_id` in an LMS group is
+//!   a stable-but-arbitrary UHC convention (the first id LMS's `syncgroups ?`
+//!   reports for that group), not an LMS fact.
+//!
+//! Both are documented on the tool description below so a client does not
+//! read either as a UHC bug.
+//!
+//! # Cross-provider grouping is refused, not attempted
+//!
+//! `join` and `leave` require every zone id involved (leader plus every
+//! member) to classify to the *same* multiroom-capable provider. Mixing
+//! providers is refused as an invalid parameter before any adapter is
+//! called — there is no protocol that groups a Roon output with an LMS
+//! player, so attempting it would only surface as a confusing adapter-side
+//! failure instead of a clear client-side one.
+
 use crate::api::AppState;
-use crate::mcp::envelope::{Envelope, Refusal};
+use crate::mcp::envelope::{Envelope, Refusal, Scope};
 use crate::mcp::routing::ZoneTarget;
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     schema::{schema_utils::CallToolError, CallToolResult},
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Every [`ZoneTarget`] that implements the multiroom contract, in the order
+/// `status`'s aggregate reports them.
+const MULTIROOM_TARGETS: &[ZoneTarget] = &[
+    ZoneTarget::Roon,
+    ZoneTarget::Lms,
+    ZoneTarget::MusicAssistant,
+];
+
+/// The accepted zone-id prefixes, for refusals that must say what a valid
+/// input looks like.
+const MULTIROOM_PREFIXES: &[&str] = &["roon:", "lms:", "musicassistant:"];
+
+/// Classify `zone_id` and accept it only if its provider implements the
+/// multiroom contract.
+fn multiroom_target(zone_id: &str) -> Option<ZoneTarget> {
+    let target = ZoneTarget::classify(zone_id);
+    MULTIROOM_TARGETS.contains(&target).then_some(target)
+}
 
 #[mcp_tool(
     name = "hifi_zone_group",
-    description = "Inspect or change Music Assistant zone groups. action=status is read-only. join and leave require confirm=true because grouping changes playback topology."
+    description = "Inspect or change multiroom zone groups for any provider that supports \
+                    synchronised playback (Roon, LMS, Music Assistant). action=status is \
+                    read-only: pass zone_id to scope it to one provider, or omit zone_id to \
+                    aggregate every provider's groups (a provider that cannot be reached is \
+                    reported in `errors` rather than failing the whole read). join and leave \
+                    require confirm=true because grouping changes playback topology, and every \
+                    zone id involved (leader plus every member) must belong to the same \
+                    provider -- cross-provider groups are refused. Two provider-specific member \
+                    conventions: Roon retires a grouped zone's own id and reports/accepts its \
+                    members as roon:<output_id>; LMS sync groups are leaderless, so \
+                    leader_zone_id there is UHC's stable-but-arbitrary pick of the first member \
+                    id, not an LMS fact."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiZoneGroupTool {
     /// status, join, or leave.
     pub action: String,
-    /// Music Assistant leader zone for join.
+    /// Scopes action=status to one provider. Omit to aggregate every
+    /// multiroom-capable provider's groups.
+    #[serde(default)]
+    pub zone_id: Option<String>,
+    /// Leader zone for join. Must be the same provider as every member_zone_id.
     #[serde(default)]
     pub leader_zone_id: Option<String>,
-    /// Music Assistant member zones to add or leave.
+    /// Member zones to add (join) or remove (leave). Must all share one
+    /// provider, matching leader_zone_id for join.
     #[serde(default)]
     pub member_zone_ids: Option<Vec<String>>,
     /// Required true for topology-changing join and leave actions.
@@ -52,59 +153,219 @@ pub async fn handle_zone_group(
             "join and leave require at least one member_zone_id.",
             Refusal::invalid_parameter(
                 "member_zone_ids",
-                &["musicassistant:<player>"],
-                "Specify one or more Music Assistant zones to change.",
+                MULTIROOM_PREFIXES,
+                "Specify one or more zones to change, all from the same provider.",
             ),
         );
     }
-    let operation = match args.action.as_str() {
-        "status" => "multiroom_status",
-        "join" => "multiroom_set_members",
-        "leave" => "multiroom_ungroup",
-        _ => {
+    match args.action.as_str() {
+        "status" => handle_status(state, env, args.zone_id).await,
+        "join" => handle_join(state, env, args.leader_zone_id, member_zone_ids).await,
+        "leave" => handle_leave(state, env, member_zone_ids).await,
+        _ => env.refused(
+            "Unknown zone group action.",
+            Refusal::invalid_parameter(
+                "action",
+                &["status", "join", "leave"],
+                "Choose a documented zone group action.",
+            ),
+        ),
+    }
+}
+
+async fn handle_join(
+    state: &AppState,
+    env: Envelope,
+    leader_zone_id: Option<String>,
+    member_zone_ids: Vec<String>,
+) -> Result<CallToolResult, CallToolError> {
+    let leader_zone_id = match leader_zone_id.filter(|id| !id.is_empty()) {
+        Some(id) => id,
+        None => {
             return env.refused(
-                "Unknown zone group action.",
+                "join requires a leader_zone_id.",
                 Refusal::invalid_parameter(
-                    "action",
-                    &["status", "join", "leave"],
-                    "Choose a documented zone group action.",
+                    "leader_zone_id",
+                    MULTIROOM_PREFIXES,
+                    "Groups are addressed by the leader's zone id.",
                 ),
             )
         }
     };
-    if args.action == "join"
-        && args.leader_zone_id.as_deref().map(ZoneTarget::classify)
-            != Some(ZoneTarget::MusicAssistant)
-    {
-        return env.refused(
-            "join requires a musicassistant: leader_zone_id.",
-            Refusal::invalid_parameter(
-                "leader_zone_id",
-                &["musicassistant:<player>"],
-                "Groups are owned by Music Assistant.",
+    let leader_target =
+        match multiroom_target(&leader_zone_id) {
+            Some(target) => target,
+            None => return env.refused(
+                "join requires a leader_zone_id from a provider that supports multiroom \
+                 grouping.",
+                Refusal::invalid_parameter(
+                    "leader_zone_id",
+                    MULTIROOM_PREFIXES,
+                    "Groups are owned by Roon, LMS or Music Assistant; other zone types cannot \
+                     lead a group.",
+                ),
             ),
-        );
-    }
+        };
     if member_zone_ids
         .iter()
-        .any(|id| ZoneTarget::classify(id) != ZoneTarget::MusicAssistant)
+        .any(|id| ZoneTarget::classify(id) != leader_target)
     {
         return env.refused(
-            "Every member_zone_id must be a Music Assistant zone.",
+            format!(
+                "Every member_zone_id must be a {} zone, matching the leader.",
+                leader_target.label()
+            ),
             Refusal::invalid_parameter(
                 "member_zone_ids",
-                &["musicassistant:<player>"],
+                &[leader_target.prefix().unwrap_or_default()],
                 "Cross-provider zone groups are not supported.",
             ),
         );
     }
-    let params = serde_json::json!({"leader_zone_id": args.leader_zone_id, "member_zone_ids": member_zone_ids});
+    let params =
+        serde_json::json!({"leader_zone_id": leader_zone_id, "member_zone_ids": member_zone_ids});
     match state
         .adapter_registry
-        .library_content("musicassistant", operation, &params)
+        .library_content(leader_target.label(), "multiroom_set_members", &params)
         .await
     {
-        Ok(value) => Ok(env.json_result(&value)),
+        Ok(value) => Ok(env
+            .scope(Scope::provider_only(leader_target.provider()))
+            .json_result(&value)),
         Err(error) => env.failed(format!("Zone group error: {error}")),
+    }
+}
+
+async fn handle_leave(
+    state: &AppState,
+    env: Envelope,
+    member_zone_ids: Vec<String>,
+) -> Result<CallToolResult, CallToolError> {
+    let first_target =
+        match member_zone_ids.first().and_then(|id| multiroom_target(id)) {
+            Some(target) => target,
+            None => return env.refused(
+                "leave requires member_zone_ids from a provider that supports multiroom \
+                 grouping.",
+                Refusal::invalid_parameter(
+                    "member_zone_ids",
+                    MULTIROOM_PREFIXES,
+                    "Groups are owned by Roon, LMS or Music Assistant; other zone types cannot \
+                     be group members.",
+                ),
+            ),
+        };
+    if member_zone_ids
+        .iter()
+        .any(|id| ZoneTarget::classify(id) != first_target)
+    {
+        return env.refused(
+            format!(
+                "Every member_zone_id must be a {} zone.",
+                first_target.label()
+            ),
+            Refusal::invalid_parameter(
+                "member_zone_ids",
+                &[first_target.prefix().unwrap_or_default()],
+                "Cross-provider zone groups are not supported.",
+            ),
+        );
+    }
+    let params = serde_json::json!({"member_zone_ids": member_zone_ids});
+    match state
+        .adapter_registry
+        .library_content(first_target.label(), "multiroom_ungroup", &params)
+        .await
+    {
+        Ok(value) => Ok(env
+            .scope(Scope::provider_only(first_target.provider()))
+            .json_result(&value)),
+        Err(error) => env.failed(format!("Zone group error: {error}")),
+    }
+}
+
+/// One provider's `multiroom_status` call failing during aggregation. Reported
+/// alongside the groups every other provider did answer, rather than failing
+/// the whole read for one unreachable backend.
+#[derive(Debug, Serialize)]
+struct ProviderError {
+    provider: &'static str,
+    detail: String,
+}
+
+/// The aggregate payload for `status` with no `zone_id`: every reachable
+/// provider's groups, each tagged with `provider`, plus the providers that
+/// could not be reached.
+#[derive(Debug, Serialize)]
+struct AggregateMultiroomStatus {
+    groups: Vec<Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    errors: Vec<ProviderError>,
+}
+
+async fn handle_status(
+    state: &AppState,
+    env: Envelope,
+    zone_id: Option<String>,
+) -> Result<CallToolResult, CallToolError> {
+    match zone_id.filter(|id| !id.is_empty()) {
+        Some(zone_id) => {
+            let target = match multiroom_target(&zone_id) {
+                Some(target) => target,
+                None => {
+                    return env.refused(
+                        "zone_id must be from a provider that supports multiroom grouping.",
+                        Refusal::invalid_parameter(
+                            "zone_id",
+                            MULTIROOM_PREFIXES,
+                            "Only Roon, LMS and Music Assistant zones report multiroom status.",
+                        ),
+                    )
+                }
+            };
+            match state
+                .adapter_registry
+                .library_content(target.label(), "multiroom_status", &serde_json::json!({}))
+                .await
+            {
+                Ok(value) => Ok(env
+                    .scope(Scope::provider_only(target.provider()))
+                    .json_result(&value)),
+                Err(error) => env.failed(format!("Zone group error: {error}")),
+            }
+        }
+        None => {
+            let mut groups = Vec::new();
+            let mut errors = Vec::new();
+            for target in MULTIROOM_TARGETS {
+                match state
+                    .adapter_registry
+                    .library_content(target.label(), "multiroom_status", &serde_json::json!({}))
+                    .await
+                {
+                    Ok(value) => {
+                        let provider_groups = value
+                            .get("groups")
+                            .and_then(Value::as_array)
+                            .cloned()
+                            .unwrap_or_default();
+                        for mut group in provider_groups {
+                            if let Value::Object(map) = &mut group {
+                                map.insert(
+                                    "provider".to_string(),
+                                    Value::String(target.label().to_string()),
+                                );
+                            }
+                            groups.push(group);
+                        }
+                    }
+                    Err(error) => errors.push(ProviderError {
+                        provider: target.label(),
+                        detail: error.to_string(),
+                    }),
+                }
+            }
+            Ok(env.json_result(&AggregateMultiroomStatus { groups, errors }))
+        }
     }
 }

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -134,7 +134,13 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_play_ref" => &["ref", "zone_id", "action"],
         "hifi_queue" => &["zone_id", "action", "item_id", "position"],
         "hifi_collections" => &["zone_id", "action", "path", "media_type", "limit", "offset"],
-        "hifi_zone_group" => &["action", "leader_zone_id", "member_zone_ids", "confirm"],
+        "hifi_zone_group" => &[
+            "action",
+            "zone_id",
+            "leader_zone_id",
+            "member_zone_ids",
+            "confirm",
+        ],
         "hifi_spotify" => &[
             "action",
             "playlist_id",

--- a/tests/adapter_integration.rs
+++ b/tests/adapter_integration.rs
@@ -780,4 +780,186 @@ mod mock_server_tests {
         adapter.stop().await;
         mock.stop().await;
     }
+
+    // -------------------------------------------------------------------------
+    // LMS sync groups (#510): multiroom_status / set_group_members /
+    // ungroup_members over the mock server's `sync` / `syncgroups ?` support.
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_status_reports_no_groups_before_syncing() {
+        let mock = MockLmsServer::start().await;
+        mock.add_player("aa:bb:cc:dd:ee:ff", "Living Room").await;
+        mock.add_player("11:22:33:44:55:66", "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+
+        let status = adapter.multiroom_status().await.unwrap();
+        assert_eq!(
+            status["groups"].as_array().unwrap().len(),
+            0,
+            "no players are synced yet"
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_set_members_syncs_member_into_leaders_group() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        let member = "11:22:33:44:55:66";
+        mock.add_player(leader, "Living Room").await;
+        mock.add_player(member, "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+        mock.clear_commands().await;
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let member_zone = PrefixedZoneId::lms(member).to_string();
+        let result = adapter
+            .set_group_members(&leader_zone, &[member_zone.clone()], &[])
+            .await
+            .expect("set_group_members should succeed");
+
+        let groups = result["groups"].as_array().expect("groups array");
+        assert_eq!(groups.len(), 1, "one group after syncing one member");
+        assert_eq!(groups[0]["leader_zone_id"], serde_json::json!(leader_zone));
+        assert_eq!(groups[0]["member_zone_ids"], serde_json::json!([member_zone]));
+        assert_eq!(groups[0]["can_set_members"], serde_json::json!(true));
+
+        // The leader is addressed, the member is the argument -- verified live
+        // (#403) to make the *addressed* player the sync master and keep its
+        // queue, which is why the leader (not the member) issues the command.
+        let leader_commands = mock.write_commands(leader).await;
+        assert!(
+            leader_commands.contains(&vec!["sync".to_string(), member.to_string()]),
+            "expected `sync {member}` addressed to the leader, got {leader_commands:?}"
+        );
+
+        assert_eq!(
+            mock.sync_groups().await,
+            vec![vec![leader.to_string(), member.to_string()]]
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_ungroup_unsyncs_member() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        let member = "11:22:33:44:55:66";
+        mock.add_player(leader, "Living Room").await;
+        mock.add_player(member, "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let member_zone = PrefixedZoneId::lms(member).to_string();
+        adapter
+            .set_group_members(&leader_zone, &[member_zone.clone()], &[])
+            .await
+            .expect("initial sync should succeed");
+        mock.clear_commands().await;
+
+        let result = adapter
+            .ungroup_members(&[member_zone])
+            .await
+            .expect("ungroup_members should succeed");
+        assert_eq!(
+            result["groups"].as_array().unwrap().len(),
+            0,
+            "the group dissolves once its only member leaves"
+        );
+
+        let member_commands = mock.write_commands(member).await;
+        assert_eq!(
+            member_commands,
+            vec![vec!["sync".to_string(), "-".to_string()]],
+            "the member is addressed directly to unsync itself"
+        );
+
+        assert!(
+            mock.sync_groups().await.is_empty(),
+            "server-side group state must also be gone"
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_set_members_rejects_unknown_player_before_any_sync_call() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        mock.add_player(leader, "Living Room").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+        mock.clear_commands().await;
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let unknown_zone = PrefixedZoneId::lms("00:00:00:00:00:00").to_string();
+        let result = adapter
+            .set_group_members(&leader_zone, &[unknown_zone], &[])
+            .await;
+        assert!(
+            result.is_err(),
+            "an unknown member must be refused, not synced"
+        );
+        assert!(
+            mock.write_commands(leader).await.is_empty(),
+            "no sync command should reach LMS once validation fails"
+        );
+        assert!(mock.sync_groups().await.is_empty());
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
 }

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -458,7 +458,7 @@
     }
   },
   "hifi_zone_group": {
-    "description": "Inspect or change Music Assistant zone groups. action=status is read-only. join and leave require confirm=true because grouping changes playback topology.",
+    "description": "Inspect or change multiroom zone groups for any provider that supports synchronised playback (Roon, LMS, Music Assistant). action=status is read-only: pass zone_id to scope it to one provider, or omit zone_id to aggregate every provider's groups (a provider that cannot be reached is reported in `errors` rather than failing the whole read). join and leave require confirm=true because grouping changes playback topology, and every zone id involved (leader plus every member) must belong to the same provider -- cross-provider groups are refused. Two provider-specific member conventions: Roon retires a grouped zone's own id and reports/accepts its members as roon:<output_id>; LMS sync groups are leaderless, so leader_zone_id there is UHC's stable-but-arbitrary pick of the first member id, not an LMS fact.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -471,17 +471,22 @@
           "type": "boolean"
         },
         "leader_zone_id": {
-          "description": "Music Assistant leader zone for join.",
+          "description": "Leader zone for join. Must be the same provider as every member_zone_id.",
           "nullable": true,
           "type": "string"
         },
         "member_zone_ids": {
-          "description": "Music Assistant member zones to add or leave.",
+          "description": "Member zones to add (join) or remove (leave). Must all share one\nprovider, matching leader_zone_id for join.",
           "items": {
             "type": "string"
           },
           "nullable": true,
           "type": "array"
+        },
+        "zone_id": {
+          "description": "Scopes action=status to one provider. Omit to aggregate every\nmultiroom-capable provider's groups.",
+          "nullable": true,
+          "type": "string"
         }
       },
       "required": [

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -206,15 +206,16 @@ struct TestApp {
 }
 
 async fn build_state(lms: Option<Arc<LmsAdapter>>) -> AppState {
-    build_state_with_bus(create_bus(), lms).await
+    build_state_with_bus(create_bus(), lms, None).await
 }
 
 async fn build_state_with_bus(
     bus: unified_hifi_control::bus::SharedBus,
     lms: Option<Arc<LmsAdapter>>,
+    roon: Option<Arc<RoonAdapter>>,
 ) -> AppState {
     let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
-    let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
+    let roon = roon.unwrap_or_else(|| Arc::new(RoonAdapter::new_disconnected(bus.clone())));
     let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
     let hqp_instances = Arc::new(HqpInstanceManager::new_with_native_sink(
         bus.clone(),
@@ -228,12 +229,12 @@ async fn build_state_with_bus(
     let startable_adapters: Vec<Arc<dyn Startable>> =
         vec![roon.clone(), lms.clone(), openhome.clone(), upnp.clone()];
 
-    AppState::new(
-        roon,
+    let state = AppState::new(
+        roon.clone(),
         hqplayer,
         hqp_instances,
         hqp_zone_links,
-        lms,
+        lms.clone(),
         openhome,
         upnp,
         KnobStore::new(),
@@ -243,7 +244,15 @@ async fn build_state_with_bus(
         startable_adapters,
         Instant::now(),
         CancellationToken::new(),
-    )
+    );
+    // Mirror main.rs's unconditional content-library registration (#513/#515):
+    // `hifi_zone_group` (#517) dispatches multiroom_status/set_members/ungroup
+    // to Roon and LMS through `AdapterRegistry::library_content` exactly like
+    // Music Assistant, so the test harness must expose the same registry
+    // entries production wiring does.
+    state.adapter_registry.register_library("roon", roon).await;
+    state.adapter_registry.register_library("lms", lms).await;
+    state
 }
 
 impl TestApp {
@@ -853,6 +862,7 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
         "hifi_zone_group",
         &[
             ("action", true),
+            ("zone_id", false),
             ("leader_zone_id", false),
             ("member_zone_ids", false),
             ("confirm", false),
@@ -1836,7 +1846,7 @@ async fn musicassistant_mcp_app() -> (TestApp, MusicAssistantMcpMock, tokio::tas
     });
 
     let bus = create_bus();
-    let state = build_state_with_bus(bus.clone(), None).await;
+    let state = build_state_with_bus(bus.clone(), None, None).await;
     let adapter = Arc::new(
         MusicAssistantAdapter::new(
             bus,
@@ -2121,6 +2131,187 @@ async fn musicassistant_zone_group_refuses_invalid_inputs_before_ma_calls() {
     server.abort();
 }
 
+/// Cross-provider grouping is refused for every pairing among the three
+/// multiroom-capable providers (#517's acceptance criterion), not just the
+/// musicassistant/roon pair the original single-provider tests happened to
+/// cover. Nothing here needs a live backend: every case is refused by zone-id
+/// classification before any adapter is called.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn zone_group_refuses_every_cross_provider_pairing() {
+    let app = TestApp::new().await;
+    for args in [
+        // join: leader and member disagree, for every ordered pairing.
+        json!({"action":"join", "leader_zone_id":"roon:a", "member_zone_ids":["lms:b"], "confirm":true}),
+        json!({"action":"join", "leader_zone_id":"lms:a", "member_zone_ids":["roon:b"], "confirm":true}),
+        json!({"action":"join", "leader_zone_id":"roon:a", "member_zone_ids":["musicassistant:b"], "confirm":true}),
+        json!({"action":"join", "leader_zone_id":"musicassistant:a", "member_zone_ids":["lms:b"], "confirm":true}),
+        // join: a mix of matching and mismatching members must still refuse.
+        json!({"action":"join", "leader_zone_id":"roon:a", "member_zone_ids":["roon:b", "lms:c"], "confirm":true}),
+        // join: a leader from a provider that does not implement grouping at all.
+        json!({"action":"join", "leader_zone_id":"openhome:a", "member_zone_ids":["openhome:b"], "confirm":true}),
+        // leave: members from two different multiroom providers.
+        json!({"action":"leave", "member_zone_ids":["roon:a", "lms:b"], "confirm":true}),
+        json!({"action":"leave", "member_zone_ids":["lms:a", "musicassistant:b"], "confirm":true}),
+        // leave: a provider that does not implement grouping at all.
+        json!({"action":"leave", "member_zone_ids":["upnp:a"], "confirm":true}),
+        // status: a zone_id from a provider that does not implement grouping.
+        json!({"action":"status", "zone_id":"upnp:a"}),
+    ] {
+        let result = app.call_tool("hifi_zone_group", args.clone()).await;
+        assert_eq!(
+            result["structuredContent"]["outcome"], "invalid",
+            "{args} must be refused as invalid: {result}"
+        );
+        assert_eq!(
+            result["structuredContent"]["refusal"]["reason"], "invalid_parameter",
+            "{args}: {result}"
+        );
+    }
+}
+
+/// A `TestApp` wired to a real `RoonAdapter` driven against
+/// `tests/mock_servers/roon_core.rs`'s `FakeRoonCore` -- the same harness
+/// `tests/roon_protocol.rs` uses for Roon's own multiroom tests
+/// (`roon_set_group_members_merges_outputs_into_one_zone` and friends), but
+/// wrapped in the real `/mcp` route so `hifi_zone_group`'s routing (#517) is
+/// proved end to end rather than only at the adapter layer.
+async fn roon_mcp_app(core: &mock_servers::roon_core::FakeRoonCore) -> TestApp {
+    let bus = create_bus();
+    let roon = std::sync::Arc::new(RoonAdapter::new_configured(
+        bus.clone(),
+        "http://test.invalid:8088".to_string(),
+        KnobStore::new(),
+    ));
+    let runner = roon.clone();
+    let ip = core.ip();
+    let port = core.port();
+    tokio::spawn(async move {
+        let _ = runner
+            .run_event_loop_against_core_for_tests(ip, &port)
+            .await;
+    });
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if roon.is_browse_connected().await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        roon.is_browse_connected().await,
+        "RoonAdapter never connected to the fake core"
+    );
+
+    let state = build_state_with_bus(bus, None, Some(roon)).await;
+    TestApp::with_state(state)
+}
+
+/// `hifi_zone_group` routing generalized to Roon (issue #517), proved against
+/// the same `FakeRoonCore` fixture `tests/roon_protocol.rs` uses at the
+/// adapter layer -- join merges two single-output zones' outputs via
+/// `group_outputs`, status reports the merge, and leave splits them back via
+/// `ungroup_outputs`, all addressed by `roon:` zone ids with no Music
+/// Assistant or LMS involved.
+///
+/// Roon confirms grouping asynchronously through its ordinary zone
+/// subscription rather than a synchronous RPC reply (documented on
+/// `RoonAdapter::set_group_members`), so this polls `hifi_zone_group`
+/// status rather than trusting the immediate `join`/`leave` response to
+/// reflect the merge -- the same caveat #517 documents on the tool itself.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn roon_zone_group_routes_join_status_and_leave_through_the_registry() {
+    use mock_servers::roon_core::{zone_with_grouping, FakeRoonCore};
+
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let app = roon_mcp_app(&core).await;
+
+    // Poll status until the aggregate view either shows the expected group
+    // count or a bound is hit, so a slow merge shows what actually arrived
+    // instead of just "assertion failed".
+    async fn wait_for_group_count(app: &TestApp, expected: usize) -> Value {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let status = app
+                .call_tool(
+                    "hifi_zone_group",
+                    json!({"action": "status", "zone_id": "roon:zone_a"}),
+                )
+                .await;
+            let payload: Value =
+                serde_json::from_str(&result_text(&status)).expect("status payload JSON");
+            let count = payload["groups"].as_array().map(Vec::len).unwrap_or(0);
+            if count == expected || std::time::Instant::now() >= deadline {
+                return payload;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    let before = wait_for_group_count(&app, 0).await;
+    assert_eq!(before["groups"].as_array().unwrap().len(), 0, "{before}");
+
+    let joined = app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "join",
+                "leader_zone_id": "roon:zone_a",
+                "member_zone_ids": ["roon:zone_b"],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(joined["structuredContent"]["outcome"], "accepted");
+
+    let after = wait_for_group_count(&app, 1).await;
+    let groups = after["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 1, "{after}");
+    assert_eq!(groups[0]["leader_zone_id"], json!("roon:zone_a"));
+    assert_eq!(
+        groups[0]["member_zone_ids"],
+        json!(["roon:output_b"]),
+        "zone_b was retired by the merge, so the surviving member is named by output id: {after}"
+    );
+    let group_requests = core
+        .requests_named("com.roonlabs.transport:2/group_outputs")
+        .await;
+    assert_eq!(group_requests.len(), 1, "exactly one group_outputs call");
+
+    let left = app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "leave",
+                "member_zone_ids": ["roon:output_b"],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(left["structuredContent"]["outcome"], "accepted");
+
+    let split = wait_for_group_count(&app, 0).await;
+    assert_eq!(split["groups"].as_array().unwrap().len(), 0, "{split}");
+    let ungroup_requests = core
+        .requests_named("com.roonlabs.transport:2/ungroup_outputs")
+        .await;
+    assert_eq!(
+        ungroup_requests.len(),
+        1,
+        "exactly one ungroup_outputs call"
+    );
+
+    core.stop().await;
+}
+
 /// Collections must have one provider-neutral wire shape: no MA URI escapes,
 /// pages are explicit, paths continue browse, and playable rows use the same
 /// opaque refs as search.
@@ -2282,7 +2473,7 @@ impl LmsHarness {
         )
         .await;
 
-        let state = build_state_with_bus(bus, Some(lms.clone())).await;
+        let state = build_state_with_bus(bus, Some(lms.clone()), None).await;
 
         // The aggregator only learns about zones by consuming bus events.
         let aggregator = state.aggregator.clone();
@@ -2409,6 +2600,88 @@ async fn lms_round_trip_pins_the_action_map_and_the_volume_sign() {
              mock received {commands:?}"
         );
     }
+
+    h.stop().await;
+}
+
+/// `hifi_zone_group` routing generalized to LMS (issue #517): a real mock
+/// server, a real adapter registered as an `AdapterRegistry` library (exactly
+/// the wiring `main.rs` does for #513), and the MCP tool driven over the real
+/// `/mcp` route -- join syncs the mock's second player into the first's
+/// group, status reports it, and leave unsyncs it, all addressed by `lms:`
+/// zone ids with no Music Assistant involved.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_zone_group_routes_join_status_and_leave_through_the_registry() {
+    let h = LmsHarness::start().await;
+    const MEMBER_ID: &str = "11:22:33:44:55:66";
+    h.mock.add_player(MEMBER_ID, "Kitchen").await;
+
+    let leader_zone = h.zone_id();
+    let member_zone = format!("lms:{MEMBER_ID}");
+
+    let before = h
+        .app
+        .call_tool(
+            "hifi_zone_group",
+            json!({"action": "status", "zone_id": leader_zone}),
+        )
+        .await;
+    assert_eq!(before["structuredContent"]["outcome"], "ok");
+    assert_eq!(
+        before["structuredContent"]["scope"]["provider"],
+        json!("lms"),
+        "a zone_id-scoped status must identify lms, not aggregate: {before}"
+    );
+    let before_payload: Value =
+        serde_json::from_str(&result_text(&before)).expect("status payload JSON");
+    assert_eq!(
+        before_payload["groups"].as_array().map(Vec::len),
+        Some(0),
+        "no sync group exists yet: {before_payload}"
+    );
+
+    let joined = h
+        .app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "join",
+                "leader_zone_id": leader_zone,
+                "member_zone_ids": [member_zone.clone()],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(joined["structuredContent"]["outcome"], "accepted");
+    let joined_payload: Value =
+        serde_json::from_str(&result_text(&joined)).expect("join payload JSON");
+    let groups = joined_payload["groups"].as_array().expect("groups array");
+    assert_eq!(groups.len(), 1, "{joined_payload}");
+    assert_eq!(groups[0]["leader_zone_id"], json!(leader_zone));
+    assert_eq!(groups[0]["member_zone_ids"], json!([member_zone.clone()]));
+    assert_eq!(
+        h.mock.sync_groups().await,
+        vec![vec![h.player_id.to_string(), MEMBER_ID.to_string()]],
+        "the wire command must address the leader with `sync <member>`, per #403"
+    );
+
+    let left = h
+        .app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "leave",
+                "member_zone_ids": [member_zone],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(left["structuredContent"]["outcome"], "accepted");
+    assert!(
+        h.mock.sync_groups().await.is_empty(),
+        "leave must unsync the member"
+    );
 
     h.stop().await;
 }
@@ -5029,7 +5302,9 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
         "shuffle_mode",
         "saved_playlists",
         "favorites",
-        "multiroom_sync",
+        // multiroom_sync is deliberately absent here: #517 wired LMS sync
+        // groups (#513) to `hifi_zone_group`, so it is `supported` and is
+        // asserted as such below rather than as not-yet-implemented.
     ] {
         let entry = caps
             .get(capability)
@@ -5040,6 +5315,13 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
             "lms/{capability} must read as not-yet-implemented until its issue lands"
         );
     }
+
+    assert_eq!(
+        support_of(&caps["multiroom_sync"]),
+        "supported",
+        "lms/multiroom_sync must be supported: #513 wired native sync groups and #517 routes \
+         hifi_zone_group to them"
+    );
 }
 
 /// OpenHome and UPnP volume was ❌ in AGENTS.md and `not_implemented` in #395.
@@ -5235,7 +5517,29 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 "hifi_control",
                 json!({ "zone_id": zone_id, "action": "shuffle_off" }),
             )),
-            "multiroom_sync" => Some(("hifi_zone_group", json!({ "action": "status" }))),
+            // musicassistant's "multiroom" library is never registered in this
+            // generic TestApp, so a scoped status call reaches the registry's
+            // own "not configured" wording -- the same fingerprint every other
+            // musicassistant probe above proves against.
+            "multiroom_sync" if provider == "musicassistant" => Some((
+                "hifi_zone_group",
+                json!({ "action": "status", "zone_id": zone_id }),
+            )),
+            // Roon and LMS libraries *are* registered (`build_state_with_bus`),
+            // so status would reach a live, empty adapter and succeed instead of
+            // naming it. `join` reaches deep enough into each adapter's own
+            // group-membership resolution to name the provider even while
+            // disconnected/unconfigured -- see the bespoke `expected` strings
+            // below for why status is not used here.
+            "multiroom_sync" => Some((
+                "hifi_zone_group",
+                json!({
+                    "action": "join",
+                    "leader_zone_id": zone_id,
+                    "member_zone_ids": [format!("{provider}:def")],
+                    "confirm": true,
+                }),
+            )),
             _ => None,
         }
     }
@@ -5265,6 +5569,13 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 && capability == "play_by_ref"
             {
                 "unknown or expired"
+            } else if *provider == "roon" && capability == "multiroom_sync" {
+                // The disconnected fake never populates a zone, so
+                // `resolve_roon_output` fails before `set_group_members` ever
+                // reaches its own "Not connected to Roon" transport check --
+                // this is still RoonAdapter's own wording, just from a step
+                // earlier in the same call.
+                "Roon group leader was not found"
             } else {
                 fingerprint(provider)
             };
@@ -5279,15 +5590,16 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     }
     // The routed Spotify content and mode cells plus Music Assistant's queue
     // mutations, mode, collections, and zone-group cells add twenty-three probes to the
-    // original provider transport set.
+    // original provider transport set. #517 adds two more: Roon and LMS
+    // multiroom_sync, generalized from the Music Assistant-only original.
     // Apple Music's transport/skip/volume
     // cells remain gated until signed physical companion validation (#465).
     // Asserted exactly, not as a floor: a floor would pass while a cell silently
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 45,
-        "{proved} supported cells were proved end to end, expected 45. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 47,
+        "{proved} supported cells were proved end to end, expected 47. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 
@@ -5841,7 +6153,7 @@ async fn now_playing_resource_agrees_with_hifi_now_playing_tool_for_a_live_zone(
 async fn a_newly_discovered_zone_is_addressable_without_a_restart() {
     let _settings = SettingsFixture::with_hqplayer(true);
     let bus = create_bus();
-    let state = build_state_with_bus(bus.clone(), None).await;
+    let state = build_state_with_bus(bus.clone(), None, None).await;
 
     let aggregator = state.aggregator.clone();
     let aggregator_task = tokio::spawn(async move { aggregator.run().await });

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -99,6 +99,15 @@ struct MockLmsState {
     /// `playlistcontrol` call. Keyed by [`LmsSearchResultType`]-shaped kind:
     /// `"album"`, `"artist"`, `"track"`.
     library: HashMap<&'static str, Vec<MockLibraryItem>>,
+    /// Active sync groups (#510). Each inner `Vec` is one group's full
+    /// membership, first-added player first -- mirroring what real LMS's
+    /// `syncgroups ?` reports (a flat member list with no leader marker).
+    /// This is a simplified peer model, not a full replica of LMS's
+    /// undocumented internal master-election-on-leave behavior: `sync -`
+    /// dissolves the whole group rather than promoting a new master, which is
+    /// enough to exercise the adapter's join/leave/status calls without
+    /// claiming to model LMS's internals exactly.
+    sync_groups: Vec<Vec<String>>,
 }
 
 /// Mock LMS Server
@@ -115,6 +124,7 @@ impl MockLmsServer {
             players: HashMap::new(),
             commands: Vec::new(),
             library: HashMap::new(),
+            sync_groups: Vec::new(),
         }));
 
         let app = Router::new()
@@ -232,10 +242,53 @@ impl MockLmsServer {
             .collect()
     }
 
+    /// Current sync groups, each as its full member id list (#510). Lets a
+    /// test assert on server-side membership directly, independent of how
+    /// the adapter reports it.
+    pub async fn sync_groups(&self) -> Vec<Vec<String>> {
+        self.state.read().await.sync_groups.clone()
+    }
+
     /// Stop the mock server
     pub async fn stop(self) {
         self.handle.abort();
     }
+}
+
+/// Join `member` into `master`'s sync group (#510).
+///
+/// Mirrors the live-verified behavior (issue #403): the *addressed* player
+/// (`master`) becomes/stays the sync master, and `member` joins its group.
+/// `member` is first removed from any group it was previously in.
+fn mock_sync_join(state: &mut MockLmsState, master: &str, member: &str) {
+    mock_sync_remove(state, member);
+    if let Some(group) = state
+        .sync_groups
+        .iter_mut()
+        .find(|group| group.first().map(String::as_str) == Some(master))
+    {
+        if !group.iter().any(|id| id == member) {
+            group.push(member.to_string());
+        }
+        return;
+    }
+    // `master` was not already a group's first (leader) entry. If it was a
+    // member of some other group, leaving that group first keeps this model
+    // consistent with "the addressed player becomes master".
+    mock_sync_remove(state, master);
+    state
+        .sync_groups
+        .push(vec![master.to_string(), member.to_string()]);
+}
+
+/// Remove `player` from whatever sync group it currently belongs to, if any.
+/// A group left with fewer than two members is no longer a sync group and is
+/// dropped entirely.
+fn mock_sync_remove(state: &mut MockLmsState, player: &str) {
+    for group in state.sync_groups.iter_mut() {
+        group.retain(|id| id != player);
+    }
+    state.sync_groups.retain(|group| group.len() >= 2);
 }
 
 /// JSON-RPC request format
@@ -378,6 +431,21 @@ async fn handle_jsonrpc(
                 result: json!({}),
             }));
         }
+        // `<playerid> sync <otherplayerid>` joins a group; `<playerid> sync -`
+        // leaves whatever group it is in (#510).
+        "sync" if commands.get(1).is_some() => {
+            let target = commands.get(1).and_then(Value::as_str).unwrap_or("");
+            let mut state = state.write().await;
+            if target == "-" {
+                mock_sync_remove(&mut state, player_id);
+            } else {
+                mock_sync_join(&mut state, player_id, target);
+            }
+            return Ok(Json(JsonRpcResponse {
+                id: request.id,
+                result: json!({}),
+            }));
+        }
         _ => {}
     }
 
@@ -436,6 +504,36 @@ async fn handle_jsonrpc(
         "mixer" => {
             // Volume control - return empty success
             json!({})
+        }
+        // Server-scoped `syncgroups ?` (#510): one entry per active group,
+        // with the full membership as a comma-joined id list, matching the
+        // `sync_members`/`sync_member_names` shape verified live against
+        // Lyrion 9.1.2 (issue #403's investigation).
+        "syncgroups" => {
+            let syncgroups_loop: Vec<Value> = state
+                .sync_groups
+                .iter()
+                .map(|group| {
+                    let names: Vec<String> = group
+                        .iter()
+                        .map(|id| {
+                            state
+                                .players
+                                .get(id)
+                                .map(|p| p.name.clone())
+                                .unwrap_or_default()
+                        })
+                        .collect();
+                    json!({
+                        "sync_members": group.join(","),
+                        "sync_member_names": names.join(","),
+                    })
+                })
+                .collect();
+            json!({
+                "count": syncgroups_loop.len(),
+                "syncgroups_loop": syncgroups_loop
+            })
         }
         "playlist" => {
             // Playlist control (next/prev) - return empty success

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -562,6 +562,11 @@ struct CoreState {
     core_id: String,
     display_name: String,
     display_version: String,
+    /// The zone subscription's `(req_id, writer)`, captured when
+    /// `subscribe_zones` completes (#509). `group_outputs`/`ungroup_outputs`
+    /// push their effect on this same subscription, mirroring a real Core --
+    /// see the `SubscribeZones` handler for why it must be this req_id.
+    zone_push: Option<(usize, Writer)>,
 }
 
 // =============================================================================
@@ -611,6 +616,7 @@ impl FakeRoonCore {
             core_id: format!("fake-core-408-{}", addr.port()),
             display_name: "Fake Roon Core".to_string(),
             display_version: "2.0.408".to_string(),
+            zone_push: None,
         }));
         let root_title = library.root_title.clone();
 
@@ -951,6 +957,48 @@ pub fn default_zone(zone_id: &str, display_name: &str) -> Value {
     })
 }
 
+/// A single-output zone with an explicit output id and grouping
+/// compatibility list (issue #509), for tests that need several distinct
+/// zones whose outputs can (or deliberately cannot) be grouped together.
+/// `default_zone` above always derives `"{zone_id}_output"` and leaves
+/// `can_group_with_output_ids` empty, which cannot express either.
+pub fn zone_with_grouping(
+    zone_id: &str,
+    display_name: &str,
+    output_id: &str,
+    can_group_with_output_ids: &[&str],
+) -> Value {
+    json!({
+        "zone_id": zone_id,
+        "display_name": display_name,
+        "state": "stopped",
+        "is_next_allowed": true,
+        "is_previous_allowed": true,
+        "is_pause_allowed": false,
+        "is_play_allowed": true,
+        "is_seek_allowed": false,
+        "queue_items_remaining": 0,
+        "queue_time_remaining": 0,
+        "now_playing": null,
+        "settings": { "loop": "disabled", "shuffle": false, "auto_radio": false },
+        "outputs": [{
+            "output_id": output_id,
+            "zone_id": zone_id,
+            "can_group_with_output_ids": can_group_with_output_ids,
+            "display_name": display_name,
+            "source_controls": null,
+            "volume": {
+                "type": "number",
+                "min": 0.0,
+                "max": 100.0,
+                "value": 50.0,
+                "step": 1.0,
+                "is_muted": false
+            }
+        }]
+    })
+}
+
 // =============================================================================
 // MOO framing
 // =============================================================================
@@ -1186,6 +1234,14 @@ async fn handle_request(
         }
         RequestKind::SubscribeZones => {
             let body = json!({ "zones": core.read().await.zones.clone() });
+            // Remember this request id and connection so group_outputs /
+            // ungroup_outputs (#509) can push a later `CONTINUE Changed` on
+            // the same subscription -- exactly how a real Core reports the
+            // effect of grouping, per the fork's own `parse_msg`
+            // (`transport.rs:457-484`): it only recognises `zones_changed` /
+            // `zones_added` / `zones_removed` arriving on the *subscription's*
+            // `req_id`, not a fresh one.
+            core.write().await.zone_push = Some((req_id, writer.clone()));
             // FROM FORK: transport.rs:479 accepts name "Subscribed"; a
             // subscription stays open, hence CONTINUE.
             respond(
@@ -1203,6 +1259,8 @@ async fn handle_request(
         }
         RequestKind::Browse => handle_browse(req_id, &body, &core, &writer, &root_title).await,
         RequestKind::Load => handle_load(req_id, &body, &core, &writer).await,
+        RequestKind::GroupOutputs => handle_group_outputs(req_id, &body, &core, &writer).await,
+        RequestKind::UngroupOutputs => handle_ungroup_outputs(req_id, &body, &core, &writer).await,
         RequestKind::Unknown => {
             // Mirrors the fork's own reply to an unknown service (lib.rs:588-592).
             // FROM ROONLABS' PUBLISHED API: `InvalidRequest` with an `error` string
@@ -1232,6 +1290,8 @@ enum RequestKind {
     Browse,
     Load,
     Ping,
+    GroupOutputs,
+    UngroupOutputs,
     Unknown,
 }
 
@@ -1245,6 +1305,9 @@ impl RequestKind {
             "com.roonlabs.browse:1/browse" => Self::Browse,
             "com.roonlabs.browse:1/load" => Self::Load,
             "com.roonlabs.ping:1/ping" => Self::Ping,
+            // FROM FORK: transport.rs:334,343 -- both send only `output_ids`.
+            "com.roonlabs.transport:2/group_outputs" => Self::GroupOutputs,
+            "com.roonlabs.transport:2/ungroup_outputs" => Self::UngroupOutputs,
             _ => Self::Unknown,
         }
     }
@@ -1496,6 +1559,231 @@ async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>,
     // FROM FORK: browse.rs:93-98 LoadResult { items, offset, list } — all required.
     let body = json!({ "items": items, "offset": offset, "list": list });
     respond(core, writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+}
+
+// =============================================================================
+// Grouping: group_outputs / ungroup_outputs (issue #509)
+// =============================================================================
+//
+// FROM FORK: `transport.rs:334-350` sends only `{"output_ids": [...]}` and
+// reads no reply body at all -- `Transport::group_outputs`/`ungroup_outputs`
+// return the raw `Option<usize>` request id, not a parsed result. So the
+// client observes the *effect* of grouping only through the zone
+// subscription's `Changed` push, exactly like every other Roon transport
+// write in this fake (`control`, `mute`, `change_volume` get the same
+// body-less `COMPLETE Success`). This fake's own zone-merge/split semantics
+// below are a simplified model, not a documented Core behavior: real Roon's
+// exact index/ordering rules for a merged zone's `outputs` list are
+// unpublished. What is load-bearing is that a merge (a) keeps the leader's
+// zone_id, (b) unions the outputs, and (c) retires any source zone left with
+// none -- which is exactly what issue #509's acceptance criteria describe.
+
+async fn handle_group_outputs(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>, writer: &Writer) {
+    let output_ids = string_array(body, "output_ids");
+    respond(core, writer, "COMPLETE", "Success", req_id, None).await;
+
+    let (merge, push) = {
+        let mut state = core.write().await;
+        let merge = merge_zone_outputs(&mut state.zones, &output_ids);
+        (merge, state.zone_push.clone())
+    };
+    let Some((merged_zone, removed_zone_ids)) = merge else {
+        return;
+    };
+    if let Some((sub_req_id, sub_writer)) = push {
+        let mut change = json!({ "zones_changed": [merged_zone] });
+        if !removed_zone_ids.is_empty() {
+            change["zones_removed"] = json!(removed_zone_ids);
+        }
+        send(&sub_writer, "CONTINUE", "Changed", sub_req_id, Some(&change)).await;
+    }
+}
+
+async fn handle_ungroup_outputs(
+    req_id: usize,
+    body: &Value,
+    core: &Arc<RwLock<CoreState>>,
+    writer: &Writer,
+) {
+    let output_ids = string_array(body, "output_ids");
+    respond(core, writer, "COMPLETE", "Success", req_id, None).await;
+
+    let (changed, added, removed, push) = {
+        let mut state = core.write().await;
+        let (changed, added, removed) = split_zone_outputs(&mut state.zones, &output_ids);
+        (changed, added, removed, state.zone_push.clone())
+    };
+    if changed.is_empty() && added.is_empty() && removed.is_empty() {
+        return;
+    }
+    if let Some((sub_req_id, sub_writer)) = push {
+        let mut zones_changed = changed;
+        zones_changed.extend(added);
+        let mut change = json!({});
+        if !zones_changed.is_empty() {
+            change["zones_changed"] = json!(zones_changed);
+        }
+        if !removed.is_empty() {
+            change["zones_removed"] = json!(removed);
+        }
+        send(&sub_writer, "CONTINUE", "Changed", sub_req_id, Some(&change)).await;
+    }
+}
+
+fn string_array(body: &Value, field: &str) -> Vec<String> {
+    body.get(field)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The `(zone index, output index)` of the zone currently holding `output_id`.
+fn zone_output_index(zones: &[Value], output_id: &str) -> Option<(usize, usize)> {
+    zones.iter().enumerate().find_map(|(zi, zone)| {
+        let outs = zone.get("outputs")?.as_array()?;
+        let oi = outs
+            .iter()
+            .position(|o| o.get("output_id").and_then(Value::as_str) == Some(output_id))?;
+        Some((zi, oi))
+    })
+}
+
+/// Merge every output in `output_ids` into the zone holding the first id.
+/// Returns the merged zone's full JSON and the zone_ids of any source zones
+/// that lost their last output and were retired as a result. `None` when
+/// there was nothing to merge (the leader output was not found, or every
+/// other requested output already belongs to the leader's zone).
+fn merge_zone_outputs(zones: &mut Vec<Value>, output_ids: &[String]) -> Option<(Value, Vec<String>)> {
+    let leader_output_id = output_ids.first()?;
+    let (leader_zi, _) = zone_output_index(zones, leader_output_id)?;
+    let leader_zone_id = zones[leader_zi]["zone_id"].as_str()?.to_string();
+
+    let mut moved_from = Vec::new();
+    let mut moved_outputs = Vec::new();
+    for output_id in &output_ids[1..] {
+        let Some((zi, _)) = zone_output_index(zones, output_id) else {
+            continue;
+        };
+        if zi == leader_zi {
+            continue; // already part of the leader's zone
+        }
+        let outs = zones[zi]["outputs"].as_array_mut()?;
+        let Some(pos) = outs
+            .iter()
+            .position(|o| o["output_id"].as_str() == Some(output_id.as_str()))
+        else {
+            continue;
+        };
+        let mut out = outs.remove(pos);
+        out["zone_id"] = json!(leader_zone_id);
+        moved_from.push(zi);
+        moved_outputs.push(out);
+    }
+    if moved_outputs.is_empty() {
+        return None;
+    }
+
+    // Retire any source zone that lost its last output. Removing in
+    // descending index order keeps the remaining indices (including
+    // `leader_zi`, adjusted below) valid.
+    let mut emptied: Vec<usize> = moved_from;
+    emptied.sort_unstable();
+    emptied.dedup();
+    let mut removed_zone_ids = Vec::new();
+    let mut leader_zi = leader_zi;
+    for zi in emptied.into_iter().rev() {
+        if zones[zi]["outputs"]
+            .as_array()
+            .is_some_and(|outs| outs.is_empty())
+        {
+            removed_zone_ids.push(zones[zi]["zone_id"].as_str().unwrap_or_default().to_string());
+            zones.remove(zi);
+            if zi < leader_zi {
+                leader_zi -= 1;
+            }
+        }
+    }
+
+    let leader_outputs = zones[leader_zi]["outputs"].as_array_mut()?;
+    leader_outputs.extend(moved_outputs);
+
+    Some((zones[leader_zi].clone(), removed_zone_ids))
+}
+
+/// Pull every output in `output_ids` out of its current zone into its own
+/// standalone zone. Returns `(zones_changed, zones_added, zones_removed)`:
+/// a source zone that keeps at least one output after losing this one is
+/// `zones_changed`; a source zone left empty is retired into `zones_removed`.
+/// An output already alone in its zone is left untouched (not returned in
+/// any of the three).
+fn split_zone_outputs(
+    zones: &mut Vec<Value>,
+    output_ids: &[String],
+) -> (Vec<Value>, Vec<Value>, Vec<String>) {
+    let mut zones_changed = Vec::new();
+    let mut zones_added = Vec::new();
+    let mut zones_removed = Vec::new();
+
+    for output_id in output_ids {
+        let Some((zi, _)) = zone_output_index(zones, output_id) else {
+            continue;
+        };
+        let output_count = zones[zi]["outputs"].as_array().map_or(0, Vec::len);
+        if output_count <= 1 {
+            continue; // already standalone
+        }
+        let outs = zones[zi]["outputs"].as_array_mut().unwrap();
+        let pos = outs
+            .iter()
+            .position(|o| o["output_id"].as_str() == Some(output_id.as_str()))
+            .unwrap();
+        let mut out = outs.remove(pos);
+
+        let new_zone_id = format!("ungrouped-{output_id}");
+        out["zone_id"] = json!(new_zone_id);
+        let new_zone = standalone_zone_from_output(&new_zone_id, out);
+        zones.push(new_zone.clone());
+        zones_added.push(new_zone);
+
+        if zones[zi]["outputs"].as_array().unwrap().is_empty() {
+            zones_removed.push(zones[zi]["zone_id"].as_str().unwrap_or_default().to_string());
+        } else {
+            zones_changed.push(zones[zi].clone());
+        }
+    }
+    if !zones_removed.is_empty() {
+        zones.retain(|z| {
+            !zones_removed.contains(&z["zone_id"].as_str().unwrap_or_default().to_string())
+        });
+    }
+    (zones_changed, zones_added, zones_removed)
+}
+
+/// Build a minimal, fully-populated standalone zone (every field
+/// `roon_api`'s `transport::Zone` requires, same as [`default_zone`]) around
+/// one output that just left a group.
+fn standalone_zone_from_output(zone_id: &str, output: Value) -> Value {
+    json!({
+        "zone_id": zone_id,
+        "display_name": output["display_name"],
+        "state": "stopped",
+        "is_next_allowed": true,
+        "is_previous_allowed": true,
+        "is_pause_allowed": false,
+        "is_play_allowed": true,
+        "is_seek_allowed": false,
+        "queue_items_remaining": 0,
+        "queue_time_remaining": 0,
+        "now_playing": null,
+        "settings": { "loop": "disabled", "shuffle": false, "auto_radio": false },
+        "outputs": [output],
+    })
 }
 
 fn current_list(state: &CoreState, session_key: &str) -> Value {

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -30,7 +30,9 @@ mod mock_servers;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use mock_servers::roon_core::{album, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope};
+use mock_servers::roon_core::{
+    album, zone_with_grouping, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
+};
 use roon_api::browse::{BrowseOpts, LoadOpts};
 use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
 use unified_hifi_control::bus::create_bus;
@@ -1602,6 +1604,216 @@ async fn a_shared_session_key_is_one_level_stack_however_well_results_correlate(
         Some(&here.list.title),
         levels.last(),
         "a following load pages the level that landed last, whoever asked for it"
+    );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// Multiroom grouping: group_outputs / ungroup_outputs (issue #509)
+// =============================================================================
+//
+// Roon confirms grouping asynchronously through the ordinary zone
+// subscription (`RoonAdapter::set_group_members`'s own docs explain why), so
+// these tests poll `RoonAdapter::get_zones` rather than asserting on the
+// instant `set_group_members`/`ungroup_members` return.
+
+/// Poll `RoonAdapter::get_zones` until it reports exactly `expected` zones or
+/// a bound is hit, then return the last observation either way -- so a
+/// failing assertion downstream shows what actually arrived instead of just
+/// "timed out".
+async fn wait_for_zone_count(
+    adapter: &RoonAdapter,
+    expected: usize,
+) -> Vec<unified_hifi_control::adapters::roon::Zone> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let zones = adapter.get_zones().await;
+        if zones.len() == expected || Instant::now() >= deadline {
+            return zones;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn roon_multiroom_status_reports_no_groups_for_single_output_zones() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    // `connected()` only waits for Browse to register; the zone subscription
+    // it triggers as a side effect can still be in flight, so wait for both
+    // configured zones to have actually arrived before trusting the status
+    // below to mean anything.
+    wait_for_zone_count(&adapter, 2).await;
+
+    let status = adapter.multiroom_status().await.unwrap();
+    assert_eq!(
+        status["groups"].as_array().unwrap().len(),
+        0,
+        "no zone has more than one output yet"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_set_group_members_merges_outputs_into_one_zone() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    // See the status test above: wait for both zones before grouping them.
+    wait_for_zone_count(&adapter, 2).await;
+
+    adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await
+        .expect("set_group_members should succeed");
+
+    // Merging is confirmed asynchronously (the Core's `group_outputs` handler
+    // runs in its own spawned task, and the merge itself is only visible once
+    // its zone push round-trips back to the adapter), so wait for that before
+    // inspecting either the wire log or the adapter's own zone state.
+    let zones = wait_for_zone_count(&adapter, 1).await;
+    assert_eq!(
+        zones.len(),
+        1,
+        "the two zones merge into one once the Core's push arrives"
+    );
+
+    // The wire request the Core actually saw: `group_outputs` addressed by
+    // output id, leader first, exactly as `Transport::group_outputs`
+    // (`transport.rs:334-341`) sends it.
+    let group_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/group_outputs")
+        .collect();
+    assert_eq!(group_requests.len(), 1, "exactly one group_outputs call");
+    assert_eq!(
+        group_requests[0].body["output_ids"],
+        serde_json::json!(["output_a", "output_b"])
+    );
+    let merged = &zones[0];
+    assert_eq!(merged.zone_id, "zone_a", "the leader's zone_id survives");
+    let mut output_ids: Vec<&str> = merged.outputs.iter().map(|o| o.output_id.as_str()).collect();
+    output_ids.sort_unstable();
+    assert_eq!(output_ids, vec!["output_a", "output_b"]);
+
+    let status = adapter.multiroom_status().await.unwrap();
+    let groups = status["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 1, "the merged zone reports as one group");
+    assert_eq!(groups[0]["leader_zone_id"], serde_json::json!("roon:zone_a"));
+    assert_eq!(
+        groups[0]["member_zone_ids"],
+        serde_json::json!(["roon:output_b"]),
+        "member zone_a was retired, so the surviving member is named by output id"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_ungroup_members_splits_outputs_back_into_separate_zones() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    wait_for_zone_count(&adapter, 2).await;
+
+    adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await
+        .expect("initial grouping should succeed");
+    wait_for_zone_count(&adapter, 1).await;
+
+    adapter
+        .ungroup_members(&["roon:output_b".to_string()])
+        .await
+        .expect("ungroup_members should succeed");
+
+    // See the merge test above for why this waits before inspecting either
+    // the wire log or the adapter's own zone state.
+    let zones = wait_for_zone_count(&adapter, 2).await;
+    assert_eq!(
+        zones.len(),
+        2,
+        "output_b splits back into its own zone once the Core's push arrives"
+    );
+
+    let ungroup_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/ungroup_outputs")
+        .collect();
+    assert_eq!(ungroup_requests.len(), 1, "exactly one ungroup_outputs call");
+    assert_eq!(
+        ungroup_requests[0].body["output_ids"],
+        serde_json::json!(["output_b"])
+    );
+    assert!(
+        zones.iter().all(|z| z.outputs.len() == 1),
+        "each zone is single-output again: {zones:?}"
+    );
+
+    let status = adapter.multiroom_status().await.unwrap();
+    assert_eq!(
+        status["groups"].as_array().unwrap().len(),
+        0,
+        "no zone has more than one output after the split"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_set_group_members_refuses_mixed_protocol_outputs() {
+    let core = FakeRoonCore::start().await;
+    // Neither output lists the other as groupable -- e.g. one is RAAT and the
+    // other AirPlay. Real Roon Cores only group outputs that share a
+    // streaming protocol; `can_group_with_output_ids` is the Core's own
+    // compatibility list for exactly this.
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &[]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &[]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    wait_for_zone_count(&adapter, 2).await;
+
+    let result = adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await;
+
+    let error = result.expect_err("mixed-protocol grouping must be refused, not attempted");
+    let message = error.to_string();
+    assert!(
+        message.contains("protocol"),
+        "refusal should explain why, got: {message}"
+    );
+
+    let group_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/group_outputs")
+        .collect();
+    assert!(
+        group_requests.is_empty(),
+        "the incompatible request must never reach the Core: {group_requests:?}"
     );
 
     core.stop().await;

--- a/tests/volume_safety.rs
+++ b/tests/volume_safety.rs
@@ -22,6 +22,7 @@ fn db_output() -> Output {
             is_muted: Some(false),
             step: Some(1.0),
         }),
+        can_group_with_output_ids: Vec::new(),
     }
 }
 
@@ -71,6 +72,7 @@ fn pct_output() -> Output {
             is_muted: Some(false),
             step: Some(1.0),
         }),
+        can_group_with_output_ids: Vec::new(),
     }
 }
 
@@ -113,6 +115,7 @@ fn missing_volume_uses_safe_defaults() {
         output_id: "no-vol".to_string(),
         display_name: "No Volume".to_string(),
         volume: None,
+        can_group_with_output_ids: Vec::new(),
     };
     let (min, max) = get_volume_range(Some(&output));
     assert_eq!(min, 0.0);


### PR DESCRIPTION
Closes #517

## Dependency status

At the time this branch was created, PR #513 (LMS sync groups, `issue/510`) and PR #515 (Roon grouping, `issue/509`) were both **open** against `feat/issue-462-streaming-adapters`, not yet merged. Per the dependency-handling instructions for this issue, this branch:

- was created from `feat/issue-462-streaming-adapters`
- merged `origin/issue/510` and `origin/issue/509` directly into it (one merge commit, `ef96921`, with a trivial conflict in `src/main.rs` resolved by keeping both adapters' `register_library` calls)

**This PR includes the full contents of #513 and #515 and should merge after both of them**, in the same order they land (or be rebased once they merge, whichever is cleaner for the maintainer). The commit `ef96921` is a straight merge with no `hifi_zone_group`-specific changes; the actual #517 work is the commit on top of it.

If #513/#515 merge before this PR is reviewed, this branch should be rebased onto the merged base so the diff shrinks to just the #517 commit.

## Summary

- `hifi_zone_group` (`src/mcp/tools/groups.rs`) no longer hardwires Music Assistant. `join`/`leave` resolve the owning adapter from the zone id's prefix (`roon:`, `lms:`, `musicassistant:`) via `ZoneTarget`, exactly like every other MCP tool, and route through the existing `AdapterRegistry::library_content` dispatch (unchanged from what #513/#515 already wired for LMS/Roon).
- **Cross-provider grouping is refused before any adapter is called**: every zone id involved in `join` (leader + members) or `leave` (all members) must classify to the same multiroom-capable provider.
- **`status` design decision** (the issue's central open question): supports both forms explicitly rather than picking one at the other's expense —
  - `zone_id` present → scoped to that one provider (consistent with how every other zone-scoped tool infers its provider), refused if the prefix isn't multiroom-capable.
  - `zone_id` absent → aggregates every provider's groups into one `groups` list, each tagged with `provider`. A provider that can't be reached is reported in `errors` (omitted when empty) rather than failing the whole read — one backend being down must not hide the other two's groups.
  - Aggregation is the default because `status` is read-only and "what's grouped right now" usually means "everywhere," not "guess which provider I meant."
- Both providers' member-id conventions are documented on the tool description and passed through verbatim rather than normalized: Roon retires a merged zone's id and reports members as `roon:<output_id>`; LMS sync groups are leaderless, so `leader_zone_id` there is UHC's stable-but-arbitrary pick of the first member id.
- `MultiroomSync` capability (`src/mcp/capabilities.rs`) now reports `supported` for roon, lms and musicassistant (previously musicassistant only), with the two stale `GAPS` rows for roon/lms removed. `AGENTS.md`'s generated matrix regenerated to match (`UPDATE_AGENTS_MATRIX=1`).
- `tests/fixtures/mcp_tools.json` regenerated for the new `zone_id` input parameter (`UPDATE_MCP_FIXTURES=1`).

## Tests added

- `zone_group_refuses_every_cross_provider_pairing` — every join/leave/status pairing across roon/lms/musicassistant/openhome/upnp, refused by classification alone (no adapter needed).
- `lms_zone_group_routes_join_status_and_leave_through_the_registry` — real `MockLmsServer`, real `LmsAdapter` registered as an `AdapterRegistry` library, full join → status → leave round trip over the real `/mcp` route, asserting the wire-level `sync`/`sync -` commands.
- `roon_zone_group_routes_join_status_and_leave_through_the_registry` — real `FakeRoonCore` (the same fixture `tests/roon_protocol.rs` uses for Roon's adapter-level multiroom tests), full join → status → leave round trip over `/mcp`, asserting `group_outputs`/`ungroup_outputs` wire calls and the output-id member convention.
- `every_supported_capability_reaches_that_providers_own_adapter` (existing contract test) extended: roon/lms `multiroom_sync` now probed via `join` (since `status` alone doesn't reach a live check on a disconnected/unconfigured adapter), each asserted against that provider's own error wording.
- `lms_never_reports_a_uhc_gap_as_a_provider_limitation` updated: `multiroom_sync` moved from the not-yet-implemented list to an explicit `supported` assertion.

## Local verification

- `cargo test` — full workspace: all pass except the two pre-documented pre-existing failures (`web_fullstack_runner_contract::runner_builds_matching_assets_before_it_starts_the_server`; `roon_protocol::roon_core_completes_handshake` did not flake in this run but is known-intermittent under full-suite parallelism).
- `cargo clippy -- -D warnings` — clean.
- `cargo check --no-default-features --features web --target wasm32-unknown-unknown` — clean.
- `cargo test --test mcp_contract` — 115/115 pass.

## Deviations from the issue

- The oh-task workflow calls for `sg review` on staged changes before opening the PR. In this environment `sg` resolves to `ast-grep`, not the review tool the skill expects, so that step could not be run. I did a manual line-by-line review of the diff instead; no automated second-opinion review was performed.