### PR TITLE
ci: build each release once, and give the LMS beta channel a real URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,25 @@ on:
     types: [opened, synchronize, reopened, labeled]
   push:
     branches: [v3, 'feature/**']
+    # Tag pushes are the single release trigger. `release: [published]` used to be
+    # listed here as well, which meant `gh release create` — the way releases are
+    # actually cut — fired both events for the same commit and built the entire
+    # matrix twice: two macOS builds, two Windows, two Docker, two of every NAS
+    # package, ~20 minutes of duplicated CI per release. It also made the release
+    # page link the slower duplicate, so a release looked mid-build long after its
+    # artifacts had been uploaded by the other run.
+    #
+    # Dropping the `release` trigger loses nothing. Both branches of the version
+    # logic below resolve `${GITHUB_REF#refs/tags/v}`, `is_beta` reads
+    # `GITHUB_REF_NAME`, and no job references the `github.event.release` payload —
+    # the two runs were byte-for-byte equivalent work.
+    #
+    # Kept this side rather than the other because it covers strictly more: a bare
+    # `git push --tags` still builds and publishes (softprops/action-gh-release
+    # creates the release if absent), whereas a release-only trigger would silently
+    # skip that path.
     tags:
       - 'v*'
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       build_lms:
@@ -1803,6 +1818,65 @@ jobs:
           add-paths: |
             lms-plugin/repo.xml
             lms-plugin/install.xml
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --squash --auto
+
+  # The beta counterpart of update-repo-xml.
+  #
+  # `upload-release` already generates `lms-beta.xml` and attaches it to the release, but a release
+  # asset URL contains the version, so it changes with every beta. An LMS user cannot subscribe to
+  # that: they would have to re-point their Additional Repositories entry at each new build, and
+  # nothing told them the channel existed. The feed was generated and then unreachable.
+  #
+  # This commits the same file to a fixed path on `v3`, so the beta channel gets a permanent URL the
+  # way the stable channel already has one via `lms-plugin/repo.xml`.
+  #
+  # It downloads the asset rather than regenerating the XML, so there is exactly one definition of
+  # the beta feed. Regenerating it here would put a second copy of the template in this file, free
+  # to drift from the one that actually ships.
+  update-beta-repo-xml:
+    name: Update LMS beta repo.xml
+    needs: [plan, upload-release]
+    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_beta == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: v3
+
+      - name: Fetch the published beta feed
+        run: |
+          FEED_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/lms-beta.xml"
+          echo "Downloading $FEED_URL"
+          curl -fSL --retry 3 --retry-delay 5 "$FEED_URL" -o lms-plugin/repo-beta.xml
+
+          # A GitHub error page is still a 200 from some proxies; refuse anything that is not the
+          # feed rather than committing a broken repository file that LMS would choke on.
+          if ! grep -q '<plugin name="UnifiedHiFi"' lms-plugin/repo-beta.xml; then
+            echo "Downloaded file is not an LMS plugin feed:"
+            head -20 lms-plugin/repo-beta.xml
+            exit 1
+          fi
+          cat lms-plugin/repo-beta.xml
+
+      - name: Create PR for LMS beta feed update
+        id: create-pr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: Point LMS beta feed at v${{ needs.plan.outputs.version }}"
+          title: "chore: Point LMS beta feed at v${{ needs.plan.outputs.version }}"
+          body: "Auto-generated. Updates `lms-plugin/repo-beta.xml` so the beta repository URL serves v${{ needs.plan.outputs.version }}."
+          branch: chore/lms-beta-feed-${{ needs.plan.outputs.version }}
+          base: v3
+          add-paths: lms-plugin/repo-beta.xml
 
       - name: Enable auto-merge
         if: steps.create-pr.outputs.pull-request-number

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-
 ```
 Then install "Unified Hi-Fi Control" from the plugin list. The plugin automatically downloads and manages the bridge binary.
 
+**Beta channel.** To test pre-releases instead, use this URL — it always points at the newest beta, so LMS picks up each one without you re-pointing it:
+```
+https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-plugin/repo-beta.xml
+```
+Betas are less soaked than releases. Use one channel or the other, not both at once — LMS would see two entries for the same plugin.
+
 ### Binary Downloads
 
 Pre-built binaries available for Linux (x64, arm64, armv7), macOS (x64, arm64), and Windows from [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases).

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Download the QPKG package from [Releases](https://github.com/open-horizon-labs/u
 ### LMS Plugin
 
 Add this repository URL in LMS Settings → Plugins → Additional Repositories:
-```
+```text
 https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-plugin/repo.xml
 ```
 Then install "Unified Hi-Fi Control" from the plugin list. The plugin automatically downloads and manages the bridge binary.
 
 **Beta channel.** To test pre-releases instead, use this URL — it always points at the newest beta, so LMS picks up each one without you re-pointing it:
-```
+```text
 https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-plugin/repo-beta.xml
 ```
 Betas are less soaked than releases. Use one channel or the other, not both at once — LMS would see two entries for the same plugin.

--- a/lms-plugin/repo-beta.xml
+++ b/lms-plugin/repo-beta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <plugins>
+    <plugin name="UnifiedHiFi"
+            version="3.6.1-beta"
+            minTarget="8.0"
+            maxTarget="*">
+      <title lang="EN">Unified Hi-Fi Control (Beta)</title>
+      <desc lang="EN">Beta builds of Unified Hi-Fi Control for testing.</desc>
+      <url>https://github.com/open-horizon-labs/unified-hifi-control/releases/download/v3.6.1-beta/lms-unified-hifi-control-3.6.1-beta.zip</url>
+      <sha>4cb7a34410ec30f1c243d0024644a95af3ffdbe4</sha>
+      <creator>Muness Castle</creator>
+      <link>https://github.com/open-horizon-labs/unified-hifi-control/releases/tag/v3.6.1-beta</link>
+    </plugin>
+  </plugins>
+</extensions>


### PR DESCRIPTION
Two fixes, both surfaced while shipping v3.6.1-beta.

## Every release builds the whole matrix twice

`build.yml` triggers on both `push: tags: v*` and `release: [published]`. `gh release create` — how releases are actually cut — fires **both** for the same commit, so every release runs the entire matrix twice: two macOS builds, two Windows, two Docker, two of every NAS package. Roughly 20 minutes of duplicated CI per release.

It also explains a confusing symptom: the release page links the *slower* duplicate, so `v3.6.1-beta` looked mid-build for 20 minutes after its artifacts had already been uploaded by the other run.

**And it is not just wasted minutes — `update-repo-xml` ran twice too**, opening two identical bot PRs per release:

| Release | LMS bot PRs |
|---|---|
| v3.4.1 | #381 |
| v3.5.0 | #443 |
| v3.5.1 | **#496 + #497** |
| v3.6.0 | **#522 + #524** |

The duplication starts exactly where the double-run pattern does.

### Why dropping `release:` is safe

Verified before changing anything:

- Both branches of the version logic resolve the same expression, `${GITHUB_REF#refs/tags/v}`.
- `is_beta` derives from `GITHUB_REF_NAME`, not the event.
- No job anywhere references `github.event.release` (`grep` across all workflows returns nothing).

The two runs were equivalent work. I kept the **tag-push** side rather than the release side because it covers strictly more: a bare `git push --tags` still builds and publishes, since `softprops/action-gh-release` creates the release if it is absent. A release-only trigger would silently skip that path.

## The LMS beta feed was generated and then unreachable

`upload-release` already builds `lms-beta.xml` and attaches it to each beta. But a release asset URL contains the version:

```
.../releases/download/v3.6.1-beta/lms-beta.xml
```

so it changes with every build. An LMS user cannot subscribe to that — they would have to re-point their Additional Repositories entry at each new beta, and nothing in the README told them the channel existed. The stable channel has had a permanent `raw.githubusercontent` URL all along; the beta channel had none, so the feed was produced and then effectively nobody could use it.

This adds:

- **`lms-plugin/repo-beta.xml`** at a fixed path on `v3`, mirroring how the stable feed already works.
- **`update-beta-repo-xml`**, the beta counterpart of `update-repo-xml`, refreshing it on every beta via the same PR + auto-merge flow.
- A **README** entry for the beta URL, with a note not to enable both channels at once (LMS would show two entries for one plugin).

The job **downloads the published asset** rather than regenerating the XML, so there is one definition of the beta feed instead of two copies free to drift. It also refuses anything that does not parse as a plugin feed, rather than committing a file LMS would choke on.

## Verification

- Workflow YAML parses; triggers are now `pull_request`, `push` (branches + `tags: [v*]`), `workflow_dispatch`. 26 jobs, `update-beta-repo-xml` present and gated `is_beta == true`.
- `repo-beta.xml` parses as XML; version `3.6.1-beta`, URL resolves.
- **SHA1 verified against the real artifact**: downloaded the published 49 MB zip and confirmed `4cb7a34410ec30f1c243d0024644a95af3ffdbe4` matches the feed. The beta URL works on merge, not just from the next beta.

The trigger change cannot be fully proven until the next release cuts — that is the one claim here resting on reading rather than execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a beta update channel for the LMS Plugin.
  - Published beta metadata for UnifiedHiFi version 3.6.1-beta, including compatibility and download details.
  - Added guidance for choosing either the stable or beta repository channel.

- **Improvements**
  - Beta repository metadata is now automatically updated when new beta releases are published.
  - Release processing now uses version tags for more reliable beta availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->