### PR TITLE
feat(ha): Home Assistant custom integration (HACS) for UHC media_player entities

### DIFF
--- a/.github/workflows/ha-integration.yml
+++ b/.github/workflows/ha-integration.yml
@@ -1,0 +1,74 @@
+name: Home Assistant integration
+
+# Tests for the HACS custom_components/unified_hifi_control Python
+# package. This job is intentionally independent of the Rust crate's
+# build/CI (build.yml) since it has its own toolchain and dependencies.
+#
+# Note: feature-branch PRs in this repo do not currently run CI checks
+# (see AGENTS.md / stacked-PR workflow notes); this workflow becomes
+# active once merged to v3.
+
+on:
+  push:
+    branches: [v3]
+    paths:
+      - "custom_components/unified_hifi_control/**"
+      - "hacs.json"
+      - "pyproject.toml"
+      - ".github/workflows/ha-integration.yml"
+  pull_request:
+    branches: [v3]
+    paths:
+      - "custom_components/unified_hifi_control/**"
+      - "hacs.json"
+      - "pyproject.toml"
+      - ".github/workflows/ha-integration.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: custom_components/unified_hifi_control/requirements_test.txt
+
+      - name: Install test dependencies
+        run: pip install -r custom_components/unified_hifi_control/requirements_test.txt
+
+      - name: Work around aiodns/pycares thread-leak false positive
+        # homeassistant depends on aiodns/pycares, whose AsyncResolver
+        # spins up a background c-ares thread the first time any test
+        # constructs a real aiohttp connector. pytest-homeassistant-
+        # custom-component's per-test thread-leak check then flags that
+        # thread against whichever test happened to run first, even
+        # though every HTTP call in this suite goes through
+        # aioclient_mock and never touches a real connector. Since our
+        # tests never need real DNS resolution, removing pycares avoids
+        # the false positive without weakening the check itself.
+        run: pip uninstall -y aiodns pycares
+
+      - name: Run pytest
+        run: pytest custom_components/unified_hifi_control/tests -v
+
+  hacs-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ public/tailwind.css
 # Note: public/dx-components-theme.css is hand-authored, NOT generated
 .worktrees/
 .impeccable/critique/
+
+# Python (Home Assistant integration test env)
+__pycache__/
+*.pyc
+.venv*/
+.pytest_cache/
+.ruff_cache/

--- a/custom_components/unified_hifi_control/__init__.py
+++ b/custom_components/unified_hifi_control/__init__.py
@@ -1,0 +1,45 @@
+"""The Unified Hifi Control integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .api import UnifiedHifiControlApiClient
+from .const import CONF_BASE_URL, DOMAIN
+from .coordinator import UnifiedHifiControlCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Unified Hifi Control from a config entry."""
+    session = async_get_clientsession(hass)
+    client = UnifiedHifiControlApiClient(session, entry.data[CONF_BASE_URL])
+    coordinator = UnifiedHifiControlCoordinator(hass, client)
+
+    await coordinator.async_config_entry_first_refresh()
+
+    coordinator.start_event_listener()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    entry.async_on_unload(coordinator.stop_event_listener)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        coordinator: UnifiedHifiControlCoordinator = hass.data[DOMAIN].pop(
+            entry.entry_id
+        )
+        coordinator.stop_event_listener()
+    return unload_ok

--- a/custom_components/unified_hifi_control/api.py
+++ b/custom_components/unified_hifi_control/api.py
@@ -1,0 +1,218 @@
+"""Thin async HTTP client for the Unified Hifi Control (UHC) server.
+
+Wraps the routes documented in ``src/knobs/routes.rs`` (unified,
+cross-provider zone/transport surface) plus the MCP JSON-RPC endpoint for
+functionality (zone grouping) that has no plain-REST route yet.
+
+UHC's own docs (``docs/protocol.md``) are explicit that this HTTP API is
+internal and may change without notice. This client is intentionally
+narrow and defensive so a route-shape change fails loudly (an
+``UnifiedHifiControlApiError``) rather than corrupting entity state.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable, Coroutine
+from typing import Any
+
+import aiohttp
+
+from .const import (
+    PATH_CONTROL,
+    PATH_EVENTS,
+    PATH_MCP,
+    PATH_NOW_PLAYING,
+    PATH_NOW_PLAYING_IMAGE,
+    PATH_ZONES,
+    REQUEST_TIMEOUT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class UnifiedHifiControlApiError(Exception):
+    """Base error for UHC API failures."""
+
+
+class UnifiedHifiControlConnectionError(UnifiedHifiControlApiError):
+    """Raised when the UHC server cannot be reached at all."""
+
+
+class UnifiedHifiControlAuthError(UnifiedHifiControlApiError):
+    """Raised when the UHC server rejects the request as unauthenticated.
+
+    Only relevant when the server is run with
+    ``UHC_REQUIRE_CONTROLLER_AUTH=1`` -- see docs/controller-auth.md. This
+    integration does not implement the bootstrap-cookie handshake; users
+    running with that flag set must front UHC with a reverse proxy that
+    supplies the required cookie/CSRF pair, or disable the flag for the
+    interface this integration talks to.
+    """
+
+
+class UnifiedHifiControlApiClient:
+    """Client for a single UHC server instance."""
+
+    def __init__(self, session: aiohttp.ClientSession, base_url: str) -> None:
+        self._session = session
+        self._base_url = base_url.rstrip("/")
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    async def async_get_zones(self) -> list[dict[str, Any]]:
+        """Return the unified zone list from GET /knob/zones."""
+        data = await self._request("GET", PATH_ZONES)
+        zones = data.get("zones")
+        if not isinstance(zones, list):
+            raise UnifiedHifiControlApiError(
+                f"Unexpected /knob/zones response shape: {data!r}"
+            )
+        return zones
+
+    async def async_get_now_playing(self, zone_id: str) -> dict[str, Any]:
+        """Return now-playing state for a single zone."""
+        return await self._request(
+            "GET", PATH_NOW_PLAYING, params={"zone_id": zone_id}
+        )
+
+    async def async_control(
+        self, zone_id: str, action: str, value: Any | None = None
+    ) -> None:
+        """POST a transport/volume action to /knob/control."""
+        body: dict[str, Any] = {"zone_id": zone_id, "action": action}
+        if value is not None:
+            body["value"] = value
+        await self._request("POST", PATH_CONTROL, json=body)
+
+    def image_url(self, zone_id: str) -> str:
+        """Build the direct URL for a zone's now-playing artwork."""
+        return f"{self._base_url}{PATH_NOW_PLAYING_IMAGE}?zone_id={zone_id}"
+
+    async def async_zone_group(
+        self,
+        action: str,
+        leader_zone_id: str,
+        member_zone_ids: list[str] | None = None,
+    ) -> None:
+        """Call the ``hifi_zone_group`` MCP tool (join/leave).
+
+        Grouping has no plain-REST route as of this writing; it is only
+        reachable through the MCP JSON-RPC transport at /mcp. See
+        docs/home_assistant_integration.md for the tracking note.
+        """
+        params: dict[str, Any] = {
+            "name": "hifi_zone_group",
+            "arguments": {
+                "action": action,
+                "leader_zone_id": leader_zone_id,
+                "confirm": True,
+            },
+        }
+        if member_zone_ids is not None:
+            params["arguments"]["member_zone_ids"] = member_zone_ids
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": params,
+        }
+        result = await self._request("POST", PATH_MCP, json=payload)
+        if isinstance(result, dict) and result.get("error"):
+            raise UnifiedHifiControlApiError(
+                f"hifi_zone_group failed: {result['error']!r}"
+            )
+
+    async def async_ping(self) -> None:
+        """Raise if the server is unreachable. Used by the config flow."""
+        await self.async_get_zones()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT):
+                async with self._session.request(
+                    method, url, params=params, json=json
+                ) as resp:
+                    if resp.status == 401 or resp.status == 403:
+                        raise UnifiedHifiControlAuthError(
+                            f"{method} {path} -> {resp.status}"
+                        )
+                    if resp.status >= 400:
+                        text = await resp.text()
+                        raise UnifiedHifiControlApiError(
+                            f"{method} {path} -> {resp.status}: {text}"
+                        )
+                    return await resp.json(content_type=None)
+        except UnifiedHifiControlApiError:
+            raise
+        except TimeoutError as err:
+            raise UnifiedHifiControlConnectionError(
+                f"Timed out calling {method} {path}"
+            ) from err
+        except aiohttp.ClientError as err:
+            raise UnifiedHifiControlConnectionError(
+                f"Error calling {method} {path}: {err}"
+            ) from err
+
+    async def async_listen_events(
+        self,
+        on_event: Callable[[str, dict[str, Any]], Coroutine[Any, Any, None]],
+    ) -> None:
+        """Hold a connection to GET /events and dispatch SSE frames.
+
+        Runs until cancelled. Callers are expected to wrap this in a
+        reconnect loop (see coordinator.py) since any single connection
+        may drop.
+        """
+        url = f"{self._base_url}{PATH_EVENTS}"
+        async with self._session.get(
+            url, headers={"Accept": "text/event-stream"}
+        ) as resp:
+            if resp.status >= 400:
+                raise UnifiedHifiControlApiError(f"GET /events -> {resp.status}")
+            async for event_type, data in _parse_sse(resp.content):
+                await on_event(event_type, data)
+
+
+async def _parse_sse(
+    content: aiohttp.StreamReader,
+) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+    """Minimal Server-Sent-Events parser.
+
+    UHC's /events handler (src/api/mod.rs::events_handler) emits plain
+    ``data: <json>`` frames (one JSON object per BusEvent, tagged with a
+    "type" field) separated by blank lines, plus periodic ``: ping``
+    keep-alive comments. We only care about ``data:`` lines.
+    """
+    import json as json_module
+
+    buffer: list[str] = []
+    async for raw_line in content:
+        line = raw_line.decode("utf-8", errors="replace").rstrip("\n").rstrip("\r")
+        if line == "":
+            if buffer:
+                payload = "\n".join(buffer)
+                buffer = []
+                try:
+                    parsed = json_module.loads(payload)
+                except ValueError:
+                    _LOGGER.debug("Ignoring non-JSON SSE frame: %s", payload)
+                    continue
+                event_type = parsed.get("type", "")
+                data = parsed.get("payload", parsed)
+                yield event_type, data
+            continue
+        if line.startswith(":"):
+            continue  # comment / keep-alive
+        if line.startswith("data:"):
+            buffer.append(line[len("data:") :].lstrip())

--- a/custom_components/unified_hifi_control/config_flow.py
+++ b/custom_components/unified_hifi_control/config_flow.py
@@ -1,0 +1,113 @@
+"""Config flow for Unified Hifi Control."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+if TYPE_CHECKING:
+    # Only needed for type hints. The actual module path has moved
+    # across Home Assistant versions (helpers.service_info.zeroconf in
+    # 2025.x+, components.zeroconf before that, and the latter requires
+    # the optional `zeroconf` PyPI package to even import). Since this
+    # file uses `from __future__ import annotations`, annotations are
+    # never evaluated at runtime, so we can avoid importing either at
+    # import time and only pay the cost when a real zeroconf discovery
+    # actually happens.
+    from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .api import (
+    UnifiedHifiControlApiClient,
+    UnifiedHifiControlApiError,
+    UnifiedHifiControlAuthError,
+    UnifiedHifiControlConnectionError,
+)
+from .const import CONF_BASE_URL, DEFAULT_NAME, DEFAULT_PORT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_BASE_URL): cv.string})
+
+
+def _normalize_base_url(value: str) -> str:
+    value = value.strip().rstrip("/")
+    if not value.startswith(("http://", "https://")):
+        value = f"http://{value}"
+    return value
+
+
+class UnifiedHifiControlConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Unified Hifi Control."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        self._discovered_base_url: str | None = None
+
+    async def _async_validate(self, base_url: str) -> dict[str, str]:
+        """Return a dict of errors (empty on success)."""
+        session = async_get_clientsession(self.hass)
+        client = UnifiedHifiControlApiClient(session, base_url)
+        try:
+            await client.async_ping()
+        except UnifiedHifiControlAuthError:
+            return {"base": "auth_required"}
+        except UnifiedHifiControlConnectionError:
+            return {"base": "cannot_connect"}
+        except UnifiedHifiControlApiError:
+            return {"base": "unknown"}
+        return {}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            base_url = _normalize_base_url(user_input[CONF_BASE_URL])
+            errors = await self._async_validate(base_url)
+            if not errors:
+                await self.async_set_unique_id(base_url)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=DEFAULT_NAME, data={CONF_BASE_URL: base_url}
+                )
+
+        schema = STEP_USER_DATA_SCHEMA
+        if self._discovered_base_url:
+            schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_BASE_URL, default=self._discovered_base_url
+                    ): cv.string
+                }
+            )
+        return self.async_show_form(
+            step_id="user", data_schema=schema, errors=errors
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery of a UHC server (_uhc._tcp.local.)."""
+        base_url = discovery_info.properties.get("base")
+        if not base_url:
+            host = discovery_info.host
+            port = discovery_info.port or DEFAULT_PORT
+            base_url = f"http://{host}:{port}"
+        base_url = _normalize_base_url(base_url)
+
+        await self.async_set_unique_id(base_url)
+        self._abort_if_unique_id_configured()
+
+        errors = await self._async_validate(base_url)
+        if errors:
+            return self.async_abort(reason="cannot_connect")
+
+        self._discovered_base_url = base_url
+        self.context["title_placeholders"] = {"base_url": base_url}
+        return await self.async_step_user()

--- a/custom_components/unified_hifi_control/const.py
+++ b/custom_components/unified_hifi_control/const.py
@@ -1,0 +1,55 @@
+"""Constants for the Unified Hifi Control integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+DOMAIN = "unified_hifi_control"
+
+CONF_BASE_URL = "base_url"
+
+DEFAULT_PORT = 8088
+DEFAULT_NAME = "Unified Hifi Control"
+
+# Zeroconf service type advertised by the UHC server (src/mdns.rs).
+ZEROCONF_SERVICE_TYPE = "_uhc._tcp.local."
+
+# UHC HTTP API paths (see src/knobs/routes.rs).
+PATH_ZONES = "/knob/zones"
+PATH_NOW_PLAYING = "/knob/now_playing"
+PATH_NOW_PLAYING_IMAGE = "/knob/now_playing/image"
+PATH_CONTROL = "/knob/control"
+PATH_EVENTS = "/events"
+PATH_MCP = "/mcp"
+
+# Poll interval used as a safety-net fallback in case the SSE stream to
+# /events silently drops without the underlying connection erroring out.
+# Real-time updates normally arrive via SSE well before this fires.
+FALLBACK_POLL_INTERVAL = timedelta(seconds=60)
+
+# How long to wait for the initial HTTP round-trip during config flow
+# validation and coordinator refreshes.
+REQUEST_TIMEOUT = 10
+
+# Providers known to implement the multiroom join/leave verbs today.
+# Roon and LMS grouping work landed on a sibling branch (issue #517 /
+# PR #521) that had not merged into this integration's base branch at
+# the time this was written -- see docs/home_assistant_integration.md.
+GROUPING_CAPABLE_PROVIDERS: set[str] = {"musicassistant"}
+
+# Providers whose adapters explicitly refuse next/previous (see
+# src/adapters/upnp.rs::REFUSED_TRANSPORT_ACTIONS).
+NO_SKIP_PROVIDERS: set[str] = {"upnp"}
+
+# Providers where transport/volume control is not yet reliably wired
+# end-to-end (see AGENTS.md capability matrix, e.g. AppleMusic #465).
+NO_TRANSPORT_PROVIDERS: set[str] = {"applemusic"}
+
+STATE_MAP = {
+    "playing": "playing",
+    "paused": "paused",
+    "stopped": "idle",
+    "loading": "buffering",
+    "buffering": "buffering",
+}
+
+MANUFACTURER = "Unified Hifi Control"

--- a/custom_components/unified_hifi_control/coordinator.py
+++ b/custom_components/unified_hifi_control/coordinator.py
@@ -1,0 +1,261 @@
+"""Data coordination for the Unified Hifi Control integration.
+
+State updates are push-based: a background task holds a connection to
+UHC's ``/events`` Server-Sent-Events stream (backed by a real
+``tokio::sync::broadcast`` bus on the server, see src/api/mod.rs and
+src/bus/mod.rs) and applies incremental updates to zone state as
+``NowPlayingChanged`` / ``VolumeChanged`` / ``SeekPositionChanged`` /
+``ZoneUpdated`` / ``ZoneDiscovered`` / ``ZoneRemoved`` events arrive.
+
+A slow periodic poll (``FALLBACK_POLL_INTERVAL``) runs alongside the SSE
+listener purely as a safety net in case a connection drops silently
+without erroring (some proxies/NAT setups swallow TCP resets on idle
+long-lived connections). Under normal operation the poll is a no-op
+because SSE has already kept state current.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import UnifiedHifiControlApiClient, UnifiedHifiControlApiError
+from .const import DOMAIN, FALLBACK_POLL_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+# Reconnect backoff for the SSE listener.
+_SSE_RECONNECT_MIN = 2
+_SSE_RECONNECT_MAX = 60
+
+
+@dataclass
+class ZoneState:
+    """In-memory state for a single UHC zone."""
+
+    zone_id: str
+    zone_name: str
+    source: str
+    state: str = "unknown"
+    volume: float | None = None
+    volume_min: float | None = None
+    volume_max: float | None = None
+    volume_step: float | None = None
+    is_muted: bool | None = None
+    title: str | None = None
+    artist: str | None = None
+    album: str | None = None
+    image_key: str | None = None
+    seek_position: int | None = None
+    length: int | None = None
+    is_play_allowed: bool = True
+    is_pause_allowed: bool = True
+    is_next_allowed: bool = True
+    is_previous_allowed: bool = True
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+class UnifiedHifiControlCoordinator(DataUpdateCoordinator[dict[str, ZoneState]]):
+    """Owns zone state for one UHC server and keeps it current."""
+
+    def __init__(self, hass: HomeAssistant, client: UnifiedHifiControlApiClient) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=FALLBACK_POLL_INTERVAL,
+        )
+        self.client = client
+        self._sse_task: asyncio.Task | None = None
+        self.sse_connected = False
+
+    async def _async_update_data(self) -> dict[str, ZoneState]:
+        """Full poll: fetch zones + now-playing for each. Fallback path."""
+        try:
+            zones = await self.client.async_get_zones()
+        except UnifiedHifiControlApiError as err:
+            raise UpdateFailed(f"Could not reach UHC server: {err}") from err
+
+        result: dict[str, ZoneState] = {}
+        for zone in zones:
+            zone_id = zone.get("zone_id")
+            if not zone_id:
+                continue
+            existing = self.data.get(zone_id) if self.data else None
+            zs = ZoneState(
+                zone_id=zone_id,
+                zone_name=zone.get("zone_name", zone_id),
+                source=zone.get("source", "unknown"),
+            )
+            if existing is not None:
+                # Preserve push-derived fields (mute, now-playing) that
+                # aren't present on the lightweight zones list.
+                zs.volume = existing.volume
+                zs.volume_min = existing.volume_min
+                zs.volume_max = existing.volume_max
+                zs.volume_step = existing.volume_step
+                zs.is_muted = existing.is_muted
+                zs.title = existing.title
+                zs.artist = existing.artist
+                zs.album = existing.album
+                zs.image_key = existing.image_key
+                zs.seek_position = existing.seek_position
+                zs.length = existing.length
+            zs.state = zone.get("state", zs.state)
+            vc = zone.get("volume_control") or {}
+            if vc:
+                zs.volume = vc.get("value", zs.volume)
+                zs.volume_min = vc.get("min", zs.volume_min)
+                zs.volume_max = vc.get("max", zs.volume_max)
+                zs.volume_step = vc.get("step", zs.volume_step)
+            zs.raw = zone
+            try:
+                now_playing = await self.client.async_get_now_playing(zone_id)
+            except UnifiedHifiControlApiError as err:
+                _LOGGER.debug("now_playing failed for %s: %s", zone_id, err)
+                now_playing = {}
+            if now_playing:
+                zs.title = now_playing.get("line1", zs.title)
+                zs.artist = now_playing.get("line2", zs.artist)
+                zs.album = now_playing.get("line3", zs.album)
+                zs.image_key = now_playing.get("image_key", zs.image_key)
+                zs.seek_position = now_playing.get("seek_position", zs.seek_position)
+                zs.length = now_playing.get("length", zs.length)
+                zs.is_play_allowed = now_playing.get("is_play_allowed", True)
+                zs.is_pause_allowed = now_playing.get("is_pause_allowed", True)
+                zs.is_next_allowed = now_playing.get("is_next_allowed", True)
+                zs.is_previous_allowed = now_playing.get("is_previous_allowed", True)
+                if now_playing.get("volume") is not None:
+                    zs.volume = now_playing.get("volume")
+                    zs.volume_min = now_playing.get("volume_min", zs.volume_min)
+                    zs.volume_max = now_playing.get("volume_max", zs.volume_max)
+                    zs.volume_step = now_playing.get("volume_step", zs.volume_step)
+            result[zone_id] = zs
+        return result
+
+    def start_event_listener(self) -> None:
+        """Start the background SSE listener task."""
+        if self._sse_task is None or self._sse_task.done():
+            self._sse_task = self.hass.loop.create_task(self._event_listener_loop())
+
+    def stop_event_listener(self) -> None:
+        if self._sse_task is not None:
+            self._sse_task.cancel()
+            self._sse_task = None
+
+    async def _event_listener_loop(self) -> None:
+        backoff = _SSE_RECONNECT_MIN
+        loop = self.hass.loop
+        while True:
+            started_at = loop.time()
+            try:
+                self.sse_connected = True
+                await self.client.async_listen_events(self._handle_event)
+            except asyncio.CancelledError:
+                self.sse_connected = False
+                raise
+            except UnifiedHifiControlApiError as err:
+                _LOGGER.debug("SSE connection error, will retry: %s", err)
+            except Exception:  # keep the listener alive on unexpected errors
+                _LOGGER.exception("Unexpected error in UHC event listener")
+            self.sse_connected = False
+            # A connection that stayed up for a while was healthy; reset
+            # backoff so a brief blip doesn't leave us waiting a full
+            # minute to reconnect next time.
+            if loop.time() - started_at >= 5:
+                backoff = _SSE_RECONNECT_MIN
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, _SSE_RECONNECT_MAX)
+
+    async def _handle_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        data = dict(self.data) if self.data else {}
+        handler = _EVENT_HANDLERS.get(event_type)
+        if handler is None:
+            return
+        changed = handler(data, payload)
+        if changed:
+            self.async_set_updated_data(data)
+
+
+def _zone_id_from(payload: dict[str, Any], key: str = "zone_id") -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _h_now_playing_changed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    zs.title = payload.get("title", zs.title)
+    zs.artist = payload.get("artist", zs.artist)
+    zs.album = payload.get("album", zs.album)
+    zs.image_key = payload.get("image_key", zs.image_key)
+    return True
+
+
+def _h_volume_changed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload, "output_id") or _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    if "value" in payload:
+        zs.volume = payload["value"]
+    if "is_muted" in payload:
+        zs.is_muted = payload["is_muted"]
+    return True
+
+
+def _h_seek_changed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    zs.seek_position = payload.get("position", zs.seek_position)
+    return True
+
+
+def _h_zone_updated(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    zs.zone_name = payload.get("display_name", zs.zone_name)
+    zs.state = payload.get("state", zs.state)
+    return True
+
+
+def _h_zone_removed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    if zone_id and zone_id in data:
+        del data[zone_id]
+        return True
+    return False
+
+
+def _h_zone_discovered(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone = payload.get("zone") if isinstance(payload.get("zone"), dict) else payload
+    zone_id = _zone_id_from(zone)
+    if not zone_id or zone_id in data:
+        return False
+    data[zone_id] = ZoneState(
+        zone_id=zone_id,
+        zone_name=zone.get("zone_name", zone_id),
+        source=zone.get("source", "unknown"),
+        state=zone.get("state", "unknown"),
+    )
+    return True
+
+
+_EVENT_HANDLERS = {
+    "NowPlayingChanged": _h_now_playing_changed,
+    "VolumeChanged": _h_volume_changed,
+    "SeekPositionChanged": _h_seek_changed,
+    "ZoneUpdated": _h_zone_updated,
+    "ZoneRemoved": _h_zone_removed,
+    "ZoneDiscovered": _h_zone_discovered,
+}

--- a/custom_components/unified_hifi_control/manifest.json
+++ b/custom_components/unified_hifi_control/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "unified_hifi_control",
+  "name": "Unified Hifi Control",
+  "codeowners": ["@muness"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/open-horizon-labs/unified-hifi-control/blob/v3/docs/home_assistant_integration.md",
+  "integration_type": "hub",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/open-horizon-labs/unified-hifi-control/issues",
+  "requirements": [],
+  "version": "0.1.0",
+  "zeroconf": ["_uhc._tcp.local."]
+}

--- a/custom_components/unified_hifi_control/media_player.py
+++ b/custom_components/unified_hifi_control/media_player.py
@@ -1,0 +1,268 @@
+"""Media player platform for Unified Hifi Control zones."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api import UnifiedHifiControlApiError
+from .const import (
+    DOMAIN,
+    GROUPING_CAPABLE_PROVIDERS,
+    MANUFACTURER,
+    NO_SKIP_PROVIDERS,
+    NO_TRANSPORT_PROVIDERS,
+    STATE_MAP,
+)
+from .coordinator import UnifiedHifiControlCoordinator, ZoneState
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up media_player entities for each known UHC zone."""
+    coordinator: UnifiedHifiControlCoordinator = hass.data[DOMAIN][entry.entry_id]
+    known_zone_ids: set[str] = set()
+
+    def _add_new_entities() -> None:
+        new_entities = []
+        for zone_id in coordinator.data:
+            if zone_id in known_zone_ids:
+                continue
+            known_zone_ids.add(zone_id)
+            new_entities.append(UnifiedHifiControlMediaPlayer(coordinator, zone_id))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_new_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
+
+
+def _supported_features(zone: ZoneState) -> MediaPlayerEntityFeature:
+    if zone.source in NO_TRANSPORT_PROVIDERS:
+        return MediaPlayerEntityFeature(0)
+
+    features = (
+        MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.SEEK
+    )
+    if zone.source not in NO_SKIP_PROVIDERS:
+        features |= (
+            MediaPlayerEntityFeature.NEXT_TRACK
+            | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        )
+    if zone.source in GROUPING_CAPABLE_PROVIDERS:
+        features |= (
+            MediaPlayerEntityFeature.GROUPING
+        )
+    return features
+
+
+class UnifiedHifiControlMediaPlayer(
+    CoordinatorEntity[UnifiedHifiControlCoordinator], MediaPlayerEntity
+):
+    """A media_player entity backed by a single UHC zone."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+
+    def __init__(
+        self, coordinator: UnifiedHifiControlCoordinator, zone_id: str
+    ) -> None:
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        # UHC's zone ids are provider-prefixed (e.g. "roon:<zone_id>",
+        # "lms:<mac>") and stable for the lifetime of that zone on the
+        # server. One documented exception: Roon's own zone_id can churn
+        # when outputs are grouped/ungrouped in Roon itself (see PR
+        # #515's discussion of the roon:<output_id> convention) -- that
+        # churn is inherent to Roon's zone model and outside UHC/this
+        # integration's control.
+        self._attr_unique_id = zone_id
+        zone = coordinator.data.get(zone_id)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, zone_id)},
+            name=zone.zone_name if zone else zone_id,
+            manufacturer=MANUFACTURER,
+            model=zone.source if zone else None,
+        )
+        self._attr_supported_features = (
+            _supported_features(zone) if zone else MediaPlayerEntityFeature(0)
+        )
+
+    @property
+    def _zone(self) -> ZoneState | None:
+        return self.coordinator.data.get(self._zone_id)
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._zone is not None
+
+    @property
+    def name(self) -> str | None:
+        zone = self._zone
+        return zone.zone_name if zone else self._zone_id
+
+    @property
+    def state(self) -> MediaPlayerState | None:
+        zone = self._zone
+        if zone is None:
+            return None
+        return MediaPlayerState(STATE_MAP.get(zone.state, "idle"))
+
+    @property
+    def media_title(self) -> str | None:
+        zone = self._zone
+        return zone.title if zone else None
+
+    @property
+    def media_artist(self) -> str | None:
+        zone = self._zone
+        return zone.artist if zone else None
+
+    @property
+    def media_album_name(self) -> str | None:
+        zone = self._zone
+        return zone.album if zone else None
+
+    @property
+    def media_duration(self) -> int | None:
+        zone = self._zone
+        return zone.length if zone else None
+
+    @property
+    def media_position(self) -> int | None:
+        zone = self._zone
+        return zone.seek_position if zone else None
+
+    @property
+    def media_image_url(self) -> str | None:
+        zone = self._zone
+        if zone is None or not zone.image_key:
+            return None
+        return self.coordinator.client.image_url(self._zone_id)
+
+    @property
+    def media_image_hash(self) -> str | None:
+        zone = self._zone
+        return zone.image_key if zone else None
+
+    @property
+    def volume_level(self) -> float | None:
+        zone = self._zone
+        if zone is None or zone.volume is None:
+            return None
+        vmin = zone.volume_min if zone.volume_min is not None else 0.0
+        vmax = zone.volume_max if zone.volume_max is not None else 100.0
+        if vmax <= vmin:
+            return None
+        return max(0.0, min(1.0, (zone.volume - vmin) / (vmax - vmin)))
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        zone = self._zone
+        # UHC's now_playing payload does not report mute state; this is
+        # only known once at least one VolumeChanged SSE event with
+        # is_muted has been observed for this zone.
+        return zone.is_muted if zone else None
+
+    async def async_media_play(self) -> None:
+        await self._async_control("play")
+
+    async def async_media_pause(self) -> None:
+        await self._async_control("pause")
+
+    async def async_media_stop(self) -> None:
+        await self._async_control("stop")
+
+    async def async_media_next_track(self) -> None:
+        await self._async_control("next")
+
+    async def async_media_previous_track(self) -> None:
+        await self._async_control("previous")
+
+    async def async_media_seek(self, position: float) -> None:
+        await self._async_control("seek", value=position)
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        zone = self._zone
+        if zone is None:
+            raise HomeAssistantError(f"Zone {self._zone_id} is unavailable")
+        vmin = zone.volume_min if zone.volume_min is not None else 0.0
+        vmax = zone.volume_max if zone.volume_max is not None else 100.0
+        absolute = vmin + volume * (vmax - vmin)
+        await self._async_control("vol_abs", value=absolute)
+
+    async def async_volume_up(self) -> None:
+        await self._async_control("vol_up")
+
+    async def async_volume_down(self) -> None:
+        await self._async_control("vol_down")
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        # Best-effort: not every provider has confirmed mute/unmute
+        # wiring through /knob/control (see docs/home_assistant_integration.md).
+        await self._async_control("mute", value=mute)
+
+    async def _async_control(self, action: str, value: Any | None = None) -> None:
+        try:
+            await self.coordinator.client.async_control(
+                self._zone_id, action, value
+            )
+        except UnifiedHifiControlApiError as err:
+            raise HomeAssistantError(
+                f"Failed to send '{action}' to zone {self._zone_id}: {err}"
+            ) from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_join_players(self, group_members: list[str]) -> None:
+        zone = self._zone
+        if zone is None or zone.source not in GROUPING_CAPABLE_PROVIDERS:
+            source = zone.source if zone else "unknown"
+            raise HomeAssistantError(
+                f"Grouping is not supported for provider '{source}' yet "
+                "(tracked in unified-hifi-control issue #517/#521)."
+            )
+        try:
+            await self.coordinator.client.async_zone_group(
+                "join", self._zone_id, member_zone_ids=group_members
+            )
+        except UnifiedHifiControlApiError as err:
+            raise HomeAssistantError(f"Failed to join players: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_unjoin_player(self) -> None:
+        zone = self._zone
+        if zone is None or zone.source not in GROUPING_CAPABLE_PROVIDERS:
+            source = zone.source if zone else "unknown"
+            raise HomeAssistantError(
+                f"Grouping is not supported for provider '{source}' yet "
+                "(tracked in unified-hifi-control issue #517/#521)."
+            )
+        try:
+            await self.coordinator.client.async_zone_group(
+                "leave", self._zone_id, member_zone_ids=[self._zone_id]
+            )
+        except UnifiedHifiControlApiError as err:
+            raise HomeAssistantError(f"Failed to unjoin player: {err}") from err
+        await self.coordinator.async_request_refresh()

--- a/custom_components/unified_hifi_control/requirements_test.txt
+++ b/custom_components/unified_hifi_control/requirements_test.txt
@@ -1,0 +1,5 @@
+homeassistant>=2024.1.0
+pytest>=7.4.0
+pytest-asyncio>=0.23.0
+pytest-homeassistant-custom-component>=0.13.0
+aiohttp>=3.9.0

--- a/custom_components/unified_hifi_control/strings.json
+++ b/custom_components/unified_hifi_control/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Unified Hifi Control",
+        "description": "Enter the base URL of your UHC server, e.g. http://192.168.1.50:8088",
+        "data": {
+          "base_url": "Base URL"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Could not connect to the UHC server at that address.",
+      "auth_required": "This UHC server requires controller authentication, which this integration does not yet support. Disable UHC_REQUIRE_CONTROLLER_AUTH or front it with a proxy that supplies the session cookie.",
+      "unknown": "Unexpected error communicating with UHC."
+    },
+    "abort": {
+      "already_configured": "This UHC server is already configured.",
+      "cannot_connect": "Could not connect to the discovered UHC server."
+    }
+  }
+}

--- a/custom_components/unified_hifi_control/tests/__init__.py
+++ b/custom_components/unified_hifi_control/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the unified_hifi_control custom component."""

--- a/custom_components/unified_hifi_control/tests/conftest.py
+++ b/custom_components/unified_hifi_control/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Fixtures for unified_hifi_control tests."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations for every test (pytest-homeassistant-custom-component)."""
+    yield

--- a/custom_components/unified_hifi_control/tests/test_api.py
+++ b/custom_components/unified_hifi_control/tests/test_api.py
@@ -1,0 +1,129 @@
+"""Tests for the UHC API client, including the SSE frame parser.
+
+Uses Home Assistant's ``aioclient_mock`` fixture (an aiohttp session
+mock) rather than a real TestServer/socket, since the pytest-socket
+plugin bundled with pytest-homeassistant-custom-component blocks real
+network sockets by default.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.unified_hifi_control.api import (
+    UnifiedHifiControlApiClient,
+    UnifiedHifiControlApiError,
+    UnifiedHifiControlAuthError,
+    UnifiedHifiControlConnectionError,
+    _parse_sse,
+)
+
+BASE_URL = "http://uhc.local:8088"
+
+
+async def _fake_content_lines(lines: list[bytes]):
+    for line in lines:
+        yield line
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_single_event():
+    lines = [
+        b'data: {"type":"VolumeChanged","payload":{"output_id":"roon:1","value":42,"is_muted":false}}\n',
+        b"\n",
+    ]
+    events = [e async for e in _parse_sse(_fake_content_lines(lines))]
+    assert events == [
+        ("VolumeChanged", {"output_id": "roon:1", "value": 42, "is_muted": False})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_ignores_comments_and_multiple_frames():
+    lines = [
+        b": ping\n",
+        b'data: {"type":"NowPlayingChanged","payload":{"zone_id":"lms:aa","title":"Song"}}\n',
+        b"\n",
+        b'data: {"type":"SeekPositionChanged","payload":{"zone_id":"lms:aa","position":10}}\n',
+        b"\n",
+    ]
+    events = [e async for e in _parse_sse(_fake_content_lines(lines))]
+    assert events[0][0] == "NowPlayingChanged"
+    assert events[1][0] == "SeekPositionChanged"
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_skips_invalid_json():
+    lines = [b"data: {not valid json\n", b"\n"]
+    events = [e async for e in _parse_sse(_fake_content_lines(lines))]
+    assert events == []
+
+
+def _client(hass) -> UnifiedHifiControlApiClient:
+    """Build a client using HA's managed, test-harness-owned session.
+
+    Using homeassistant.helpers.aiohttp_client.async_get_clientsession
+    (routed through aioclient_mock by the test harness) rather than a
+    raw aiohttp.ClientSession avoids leaking background resolver
+    threads that the harness's cleanup fixture would otherwise flag.
+    """
+    from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+    return UnifiedHifiControlApiClient(async_get_clientsession(hass), BASE_URL)
+
+
+@pytest.mark.asyncio
+async def test_get_zones(hass, aioclient_mock):
+    aioclient_mock.get(
+        f"{BASE_URL}/knob/zones",
+        json={"zones": [{"zone_id": "roon:1", "zone_name": "Kitchen"}]},
+    )
+    zones = await _client(hass).async_get_zones()
+    assert zones == [{"zone_id": "roon:1", "zone_name": "Kitchen"}]
+
+
+@pytest.mark.asyncio
+async def test_get_zones_bad_shape_raises(hass, aioclient_mock):
+    aioclient_mock.get(f"{BASE_URL}/knob/zones", json={"unexpected": True})
+    with pytest.raises(UnifiedHifiControlApiError):
+        await _client(hass).async_get_zones()
+
+
+@pytest.mark.asyncio
+async def test_control_posts_expected_body(hass, aioclient_mock):
+    aioclient_mock.post(f"{BASE_URL}/knob/control", json={"ok": True})
+    await _client(hass).async_control("roon:1", "vol_abs", value=50)
+    assert aioclient_mock.mock_calls[0][2] == {
+        "zone_id": "roon:1",
+        "action": "vol_abs",
+        "value": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_auth_error_raised_on_401(hass, aioclient_mock):
+    aioclient_mock.get(f"{BASE_URL}/knob/zones", status=401, json={"error": "no"})
+    with pytest.raises(UnifiedHifiControlAuthError):
+        await _client(hass).async_get_zones()
+
+
+@pytest.mark.asyncio
+async def test_connection_error_wraps_client_exceptions(hass, aioclient_mock):
+    import aiohttp
+
+    aioclient_mock.get(
+        f"{BASE_URL}/knob/zones",
+        exc=aiohttp.ClientConnectionError("boom"),
+    )
+    with pytest.raises(UnifiedHifiControlConnectionError):
+        await _client(hass).async_get_zones()
+
+
+def test_image_url_builds_expected_path():
+    class _FakeSession:
+        pass
+
+    api = UnifiedHifiControlApiClient(_FakeSession(), "http://uhc.local:8088/")
+    assert (
+        api.image_url("roon:1")
+        == "http://uhc.local:8088/knob/now_playing/image?zone_id=roon:1"
+    )

--- a/custom_components/unified_hifi_control/tests/test_config_flow.py
+++ b/custom_components/unified_hifi_control/tests/test_config_flow.py
@@ -1,0 +1,61 @@
+"""Tests for the config flow."""
+from __future__ import annotations
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.unified_hifi_control.const import CONF_BASE_URL, DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_user_flow_success(hass: HomeAssistant, aioclient_mock) -> None:
+    aioclient_mock.get(
+        "http://192.168.1.50:8088/knob/zones",
+        json={"zones": [{"zone_id": "roon:1", "zone_name": "Kitchen"}]},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_BASE_URL: "192.168.1.50:8088"}
+    )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_BASE_URL] == "http://192.168.1.50:8088"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_cannot_connect(hass: HomeAssistant, aioclient_mock) -> None:
+    import aiohttp
+
+    aioclient_mock.get(
+        "http://192.168.1.50:8088/knob/zones",
+        exc=aiohttp.ClientConnectionError("boom"),
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_BASE_URL: "http://192.168.1.50:8088"}
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.asyncio
+async def test_user_flow_auth_required(hass: HomeAssistant, aioclient_mock) -> None:
+    aioclient_mock.get("http://192.168.1.50:8088/knob/zones", status=401)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_BASE_URL: "http://192.168.1.50:8088"}
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "auth_required"}

--- a/custom_components/unified_hifi_control/tests/test_coordinator.py
+++ b/custom_components/unified_hifi_control/tests/test_coordinator.py
@@ -1,0 +1,95 @@
+"""Tests for coordinator event handling."""
+from __future__ import annotations
+
+from custom_components.unified_hifi_control.coordinator import (
+    ZoneState,
+    _h_now_playing_changed,
+    _h_seek_changed,
+    _h_volume_changed,
+    _h_zone_discovered,
+    _h_zone_removed,
+    _h_zone_updated,
+)
+
+
+def _zone(zone_id="roon:1", zone_name="Kitchen", **kw):
+    return ZoneState(zone_id=zone_id, zone_name=zone_name, source="roon", **kw)
+
+
+def test_now_playing_changed_updates_metadata():
+    data = {"roon:1": _zone()}
+    changed = _h_now_playing_changed(
+        data, {"zone_id": "roon:1", "title": "Song", "artist": "Artist"}
+    )
+    assert changed
+    assert data["roon:1"].title == "Song"
+    assert data["roon:1"].artist == "Artist"
+
+
+def test_now_playing_changed_unknown_zone_is_noop():
+    data = {"roon:1": _zone()}
+    changed = _h_now_playing_changed(data, {"zone_id": "roon:999", "title": "Song"})
+    assert not changed
+    assert data["roon:1"].title is None
+
+
+def test_volume_changed_uses_output_id():
+    data = {"roon:1": _zone()}
+    changed = _h_volume_changed(
+        data, {"output_id": "roon:1", "value": 33, "is_muted": True}
+    )
+    assert changed
+    assert data["roon:1"].volume == 33
+    assert data["roon:1"].is_muted is True
+
+
+def test_seek_changed_updates_position():
+    data = {"roon:1": _zone()}
+    assert _h_seek_changed(data, {"zone_id": "roon:1", "position": 42})
+    assert data["roon:1"].seek_position == 42
+
+
+def test_zone_updated_changes_name_and_state():
+    data = {"roon:1": _zone()}
+    assert _h_zone_updated(
+        data, {"zone_id": "roon:1", "display_name": "Den", "state": "playing"}
+    )
+    assert data["roon:1"].zone_name == "Den"
+    assert data["roon:1"].state == "playing"
+
+
+def test_zone_removed_deletes_entry():
+    data = {"roon:1": _zone()}
+    assert _h_zone_removed(data, {"zone_id": "roon:1"})
+    assert "roon:1" not in data
+
+
+def test_zone_removed_unknown_zone_is_noop():
+    data = {"roon:1": _zone()}
+    assert not _h_zone_removed(data, {"zone_id": "roon:999"})
+
+
+def test_zone_discovered_adds_new_zone():
+    data: dict[str, ZoneState] = {}
+    changed = _h_zone_discovered(
+        data,
+        {
+            "zone": {
+                "zone_id": "lms:aa",
+                "zone_name": "Bedroom",
+                "source": "lms",
+                "state": "stopped",
+            }
+        },
+    )
+    assert changed
+    assert data["lms:aa"].zone_name == "Bedroom"
+
+
+def test_zone_discovered_existing_zone_is_noop():
+    data = {"roon:1": _zone(zone_name="Kitchen")}
+    changed = _h_zone_discovered(
+        data, {"zone": {"zone_id": "roon:1", "zone_name": "Renamed"}}
+    )
+    assert not changed
+    assert data["roon:1"].zone_name == "Kitchen"

--- a/custom_components/unified_hifi_control/tests/test_media_player.py
+++ b/custom_components/unified_hifi_control/tests/test_media_player.py
@@ -1,0 +1,45 @@
+"""Tests for capability mapping in media_player.py."""
+from __future__ import annotations
+
+from homeassistant.components.media_player import MediaPlayerEntityFeature
+
+from custom_components.unified_hifi_control.coordinator import ZoneState
+from custom_components.unified_hifi_control.media_player import _supported_features
+
+
+def test_roon_zone_gets_full_transport_and_skip():
+    zone = ZoneState(zone_id="roon:1", zone_name="Kitchen", source="roon")
+    features = _supported_features(zone)
+    assert features & MediaPlayerEntityFeature.NEXT_TRACK
+    assert features & MediaPlayerEntityFeature.PREVIOUS_TRACK
+    assert features & MediaPlayerEntityFeature.VOLUME_SET
+    assert not (features & MediaPlayerEntityFeature.GROUPING)
+
+
+def test_upnp_zone_has_no_skip_per_adapter_refusal():
+    zone = ZoneState(zone_id="upnp:1", zone_name="Office", source="upnp")
+    features = _supported_features(zone)
+    assert not (features & MediaPlayerEntityFeature.NEXT_TRACK)
+    assert not (features & MediaPlayerEntityFeature.PREVIOUS_TRACK)
+    # Transport/volume are still supported for UPnP.
+    assert features & MediaPlayerEntityFeature.PLAY
+    assert features & MediaPlayerEntityFeature.VOLUME_SET
+
+
+def test_musicassistant_zone_gets_grouping():
+    zone = ZoneState(zone_id="musicassistant:1", zone_name="Living Room", source="musicassistant")
+    features = _supported_features(zone)
+    assert features & MediaPlayerEntityFeature.GROUPING
+
+
+def test_applemusic_zone_has_no_transport_features_yet():
+    zone = ZoneState(zone_id="applemusic:1", zone_name="Phone", source="applemusic")
+    features = _supported_features(zone)
+    assert features == MediaPlayerEntityFeature(0)
+
+
+def test_lms_zone_has_no_grouping_on_this_branch():
+    zone = ZoneState(zone_id="lms:aa", zone_name="Bedroom", source="lms")
+    features = _supported_features(zone)
+    assert not (features & MediaPlayerEntityFeature.GROUPING)
+    assert features & MediaPlayerEntityFeature.NEXT_TRACK

--- a/custom_components/unified_hifi_control/translations/en.json
+++ b/custom_components/unified_hifi_control/translations/en.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Unified Hifi Control",
+        "description": "Enter the base URL of your UHC server, e.g. http://192.168.1.50:8088",
+        "data": {
+          "base_url": "Base URL"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Could not connect to the UHC server at that address.",
+      "auth_required": "This UHC server requires controller authentication, which this integration does not yet support. Disable UHC_REQUIRE_CONTROLLER_AUTH or front it with a proxy that supplies the session cookie.",
+      "unknown": "Unexpected error communicating with UHC."
+    },
+    "abort": {
+      "already_configured": "This UHC server is already configured.",
+      "cannot_connect": "Could not connect to the discovered UHC server."
+    }
+  }
+}

--- a/docs/home_assistant_integration.md
+++ b/docs/home_assistant_integration.md
@@ -1,0 +1,162 @@
+# Home Assistant integration (`custom_components/unified_hifi_control`)
+
+A HACS-installable custom integration that exposes every UHC zone as a
+`media_player` entity, giving Home Assistant native voice control
+("pause the kitchen"), media-player dashboard cards, and `media_player.*`
+service calls — beyond what the MQTT device-composition path (PR #518,
+issue #508) can offer, since HA's built-in MQTT integration has no
+`media_player` platform.
+
+## Repo location
+
+Lives at the repository root (`custom_components/unified_hifi_control/`
+plus a root-level `hacs.json`), not in a sibling repo or a nested
+subdirectory. Rationale:
+
+- HACS's "integration" category expects `custom_components/<domain>/`
+  and `hacs.json` at the **root** of the repository it's pointed at.
+  Nesting the integration under e.g. `ha_integration/` would require
+  either a second HACS-visible repo or an unsupported layout; keeping it
+  at repo root lets users add
+  `https://github.com/open-horizon-labs/unified-hifi-control` directly
+  as a HACS custom repository today, with zero extra hosting.
+- This mirrors how several other server+integration monorepos ship (the
+  Rust crate and the Python integration are independent build/test
+  units that happen to share a repo and an issue tracker).
+- A sibling repo was considered but rejected for this PR: it would
+  require creating and maintaining a second GitHub repository, which
+  isn't something this change can do unattended, and would separate the
+  integration's issue history from the UHC server changes it depends
+  on (capability matrix, zone id conventions, event bus shape).
+
+## Architecture
+
+- **Transport**: plain HTTP against UHC's unified `/knob/*` routes
+  (`src/knobs/routes.rs`) — `GET /knob/zones`, `GET /knob/now_playing`,
+  `POST /knob/control`, `GET /knob/now_playing/image`. These work across
+  every adapter (Roon, LMS, HQPlayer, OpenHome, UPnP, Music Assistant)
+  without per-provider client code.
+- **State updates**: push-based via Server-Sent Events. UHC's
+  `GET /events` (`src/api/mod.rs::events_handler`) streams every
+  `BusEvent` off a real `tokio::sync::broadcast` channel
+  (`src/bus/mod.rs`). The coordinator (`coordinator.py`) holds a
+  long-lived connection and applies `NowPlayingChanged`,
+  `VolumeChanged`, `SeekPositionChanged`, `ZoneUpdated`,
+  `ZoneDiscovered`, and `ZoneRemoved` events directly to in-memory zone
+  state, then pushes updates to entities via
+  `DataUpdateCoordinator.async_set_updated_data` — no polling delay for
+  ordinary playback changes.
+  - **Documented polling fallback**: a 60-second periodic poll
+    (`FALLBACK_POLL_INTERVAL`) runs alongside the SSE listener as a
+    safety net for connections that go idle-dead without erroring
+    (some NAT/proxy setups swallow resets on long-lived idle TCP
+    connections). Under normal operation this poll observes no changes
+    because SSE already applied them.
+  - The SSE listener reconnects with exponential backoff (2s-60s) on
+    any disconnect and resets to the minimum backoff once a connection
+    has stayed up for 5+ seconds.
+- **Unavailability**: entities report unavailable when the coordinator's
+  last poll failed (`UpdateFailed`) or when their zone_id has been
+  removed from the coordinator's zone map (e.g. after a `ZoneRemoved`
+  event, or the zone no longer appears in a poll).
+- **Capability mapping**: `media_player.py::_supported_features` derives
+  `MediaPlayerEntityFeature` flags from the zone's provider using the
+  same facts as `src/mcp/capabilities.rs` / AGENTS.md's capability
+  matrix on this branch:
+  - Transport (play/pause/stop) and volume: all providers except
+    AppleMusic, which is gated behind #465 pending physical-device
+    validation on the UHC side.
+  - Next/previous: all providers except UPnP, whose adapter explicitly
+    refuses skip actions (`src/adapters/upnp.rs::REFUSED_TRANSPORT_ACTIONS`).
+  - Grouping (`MediaPlayerEntityFeature.GROUPING`, wired to
+    `async_join_players`/`async_unjoin_player`): **Music Assistant
+    only** on this branch, matching `Capability::MultiroomSync` in
+    `src/mcp/capabilities.rs` (the only provider marked `Supported`
+    there). Roon/LMS grouping work exists on branch `issue/517`
+    (feeding PR #521) but had not merged into this integration's base
+    branch as of this PR — calling join/unjoin on any other provider
+    raises a `HomeAssistantError` naming the tracking issues instead of
+    silently failing.
+  - Grouping itself is implemented over the `/mcp` JSON-RPC endpoint
+    (`hifi_zone_group` tool) because grouping has no plain-REST route
+    yet; everything else in this integration is plain REST.
+- **Mute caveat**: UHC's `/knob/now_playing` response does not include
+  mute state, and not every provider has confirmed `mute`/`unmute`
+  wiring through `/knob/control` end-to-end (only HQPlayer's handler was
+  found to set `Command::Mute` explicitly during research for this
+  integration). `media_player.is_volume_muted` is therefore `None`
+  (unknown) until a `VolumeChanged` SSE event with `is_muted` has been
+  observed for that zone, and `async_mute_volume` is a best-effort call
+  that surfaces a `HomeAssistantError` if UHC rejects it rather than
+  failing silently.
+- **Zone id stability**: unique_id is UHC's provider-prefixed zone id
+  (`roon:<id>`, `lms:<mac>`, `hqplayer:<instance>`,
+  `musicassistant:<id>`, etc. — see `PrefixedZoneId` in
+  `src/bus/events.rs`). These are stable for the lifetime of a zone on
+  the UHC server, with one known exception: Roon's own zone_id can
+  change when a user regroups outputs inside Roon itself, since Roon's
+  zone model — not UHC — owns that identity. That churn is inherent to
+  Roon and out of this integration's control; it shows up in Home
+  Assistant as the old entity going unavailable and a new one appearing
+  after a Roon-side regroup.
+- **Auth**: this integration talks to UHC assuming the default,
+  unauthenticated-on-LAN posture. If a server is run with
+  `UHC_REQUIRE_CONTROLLER_AUTH=1` (see `docs/controller-auth.md`), most
+  `/knob/*` and provider routes become protected by a cookie+CSRF
+  session this integration does not implement; the config flow surfaces
+  a clear "auth_required" error in that case rather than silently
+  failing. Front such a server with a reverse proxy that supplies the
+  session, or leave the flag unset for the interface this integration
+  is pointed at.
+
+## Choosing MQTT vs. this integration
+
+- Use the MQTT path (PR #518 / issue #508) for lightweight dashboards
+  and automations without installing a custom component, or when HA and
+  UHC can't reach each other over plain HTTP but already share an MQTT
+  broker.
+- Use this integration for real `media_player` entities: Assist voice
+  control, media-player dashboard cards, and `media_player.*` service
+  calls (play/pause/volume/seek/grouping) — none of which HA's MQTT
+  integration can provide, since it has no `media_player` platform.
+  Both can be installed side by side; they don't conflict.
+
+## Testing
+
+`custom_components/unified_hifi_control/tests/` uses
+`pytest-homeassistant-custom-component`. Run locally with:
+
+```
+pip install -r custom_components/unified_hifi_control/requirements_test.txt
+pip uninstall -y aiodns pycares  # see note below
+pytest custom_components/unified_hifi_control/tests -v
+```
+
+The `aiodns`/`pycares` uninstall works around a false-positive thread-leak
+failure: `homeassistant` depends on `aiodns`, whose `AsyncResolver` spins
+up a background c-ares thread the first time any test constructs a real
+aiohttp connector, and pytest-homeassistant-custom-component's per-test
+thread-leak check then flags that thread against whichever test happens
+to run first — even though every HTTP call in this suite goes through
+`aioclient_mock` and never builds a real connector. Since the suite never
+needs real DNS resolution, removing `pycares` avoids the false positive
+without weakening the check for genuine leaks.
+
+CI: `.github/workflows/ha-integration.yml` runs the test suite plus
+`hacs/action` (HACS repository validation) and
+`home-assistant/actions/hassfest` (manifest/schema validation) on pushes
+and PRs to `v3` that touch the integration. Per this repo's stacked-PR
+convention, feature-branch-based PRs (including the one that introduced
+this integration) do not run CI — the workflow was verified locally and
+becomes active once this lands on `v3`.
+
+## Known follow-ups
+
+- No plain-REST route exists for zone grouping, collections, queue, or
+  play-by-ref — they're MCP-only today. This integration only uses MCP
+  for grouping; a UHC-side push endpoint or plain-REST equivalents for
+  the rest would let a future version add queue/collections support
+  without embedding an MCP client for everything.
+- Extending grouping support to Roon/LMS once `issue/517`'s work lands
+  on this integration's base branch is a follow-up, not blocking this
+  PR (the code already refuses cleanly for those providers today).

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Unified Hifi Control",
+  "render_readme": true,
+  "homeassistant": "2024.1.0"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.pytest.ini_options]
+testpaths = ["custom_components/unified_hifi_control/tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+include = ["custom_components/unified_hifi_control/**/*.py"]


### PR DESCRIPTION
Closes #519

## Base branch note

This PR targets `feat/issue-462-streaming-adapters`, not `v3`, per explicit user decision (stacked-PR workflow). CI does not run on feature-branch-based PRs in this repo and CodeRabbit is disabled for this base — verification below was done locally.

## Summary

Adds a HACS-installable Home Assistant custom integration, `custom_components/unified_hifi_control/`, that exposes every UHC zone as a real `media_player` entity — unlocking Assist voice control ("pause the kitchen"), media-player dashboard cards, and native `media_player.*` service calls. This complements (doesn't replace) the MQTT device-composition path from PR #518/issue #508, which can't offer any of that since HA's MQTT integration has no `media_player` platform.

### Repo location: in-repo, at the repository root

`custom_components/unified_hifi_control/` + a root-level `hacs.json`, rather than a sibling repo or a nested subdirectory (e.g. `ha_integration/`). Rationale: HACS's "integration" category expects `custom_components/<domain>/` and `hacs.json` at the **repository root** it's pointed at. Keeping it there lets users add this repo directly as a HACS custom repository today, with no extra hosting, and keeps the integration's issue history attached to the UHC server changes it depends on (capability matrix, zone-id conventions, event bus shape). A sibling repo was considered and rejected — creating a second GitHub repo isn't something this change can do unattended, and it would separate the two codebases' history unnecessarily.

### Architecture

- **Transport**: plain HTTP against UHC's unified `/knob/*` routes (`GET /knob/zones`, `GET /knob/now_playing`, `POST /knob/control`, `GET /knob/now_playing/image`) — works across every adapter (Roon, LMS, HQPlayer, OpenHome, UPnP, Music Assistant) without per-provider client code.
- **State updates**: push-based via Server-Sent Events. `GET /events` streams every `BusEvent` off UHC's real `tokio::sync::broadcast` bus; the coordinator holds a long-lived SSE connection and applies `NowPlayingChanged`/`VolumeChanged`/`SeekPositionChanged`/`ZoneUpdated`/`ZoneDiscovered`/`ZoneRemoved` events directly to zone state, pushing to entities immediately — no polling delay for ordinary playback changes. A 60s periodic poll runs alongside purely as a **documented fallback** for connections that go idle-dead without erroring; under normal operation it's a no-op since SSE already applied the change. The listener reconnects with exponential backoff (2s–60s).
- **Unavailability**: entities report unavailable when the coordinator's last poll failed or their zone_id has left the coordinator's zone map (e.g. after `ZoneRemoved`).
- **Capability mapping**: `_supported_features()` derives `MediaPlayerEntityFeature` flags per-provider using the same facts as `src/mcp/capabilities.rs`/AGENTS.md's capability matrix: transport+volume for all providers except AppleMusic (#465), next/previous for all except UPnP (explicit adapter refusal), grouping for Music Assistant only (the only provider `Capability::MultiroomSync` marks `Supported` on this branch).
- **Grouping**: wired to `async_join_players`/`async_unjoin_player` via UHC's `hifi_zone_group` MCP tool (no plain-REST route exists for grouping yet). Calling join/unjoin on any provider other than Music Assistant raises a clear `HomeAssistantError` naming the tracking issues (#517/#521) rather than failing silently or pretending to work.
- **Zone id stability**: `unique_id` is UHC's provider-prefixed zone id (`roon:<id>`, `lms:<mac>`, `hqplayer:<instance>`, `musicassistant:<id>`, etc.). Documented exception: Roon's own zone_id can churn when a user regroups outputs inside Roon itself — that's Roon's zone model, not UHC's, and out of this integration's control.
- **Mute caveat**: UHC's `/knob/now_playing` doesn't report mute state, and not every provider has confirmed `mute`/`unmute` wiring through `/knob/control`. `is_volume_muted` is `None` (unknown) until a `VolumeChanged` SSE event with `is_muted` has been observed for that zone; `async_mute_volume` surfaces a `HomeAssistantError` if UHC rejects it.
- Full design writeup: `docs/home_assistant_integration.md`.

### Deviations / honesty notes vs. issue #519's acceptance criteria

- Grouping is Music Assistant-only on this branch (Roon/LMS grouping work lives on `issue/517`, feeding PR #521, and hadn't merged into this integration's base as of this PR). The issue's criterion ("refused cleanly elsewhere") is met; full Roon/LMS support is a natural follow-up once that work lands here.
- Collections/queue/play-by-ref are MCP-only in UHC today (no plain-REST route) and are out of scope for this PR, which focuses on the `media_player` entity itself per the issue's acceptance criteria.
- This integration assumes UHC's default, unauthenticated-on-LAN posture. If a server runs with `UHC_REQUIRE_CONTROLLER_AUTH=1`, the config flow surfaces a clear `auth_required` error rather than silently failing, but the bootstrap-cookie+CSRF handshake itself isn't implemented (that design isn't fully implemented server-side either — see `docs/controller-auth.md`).

## Test plan

Ran locally (Python 3.12 venv, since feature-branch PRs don't run CI here):

```
pip install -r custom_components/unified_hifi_control/requirements_test.txt
pip uninstall -y aiodns pycares   # see docs/home_assistant_integration.md for why
pytest custom_components/unified_hifi_control/tests -v
```

Result: **26 passed** — covers the SSE frame parser, the API client (zones/control/auth/connection-error handling via `aioclient_mock`), coordinator event-handler unit tests (all six `BusEvent` types), config flow (success/cannot_connect/auth_required), and per-provider `supported_features` mapping (Roon, UPnP no-skip, Music Assistant grouping, AppleMusic no-transport, LMS no-grouping).

Also ran `ruff check custom_components/unified_hifi_control` — clean.

`.github/workflows/ha-integration.yml` adds a CI job (pytest matrix + `hacs/action` + `hassfest`) scoped to `v3`; per this repo's stacked-PR convention it won't run on this PR but is ready for when this lands on `v3`.

- [x] Repo location decided (in-repo, root-level) with rationale
- [x] Config flow: base URL entry + zone discovery (zeroconf `_uhc._tcp.local.` + manual)
- [x] One `media_player` entity per zone with state/metadata/volume/mute/transport
- [x] Supported-features derived from per-provider capabilities
- [x] Push-based state updates (SSE) with documented polling fallback
- [x] Entities unavailable when UHC unreachable
- [x] Grouping wired for Music Assistant, refused cleanly elsewhere
- [x] pytest-homeassistant-custom-component test suite + CI job