### PR TITLE
feat(mqtt): expose control device knobs to Home Assistant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +63,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,23 +220,55 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "axum-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "multer",
@@ -174,13 +279,30 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite 0.28.0",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -191,12 +313,12 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -208,13 +330,13 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum",
- "axum-core",
+ "axum 0.8.8",
+ "axum-core 0.5.6",
  "bytes",
  "futures-util",
  "headers",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -244,9 +366,9 @@ checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
 dependencies = [
  "bytes",
  "fs-err",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "hyper-util",
  "tokio",
  "tower-service",
@@ -260,9 +382,27 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -384,7 +524,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "encoding_rs",
 ]
 
@@ -441,10 +581,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -475,6 +661,25 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "config"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+dependencies = [
+ "async-trait",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron 0.7.1",
+ "rust-ini 0.18.0",
+ "serde",
+ "serde_json",
+ "toml 0.5.11",
+ "yaml-rust",
+]
+
+[[package]]
+name = "config"
 version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b30fa8254caad766fc03cb0ccae691e14bf3bd72bfff27f72802ce729551b3d6"
@@ -483,12 +688,12 @@ dependencies = [
  "convert_case 0.6.0",
  "json5",
  "pathdiff",
- "ron",
- "rust-ini",
+ "ron 0.12.0",
+ "rust-ini 0.21.3",
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml",
+ "toml 0.9.11+spec-1.1.0",
  "winnow",
  "yaml-rust2",
 ]
@@ -690,6 +895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84235ff0e272f15d4537603cdd50df6d45d50e51bb96326dbc0bdfd01d825226"
 dependencies = [
  "dioxus-cli-config",
- "http",
+ "http 1.4.0",
  "infer",
  "jni",
  "js-sys",
@@ -1004,10 +1218,10 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-tungstenite",
- "axum",
- "axum-core",
+ "axum 0.8.8",
+ "axum-core 0.5.6",
  "axum-extra",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "ciborium",
  "const-str",
@@ -1028,8 +1242,8 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "headers",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "inventory",
  "js-sys",
@@ -1047,7 +1261,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-layer",
  "tracing",
@@ -1067,8 +1281,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0011e9bca8da2ae6bf02ba9ef93ba6c5fa539e402de3aeb316ad86ca77c59079"
 dependencies = [
  "anyhow",
- "axum-core",
- "base64",
+ "axum-core 0.5.6",
+ "base64 0.22.1",
  "ciborium",
  "dioxus-core",
  "dioxus-document",
@@ -1078,7 +1292,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "http",
+ "http 1.4.0",
  "inventory",
  "parking_lot",
  "serde",
@@ -1192,7 +1406,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9cfecfc0037cb85b649739acc49a09dd303d1fa1daa7af609f5796b491b71c"
 dependencies = [
- "axum",
+ "axum 0.8.8",
  "dioxus-cli-config",
  "dioxus-core",
  "dioxus-devtools",
@@ -1310,8 +1524,8 @@ checksum = "ad8d8cfcc78453d8f1eba4350126161844a0b10b4dc898bac7649b8615f92c48"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
- "base64",
+ "axum 0.8.8",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "ciborium",
@@ -1335,9 +1549,9 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "http",
+ "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "inventory",
  "lru",
@@ -1352,7 +1566,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-futures",
@@ -1456,6 +1670,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dlv-list"
@@ -1837,7 +2057,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 1.4.0",
  "js-sys",
  "pin-project",
  "serde",
@@ -1884,8 +2104,8 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap",
+ "http 1.4.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1901,6 +2121,24 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -1944,10 +2182,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
- "http",
+ "http 1.4.0",
  "httpdate",
  "mime",
  "sha1",
@@ -1959,14 +2197,37 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.4.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -1980,12 +2241,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1996,8 +2268,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2021,6 +2293,29 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2030,8 +2325,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2048,13 +2343,13 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
 ]
@@ -2065,14 +2360,14 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2274,6 +2569,16 @@ checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -2324,6 +2629,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -2380,7 +2691,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "serde",
 ]
 
@@ -2436,6 +2747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2805,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "macro-string"
@@ -2555,6 +2881,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2605,6 +2937,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash 0.8.12",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.32",
+ "indexmap 1.9.3",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +3006,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2661,7 +3054,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.4.0",
  "httparse",
  "memchr",
  "mime",
@@ -2675,7 +3068,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2697,6 +3090,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2730,6 +3133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2785,10 +3198,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list 0.3.0",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -2796,7 +3231,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
- "dlv-list",
+ "dlv-list 0.5.2",
  "hashbrown 0.14.5",
 ]
 
@@ -2922,7 +3357,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2939,6 +3374,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
@@ -3020,6 +3461,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,7 +3504,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.36",
  "socket2 0.6.1",
  "thiserror 2.0.18",
  "tokio",
@@ -3067,7 +3524,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3165,6 +3622,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,7 +3642,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -3214,16 +3680,16 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cookie",
  "cookie_store",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3232,16 +3698,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3294,11 +3760,22 @@ dependencies = [
 
 [[package]]
 name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "serde",
+]
+
+[[package]]
+name = "ron"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -3341,6 +3818,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.25.0",
+]
+
+[[package]]
+name = "rumqttd"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd14965c40f3e679264cb8a8db540db511f1d7ed8b209b22d1641320bd26a58"
+dependencies = [
+ "axum 0.6.20",
+ "bytes",
+ "clap",
+ "config 0.13.4",
+ "flume",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "parking_lot",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "slab",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,12 +3895,22 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap 0.4.3",
+]
+
+[[package]]
+name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
- "ordered-multimap",
+ "ordered-multimap 0.7.3",
 ]
 
 [[package]]
@@ -3414,15 +3943,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67357f0d9ee9c28bdb0d4cf5ae23c0359342a14d177c23b4ee992df93e9a87d7"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.8",
  "axum-server",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "rust-mcp-macros",
  "rust-mcp-schema",
  "rust-mcp-transport",
@@ -3482,11 +4011,25 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3498,9 +4041,31 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3511,6 +4076,17 @@ checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3536,7 +4112,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -3573,6 +4149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,6 +4168,29 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3814,6 +4422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3932,6 +4546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subsecond"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,6 +4608,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4012,7 +4638,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -4212,11 +4838,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -4284,6 +4921,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
@@ -4310,7 +4956,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -4327,6 +4973,22 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -4334,7 +4996,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4348,12 +5010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -4364,7 +5026,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4489,7 +5151,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -4507,7 +5169,7 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -4524,7 +5186,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -4641,11 +5303,11 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
- "base64",
+ "axum 0.8.8",
+ "base64 0.22.1",
  "chacha20poly1305",
  "chrono",
- "config",
+ "config 0.15.19",
  "dioxus",
  "dioxus-primitives",
  "dioxus-sdk-time",
@@ -4667,6 +5329,8 @@ dependencies = [
  "reqwest",
  "resvg",
  "roon-api",
+ "rumqttc",
+ "rumqttd",
  "rust-embed",
  "rust-mcp-sdk",
  "serde",
@@ -4683,7 +5347,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite 0.21.0",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -4735,7 +5399,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "data-url",
  "flate2",
  "fontdb",
@@ -4768,6 +5432,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -4956,6 +5626,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,6 +5649,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -5297,6 +5989,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ server = [
     "dep:mime_guess",
     "dep:http-body-util",
     "dep:rust-mcp-sdk",
+    "dep:rumqttc",
 ]
 web = ["dioxus/web"]
 
@@ -129,6 +130,9 @@ resvg = { version = "0.47.0", features = ["default"], optional = true }
 # MCP server (server only)
 rust-mcp-sdk = { version = "0.8", default-features = false, features = ["server", "macros", "hyper-server", "sse"], optional = true }
 
+# MQTT publisher for Home Assistant discovery (server only, issue #508)
+rumqttc = { version = "0.24", default-features = false, features = ["use-rustls"], optional = true }
+
 # ============ WEB-ONLY DEPENDENCIES ============
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
@@ -166,6 +170,10 @@ tempfile = "3"
 # Pinned to the same version roon-api uses as its client, so the fake and the real
 # client library share one framing implementation and no new crate is compiled.
 tokio-tungstenite = "0.21"
+# In-process MQTT broker for tests/mqtt_integration.rs (issue #508). Pure-Rust,
+# embeddable, and wire-compatible with the `rumqttc` client used by the publisher -
+# this is the "mock/in-process broker" the issue's acceptance criteria calls for.
+rumqttd = { version = "0.19", default-features = false }
 
 [profile.release]
 lto = true

--- a/src/api/credentials.rs
+++ b/src/api/credentials.rs
@@ -31,6 +31,7 @@ const KEY_FILE_ENV: &str = "UHC_CREDENTIAL_KEY_FILE";
 const KEY_ENV: &str = "UHC_CREDENTIAL_KEY";
 const APPLE_BRIDGE_FILE_ENV: &str = "UHC_APPLE_BRIDGE_CREDENTIAL_FILE";
 const MUSIC_ASSISTANT_CREDENTIAL_FILE_ENV: &str = "UHC_MUSIC_ASSISTANT_CREDENTIAL_FILE";
+const MQTT_CREDENTIAL_FILE_ENV: &str = "UHC_MQTT_CREDENTIAL_FILE";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct EncryptedEnvelope {
@@ -311,6 +312,133 @@ impl MusicAssistantCredentialStore {
 
     /// Remove the encrypted record when rolling a failed first-time setup
     /// back to its prior absent state.
+    pub fn clear(&self) -> Result<()> {
+        match std::fs::remove_file(&self.credential_path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+/// Broker connection details for the optional Home Assistant MQTT publisher
+/// (#508), kept in one encrypted record because the broker password is a
+/// secret alongside otherwise-plain connection settings.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MqttCredentialRecord {
+    pub host: String,
+    pub port: u16,
+    pub tls: bool,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
+    pub base_topic: String,
+    pub discovery_prefix: String,
+}
+
+impl std::fmt::Debug for MqttCredentialRecord {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MqttCredentialRecord")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("tls", &self.tls)
+            .field("username", &self.username.as_ref().map(|_| "[REDACTED]"))
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .field("base_topic", &self.base_topic)
+            .field("discovery_prefix", &self.discovery_prefix)
+            .finish()
+    }
+}
+
+/// Encrypted credential storage for the MQTT broker connection.
+#[derive(Clone)]
+pub struct MqttCredentialStore {
+    credential_path: PathBuf,
+    key: [u8; KEY_BYTES],
+}
+
+impl MqttCredentialStore {
+    pub fn new(credential_path: PathBuf, key: [u8; KEY_BYTES]) -> Self {
+        Self {
+            credential_path,
+            key,
+        }
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let credential_path = std::env::var_os(MQTT_CREDENTIAL_FILE_ENV)
+            .map(PathBuf::from)
+            .unwrap_or_else(|| get_config_file_path("mqtt-credentials.enc"));
+        let key = if let Ok(value) = std::env::var(KEY_ENV) {
+            parse_key(&value).context("UHC_CREDENTIAL_KEY must be 32-byte hex or base64url")?
+        } else {
+            let key_path = std::env::var_os(KEY_FILE_ENV)
+                .map(PathBuf::from)
+                .unwrap_or_else(|| get_config_file_path("credential.key"));
+            load_or_create_key(&key_path)?
+        };
+        Ok(Self::new(credential_path, key))
+    }
+
+    pub fn load(&self) -> Result<Option<MqttCredentialRecord>> {
+        let bytes = match std::fs::read(&self.credential_path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        let envelope: EncryptedEnvelope = serde_json::from_slice(&bytes)
+            .map_err(|error| anyhow!("MQTT credential envelope is invalid: {error}"))?;
+        if envelope.version != 1 || envelope.cipher != "chacha20poly1305" {
+            return Err(anyhow!("unsupported MQTT credential envelope"));
+        }
+        let nonce = URL_SAFE_NO_PAD
+            .decode(envelope.nonce)
+            .context("MQTT credential nonce is invalid")?;
+        if nonce.len() != NONCE_BYTES {
+            return Err(anyhow!("MQTT credential nonce has an invalid length"));
+        }
+        let ciphertext = URL_SAFE_NO_PAD
+            .decode(envelope.ciphertext)
+            .context("MQTT credential ciphertext is invalid")?;
+        let plaintext = ChaCha20Poly1305::new(Key::from_slice(&self.key))
+            .decrypt(Nonce::from_slice(&nonce), ciphertext.as_ref())
+            .map_err(|_| anyhow!("MQTT credential decryption failed"))?;
+        serde_json::from_slice(&plaintext)
+            .map_err(|error| anyhow!("MQTT credential payload is invalid: {error}"))
+    }
+
+    pub fn save(&self, record: &MqttCredentialRecord) -> Result<()> {
+        let parent = self
+            .credential_path
+            .parent()
+            .ok_or_else(|| anyhow!("MQTT credential path has no parent"))?;
+        std::fs::create_dir_all(parent)?;
+        let plaintext = serde_json::to_vec(record).context("serialize MQTT credentials")?;
+        let mut nonce = [0_u8; NONCE_BYTES];
+        OsRng.fill_bytes(&mut nonce);
+        let ciphertext = ChaCha20Poly1305::new(Key::from_slice(&self.key))
+            .encrypt(Nonce::from_slice(&nonce), plaintext.as_ref())
+            .map_err(|_| anyhow!("encrypt MQTT credentials"))?;
+        let encoded = serde_json::to_vec(&EncryptedEnvelope {
+            version: 1,
+            cipher: "chacha20poly1305".to_string(),
+            nonce: URL_SAFE_NO_PAD.encode(nonce),
+            ciphertext: URL_SAFE_NO_PAD.encode(ciphertext),
+        })
+        .context("serialize MQTT credential envelope")?;
+        let temporary = self.credential_path.with_extension("enc.tmp");
+        write_private_file(&temporary, &encoded)?;
+        std::fs::rename(&temporary, &self.credential_path)
+            .context("replace MQTT credential file")?;
+        Ok(())
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.credential_path
+    }
+
     pub fn clear(&self) -> Result<()> {
         match std::fs::remove_file(&self.credential_path) {
             Ok(()) => Ok(()),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -39,6 +39,7 @@ use tokio_util::sync::CancellationToken;
 pub mod apple_bridge;
 pub mod controller_auth;
 pub mod credentials;
+pub mod mqtt_settings;
 pub mod provider_auth;
 
 const MAX_REMOTE_ARTWORK_BYTES: usize = 10 * 1024 * 1024;
@@ -300,6 +301,10 @@ pub struct AppState {
     pub apple_feedback: crate::mcp::feedback::FeedbackStore,
     /// Private reliable command ingress for provider paths with correlated readback.
     pub reliable_commands: Option<CommandGateway>,
+    /// Optional MQTT publisher exposing every zone to Home Assistant (#508).
+    /// Fully inert until both configured and enabled; see
+    /// `crate::mqtt::MqttPublisher`.
+    pub mqtt: Arc<crate::mqtt::MqttPublisher>,
 }
 
 impl AppState {
@@ -321,6 +326,12 @@ impl AppState {
         shutdown: CancellationToken,
     ) -> Self {
         let hqp_images: Arc<dyn HqpImageSource> = hqp_instances.clone();
+        let adapter_registry = Arc::new(AdapterRegistry::default());
+        let mqtt = Arc::new(crate::mqtt::MqttPublisher::new(
+            bus.clone(),
+            aggregator.clone(),
+            adapter_registry.clone(),
+        ));
         Self {
             roon,
             hqplayer,
@@ -331,7 +342,7 @@ impl AppState {
             openhome,
             upnp,
             musicassistant: Arc::new(ReconfigurableMusicAssistant::new(bus.clone())),
-            adapter_registry: Arc::new(AdapterRegistry::default()),
+            adapter_registry,
             provider_auth: Arc::new(provider_auth::ProviderAuthState::default()),
             controller_auth: controller_auth::ControllerAuthState::new(),
             apple_bridges: apple_bridge::AppleBridgeRegistry::from_env().unwrap_or_else(|error| {
@@ -350,6 +361,7 @@ impl AppState {
             listening_plans: crate::mcp::listening_plan::ListeningPlanStore::from_config(),
             apple_feedback: crate::mcp::feedback::FeedbackStore::from_config(),
             reliable_commands: None,
+            mqtt,
         }
     }
 
@@ -2545,6 +2557,10 @@ pub struct AdapterSettings {
     /// Music Assistant is an opt-in remote playback adapter.
     #[serde(default)]
     pub musicassistant: bool,
+    /// The MQTT/Home Assistant discovery publisher (#508) is opt-in and off
+    /// by default: it needs a broker configured before it can do anything.
+    #[serde(default)]
+    pub mqtt: bool,
 }
 
 fn default_true() -> bool {
@@ -2566,6 +2582,7 @@ impl Default for AppSettings {
                 spotify: false,
                 applemusic: false,
                 musicassistant: false,
+                mqtt: false,
             },
         }
     }
@@ -2685,6 +2702,7 @@ pub async fn api_settings_post_handler(
             "musicassistant",
             old_adapters.musicassistant != new_adapters.musicassistant,
         ),
+        ("mqtt", old_adapters.mqtt != new_adapters.mqtt),
     ];
 
     let mut applied_transitions = Vec::new();
@@ -2703,6 +2721,11 @@ pub async fn api_settings_post_handler(
             "spotify" => new_adapters.spotify,
             "applemusic" => new_adapters.applemusic,
             "musicassistant" => new_adapters.musicassistant,
+            // MQTT is a bus consumer, not a `Startable` in `adapters_list` -
+            // handled separately below via `state.mqtt` (the sanctioned
+            // surface `tests/adapter_boundary_lint.rs` allows this module
+            // to reach; it is not part of the legacy coordinator registry).
+            "mqtt" => continue,
             _ => continue,
         };
 
@@ -2744,6 +2767,14 @@ pub async fn api_settings_post_handler(
         }
     }
 
+    // MQTT is a bus consumer with no zones/companions to flush, so it does
+    // not go through the coordinator's start/stop-and-flush lifecycle - it
+    // simply turns its background publisher task on or off.
+    if old_adapters.mqtt != new_adapters.mqtt {
+        state.mqtt.set_enabled(new_adapters.mqtt).await;
+        applied_transitions.push("mqtt");
+    }
+
     // Persist only after every requested runtime transition succeeded.
     if !save_app_settings(&new_settings) {
         coord
@@ -2753,6 +2784,9 @@ pub async fn api_settings_post_handler(
                 &applied_transitions,
             )
             .await;
+        if applied_transitions.contains(&"mqtt") {
+            state.mqtt.set_enabled(old_adapters.mqtt).await;
+        }
         return Json(serde_json::json!({"ok": false, "error": "Failed to save settings"}));
     }
 
@@ -2770,6 +2804,7 @@ fn adapter_enabled(settings: &AdapterSettings, name: &str) -> Option<bool> {
         "spotify" => Some(settings.spotify),
         "applemusic" => Some(settings.applemusic),
         "musicassistant" => Some(settings.musicassistant),
+        "mqtt" => Some(settings.mqtt),
         _ => None,
     }
 }
@@ -2845,6 +2880,7 @@ mod tests {
         assert!(!settings.adapters.spotify);
         assert!(!settings.adapters.applemusic);
         assert!(!settings.adapters.musicassistant);
+        assert!(!settings.adapters.mqtt);
     }
 
     #[test]
@@ -2858,6 +2894,7 @@ mod tests {
             spotify: true,
             applemusic: true,
             musicassistant: true,
+            mqtt: true,
         };
         for name in [
             "roon",
@@ -2868,6 +2905,7 @@ mod tests {
             "spotify",
             "applemusic",
             "musicassistant",
+            "mqtt",
         ] {
             assert_eq!(adapter_enabled(&settings, name), Some(true), "{name}");
         }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -331,6 +331,7 @@ impl AppState {
             bus.clone(),
             aggregator.clone(),
             adapter_registry.clone(),
+            knobs.clone(),
         ));
         Self {
             roon,

--- a/src/api/mqtt_settings.rs
+++ b/src/api/mqtt_settings.rs
@@ -1,0 +1,162 @@
+//! HTTP settings surface for the optional MQTT/Home Assistant publisher
+//! (#508). Broker connection details (including the password) live in the
+//! encrypted [`crate::api::credentials::MqttCredentialStore`], the same
+//! pattern Spotify and Music Assistant use; the on/off switch lives in
+//! `AdapterSettings.mqtt` (`app-settings.json`) alongside every other
+//! adapter toggle.
+
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+use super::credentials::{MqttCredentialRecord, MqttCredentialStore};
+use super::AppState;
+use crate::mqtt::{DEFAULT_BASE_TOPIC, DEFAULT_DISCOVERY_PREFIX, DEFAULT_PORT, DEFAULT_TLS_PORT};
+
+/// Full replacement of the broker connection settings, except the password:
+/// omit or submit blank to retain whatever is already stored (the
+/// `MusicAssistantConfigureRequest` convention in `provider_auth.rs`).
+#[derive(Debug, Deserialize)]
+pub struct MqttConfigureRequest {
+    pub host: String,
+    #[serde(default)]
+    pub port: Option<u16>,
+    #[serde(default)]
+    pub tls: bool,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
+    #[serde(default)]
+    pub base_topic: Option<String>,
+    #[serde(default)]
+    pub discovery_prefix: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+pub struct MqttStatusResponse {
+    pub configured: bool,
+    pub enabled: bool,
+    pub running: bool,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub tls: Option<bool>,
+    pub base_topic: Option<String>,
+    pub discovery_prefix: Option<String>,
+    pub has_username: bool,
+    pub has_password: bool,
+}
+
+impl From<crate::mqtt::MqttStatus> for MqttStatusResponse {
+    fn from(status: crate::mqtt::MqttStatus) -> Self {
+        Self {
+            configured: status.configured,
+            enabled: status.enabled,
+            running: status.running,
+            host: status.host,
+            port: status.port,
+            tls: status.tls,
+            base_topic: status.base_topic,
+            discovery_prefix: status.discovery_prefix,
+            has_username: status.has_username,
+            has_password: status.has_password,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    error: String,
+}
+
+fn error_response(status: StatusCode, message: impl Into<String>) -> (StatusCode, Json<ErrorBody>) {
+    (
+        status,
+        Json(ErrorBody {
+            error: message.into(),
+        }),
+    )
+}
+
+/// GET /api/mqtt/status - configuration presence and liveness, no secrets.
+pub async fn status(State(state): State<AppState>) -> impl IntoResponse {
+    Json(MqttStatusResponse::from(state.mqtt.status().await))
+}
+
+/// POST /api/mqtt/configure - persist broker settings and adopt them live.
+pub async fn configure(
+    State(state): State<AppState>,
+    Json(request): Json<MqttConfigureRequest>,
+) -> Result<Json<MqttStatusResponse>, (StatusCode, Json<ErrorBody>)> {
+    if request.host.trim().is_empty() {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "MQTT broker host is required",
+        ));
+    }
+
+    let store = MqttCredentialStore::from_env().map_err(|error| {
+        error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("MQTT credential store unavailable: {error}"),
+        )
+    })?;
+
+    let previous = store.load().unwrap_or(None);
+    let tls = request.tls;
+    let record = MqttCredentialRecord {
+        host: request.host.trim().to_string(),
+        port: request
+            .port
+            .unwrap_or(if tls { DEFAULT_TLS_PORT } else { DEFAULT_PORT }),
+        tls,
+        username: request.username.filter(|value| !value.is_empty()),
+        password: request
+            .password
+            .filter(|value| !value.is_empty())
+            .or_else(|| previous.as_ref().and_then(|record| record.password.clone())),
+        base_topic: request
+            .base_topic
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| DEFAULT_BASE_TOPIC.to_string()),
+        discovery_prefix: request
+            .discovery_prefix
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| DEFAULT_DISCOVERY_PREFIX.to_string()),
+    };
+
+    store.save(&record).map_err(|error| {
+        error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to save MQTT settings: {error}"),
+        )
+    })?;
+
+    state.mqtt.configure(record).await;
+    Ok(Json(MqttStatusResponse::from(state.mqtt.status().await)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_response_never_serializes_the_password() {
+        let response = MqttStatusResponse {
+            configured: true,
+            enabled: true,
+            running: true,
+            host: Some("broker.local".to_string()),
+            port: Some(1883),
+            tls: Some(false),
+            base_topic: Some("unified-hifi".to_string()),
+            discovery_prefix: Some("homeassistant".to_string()),
+            has_username: true,
+            has_password: true,
+        };
+        let json = serde_json::to_string(&response).expect("serialize");
+        // `has_password` (a bool) is expected; the literal secret is not -
+        // `MqttStatusResponse` has no field that could carry it, and this
+        // pins that down structurally rather than trusting the field list.
+        assert!(!json.contains("\"password\":"));
+    }
+}

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -1248,6 +1248,25 @@ pub async fn knob_devices_handler(State(state): State<AppState>) -> Json<serde_j
     Json(serde_json::json!({ "knobs": knobs }))
 }
 
+/// DELETE /knob/devices/{knob_id} - Remove a registered knob (admin)
+///
+/// Callers that publish Home Assistant discovery for knobs (#523) observe
+/// this via the knob no longer appearing in the store and are responsible
+/// for retracting any retained discovery configs they previously published.
+pub async fn knob_remove_handler(
+    State(state): State<AppState>,
+    axum::extract::Path(knob_id): axum::extract::Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    if state.knobs.remove(&knob_id).await {
+        Ok(Json(serde_json::json!({ "ok": true })))
+    } else {
+        Err((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "knob not found"})),
+        ))
+    }
+}
+
 /// GET /config/{knob_id} - Get knob configuration (path parameter format)
 pub async fn knob_config_by_path_handler(
     State(state): State<AppState>,

--- a/src/knobs/store.rs
+++ b/src/knobs/store.rs
@@ -56,6 +56,13 @@ pub struct KnobConfig {
     /// Volume step override (None = use adapter default)
     /// When set, substituted in /now_playing response instead of adapter's step
     pub volume_step_override: Option<f64>,
+
+    /// User-requested zone reassignment (None = device chooses its own zone).
+    /// Distinct from `KnobStatus::zone_id`, which reports the zone the knob is
+    /// *currently* controlling; this is the desired override synced down to
+    /// the device via `config_sha`, e.g. from a Home Assistant `select`
+    /// entity (#523).
+    pub assigned_zone_id: Option<String>,
 }
 
 impl Default for KnobConfig {
@@ -99,6 +106,7 @@ impl Default for KnobConfig {
             cpu_freq_scaling_enabled: false,
             sleep_poll_stopped_sec: 60,
             volume_step_override: None,
+            assigned_zone_id: None,
         }
     }
 }
@@ -305,6 +313,9 @@ impl KnobStore {
         if let Some(v) = updates.volume_step_override {
             knob.config.volume_step_override = if v > 0.0 { Some(v) } else { None };
         }
+        if let Some(v) = updates.assigned_zone_id {
+            knob.config.assigned_zone_id = if v.is_empty() { None } else { Some(v) };
+        }
 
         // Recompute config hash
         knob.config_sha = compute_sha(&knob.config, &knob.name);
@@ -342,6 +353,32 @@ impl KnobStore {
         let knobs = self.knobs.read().await;
         knobs.get(knob_id).map(|k| k.config_sha.clone())
     }
+
+    /// List every registered knob with its full record (config + status),
+    /// keyed by knob id. Used by the MQTT/Home Assistant publisher (#523),
+    /// which needs `KnobConfig` fields `list()`'s `KnobSummary` omits.
+    pub async fn list_full(&self) -> Vec<(String, Knob)> {
+        let knobs = self.knobs.read().await;
+        knobs
+            .iter()
+            .map(|(id, knob)| (id.clone(), knob.clone()))
+            .collect()
+    }
+
+    /// Remove a registered knob entirely. Returns `true` if a knob with this
+    /// id existed. Callers (e.g. the MQTT publisher) are responsible for
+    /// retracting any Home Assistant discovery configs they published for it.
+    pub async fn remove(&self, knob_id: &str) -> bool {
+        let removed = {
+            let mut knobs = self.knobs.write().await;
+            knobs.remove(knob_id).is_some()
+        };
+        if removed {
+            self.save_to_disk().await;
+            tracing::info!("Removed knob: {}", knob_id);
+        }
+        removed
+    }
 }
 
 /// Partial status update
@@ -372,6 +409,9 @@ pub struct KnobConfigUpdate {
     pub sleep_poll_stopped_sec: Option<u32>,
     /// Volume step override (0 or negative = clear override)
     pub volume_step_override: Option<f64>,
+    /// Zone reassignment override (empty string = clear override, device
+    /// chooses its own zone again)
+    pub assigned_zone_id: Option<String>,
 }
 
 /// Summary for listing knobs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ pub mod knobs;
 pub mod mcp;
 #[cfg(feature = "server")]
 pub mod mdns;
+// Optional MQTT publisher: exposes UHC zones to Home Assistant (#508).
+#[cfg(feature = "server")]
+pub mod mqtt;
 // Adaptive producer publication: internal bus + aggregator-owned state (#324).
 // Server-only: it necessarily touches both `crate::bus` and `crate::adaptive`.
 #[cfg(feature = "server")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -582,6 +582,31 @@ mod server {
         state.startable_adapters = Arc::new(startable_adapters);
         coord.start_all_enabled(&provider_startables).await;
 
+        // Optional MQTT/Home Assistant discovery publisher (#508). A pure
+        // bus consumer with no zones of its own, so it does not join
+        // `startable_adapters`/the coordinator - just a background task
+        // this settings toggle and encrypted broker record turn on or off.
+        state.mqtt.set_base_url(base_url.clone());
+        match api::credentials::MqttCredentialStore::from_env() {
+            Ok(store) => match store.load() {
+                Ok(Some(record)) => {
+                    state.mqtt.configure(record).await;
+                    if app_settings.adapters.mqtt {
+                        state.mqtt.set_enabled(true).await;
+                    }
+                }
+                Ok(None) => {
+                    if app_settings.adapters.mqtt {
+                        tracing::info!(
+                            "MQTT publisher enabled in settings but no broker is configured yet"
+                        );
+                    }
+                }
+                Err(error) => tracing::warn!("MQTT credential record unavailable: {error}"),
+            },
+            Err(error) => tracing::warn!("MQTT credential store unavailable: {error}"),
+        }
+
         // Clone state for shutdown diagnostics
         let state_for_shutdown = state.clone();
 
@@ -609,6 +634,8 @@ mod server {
         let api_bridge_content_ack = api::apple_bridge::acknowledge_content;
         let controller_bootstrap = api::controller_auth::bootstrap;
         let controller_status = api::controller_auth::status;
+        let api_mqtt_status = api::mqtt_settings::status;
+        let api_mqtt_configure = api::mqtt_settings::configure;
         #[rustfmt::skip]
         let router = Router::new()
             // Health check
@@ -623,6 +650,9 @@ mod server {
             .route("/api/providers/{provider}/configure", post(api_provider_configure))
             .route("/api/providers/spotify/account", get(api_spotify_account))
             .route("/api/providers/musicassistant/status", get(api_musicassistant_status))
+            // MQTT/Home Assistant discovery publisher settings (#508)
+            .route("/api/mqtt/status", get(api_mqtt_status))
+            .route("/api/mqtt/configure", post(api_mqtt_configure))
             .route("/api/bridges/applemusic/pair", post(api_bridge_pair))
             .route("/api/bridges/applemusic/discover", post(api_bridge_discover_pairing))
             .route("/api/bridges/applemusic/claim", post(api_bridge_claim))
@@ -934,6 +964,10 @@ mod server {
 
         // Stop every adapter through the coordinator-owned lifecycle list.
         coord.stop_all(&state_for_shutdown.startable_adapters).await;
+        // MQTT is not in that list (see its wiring above) - stop it
+        // explicitly so it publishes "offline" rather than relying solely
+        // on the broker noticing a dropped TCP connection via the LWT.
+        state_for_shutdown.mqtt.shutdown().await;
         if let Some(ref fw) = firmware_service {
             fw.stop();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -780,6 +780,7 @@ mod server {
             .route("/knob/config", get(knobs::knob_config_handler))
             .route("/knob/config", post(knobs::knob_config_update_handler))
             .route("/knob/devices", get(knobs::knob_devices_handler))
+            .route("/knob/devices/{knob_id}", delete(knobs::routes::knob_remove_handler))
             // Knob protocol routes (firmware uses these paths directly)
             .route("/now_playing", get(knobs::knob_now_playing_handler))
             .route("/now_playing/image", get(knobs::knob_image_handler))

--- a/src/mqtt/command.rs
+++ b/src/mqtt/command.rs
@@ -1,0 +1,187 @@
+//! Inbound HA -> UHC command routing for the MQTT publisher (#508).
+//!
+//! Command topics carry a UHC zone id via a slug -> zone id map the
+//! publisher fills in as it (re)publishes discovery/state (see
+//! [`crate::mqtt::topics::zone_slug`]). Commands route to the owning
+//! adapter through `AppState::adapter_registry`, the same sanctioned
+//! surface `src/mcp/tools/transport.rs` and `src/knobs/routes.rs` use
+//! (`tests/adapter_boundary_lint.rs` forbids this module from reaching a
+//! concrete adapter field directly).
+//!
+//! **Known limitation:** `AdapterRegistry` only holds providers migrated to
+//! the `AdapterLogic` trait (Music Assistant, Spotify, Apple Music today).
+//! Roon, LMS, HQPlayer, OpenHome and UPnP zones are legacy `AppState`
+//! fields the architecture boundary lint (#436) does not yet let a new
+//! surface reach. Commands for those zones are refused with a clear log
+//! line rather than bypassing the lint; once #436 migrates a legacy
+//! adapter onto `AdapterLogic`, its zones gain MQTT command support for
+//! free through this same path.
+
+use std::sync::Arc;
+
+use crate::adapters::{AdapterCommand, AdapterCommandResponse};
+use crate::api::AdapterRegistry;
+
+/// One transport/control action parsed from a command topic.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedAction {
+    Play,
+    Pause,
+    Next,
+    Previous,
+    /// Percent volume, already clamped to 0-100.
+    Volume(f64),
+    Mute(bool),
+}
+
+/// Split a command topic into `(zone_slug, action_name)`, or `None` if it
+/// does not match `<base_topic>/media_player/<slug>/<action>/set`.
+pub fn parse_command_topic<'a>(base_topic: &str, topic: &'a str) -> Option<(&'a str, &'a str)> {
+    let rest = topic.strip_prefix(base_topic)?;
+    let rest = rest.strip_prefix("/media_player/")?;
+    let rest = rest.strip_suffix("/set")?;
+    let (slug, action) = rest.rsplit_once('/')?;
+    if slug.is_empty() || action.is_empty() {
+        return None;
+    }
+    Some((slug, action))
+}
+
+/// Interpret an action name and its raw MQTT payload as one control action.
+/// Unrecognized actions or malformed payloads return `None` - the caller
+/// logs and drops these rather than treating them as adapter errors.
+pub fn parse_action(action: &str, payload: &str) -> Option<ParsedAction> {
+    let payload = payload.trim();
+    match action {
+        "play" => Some(ParsedAction::Play),
+        "pause" => Some(ParsedAction::Pause),
+        "next" => Some(ParsedAction::Next),
+        "previous" => Some(ParsedAction::Previous),
+        "volume" => payload
+            .parse::<f64>()
+            .ok()
+            .map(|value| ParsedAction::Volume(value.clamp(0.0, 100.0))),
+        "mute" => match payload.to_ascii_uppercase().as_str() {
+            "ON" | "TRUE" | "1" => Some(ParsedAction::Mute(true)),
+            "OFF" | "FALSE" | "0" => Some(ParsedAction::Mute(false)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+impl ParsedAction {
+    fn into_adapter_command(self) -> AdapterCommand {
+        match self {
+            ParsedAction::Play => AdapterCommand::Play,
+            ParsedAction::Pause => AdapterCommand::Pause,
+            ParsedAction::Next => AdapterCommand::Next,
+            ParsedAction::Previous => AdapterCommand::Previous,
+            // The adapter registry's volume scale is each provider's native
+            // 0-100 percentage convention (see `AdapterCommand::VolumeAbsolute`
+            // call sites in `src/knobs/routes.rs`).
+            ParsedAction::Volume(value) => AdapterCommand::VolumeAbsolute(value.round() as i32),
+            ParsedAction::Mute(muted) => AdapterCommand::Mute(muted),
+        }
+    }
+}
+
+/// Outcome of routing one command, for logging/testing.
+#[derive(Debug, PartialEq)]
+pub enum DispatchOutcome {
+    Sent,
+    AdapterRefused(String),
+    /// The zone's prefix has no registry-backed adapter - see the module
+    /// doc's known limitation.
+    ProviderNotBridged,
+}
+
+/// Route one parsed action to the adapter that owns `zone_id`.
+pub async fn dispatch(
+    adapter_registry: &Arc<AdapterRegistry>,
+    zone_id: &str,
+    action: ParsedAction,
+) -> DispatchOutcome {
+    let Some(prefix) = zone_id.split(':').next().filter(|p| !p.is_empty()) else {
+        return DispatchOutcome::ProviderNotBridged;
+    };
+    if !adapter_registry.has_adapter(prefix).await {
+        return DispatchOutcome::ProviderNotBridged;
+    }
+    let command = action.into_adapter_command();
+    match adapter_registry.command(prefix, zone_id, command).await {
+        Ok(AdapterCommandResponse {
+            success: true,
+            ..
+        }) => DispatchOutcome::Sent,
+        Ok(AdapterCommandResponse { error, .. }) => {
+            DispatchOutcome::AdapterRefused(error.unwrap_or_else(|| "command refused".to_string()))
+        }
+        Err(error) => DispatchOutcome::AdapterRefused(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_well_formed_command_topics() {
+        assert_eq!(
+            parse_command_topic("unified-hifi", "unified-hifi/media_player/roon_abc/play/set"),
+            Some(("roon_abc", "play"))
+        );
+        assert_eq!(
+            parse_command_topic(
+                "unified-hifi",
+                "unified-hifi/media_player/roon_abc/volume/set"
+            ),
+            Some(("roon_abc", "volume"))
+        );
+    }
+
+    #[test]
+    fn rejects_topics_outside_the_base_or_missing_suffix() {
+        assert_eq!(
+            parse_command_topic("unified-hifi", "other-base/media_player/roon_abc/play/set"),
+            None
+        );
+        assert_eq!(
+            parse_command_topic("unified-hifi", "unified-hifi/media_player/roon_abc/play"),
+            None
+        );
+    }
+
+    #[test]
+    fn parses_transport_and_volume_and_mute_payloads() {
+        assert_eq!(parse_action("play", "PRESS"), Some(ParsedAction::Play));
+        assert_eq!(
+            parse_action("volume", "42"),
+            Some(ParsedAction::Volume(42.0))
+        );
+        assert_eq!(
+            parse_action("volume", "150"),
+            Some(ParsedAction::Volume(100.0)),
+            "volume payloads are clamped to 0-100"
+        );
+        assert_eq!(parse_action("mute", "ON"), Some(ParsedAction::Mute(true)));
+        assert_eq!(
+            parse_action("mute", "off"),
+            Some(ParsedAction::Mute(false))
+        );
+    }
+
+    #[test]
+    fn unrecognized_actions_and_payloads_are_ignored() {
+        assert_eq!(parse_action("seek", "10"), None);
+        assert_eq!(parse_action("volume", "not-a-number"), None);
+        assert_eq!(parse_action("mute", "maybe"), None);
+    }
+
+    #[tokio::test]
+    async fn dispatch_reports_unbridged_provider_for_legacy_zones() {
+        let registry = Arc::new(AdapterRegistry::default());
+        let outcome = dispatch(&registry, "roon:abc", ParsedAction::Play).await;
+        assert_eq!(outcome, DispatchOutcome::ProviderNotBridged);
+    }
+}

--- a/src/mqtt/discovery.rs
+++ b/src/mqtt/discovery.rs
@@ -1,0 +1,261 @@
+//! Home Assistant MQTT discovery payloads for one UHC zone (#508).
+//!
+//! Home Assistant's MQTT integration has no `media_player` platform - the
+//! discoverable component list
+//! (<https://www.home-assistant.io/integrations/mqtt/>) tops out at
+//! `sensor`, `image`, `number`, `switch`, `button` and friends, and
+//! `homeassistant/components/mqtt/media_player.py` does not exist in HA
+//! core. This publisher composes the same primitives every third-party
+//! "MQTT media player" project (bkbilly/mqtt_media_player,
+//! TroyFernandes/hass-mqtt-mediaplayer, etc.) uses instead: one `sensor`
+//! carrying state and now-playing attributes, one `image` for album art,
+//! one `number` for volume, one `switch` for mute, and four `button`
+//! entities for transport - all grouped under a single HA device per zone
+//! via a shared `device.identifiers`.
+
+use serde::Serialize;
+
+use crate::bus::Zone;
+use crate::mqtt::topics;
+
+/// Non-secret runtime settings the discovery payloads are built from.
+#[derive(Debug, Clone)]
+pub struct DiscoverySettings<'a> {
+    pub base_topic: &'a str,
+    pub discovery_prefix: &'a str,
+    pub availability_topic: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Device {
+    identifiers: [String; 1],
+    name: String,
+    manufacturer: &'static str,
+    model: String,
+    via_device: &'static str,
+}
+
+fn device_for(zone: &Zone) -> Device {
+    Device {
+        identifiers: [format!("uhc_{}", topics::zone_slug(&zone.zone_id))],
+        name: zone.zone_name.clone(),
+        manufacturer: "Unified Hi-Fi Control",
+        model: zone.source.clone(),
+        via_device: "unified_hifi_control",
+    }
+}
+
+/// One `(discovery_topic, retained_json_payload)` pair, or `None` for an
+/// entity this zone does not support (its transport buttons are still
+/// published unconditionally - see the module doc on graceful ignore).
+pub type DiscoveryEntry = (String, serde_json::Value);
+
+/// Build every HA discovery entry for one zone.
+///
+/// Entities always published: state `sensor`, album-art `image`, volume
+/// `number`, mute `switch`. Transport `button`s are published only for
+/// actions the zone actually allows (`Zone.is_play_allowed` etc.), so HA
+/// never shows a button that would just log a graceful refusal.
+pub fn discovery_entries(zone: &Zone, settings: &DiscoverySettings<'_>) -> Vec<DiscoveryEntry> {
+    let device = device_for(zone);
+    let state_topic = topics::state_topic(settings.base_topic, &zone.zone_id);
+    let mut entries = Vec::new();
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "sensor", &zone.zone_id, "state"),
+        serde_json::json!({
+            "name": "State",
+            "unique_id": format!("uhc_{}_state", topics::zone_slug(&zone.zone_id)),
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.state }}",
+            "json_attributes_topic": state_topic,
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "image", &zone.zone_id, "art"),
+        serde_json::json!({
+            "name": "Album Art",
+            "unique_id": format!("uhc_{}_art", topics::zone_slug(&zone.zone_id)),
+            "url_topic": state_topic,
+            "url_template": "{{ value_json.picture }}",
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    if zone.volume_control.is_some() {
+        entries.push((
+            topics::discovery_topic(settings.discovery_prefix, "number", &zone.zone_id, "volume"),
+            serde_json::json!({
+                "name": "Volume",
+                "unique_id": format!("uhc_{}_volume", topics::zone_slug(&zone.zone_id)),
+                "state_topic": state_topic,
+                "value_template": "{{ value_json.volume }}",
+                "command_topic": topics::command_topic(settings.base_topic, &zone.zone_id, "volume"),
+                "min": 0,
+                "max": 100,
+                "step": 1,
+                "mode": "slider",
+                "unit_of_measurement": "%",
+                "availability_topic": settings.availability_topic,
+                "device": device,
+            }),
+        ));
+
+        entries.push((
+            topics::discovery_topic(settings.discovery_prefix, "switch", &zone.zone_id, "mute"),
+            serde_json::json!({
+                "name": "Mute",
+                "unique_id": format!("uhc_{}_mute", topics::zone_slug(&zone.zone_id)),
+                "state_topic": state_topic,
+                "value_template": "{{ 'ON' if value_json.muted else 'OFF' }}",
+                "command_topic": topics::command_topic(settings.base_topic, &zone.zone_id, "mute"),
+                "availability_topic": settings.availability_topic,
+                "device": device,
+            }),
+        ));
+    }
+
+    let transport_buttons: [(&str, &str, bool); 4] = [
+        ("play", "Play", zone.is_play_allowed),
+        ("pause", "Pause", zone.is_pause_allowed),
+        ("next", "Next", zone.is_next_allowed),
+        ("previous", "Previous", zone.is_previous_allowed),
+    ];
+    for (action, label, allowed) in transport_buttons {
+        if !allowed {
+            continue;
+        }
+        entries.push((
+            topics::discovery_topic(settings.discovery_prefix, "button", &zone.zone_id, action),
+            serde_json::json!({
+                "name": label,
+                "unique_id": format!("uhc_{}_{action}", topics::zone_slug(&zone.zone_id)),
+                "command_topic": topics::command_topic(settings.base_topic, &zone.zone_id, action),
+                "payload_press": "PRESS",
+                "availability_topic": settings.availability_topic,
+                "device": device,
+            }),
+        ));
+    }
+
+    entries
+}
+
+/// Discovery topics for a zone that no longer exists, to retract every
+/// retained config this publisher could have written for it. Includes every
+/// possible entity regardless of what capabilities the zone last reported,
+/// since a retraction after removal has no `Zone` to consult.
+pub fn discovery_topics_for_removal(discovery_prefix: &str, zone_id: &str) -> Vec<String> {
+    let mut topics = vec![
+        topics::discovery_topic(discovery_prefix, "sensor", zone_id, "state"),
+        topics::discovery_topic(discovery_prefix, "image", zone_id, "art"),
+        topics::discovery_topic(discovery_prefix, "number", zone_id, "volume"),
+        topics::discovery_topic(discovery_prefix, "switch", zone_id, "mute"),
+    ];
+    for action in ["play", "pause", "next", "previous"] {
+        topics.push(topics::discovery_topic(
+            discovery_prefix,
+            "button",
+            zone_id,
+            action,
+        ));
+    }
+    topics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus::{PlaybackState, VolumeControl, VolumeScale};
+
+    fn zone_fixture() -> Zone {
+        Zone {
+            zone_id: "roon:abc".to_string(),
+            zone_name: "Living Room".to_string(),
+            state: PlaybackState::Playing,
+            volume_control: Some(VolumeControl {
+                value: 50.0,
+                min: 0.0,
+                max: 100.0,
+                step: 1.0,
+                is_muted: false,
+                scale: VolumeScale::Percentage,
+                output_id: None,
+            }),
+            now_playing: None,
+            source: "roon".to_string(),
+            is_controllable: true,
+            is_seekable: true,
+            last_updated: 0,
+            is_play_allowed: true,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: false,
+        }
+    }
+
+    fn settings() -> DiscoverySettings<'static> {
+        DiscoverySettings {
+            base_topic: "unified-hifi",
+            discovery_prefix: "homeassistant",
+            availability_topic: "unified-hifi/bridge/status",
+        }
+    }
+
+    #[test]
+    fn publishes_state_art_volume_mute_and_allowed_buttons_only() {
+        let zone = zone_fixture();
+        let entries = discovery_entries(&zone, &settings());
+        let topics: Vec<&str> = entries.iter().map(|(topic, _)| topic.as_str()).collect();
+
+        assert!(topics
+            .iter()
+            .any(|t| t.contains("/sensor/") && t.ends_with("_state/config")));
+        assert!(topics
+            .iter()
+            .any(|t| t.contains("/image/") && t.ends_with("_art/config")));
+        assert!(topics
+            .iter()
+            .any(|t| t.contains("/number/") && t.ends_with("_volume/config")));
+        assert!(topics
+            .iter()
+            .any(|t| t.contains("/switch/") && t.ends_with("_mute/config")));
+        assert!(topics.iter().any(|t| t.ends_with("_play/config")));
+        assert!(topics.iter().any(|t| t.ends_with("_pause/config")));
+        assert!(topics.iter().any(|t| t.ends_with("_next/config")));
+        // Zone does not allow "previous" - no button published for it.
+        assert!(!topics.iter().any(|t| t.ends_with("_previous/config")));
+    }
+
+    #[test]
+    fn entities_share_one_device_identifier() {
+        let zone = zone_fixture();
+        let entries = discovery_entries(&zone, &settings());
+        for (_, payload) in &entries {
+            assert_eq!(
+                payload["device"]["identifiers"][0],
+                serde_json::json!("uhc_roon_abc")
+            );
+        }
+    }
+
+    #[test]
+    fn no_volume_control_skips_volume_and_mute_entities() {
+        let mut zone = zone_fixture();
+        zone.volume_control = None;
+        let entries = discovery_entries(&zone, &settings());
+        let topics: Vec<&str> = entries.iter().map(|(topic, _)| topic.as_str()).collect();
+        assert!(!topics.iter().any(|t| t.contains("/number/")));
+        assert!(!topics.iter().any(|t| t.contains("/switch/")));
+    }
+
+    #[test]
+    fn removal_retracts_every_possible_entity() {
+        let topics = discovery_topics_for_removal("homeassistant", "roon:abc");
+        assert_eq!(topics.len(), 8);
+    }
+}

--- a/src/mqtt/knob_command.rs
+++ b/src/mqtt/knob_command.rs
@@ -1,0 +1,135 @@
+//! Inbound HA -> UHC command routing for knob entities (#523).
+//!
+//! The zone-reassignment `select` and volume-step `number` both route
+//! through [`crate::knobs::store::KnobStore::update_config`] - the exact
+//! same knob config path `src/knobs/routes.rs` uses for the web UI/device
+//! sync flow - rather than a new adapter surface.
+
+use crate::knobs::store::{KnobConfigUpdate, KnobStore};
+
+/// One config action parsed from a knob command topic.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedKnobAction {
+    /// Reassign the knob's controlled zone. An empty string clears the
+    /// override, letting the device choose its own zone again.
+    Zone(String),
+    /// Volume-step override in the same units `KnobConfig::volume_step_override`
+    /// uses; 0 or negative clears it.
+    VolumeStep(f64),
+}
+
+/// Split a command topic into `(knob_slug, action_name)`, or `None` if it
+/// does not match `<base_topic>/knob/<slug>/<action>/set`.
+pub fn parse_command_topic<'a>(base_topic: &str, topic: &'a str) -> Option<(&'a str, &'a str)> {
+    let rest = topic.strip_prefix(base_topic)?;
+    let rest = rest.strip_prefix("/knob/")?;
+    let rest = rest.strip_suffix("/set")?;
+    let (slug, action) = rest.rsplit_once('/')?;
+    if slug.is_empty() || action.is_empty() {
+        return None;
+    }
+    Some((slug, action))
+}
+
+/// Interpret an action name and its raw MQTT payload as one knob config
+/// action. Unrecognized actions or malformed payloads return `None`.
+pub fn parse_action(action: &str, payload: &str) -> Option<ParsedKnobAction> {
+    let payload = payload.trim();
+    match action {
+        "zone" => Some(ParsedKnobAction::Zone(payload.to_string())),
+        "volume_step" => payload
+            .parse::<f64>()
+            .ok()
+            .map(ParsedKnobAction::VolumeStep),
+        _ => None,
+    }
+}
+
+/// Outcome of routing one command, for logging/testing.
+#[derive(Debug, PartialEq)]
+pub enum DispatchOutcome {
+    Applied,
+    KnobNotFound,
+}
+
+/// Apply one parsed action to `knob_id` through `KnobStore::update_config`.
+pub async fn dispatch(
+    knobs: &KnobStore,
+    knob_id: &str,
+    action: ParsedKnobAction,
+) -> DispatchOutcome {
+    let update = match action {
+        ParsedKnobAction::Zone(zone_id) => KnobConfigUpdate {
+            assigned_zone_id: Some(zone_id),
+            ..Default::default()
+        },
+        ParsedKnobAction::VolumeStep(step) => KnobConfigUpdate {
+            volume_step_override: Some(step),
+            ..Default::default()
+        },
+    };
+    match knobs.update_config(knob_id, update).await {
+        Some(_) => DispatchOutcome::Applied,
+        None => DispatchOutcome::KnobNotFound,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_well_formed_command_topics() {
+        assert_eq!(
+            parse_command_topic("unified-hifi", "unified-hifi/knob/aabbcc/zone/set"),
+            Some(("aabbcc", "zone"))
+        );
+        assert_eq!(
+            parse_command_topic("unified-hifi", "unified-hifi/knob/aabbcc/volume_step/set"),
+            Some(("aabbcc", "volume_step"))
+        );
+    }
+
+    #[test]
+    fn rejects_topics_outside_the_base_or_missing_suffix() {
+        assert_eq!(
+            parse_command_topic("unified-hifi", "other-base/knob/aabbcc/zone/set"),
+            None
+        );
+        assert_eq!(
+            parse_command_topic("unified-hifi", "unified-hifi/knob/aabbcc/zone"),
+            None
+        );
+    }
+
+    #[test]
+    fn parses_zone_and_volume_step_payloads() {
+        assert_eq!(
+            parse_action("zone", "roon:abc"),
+            Some(ParsedKnobAction::Zone("roon:abc".to_string()))
+        );
+        assert_eq!(
+            parse_action("zone", ""),
+            Some(ParsedKnobAction::Zone(String::new())),
+            "empty payload clears the override"
+        );
+        assert_eq!(
+            parse_action("volume_step", "2.5"),
+            Some(ParsedKnobAction::VolumeStep(2.5))
+        );
+    }
+
+    #[test]
+    fn unrecognized_actions_and_payloads_are_ignored() {
+        assert_eq!(parse_action("rotation", "180"), None);
+        assert_eq!(parse_action("volume_step", "not-a-number"), None);
+    }
+
+    #[tokio::test]
+    async fn dispatch_reports_missing_knob() {
+        let knobs = KnobStore::default();
+        let outcome = dispatch(&knobs, "does-not-exist", ParsedKnobAction::Zone("roon:abc".to_string()))
+            .await;
+        assert_eq!(outcome, DispatchOutcome::KnobNotFound);
+    }
+}

--- a/src/mqtt/knob_discovery.rs
+++ b/src/mqtt/knob_discovery.rs
@@ -1,0 +1,294 @@
+//! Home Assistant MQTT discovery payloads for one UHC control device
+//! ("knob") (#523).
+//!
+//! Every entity here (`sensor`, `binary_sensor`, `select`, `number`) is
+//! natively supported by HA MQTT discovery, unlike the zone `media_player`
+//! composition in [`crate::mqtt::discovery`] - so one knob is one small HA
+//! device grouping: a battery sensor, a charging binary_sensor, a
+//! connectivity binary_sensor, a firmware version diagnostic sensor, a
+//! current-zone sensor, a zone-reassignment select, and a volume-step
+//! number. Display rotation and power-mode curves stay UHC-only; they are
+//! not exposed here.
+//!
+//! **Naming/id stability (user decision, #523):** every `unique_id` and
+//! topic component is derived from the knob id, which never changes. Only
+//! `device.name` (and the zone select's friendly labels, where used) comes
+//! from the knob's user-assigned display name, so a rename updates what HA
+//! shows without ever re-creating an entity.
+
+use serde::Serialize;
+
+use crate::knobs::store::Knob;
+use crate::mqtt::topics;
+
+/// Non-secret runtime settings the discovery payloads are built from.
+#[derive(Debug, Clone)]
+pub struct KnobDiscoverySettings<'a> {
+    pub base_topic: &'a str,
+    pub discovery_prefix: &'a str,
+    pub availability_topic: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Device {
+    identifiers: [String; 1],
+    name: String,
+    manufacturer: &'static str,
+    model: &'static str,
+    via_device: &'static str,
+}
+
+/// A knob with an empty (never-configured) display name still needs a
+/// readable device name; the knob id itself is stable and unique so it is
+/// the only safe fallback.
+fn display_name(knob_id: &str, knob: &Knob) -> String {
+    if knob.name.trim().is_empty() {
+        format!("Knob {knob_id}")
+    } else {
+        knob.name.clone()
+    }
+}
+
+fn device_for(knob_id: &str, knob: &Knob) -> Device {
+    Device {
+        identifiers: [format!("uhc_knob_{}", topics::zone_slug(knob_id))],
+        name: display_name(knob_id, knob),
+        manufacturer: "Unified Hi-Fi Control",
+        model: "S3 Knob",
+        via_device: "unified_hifi_control",
+    }
+}
+
+/// One `(discovery_topic, retained_json_payload)` pair.
+pub type DiscoveryEntry = (String, serde_json::Value);
+
+/// Build every HA discovery entry for one knob.
+///
+/// `zone_ids` is the current live zone list (ids only), used as the
+/// zone-reassignment `select`'s options - refreshed on every call so the
+/// list tracks zones as they appear or disappear.
+pub fn discovery_entries(
+    knob_id: &str,
+    knob: &Knob,
+    zone_ids: &[String],
+    settings: &KnobDiscoverySettings<'_>,
+) -> Vec<DiscoveryEntry> {
+    let device = device_for(knob_id, knob);
+    let state_topic = topics::knob_state_topic(settings.base_topic, knob_id);
+    let slug = topics::zone_slug(knob_id);
+    let mut entries = Vec::new();
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "sensor", knob_id, "battery"),
+        serde_json::json!({
+            "name": "Battery",
+            "unique_id": format!("uhc_knob_{slug}_battery"),
+            "device_class": "battery",
+            "unit_of_measurement": "%",
+            "state_class": "measurement",
+            "entity_category": "diagnostic",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.battery_level }}",
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "binary_sensor", knob_id, "charging"),
+        serde_json::json!({
+            "name": "Charging",
+            "unique_id": format!("uhc_knob_{slug}_charging"),
+            "device_class": "battery_charging",
+            "entity_category": "diagnostic",
+            "state_topic": state_topic,
+            "value_template": "{{ 'ON' if value_json.battery_charging else 'OFF' }}",
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries.push((
+        topics::discovery_topic(
+            settings.discovery_prefix,
+            "binary_sensor",
+            knob_id,
+            "connectivity",
+        ),
+        serde_json::json!({
+            "name": "Connectivity",
+            "unique_id": format!("uhc_knob_{slug}_connectivity"),
+            "device_class": "connectivity",
+            "entity_category": "diagnostic",
+            "state_topic": state_topic,
+            "value_template": "{{ 'ON' if value_json.online else 'OFF' }}",
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "sensor", knob_id, "firmware"),
+        serde_json::json!({
+            "name": "Firmware Version",
+            "unique_id": format!("uhc_knob_{slug}_firmware"),
+            "entity_category": "diagnostic",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.firmware_version }}",
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "sensor", knob_id, "zone"),
+        serde_json::json!({
+            "name": "Zone",
+            "unique_id": format!("uhc_knob_{slug}_zone"),
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.zone_id }}",
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "select", knob_id, "zone_select"),
+        serde_json::json!({
+            "name": "Zone",
+            "unique_id": format!("uhc_knob_{slug}_zone_select"),
+            "entity_category": "config",
+            "options": zone_ids,
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.assigned_zone_id }}",
+            "command_topic": topics::knob_command_topic(settings.base_topic, knob_id, "zone"),
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries.push((
+        topics::discovery_topic(settings.discovery_prefix, "number", knob_id, "volume_step"),
+        serde_json::json!({
+            "name": "Volume Step",
+            "unique_id": format!("uhc_knob_{slug}_volume_step"),
+            "entity_category": "config",
+            "min": 0,
+            "max": 20,
+            "step": 0.5,
+            "mode": "box",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.volume_step }}",
+            "command_topic": topics::knob_command_topic(settings.base_topic, knob_id, "volume_step"),
+            "availability_topic": settings.availability_topic,
+            "device": device,
+        }),
+    ));
+
+    entries
+}
+
+/// Discovery topics for a knob that no longer exists, to retract every
+/// retained config this publisher could have written for it.
+pub fn discovery_topics_for_removal(discovery_prefix: &str, knob_id: &str) -> Vec<String> {
+    vec![
+        topics::discovery_topic(discovery_prefix, "sensor", knob_id, "battery"),
+        topics::discovery_topic(discovery_prefix, "binary_sensor", knob_id, "charging"),
+        topics::discovery_topic(discovery_prefix, "binary_sensor", knob_id, "connectivity"),
+        topics::discovery_topic(discovery_prefix, "sensor", knob_id, "firmware"),
+        topics::discovery_topic(discovery_prefix, "sensor", knob_id, "zone"),
+        topics::discovery_topic(discovery_prefix, "select", knob_id, "zone_select"),
+        topics::discovery_topic(discovery_prefix, "number", knob_id, "volume_step"),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knobs::store::{KnobConfig, KnobStatus};
+    use chrono::Utc;
+
+    fn knob_fixture(name: &str) -> Knob {
+        Knob {
+            name: name.to_string(),
+            last_seen: Utc::now(),
+            version: Some("1.0.0".to_string()),
+            config: KnobConfig::default(),
+            config_sha: "abc12345".to_string(),
+            status: KnobStatus::default(),
+        }
+    }
+
+    fn settings() -> KnobDiscoverySettings<'static> {
+        KnobDiscoverySettings {
+            base_topic: "unified-hifi",
+            discovery_prefix: "homeassistant",
+            availability_topic: "unified-hifi/bridge/status",
+        }
+    }
+
+    #[test]
+    fn publishes_every_entity_grouped_under_one_device() {
+        let knob = knob_fixture("Kitchen Knob");
+        let zones = vec!["roon:abc".to_string()];
+        let entries = discovery_entries("aabbcc", &knob, &zones, &settings());
+        assert_eq!(entries.len(), 7);
+        for (_, payload) in &entries {
+            assert_eq!(
+                payload["device"]["identifiers"][0],
+                serde_json::json!("uhc_knob_aabbcc")
+            );
+            assert_eq!(payload["device"]["name"], serde_json::json!("Kitchen Knob"));
+        }
+    }
+
+    #[test]
+    fn unique_ids_and_topics_derive_from_knob_id_not_name() {
+        let knob_a = knob_fixture("Living Room Knob");
+        let knob_b = knob_fixture("Renamed To Something Else");
+        let zones: Vec<String> = vec![];
+        let entries_a = discovery_entries("aabbcc", &knob_a, &zones, &settings());
+        let entries_b = discovery_entries("aabbcc", &knob_b, &zones, &settings());
+
+        // Same knob id -> identical topics and unique_ids regardless of name.
+        for ((topic_a, payload_a), (topic_b, payload_b)) in entries_a.iter().zip(entries_b.iter())
+        {
+            assert_eq!(topic_a, topic_b);
+            assert_eq!(payload_a["unique_id"], payload_b["unique_id"]);
+            // Only the display name should differ.
+            assert_ne!(payload_a["device"]["name"], payload_b["device"]["name"]);
+        }
+    }
+
+    #[test]
+    fn empty_display_name_falls_back_to_knob_id() {
+        let knob = knob_fixture("");
+        let zones: Vec<String> = vec![];
+        let entries = discovery_entries("aabbcc", &knob, &zones, &settings());
+        assert_eq!(
+            entries[0].1["device"]["name"],
+            serde_json::json!("Knob aabbcc")
+        );
+    }
+
+    #[test]
+    fn zone_select_options_track_the_live_zone_list() {
+        let knob = knob_fixture("Kitchen Knob");
+        let zones = vec!["roon:abc".to_string(), "lms:def".to_string()];
+        let entries = discovery_entries("aabbcc", &knob, &zones, &settings());
+        let (_, select) = entries
+            .iter()
+            .find(|(topic, _)| topic.contains("/select/"))
+            .expect("select entry present");
+        assert_eq!(
+            select["options"],
+            serde_json::json!(["roon:abc", "lms:def"])
+        );
+    }
+
+    #[test]
+    fn removal_retracts_every_entity() {
+        let topics = discovery_topics_for_removal("homeassistant", "aabbcc");
+        assert_eq!(topics.len(), 7);
+    }
+}

--- a/src/mqtt/knob_state.rs
+++ b/src/mqtt/knob_state.rs
@@ -1,0 +1,119 @@
+//! Retained per-knob state payload for the MQTT publisher (#523).
+//!
+//! One JSON object per knob carries everything the composed HA entities
+//! read via `value_template`: battery level/charging, derived online
+//! connectivity, the zone the knob is currently controlling, the desired
+//! zone override, firmware version, and the volume-step override.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::knobs::store::Knob;
+
+/// A knob with no `now_playing`/status poll in this long is considered
+/// offline. Chosen to comfortably exceed the knob firmware's normal poll
+/// interval (seconds) while still surfacing a real disconnect promptly.
+pub const OFFLINE_AFTER_SECS: i64 = 300;
+
+/// Retained payload published to `<base_topic>/knob/<knob_id>/state`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct KnobStatePayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub battery_level: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub battery_charging: Option<bool>,
+    /// Derived from `last_seen` staleness, not a field UHC stores directly.
+    pub online: bool,
+    /// The zone this knob is currently controlling, as last reported by the
+    /// device itself.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zone_id: Option<String>,
+    /// The user-requested zone override (Home Assistant `select`), distinct
+    /// from `zone_id` above.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assigned_zone_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub firmware_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume_step: Option<f64>,
+}
+
+/// Build the retained state payload for one knob at `now`.
+pub fn build_state_payload(knob: &Knob, now: DateTime<Utc>) -> KnobStatePayload {
+    let online = (now - knob.last_seen).num_seconds() < OFFLINE_AFTER_SECS;
+    KnobStatePayload {
+        battery_level: knob.status.battery_level,
+        battery_charging: knob.status.battery_charging,
+        online,
+        zone_id: knob.status.zone_id.clone(),
+        assigned_zone_id: knob.config.assigned_zone_id.clone(),
+        firmware_version: knob.version.clone(),
+        volume_step: knob.config.volume_step_override,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::knobs::store::{KnobConfig, KnobStatus};
+    use chrono::Duration;
+
+    fn knob_fixture(last_seen: DateTime<Utc>) -> Knob {
+        Knob {
+            name: "Kitchen Knob".to_string(),
+            last_seen,
+            version: Some("1.2.3".to_string()),
+            config: KnobConfig {
+                volume_step_override: Some(2.5),
+                assigned_zone_id: Some("roon:abc".to_string()),
+                ..KnobConfig::default()
+            },
+            config_sha: "deadbeef".to_string(),
+            status: KnobStatus {
+                battery_level: Some(80),
+                battery_charging: Some(true),
+                zone_id: Some("roon:def".to_string()),
+                ip: None,
+            },
+        }
+    }
+
+    #[test]
+    fn recently_seen_knob_is_online() {
+        let payload = build_state_payload(&knob_fixture(Utc::now()), Utc::now());
+        assert!(payload.online);
+        assert_eq!(payload.battery_level, Some(80));
+        assert_eq!(payload.battery_charging, Some(true));
+        assert_eq!(payload.zone_id.as_deref(), Some("roon:def"));
+        assert_eq!(payload.assigned_zone_id.as_deref(), Some("roon:abc"));
+        assert_eq!(payload.firmware_version.as_deref(), Some("1.2.3"));
+        assert_eq!(payload.volume_step, Some(2.5));
+    }
+
+    #[test]
+    fn stale_last_seen_reports_offline() {
+        let now = Utc::now();
+        let stale = now - Duration::seconds(OFFLINE_AFTER_SECS + 60);
+        let payload = build_state_payload(&knob_fixture(stale), now);
+        assert!(!payload.online);
+    }
+
+    #[test]
+    fn missing_optional_fields_are_omitted() {
+        let mut knob = knob_fixture(Utc::now());
+        knob.status.battery_level = None;
+        knob.status.battery_charging = None;
+        knob.config.volume_step_override = None;
+        knob.config.assigned_zone_id = None;
+        knob.version = None;
+        let payload = build_state_payload(&knob, Utc::now());
+        let json = serde_json::to_value(&payload).expect("serializes");
+        assert!(json.get("battery_level").is_none());
+        assert!(json.get("battery_charging").is_none());
+        assert!(json.get("assigned_zone_id").is_none());
+        assert!(json.get("firmware_version").is_none());
+        assert!(json.get("volume_step").is_none());
+        // `online` and `zone_id` policy differs: online always present.
+        assert!(json.get("online").is_some());
+    }
+}

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -16,13 +16,27 @@
 //! [`discovery`]'s module doc), so one UHC zone is represented as a small
 //! HA device composed of a state `sensor`, an `image`, a volume `number`,
 //! a mute `switch`, and up to four transport `button`s.
+//!
+//! Control devices ("knobs") are published the same way (#523), but every
+//! entity they need - `sensor`, `binary_sensor`, `select`, `number` - is
+//! natively supported by HA MQTT discovery, so [`knob_discovery`] needs no
+//! workaround composition. Unlike zones, the knob store has no bus events
+//! of its own (battery/last-seen updates land via HTTP polls from the
+//! device, not the zone bus), so knob state is re-published on a fixed
+//! timer (see `run`'s `knob_tick`) rather than driven by [`BusEvent`]s -
+//! zone-add/remove events still trigger an immediate re-announce so the
+//! zone-reassignment `select`'s options stay current without waiting for
+//! the next tick.
 
 pub mod command;
 pub mod discovery;
+pub mod knob_command;
+pub mod knob_discovery;
+pub mod knob_state;
 pub mod state;
 pub mod topics;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -34,8 +48,14 @@ use tokio_util::sync::CancellationToken;
 use crate::aggregator::ZoneAggregator;
 use crate::api::AdapterRegistry;
 use crate::bus::{BusEvent, SharedBus, Zone};
+use crate::knobs::store::Knob;
+use crate::knobs::KnobStore;
 
 pub use crate::api::credentials::MqttCredentialRecord;
+
+/// How often knob state/discovery is re-published, since the knob store has
+/// no bus events of its own to react to (see module doc).
+const KNOB_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Default namespace for state/command topics, distinct from HA's
 /// `discovery_prefix` so operators can point discovery at a shared
@@ -62,6 +82,7 @@ pub struct MqttPublisher {
     bus: SharedBus,
     aggregator: Arc<ZoneAggregator>,
     adapter_registry: Arc<AdapterRegistry>,
+    knobs: KnobStore,
     base_url: std::sync::RwLock<String>,
     runtime: Mutex<Runtime>,
 }
@@ -87,11 +108,13 @@ impl MqttPublisher {
         bus: SharedBus,
         aggregator: Arc<ZoneAggregator>,
         adapter_registry: Arc<AdapterRegistry>,
+        knobs: KnobStore,
     ) -> Self {
         Self {
             bus,
             aggregator,
             adapter_registry,
+            knobs,
             base_url: std::sync::RwLock::new(String::new()),
             runtime: Mutex::new(Runtime::default()),
         }
@@ -167,6 +190,7 @@ impl MqttPublisher {
             self.bus.clone(),
             self.aggregator.clone(),
             self.adapter_registry.clone(),
+            self.knobs.clone(),
             self.base_url_snapshot(),
             shutdown.clone(),
         ));
@@ -312,6 +336,99 @@ async fn retract_zone(client: &AsyncClient, record: &MqttCredentialRecord, zone_
     }
 }
 
+/// Publish HA discovery configs and the retained state topic for one knob.
+async fn publish_knob(
+    client: &AsyncClient,
+    record: &MqttCredentialRecord,
+    knob_id: &str,
+    knob: &Knob,
+    zone_ids: &[String],
+    availability_topic: &str,
+) {
+    let settings = knob_discovery::KnobDiscoverySettings {
+        base_topic: &record.base_topic,
+        discovery_prefix: &record.discovery_prefix,
+        availability_topic,
+    };
+    for (topic, payload) in knob_discovery::discovery_entries(knob_id, knob, zone_ids, &settings) {
+        match serde_json::to_vec(&payload) {
+            Ok(json) => {
+                if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, json).await {
+                    tracing::warn!("MQTT knob discovery publish failed: {error}");
+                }
+            }
+            Err(error) => {
+                tracing::warn!("failed to serialize MQTT knob discovery payload: {error}")
+            }
+        }
+    }
+
+    let payload = knob_state::build_state_payload(knob, chrono::Utc::now());
+    match serde_json::to_vec(&payload) {
+        Ok(json) => {
+            let topic = topics::knob_state_topic(&record.base_topic, knob_id);
+            if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, json).await {
+                tracing::warn!("MQTT knob state publish failed: {error}");
+            }
+        }
+        Err(error) => tracing::warn!("failed to serialize MQTT knob state payload: {error}"),
+    }
+}
+
+/// Clear every retained discovery/state topic a removed knob could have had.
+async fn retract_knob(client: &AsyncClient, record: &MqttCredentialRecord, knob_id: &str) {
+    for topic in knob_discovery::discovery_topics_for_removal(&record.discovery_prefix, knob_id) {
+        if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, Vec::new()).await {
+            tracing::warn!("MQTT knob discovery retraction failed: {error}");
+        }
+    }
+    let topic = topics::knob_state_topic(&record.base_topic, knob_id);
+    if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, Vec::new()).await {
+        tracing::warn!("MQTT knob state retraction failed: {error}");
+    }
+}
+
+/// Republish discovery + state for every knob currently known to the store,
+/// retracting any knob that has disappeared since the last call. Refreshes
+/// `knob_slugs` (used to route inbound commands) and returns the current
+/// zone id list so the caller can decide whether it changed.
+async fn announce_all_knobs(
+    client: &AsyncClient,
+    record: &MqttCredentialRecord,
+    knobs: &KnobStore,
+    aggregator: &ZoneAggregator,
+    availability_topic: &str,
+    known_knob_ids: &mut HashSet<String>,
+    knob_slugs: &mut HashMap<String, String>,
+) {
+    let zone_ids: Vec<String> = aggregator
+        .get_zones()
+        .await
+        .into_iter()
+        .map(|zone| zone.zone_id)
+        .collect();
+
+    let current = knobs.list_full().await;
+    let current_ids: HashSet<String> = current.iter().map(|(id, _)| id.clone()).collect();
+
+    for removed_id in known_knob_ids.difference(&current_ids).cloned().collect::<Vec<_>>() {
+        knob_slugs.remove(&topics::zone_slug(&removed_id));
+        retract_knob(client, record, &removed_id).await;
+    }
+
+    for (knob_id, knob) in &current {
+        knob_slugs.insert(topics::zone_slug(knob_id), knob_id.clone());
+        publish_knob(client, record, knob_id, knob, &zone_ids, availability_topic).await;
+    }
+
+    *known_knob_ids = current_ids;
+
+    let command_filter = format!("{}/knob/+/+/set", record.base_topic);
+    if let Err(error) = client.subscribe(command_filter, QoS::AtLeastOnce).await {
+        tracing::warn!("MQTT knob command subscription failed: {error}");
+    }
+}
+
 /// Republish discovery + state for every zone currently known to the
 /// aggregator, refreshing the slug -> zone id map used to route inbound
 /// commands. Called on every fresh broker connection, since a new session
@@ -344,29 +461,65 @@ async fn announce_all_zones(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_bus_event(
     client: &AsyncClient,
     record: &MqttCredentialRecord,
     aggregator: &ZoneAggregator,
+    knobs: &KnobStore,
     base_url: &str,
     availability_topic: &str,
     zone_slugs: &mut HashMap<String, String>,
+    known_knob_ids: &mut HashSet<String>,
+    knob_slugs: &mut HashMap<String, String>,
     event: BusEvent,
 ) {
     match event {
         BusEvent::ZoneDiscovered { zone } => {
             zone_slugs.insert(topics::zone_slug(&zone.zone_id), zone.zone_id.clone());
             publish_zone(client, record, &zone, base_url, availability_topic).await;
+            // A newly discovered zone changes every knob's zone-select
+            // options, so re-announce them too.
+            announce_all_knobs(
+                client,
+                record,
+                knobs,
+                aggregator,
+                availability_topic,
+                known_knob_ids,
+                knob_slugs,
+            )
+            .await;
         }
         BusEvent::ZoneRemoved { zone_id } => {
             zone_slugs.remove(&topics::zone_slug(zone_id.as_str()));
             retract_zone(client, record, zone_id.as_str()).await;
+            announce_all_knobs(
+                client,
+                record,
+                knobs,
+                aggregator,
+                availability_topic,
+                known_knob_ids,
+                knob_slugs,
+            )
+            .await;
         }
         BusEvent::ZonesFlushed { zone_ids, .. } => {
             for zone_id in zone_ids {
                 zone_slugs.remove(&topics::zone_slug(&zone_id));
                 retract_zone(client, record, &zone_id).await;
             }
+            announce_all_knobs(
+                client,
+                record,
+                knobs,
+                aggregator,
+                availability_topic,
+                known_knob_ids,
+                knob_slugs,
+            )
+            .await;
         }
         BusEvent::ZoneUpdated { zone_id, .. }
         | BusEvent::NowPlayingChanged { zone_id, .. }
@@ -394,9 +547,30 @@ async fn handle_bus_event(
 async fn handle_incoming_publish(
     record: &MqttCredentialRecord,
     adapter_registry: &Arc<AdapterRegistry>,
+    knobs: &KnobStore,
     zone_slugs: &HashMap<String, String>,
+    knob_slugs: &HashMap<String, String>,
     publish: &rumqttc::Publish,
 ) {
+    if let Some((slug, action)) = knob_command::parse_command_topic(&record.base_topic, &publish.topic) {
+        let Some(knob_id) = knob_slugs.get(slug) else {
+            tracing::debug!(slug, "MQTT command for unknown knob slug; ignoring");
+            return;
+        };
+        let payload = String::from_utf8_lossy(&publish.payload);
+        let Some(parsed) = knob_command::parse_action(action, &payload) else {
+            tracing::debug!(topic = %publish.topic, "MQTT knob command topic had an unrecognized action or payload");
+            return;
+        };
+        match knob_command::dispatch(knobs, knob_id, parsed).await {
+            knob_command::DispatchOutcome::Applied => {}
+            knob_command::DispatchOutcome::KnobNotFound => {
+                tracing::warn!(knob_id, "MQTT knob command refused: knob not found");
+            }
+        }
+        return;
+    }
+
     let Some((slug, action)) = command::parse_command_topic(&record.base_topic, &publish.topic)
     else {
         return;
@@ -433,6 +607,7 @@ async fn run(
     bus: SharedBus,
     aggregator: Arc<ZoneAggregator>,
     adapter_registry: Arc<AdapterRegistry>,
+    knobs: KnobStore,
     base_url: String,
     shutdown: CancellationToken,
 ) {
@@ -441,6 +616,23 @@ async fn run(
     let (client, mut eventloop) = AsyncClient::new(options, 64);
     let mut bus_rx = bus.subscribe();
     let mut zone_slugs: HashMap<String, String> = HashMap::new();
+    let mut known_knob_ids: HashSet<String> = HashSet::new();
+    let mut knob_slugs: HashMap<String, String> = HashMap::new();
+    // The knob store has no bus events of its own (see module doc) - poll
+    // it on a fixed timer instead so battery/last-seen changes still reach
+    // Home Assistant. `interval_at` (rather than `interval`) skips firing
+    // immediately: the `ConnAck` handler below already announces knobs on
+    // every fresh connection, and firing a tick before the client has even
+    // connected would queue a knob command subscribe ahead of the
+    // publisher's own CONNECT - observed to trip a spurious reconnect (the
+    // broker treats the second CONNECT with the same client id as replacing
+    // a live session and fires that session's LWT) that briefly retains
+    // "offline" before the publisher's real "online" lands.
+    let mut knob_tick = tokio::time::interval_at(
+        tokio::time::Instant::now() + KNOB_POLL_INTERVAL,
+        KNOB_POLL_INTERVAL,
+    );
+    knob_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
         tokio::select! {
@@ -463,10 +655,27 @@ async fn run(
                             &mut zone_slugs,
                         )
                         .await;
+                        announce_all_knobs(
+                            &client,
+                            &record,
+                            &knobs,
+                            &aggregator,
+                            &availability_topic,
+                            &mut known_knob_ids,
+                            &mut knob_slugs,
+                        )
+                        .await;
                     }
                     Ok(Event::Incoming(Packet::Publish(publish))) => {
-                        handle_incoming_publish(&record, &adapter_registry, &zone_slugs, &publish)
-                            .await;
+                        handle_incoming_publish(
+                            &record,
+                            &adapter_registry,
+                            &knobs,
+                            &zone_slugs,
+                            &knob_slugs,
+                            &publish,
+                        )
+                        .await;
                     }
                     Ok(_) => {}
                     Err(error) => {
@@ -482,9 +691,12 @@ async fn run(
                             &client,
                             &record,
                             &aggregator,
+                            &knobs,
                             &base_url,
                             &availability_topic,
                             &mut zone_slugs,
+                            &mut known_knob_ids,
+                            &mut knob_slugs,
                             event,
                         )
                         .await;
@@ -503,9 +715,31 @@ async fn run(
                             &mut zone_slugs,
                         )
                         .await;
+                        announce_all_knobs(
+                            &client,
+                            &record,
+                            &knobs,
+                            &aggregator,
+                            &availability_topic,
+                            &mut known_knob_ids,
+                            &mut knob_slugs,
+                        )
+                        .await;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }
+            }
+            _ = knob_tick.tick() => {
+                announce_all_knobs(
+                    &client,
+                    &record,
+                    &knobs,
+                    &aggregator,
+                    &availability_topic,
+                    &mut known_knob_ids,
+                    &mut knob_slugs,
+                )
+                .await;
             }
         }
     }

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -1,0 +1,512 @@
+//! Optional MQTT publisher: exposes every UHC zone to Home Assistant via
+//! MQTT discovery (#508).
+//!
+//! Fully off by default. Once configured with a broker and enabled, this
+//! module is a plain bus consumer: it reads [`crate::bus::SharedBus`] and
+//! [`crate::aggregator::ZoneAggregator`] snapshots to publish HA discovery
+//! configs and retained per-zone state, and routes inbound HA command
+//! topics through [`crate::adapters::AdapterRegistry`] - the same three
+//! sanctioned surfaces every other UHC feature outside `src/adapters/`,
+//! `src/bus/`, `src/aggregator.rs`, `src/coordinator.rs` and `src/main.rs`
+//! is restricted to (`tests/adapter_boundary_lint.rs`). See
+//! [`command`]'s module doc for the one deliberate scope limit this
+//! implies: legacy (non-registry) adapters do not yet accept MQTT commands.
+//!
+//! Home Assistant has no native MQTT `media_player` platform (see
+//! [`discovery`]'s module doc), so one UHC zone is represented as a small
+//! HA device composed of a state `sensor`, an `image`, a volume `number`,
+//! a mute `switch`, and up to four transport `button`s.
+
+pub mod command;
+pub mod discovery;
+pub mod state;
+pub mod topics;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use rumqttc::{AsyncClient, Event, LastWill, MqttOptions, Packet, QoS, Transport};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::aggregator::ZoneAggregator;
+use crate::api::AdapterRegistry;
+use crate::bus::{BusEvent, SharedBus, Zone};
+
+pub use crate::api::credentials::MqttCredentialRecord;
+
+/// Default namespace for state/command topics, distinct from HA's
+/// `discovery_prefix` so operators can point discovery at a shared
+/// `homeassistant` prefix while keeping UHC's own traffic namespaced.
+pub const DEFAULT_BASE_TOPIC: &str = "unified-hifi";
+/// Default Home Assistant MQTT discovery prefix.
+pub const DEFAULT_DISCOVERY_PREFIX: &str = "homeassistant";
+pub const DEFAULT_PORT: u16 = 1883;
+pub const DEFAULT_TLS_PORT: u16 = 8883;
+
+/// Lifecycle state guarded together so configure/enable/disable never race
+/// each other into starting two publisher tasks.
+#[derive(Default)]
+struct Runtime {
+    record: Option<MqttCredentialRecord>,
+    enabled: bool,
+    task: Option<(CancellationToken, JoinHandle<()>)>,
+}
+
+/// Optional MQTT publisher. Held on `AppState` as `Arc<MqttPublisher>`;
+/// cheap to construct, inert until [`MqttPublisher::configure`] and
+/// [`MqttPublisher::set_enabled`] have both been satisfied.
+pub struct MqttPublisher {
+    bus: SharedBus,
+    aggregator: Arc<ZoneAggregator>,
+    adapter_registry: Arc<AdapterRegistry>,
+    base_url: std::sync::RwLock<String>,
+    runtime: Mutex<Runtime>,
+}
+
+/// Snapshot of publisher state for the settings API, deliberately excluding
+/// the broker password.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MqttStatus {
+    pub configured: bool,
+    pub enabled: bool,
+    pub running: bool,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub tls: Option<bool>,
+    pub base_topic: Option<String>,
+    pub discovery_prefix: Option<String>,
+    pub has_username: bool,
+    pub has_password: bool,
+}
+
+impl MqttPublisher {
+    pub fn new(
+        bus: SharedBus,
+        aggregator: Arc<ZoneAggregator>,
+        adapter_registry: Arc<AdapterRegistry>,
+    ) -> Self {
+        Self {
+            bus,
+            aggregator,
+            adapter_registry,
+            base_url: std::sync::RwLock::new(String::new()),
+            runtime: Mutex::new(Runtime::default()),
+        }
+    }
+
+    /// Set the absolute base URL (`http://host:port`) UHC's own HTTP server
+    /// is reachable at, used to build `entity_picture` art URLs. Safe to
+    /// call before or after the publisher is running.
+    pub fn set_base_url(&self, base_url: String) {
+        if let Ok(mut guard) = self.base_url.write() {
+            *guard = base_url;
+        }
+    }
+
+    fn base_url_snapshot(&self) -> String {
+        self.base_url
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// Persist and adopt new broker connection settings. Restarts the
+    /// publisher task immediately if it is currently enabled.
+    pub async fn configure(&self, record: MqttCredentialRecord) {
+        let enabled = {
+            let mut runtime = self.runtime.lock().await;
+            runtime.record = Some(record.clone());
+            runtime.enabled
+        };
+        if enabled {
+            self.restart(Some(record)).await;
+        }
+    }
+
+    /// Turn the publisher on or off. A no-op flip when already in that
+    /// state still restarts on enable, matching the settings-toggle
+    /// semantics `api_settings_post_handler` uses for every other adapter.
+    pub async fn set_enabled(&self, enabled: bool) {
+        let (record, previous_task) = {
+            let mut runtime = self.runtime.lock().await;
+            runtime.enabled = enabled;
+            let previous_task = if !enabled { runtime.task.take() } else { None };
+            (runtime.record.clone(), previous_task)
+        };
+        if let Some((shutdown, handle)) = previous_task {
+            stop_task(shutdown, handle).await;
+        }
+        if enabled {
+            self.restart(record).await;
+        }
+    }
+
+    /// Stop any running task and, if `record` is present, start a fresh one.
+    async fn restart(&self, record: Option<MqttCredentialRecord>) {
+        let previous_task = {
+            let mut runtime = self.runtime.lock().await;
+            runtime.task.take()
+        };
+        if let Some((shutdown, handle)) = previous_task {
+            stop_task(shutdown, handle).await;
+        }
+
+        let Some(record) = record else {
+            tracing::info!(
+                "MQTT publisher enabled but not yet configured; waiting for broker settings"
+            );
+            return;
+        };
+
+        let shutdown = CancellationToken::new();
+        let task = tokio::spawn(run(
+            record,
+            self.bus.clone(),
+            self.aggregator.clone(),
+            self.adapter_registry.clone(),
+            self.base_url_snapshot(),
+            shutdown.clone(),
+        ));
+
+        let mut runtime = self.runtime.lock().await;
+        // Another caller may have already disabled/reconfigured while this
+        // task was spawning; only keep it if still enabled.
+        if runtime.enabled {
+            runtime.task = Some((shutdown, task));
+        } else {
+            drop(runtime);
+            stop_task(shutdown, task).await;
+        }
+    }
+
+    pub async fn is_running(&self) -> bool {
+        self.runtime.lock().await.task.is_some()
+    }
+
+    pub async fn is_configured(&self) -> bool {
+        self.runtime.lock().await.record.is_some()
+    }
+
+    pub async fn status(&self) -> MqttStatus {
+        let runtime = self.runtime.lock().await;
+        MqttStatus {
+            configured: runtime.record.is_some(),
+            enabled: runtime.enabled,
+            running: runtime.task.is_some(),
+            host: runtime.record.as_ref().map(|r| r.host.clone()),
+            port: runtime.record.as_ref().map(|r| r.port),
+            tls: runtime.record.as_ref().map(|r| r.tls),
+            base_topic: runtime.record.as_ref().map(|r| r.base_topic.clone()),
+            discovery_prefix: runtime.record.as_ref().map(|r| r.discovery_prefix.clone()),
+            has_username: runtime
+                .record
+                .as_ref()
+                .is_some_and(|r| r.username.as_ref().is_some_and(|u| !u.is_empty())),
+            has_password: runtime
+                .record
+                .as_ref()
+                .is_some_and(|r| r.password.as_ref().is_some_and(|p| !p.is_empty())),
+        }
+    }
+
+    /// Stop the publisher for shutdown, publishing "offline" for a clean
+    /// availability transition rather than relying solely on the LWT.
+    pub async fn shutdown(&self) {
+        let previous_task = {
+            let mut runtime = self.runtime.lock().await;
+            runtime.task.take()
+        };
+        if let Some((shutdown, handle)) = previous_task {
+            stop_task(shutdown, handle).await;
+        }
+    }
+}
+
+async fn stop_task(shutdown: CancellationToken, handle: JoinHandle<()>) {
+    shutdown.cancel();
+    if tokio::time::timeout(Duration::from_secs(5), handle)
+        .await
+        .is_err()
+    {
+        tracing::warn!("MQTT publisher task did not stop within 5s of cancellation");
+    }
+}
+
+fn client_id() -> String {
+    format!(
+        "uhc-{}",
+        gethostname::gethostname().to_string_lossy().replace(
+            |c: char| !c.is_ascii_alphanumeric(),
+            "-"
+        )
+    )
+}
+
+fn mqtt_options(record: &MqttCredentialRecord, availability_topic: &str) -> MqttOptions {
+    let mut options = MqttOptions::new(client_id(), record.host.clone(), record.port);
+    options.set_keep_alive(Duration::from_secs(30));
+    if let Some(username) = record.username.as_ref().filter(|u| !u.is_empty()) {
+        options.set_credentials(username.clone(), record.password.clone().unwrap_or_default());
+    }
+    if record.tls {
+        options.set_transport(Transport::tls_with_default_config());
+    }
+    options.set_last_will(LastWill::new(
+        availability_topic,
+        b"offline".to_vec(),
+        QoS::AtLeastOnce,
+        true,
+    ));
+    options
+}
+
+/// Publish HA discovery configs and the retained state topic for one zone.
+async fn publish_zone(
+    client: &AsyncClient,
+    record: &MqttCredentialRecord,
+    zone: &Zone,
+    base_url: &str,
+    availability_topic: &str,
+) {
+    let settings = discovery::DiscoverySettings {
+        base_topic: &record.base_topic,
+        discovery_prefix: &record.discovery_prefix,
+        availability_topic,
+    };
+    for (topic, payload) in discovery::discovery_entries(zone, &settings) {
+        match serde_json::to_vec(&payload) {
+            Ok(json) => {
+                if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, json).await {
+                    tracing::warn!("MQTT discovery publish failed: {error}");
+                }
+            }
+            Err(error) => tracing::warn!("failed to serialize MQTT discovery payload: {error}"),
+        }
+    }
+
+    let payload = state::build_state_payload(zone, base_url);
+    match serde_json::to_vec(&payload) {
+        Ok(json) => {
+            let topic = topics::state_topic(&record.base_topic, &zone.zone_id);
+            if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, json).await {
+                tracing::warn!("MQTT state publish failed: {error}");
+            }
+        }
+        Err(error) => tracing::warn!("failed to serialize MQTT state payload: {error}"),
+    }
+}
+
+/// Clear every retained discovery/state topic a removed zone could have had.
+async fn retract_zone(client: &AsyncClient, record: &MqttCredentialRecord, zone_id: &str) {
+    for topic in discovery::discovery_topics_for_removal(&record.discovery_prefix, zone_id) {
+        if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, Vec::new()).await {
+            tracing::warn!("MQTT discovery retraction failed: {error}");
+        }
+    }
+    let topic = topics::state_topic(&record.base_topic, zone_id);
+    if let Err(error) = client.publish(topic, QoS::AtLeastOnce, true, Vec::new()).await {
+        tracing::warn!("MQTT state retraction failed: {error}");
+    }
+}
+
+/// Republish discovery + state for every zone currently known to the
+/// aggregator, refreshing the slug -> zone id map used to route inbound
+/// commands. Called on every fresh broker connection, since a new session
+/// has no retained knowledge of what this publisher already announced.
+async fn announce_all_zones(
+    client: &AsyncClient,
+    record: &MqttCredentialRecord,
+    aggregator: &ZoneAggregator,
+    base_url: &str,
+    availability_topic: &str,
+    zone_slugs: &mut HashMap<String, String>,
+) {
+    if let Err(error) = client
+        .publish(availability_topic, QoS::AtLeastOnce, true, b"online".to_vec())
+        .await
+    {
+        tracing::warn!("MQTT availability publish failed: {error}");
+    }
+
+    let zones = aggregator.get_zones().await;
+    zone_slugs.clear();
+    for zone in &zones {
+        zone_slugs.insert(topics::zone_slug(&zone.zone_id), zone.zone_id.clone());
+        publish_zone(client, record, zone, base_url, availability_topic).await;
+    }
+
+    let command_filter = format!("{}/media_player/+/+/set", record.base_topic);
+    if let Err(error) = client.subscribe(command_filter, QoS::AtLeastOnce).await {
+        tracing::warn!("MQTT command subscription failed: {error}");
+    }
+}
+
+async fn handle_bus_event(
+    client: &AsyncClient,
+    record: &MqttCredentialRecord,
+    aggregator: &ZoneAggregator,
+    base_url: &str,
+    availability_topic: &str,
+    zone_slugs: &mut HashMap<String, String>,
+    event: BusEvent,
+) {
+    match event {
+        BusEvent::ZoneDiscovered { zone } => {
+            zone_slugs.insert(topics::zone_slug(&zone.zone_id), zone.zone_id.clone());
+            publish_zone(client, record, &zone, base_url, availability_topic).await;
+        }
+        BusEvent::ZoneRemoved { zone_id } => {
+            zone_slugs.remove(&topics::zone_slug(zone_id.as_str()));
+            retract_zone(client, record, zone_id.as_str()).await;
+        }
+        BusEvent::ZonesFlushed { zone_ids, .. } => {
+            for zone_id in zone_ids {
+                zone_slugs.remove(&topics::zone_slug(&zone_id));
+                retract_zone(client, record, &zone_id).await;
+            }
+        }
+        BusEvent::ZoneUpdated { zone_id, .. }
+        | BusEvent::NowPlayingChanged { zone_id, .. }
+        | BusEvent::PlaybackModesChanged { zone_id, .. }
+        | BusEvent::SeekPositionChanged { zone_id, .. } => {
+            if let Some(zone) = aggregator.get_zone(zone_id.as_str()).await {
+                zone_slugs.insert(topics::zone_slug(&zone.zone_id), zone.zone_id.clone());
+                publish_zone(client, record, &zone, base_url, availability_topic).await;
+            }
+        }
+        BusEvent::VolumeChanged { .. } => {
+            // Keyed by output_id rather than zone_id - refresh every known
+            // zone rather than guess which one owns this output.
+            let zone_ids: Vec<String> = zone_slugs.values().cloned().collect();
+            for zone_id in zone_ids {
+                if let Some(zone) = aggregator.get_zone(&zone_id).await {
+                    publish_zone(client, record, &zone, base_url, availability_topic).await;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+async fn handle_incoming_publish(
+    record: &MqttCredentialRecord,
+    adapter_registry: &Arc<AdapterRegistry>,
+    zone_slugs: &HashMap<String, String>,
+    publish: &rumqttc::Publish,
+) {
+    let Some((slug, action)) = command::parse_command_topic(&record.base_topic, &publish.topic)
+    else {
+        return;
+    };
+    let Some(zone_id) = zone_slugs.get(slug) else {
+        tracing::debug!(slug, "MQTT command for unknown zone slug; ignoring");
+        return;
+    };
+    let payload = String::from_utf8_lossy(&publish.payload);
+    let Some(parsed) = command::parse_action(action, &payload) else {
+        tracing::debug!(topic = %publish.topic, "MQTT command topic had an unrecognized action or payload");
+        return;
+    };
+    match command::dispatch(adapter_registry, zone_id, parsed).await {
+        command::DispatchOutcome::Sent => {}
+        command::DispatchOutcome::AdapterRefused(error) => {
+            tracing::warn!(zone_id, error, "MQTT command refused by adapter");
+        }
+        command::DispatchOutcome::ProviderNotBridged => {
+            tracing::debug!(
+                zone_id,
+                "MQTT command ignored: provider not yet bridged to the adapter registry (#436)"
+            );
+        }
+    }
+}
+
+/// The publisher's connect/reconnect loop. `rumqttc`'s `EventLoop` retries
+/// the underlying TCP/TLS connection on its own; this loop only needs to
+/// re-announce state on every fresh `ConnAck`, since a new MQTT session (or
+/// a broker restart) has no memory of what was previously retained here.
+async fn run(
+    record: MqttCredentialRecord,
+    bus: SharedBus,
+    aggregator: Arc<ZoneAggregator>,
+    adapter_registry: Arc<AdapterRegistry>,
+    base_url: String,
+    shutdown: CancellationToken,
+) {
+    let availability_topic = topics::availability_topic(&record.base_topic);
+    let options = mqtt_options(&record, &availability_topic);
+    let (client, mut eventloop) = AsyncClient::new(options, 64);
+    let mut bus_rx = bus.subscribe();
+    let mut zone_slugs: HashMap<String, String> = HashMap::new();
+
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                let _ = client
+                    .publish(&availability_topic, QoS::AtLeastOnce, true, b"offline".to_vec())
+                    .await;
+                let _ = client.disconnect().await;
+                break;
+            }
+            event = eventloop.poll() => {
+                match event {
+                    Ok(Event::Incoming(Packet::ConnAck(_))) => {
+                        announce_all_zones(
+                            &client,
+                            &record,
+                            &aggregator,
+                            &base_url,
+                            &availability_topic,
+                            &mut zone_slugs,
+                        )
+                        .await;
+                    }
+                    Ok(Event::Incoming(Packet::Publish(publish))) => {
+                        handle_incoming_publish(&record, &adapter_registry, &zone_slugs, &publish)
+                            .await;
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!("MQTT publisher connection error: {error}");
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                    }
+                }
+            }
+            bus_event = bus_rx.recv() => {
+                match bus_event {
+                    Ok(event) => {
+                        handle_bus_event(
+                            &client,
+                            &record,
+                            &aggregator,
+                            &base_url,
+                            &availability_topic,
+                            &mut zone_slugs,
+                            event,
+                        )
+                        .await;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::warn!(
+                            skipped,
+                            "MQTT publisher lagged behind the event bus; resyncing from the aggregator"
+                        );
+                        announce_all_zones(
+                            &client,
+                            &record,
+                            &aggregator,
+                            &base_url,
+                            &availability_topic,
+                            &mut zone_slugs,
+                        )
+                        .await;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        }
+    }
+}

--- a/src/mqtt/state.rs
+++ b/src/mqtt/state.rs
@@ -1,0 +1,186 @@
+//! Retained per-zone state payload for the MQTT publisher (#508).
+//!
+//! One JSON object per zone carries everything the composed HA entities
+//! read via `value_template`/`json_attributes_topic`: playback state,
+//! volume, mute, and now-playing metadata including an `entity_picture`
+//! URL built from UHC's existing art proxy.
+
+use serde::Serialize;
+
+use crate::bus::Zone;
+
+/// Retained payload published to `<base_topic>/media_player/<zone>/state`.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ZoneStatePayload {
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artist: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album: Option<String>,
+    /// Volume normalized to a 0-100 percentage regardless of the source
+    /// adapter's native scale, so one HA `number` entity works for every
+    /// provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume: Option<f64>,
+    pub muted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<f64>,
+    /// Absolute `entity_picture` URL via UHC's existing `/now_playing/image`
+    /// proxy, present only when the zone has known art.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub picture: Option<String>,
+}
+
+/// Normalize a volume control's value to a 0-100 percentage.
+///
+/// Decibel and unknown scales are not linear percentages; rather than
+/// publish a misleading number, only percentage and linear scales are
+/// converted. Other scales report no volume, and the HA `number` entity
+/// simply keeps its last retained value.
+fn normalized_volume(zone: &Zone) -> Option<f64> {
+    let volume = zone.volume_control.as_ref()?;
+    use crate::bus::VolumeScale;
+    match volume.scale {
+        VolumeScale::Percentage => Some(volume.value as f64),
+        VolumeScale::Linear => {
+            let span = (volume.max - volume.min).max(f32::EPSILON);
+            Some((((volume.value - volume.min) / span) * 100.0) as f64)
+        }
+        VolumeScale::Decibel | VolumeScale::Unknown => None,
+    }
+}
+
+/// Build the retained state payload for one zone.
+///
+/// `picture_base_url` is the absolute base URL of UHC's HTTP server (e.g.
+/// `http://uhc.local:8088`); when the zone has a `now_playing.image_key`,
+/// the payload's `picture` points at UHC's own art proxy rather than the
+/// adapter's raw image key, so it works for every provider (Roon browse
+/// keys, remote HTTPS URLs, MusicKit CDN references, etc.) without HA ever
+/// needing provider-specific credentials.
+pub fn build_state_payload(zone: &Zone, picture_base_url: &str) -> ZoneStatePayload {
+    let now_playing = zone.now_playing.as_ref();
+    let picture = now_playing
+        .and_then(|np| np.image_key.as_ref())
+        .map(|_| {
+            format!(
+                "{picture_base_url}/now_playing/image?zone_id={}",
+                urlencoding::encode(&zone.zone_id)
+            )
+        });
+
+    ZoneStatePayload {
+        state: zone.state.to_string(),
+        title: now_playing.map(|np| np.title.clone()),
+        artist: now_playing.map(|np| np.artist.clone()),
+        album: now_playing.map(|np| np.album.clone()),
+        volume: normalized_volume(zone),
+        muted: zone
+            .volume_control
+            .as_ref()
+            .map(|v| v.is_muted)
+            .unwrap_or(false),
+        position: now_playing.and_then(|np| np.seek_position),
+        duration: now_playing.and_then(|np| np.duration),
+        picture,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bus::{NowPlaying, PlaybackState, VolumeControl, VolumeScale};
+
+    fn zone_fixture() -> Zone {
+        Zone {
+            zone_id: "roon:abc".to_string(),
+            zone_name: "Living Room".to_string(),
+            state: PlaybackState::Playing,
+            volume_control: Some(VolumeControl {
+                value: 50.0,
+                min: 0.0,
+                max: 100.0,
+                step: 1.0,
+                is_muted: false,
+                scale: VolumeScale::Percentage,
+                output_id: None,
+            }),
+            now_playing: Some(NowPlaying {
+                title: "Song".to_string(),
+                artist: "Artist".to_string(),
+                album: "Album".to_string(),
+                image_key: Some("key123".to_string()),
+                seek_position: Some(12.5),
+                duration: Some(200.0),
+                metadata: None,
+                repeat_mode: None,
+                shuffle: None,
+            }),
+            source: "roon".to_string(),
+            is_controllable: true,
+            is_seekable: true,
+            last_updated: 0,
+            is_play_allowed: true,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        }
+    }
+
+    #[test]
+    fn builds_full_payload_with_picture_url() {
+        let zone = zone_fixture();
+        let payload = build_state_payload(&zone, "http://uhc.local:8088");
+        assert_eq!(payload.state, "playing");
+        assert_eq!(payload.title.as_deref(), Some("Song"));
+        assert_eq!(payload.volume, Some(50.0));
+        assert!(!payload.muted);
+        assert_eq!(
+            payload.picture.as_deref(),
+            Some("http://uhc.local:8088/now_playing/image?zone_id=roon%3Aabc")
+        );
+    }
+
+    #[test]
+    fn missing_now_playing_omits_metadata_and_picture() {
+        let mut zone = zone_fixture();
+        zone.now_playing = None;
+        let payload = build_state_payload(&zone, "http://uhc.local:8088");
+        assert!(payload.title.is_none());
+        assert!(payload.picture.is_none());
+    }
+
+    #[test]
+    fn decibel_scale_reports_no_normalized_volume() {
+        let mut zone = zone_fixture();
+        zone.volume_control.as_mut().unwrap().scale = VolumeScale::Decibel;
+        let payload = build_state_payload(&zone, "http://uhc.local:8088");
+        assert_eq!(payload.volume, None);
+    }
+
+    #[test]
+    fn linear_scale_normalizes_to_percentage() {
+        let mut zone = zone_fixture();
+        {
+            let volume = zone.volume_control.as_mut().unwrap();
+            volume.scale = VolumeScale::Linear;
+            volume.min = 0.0;
+            volume.max = 1.0;
+            volume.value = 0.25;
+        }
+        let payload = build_state_payload(&zone, "http://uhc.local:8088");
+        assert_eq!(payload.volume, Some(25.0));
+    }
+
+    #[test]
+    fn muted_flag_reflects_volume_control() {
+        let mut zone = zone_fixture();
+        zone.volume_control.as_mut().unwrap().is_muted = true;
+        let payload = build_state_payload(&zone, "http://uhc.local:8088");
+        assert!(payload.muted);
+    }
+}

--- a/src/mqtt/topics.rs
+++ b/src/mqtt/topics.rs
@@ -1,0 +1,86 @@
+//! MQTT topic naming for the Home Assistant publisher (#508).
+//!
+//! One zone maps to one HA "device" grouping several entities (state sensor,
+//! album art image, volume number, mute switch, transport buttons). Topics
+//! are namespaced under a configurable `base_topic` (state/command) and a
+//! separate `discovery_prefix` (HA's `homeassistant` convention), matching
+//! the split UHC settings expose.
+
+/// Turn a UHC zone id (e.g. `roon:1234`) into an MQTT/HA-safe slug.
+///
+/// HA object ids and MQTT topic levels both reject `:`, so the prefix
+/// separator becomes `_`. Collisions are not possible: no adapter mints a
+/// zone id containing `_` where another's `:`-joined form would collide,
+/// because `PrefixedZoneId` enforces exactly one `source:raw_id` split.
+pub fn zone_slug(zone_id: &str) -> String {
+    zone_id
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// Bridge-wide availability topic (Last Will + online announcement).
+pub fn availability_topic(base_topic: &str) -> String {
+    format!("{base_topic}/bridge/status")
+}
+
+/// Retained JSON state topic for one zone.
+pub fn state_topic(base_topic: &str, zone_id: &str) -> String {
+    format!("{base_topic}/media_player/{}/state", zone_slug(zone_id))
+}
+
+/// Command topic for one transport/control action on one zone.
+pub fn command_topic(base_topic: &str, zone_id: &str, action: &str) -> String {
+    format!(
+        "{base_topic}/media_player/{}/{action}/set",
+        zone_slug(zone_id)
+    )
+}
+
+/// HA MQTT discovery config topic for one entity of one zone.
+///
+/// `<discovery_prefix>/<component>/<node_id>/<object_id>/config`, the
+/// single-entity discovery form documented at
+/// <https://www.home-assistant.io/integrations/mqtt/#discovery-topic>.
+pub fn discovery_topic(
+    discovery_prefix: &str,
+    component: &str,
+    zone_id: &str,
+    entity_suffix: &str,
+) -> String {
+    format!(
+        "{discovery_prefix}/{component}/unified_hifi_control/{}_{entity_suffix}/config",
+        zone_slug(zone_id)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugs_replace_non_alphanumeric_with_underscore() {
+        assert_eq!(zone_slug("roon:1234abCD"), "roon_1234abCD");
+        assert_eq!(zone_slug("lms:00:11:22:33:44:55"), "lms_00_11_22_33_44_55");
+    }
+
+    #[test]
+    fn topics_are_namespaced_under_base_and_discovery_prefix() {
+        assert_eq!(
+            availability_topic("unified-hifi"),
+            "unified-hifi/bridge/status"
+        );
+        assert_eq!(
+            state_topic("unified-hifi", "roon:abc"),
+            "unified-hifi/media_player/roon_abc/state"
+        );
+        assert_eq!(
+            command_topic("unified-hifi", "roon:abc", "volume"),
+            "unified-hifi/media_player/roon_abc/volume/set"
+        );
+        assert_eq!(
+            discovery_topic("homeassistant", "sensor", "roon:abc", "state"),
+            "homeassistant/sensor/unified_hifi_control/roon_abc_state/config"
+        );
+    }
+}

--- a/src/mqtt/topics.rs
+++ b/src/mqtt/topics.rs
@@ -42,6 +42,10 @@ pub fn command_topic(base_topic: &str, zone_id: &str, action: &str) -> String {
 /// `<discovery_prefix>/<component>/<node_id>/<object_id>/config`, the
 /// single-entity discovery form documented at
 /// <https://www.home-assistant.io/integrations/mqtt/#discovery-topic>.
+///
+/// Also used for knob entities (#523): `zone_slug` is a generic
+/// non-alphanumeric-to-underscore slug, so it works equally well on a knob
+/// id.
 pub fn discovery_topic(
     discovery_prefix: &str,
     component: &str,
@@ -52,6 +56,19 @@ pub fn discovery_topic(
         "{discovery_prefix}/{component}/unified_hifi_control/{}_{entity_suffix}/config",
         zone_slug(zone_id)
     )
+}
+
+/// Retained JSON state topic for one knob (#523).
+///
+/// Uses the knob id, never its display name, so the topic - and every
+/// entity's `unique_id` derived from it - stays stable across a rename.
+pub fn knob_state_topic(base_topic: &str, knob_id: &str) -> String {
+    format!("{base_topic}/knob/{}/state", zone_slug(knob_id))
+}
+
+/// Command topic for one config action (`zone`, `volume_step`) on one knob.
+pub fn knob_command_topic(base_topic: &str, knob_id: &str, action: &str) -> String {
+    format!("{base_topic}/knob/{}/{action}/set", zone_slug(knob_id))
 }
 
 #[cfg(test)]
@@ -81,6 +98,18 @@ mod tests {
         assert_eq!(
             discovery_topic("homeassistant", "sensor", "roon:abc", "state"),
             "homeassistant/sensor/unified_hifi_control/roon_abc_state/config"
+        );
+    }
+
+    #[test]
+    fn knob_topics_are_namespaced_under_base_topic() {
+        assert_eq!(
+            knob_state_topic("unified-hifi", "aabbccddeeff"),
+            "unified-hifi/knob/aabbccddeeff/state"
+        );
+        assert_eq!(
+            knob_command_topic("unified-hifi", "aabbccddeeff", "zone"),
+            "unified-hifi/knob/aabbccddeeff/zone/set"
         );
     }
 }

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -19,6 +19,7 @@ GET /api/bridges/applemusic/commands
 GET /api/bridges/applemusic/content
 GET /api/bridges/applemusic/status
 GET /api/controller/status
+GET /api/mqtt/status
 GET /api/providers/musicassistant/status
 GET /api/providers/spotify/account
 GET /api/providers/{provider}/oauth/callback
@@ -77,6 +78,7 @@ POST /api/bridges/applemusic/rename
 POST /api/bridges/applemusic/revoke
 POST /api/bridges/applemusic/state
 POST /api/controller/bootstrap
+POST /api/mqtt/configure
 POST /api/providers/{provider}/configure
 POST /api/providers/{provider}/oauth/revoke
 POST /api/settings

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -13,6 +13,7 @@
 # are served by Dioxus SPA router (fallback handler), not explicit Axum routes.
 # multi-line closures that the route extractor doesn't detect, and they may change
 # with build configuration.
+DELETE /knob/devices/{knob_id}
 DELETE /mcp
 GET /admin
 GET /api/bridges/applemusic/commands

--- a/tests/mqtt_integration.rs
+++ b/tests/mqtt_integration.rs
@@ -1,0 +1,498 @@
+//! End-to-end coverage for the MQTT/Home Assistant publisher (#508) against
+//! a real, in-process MQTT broker (`rumqttd`), the "mock/in-process broker"
+//! the issue's acceptance criteria calls for. Exercises the three
+//! acceptance criteria that need a live broker round trip:
+//! - HA discovery configs are published (retained) for a newly discovered
+//!   zone, grouped under one device, and retracted when the zone is removed.
+//! - The retained state topic reflects playback/volume/mute/now-playing
+//!   from bus events.
+//! - Inbound command topics route to the owning adapter through the
+//!   registry, and are gracefully ignored for a zone with no bridged
+//!   adapter.
+
+use std::collections::HashMap;
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
+use tokio::time::timeout;
+
+use unified_hifi_control::adapters::{AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic};
+use unified_hifi_control::aggregator::ZoneAggregator;
+use unified_hifi_control::api::credentials::MqttCredentialRecord;
+use unified_hifi_control::api::AdapterRegistry;
+use unified_hifi_control::bus::{
+    create_bus, BusEvent, NowPlaying, PlaybackState, PrefixedZoneId, VolumeControl, VolumeScale,
+    Zone,
+};
+use unified_hifi_control::mqtt::MqttPublisher;
+
+/// Bind an ephemeral port and hand its number back for `rumqttd`'s config,
+/// which does its own binding. The listener is dropped immediately before
+/// the broker binds - the same "ask the OS for a free port" pattern
+/// `tests/mock_servers` uses elsewhere in this suite, just synchronous
+/// since `rumqttd::Broker` cannot adopt a pre-bound listener.
+fn free_port() -> u16 {
+    #[allow(clippy::unwrap_used)] // binding to port 0 on loopback cannot fail in test envs
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Start an in-process MQTT broker on `port` and return once it has
+/// accepted the port (best-effort: rumqttd has no readiness hook, so
+/// callers retry their first connection instead of trusting a fixed delay
+/// alone).
+fn start_test_broker(port: u16) {
+    let mut connections = HashMap::new();
+    connections.insert(
+        "test".to_string(),
+        rumqttd::ServerSettings {
+            name: "test".to_string(),
+            listen: format!("127.0.0.1:{port}").parse().expect("valid loopback addr"),
+            tls: None,
+            next_connection_delay_ms: 0,
+            connections: rumqttd::ConnectionSettings {
+                connection_timeout_ms: 5000,
+                max_payload_size: 256 * 1024,
+                max_inflight_count: 100,
+                auth: None,
+                external_auth: None,
+                dynamic_filters: false,
+            },
+        },
+    );
+    let config = rumqttd::Config {
+        id: 0,
+        router: rumqttd::RouterConfig {
+            max_connections: 100,
+            max_outgoing_packet_count: 200,
+            max_segment_size: 1024 * 1024,
+            max_segment_count: 10,
+            custom_segment: None,
+            initialized_filters: None,
+            shared_subscriptions_strategy: Default::default(),
+        },
+        v4: Some(connections),
+        v5: None,
+        ws: None,
+        cluster: None,
+        console: None,
+        bridge: None,
+        prometheus: None,
+        metrics: None,
+    };
+
+    std::thread::spawn(move || {
+        let mut broker = rumqttd::Broker::new(config);
+        // rumqttd's `start()` blocks the calling thread for the broker's
+        // lifetime; a dedicated OS thread keeps it off the Tokio runtime
+        // the test itself uses. Readiness is confirmed by
+        // `wait_for_broker_ready` below rather than a fixed delay.
+        let _ = broker.start();
+    });
+}
+
+/// Poll the broker's TCP port until it accepts a connection, rather than
+/// trusting a fixed sleep after spawning it (rumqttd has no readiness hook).
+async fn wait_for_broker_ready(port: u16, deadline: Duration) {
+    let started = tokio::time::Instant::now();
+    loop {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        assert!(
+            started.elapsed() < deadline,
+            "test broker on port {port} never accepted a connection"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn connect_test_client(port: u16, client_id: &str) -> (AsyncClient, rumqttc::EventLoop) {
+    let mut options = MqttOptions::new(client_id, "127.0.0.1", port);
+    options.set_keep_alive(Duration::from_secs(5));
+    AsyncClient::new(options, 64)
+}
+
+/// Subscribe and drive the event loop until the broker acknowledges it, so
+/// the caller can rely on the subscription being live rather than merely
+/// queued in-process.
+async fn subscribe_and_wait(client: &AsyncClient, eventloop: &mut rumqttc::EventLoop, topic: &str) {
+    client
+        .subscribe(topic, QoS::AtLeastOnce)
+        .await
+        .expect("queue subscribe request");
+    timeout(Duration::from_secs(10), async {
+        loop {
+            match eventloop.poll().await {
+                Ok(Event::Incoming(Packet::SubAck(_))) => return,
+                Ok(_) => continue,
+                Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+    })
+    .await
+    .expect("broker acknowledged subscribe");
+}
+
+/// Poll an event loop until `predicate` matches an incoming publish, or the
+/// deadline elapses.
+async fn wait_for_publish<F>(
+    eventloop: &mut rumqttc::EventLoop,
+    deadline: Duration,
+    mut predicate: F,
+) -> Option<rumqttc::Publish>
+where
+    F: FnMut(&rumqttc::Publish) -> bool,
+{
+    timeout(deadline, async {
+        loop {
+            match eventloop.poll().await {
+                Ok(Event::Incoming(Packet::Publish(publish))) if predicate(&publish) => {
+                    return publish;
+                }
+                Ok(_) => continue,
+                Err(_) => {
+                    // Transient connection errors are expected while the
+                    // client is still establishing its session; keep polling.
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+            }
+        }
+    })
+    .await
+    .ok()
+}
+
+fn zone_fixture(zone_id: &str, source: &str) -> Zone {
+    Zone {
+        zone_id: zone_id.to_string(),
+        zone_name: "Test Zone".to_string(),
+        state: PlaybackState::Playing,
+        volume_control: Some(VolumeControl {
+            value: 30.0,
+            min: 0.0,
+            max: 100.0,
+            step: 1.0,
+            is_muted: false,
+            scale: VolumeScale::Percentage,
+            output_id: Some("out1".to_string()),
+        }),
+        now_playing: Some(NowPlaying {
+            title: "Integration Song".to_string(),
+            artist: "Integration Artist".to_string(),
+            album: "Integration Album".to_string(),
+            image_key: Some("art-key".to_string()),
+            seek_position: Some(1.0),
+            duration: Some(100.0),
+            metadata: None,
+            repeat_mode: None,
+            shuffle: None,
+        }),
+        source: source.to_string(),
+        is_controllable: true,
+        is_seekable: true,
+        last_updated: 0,
+        is_play_allowed: true,
+        is_pause_allowed: true,
+        is_next_allowed: true,
+        is_previous_allowed: true,
+    }
+}
+
+/// Records every command it receives so the test can assert on routing.
+struct RecordingAdapter {
+    prefix: &'static str,
+    received: Mutex<Vec<(String, AdapterCommand)>>,
+}
+
+#[async_trait]
+impl AdapterLogic for RecordingAdapter {
+    fn prefix(&self) -> &'static str {
+        self.prefix
+    }
+
+    async fn run(&self, _ctx: AdapterContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn handle_command(
+        &self,
+        zone_id: &str,
+        command: AdapterCommand,
+    ) -> anyhow::Result<AdapterCommandResponse> {
+        self.received
+            .lock()
+            .expect("recording adapter mutex")
+            .push((zone_id.to_string(), command));
+        Ok(AdapterCommandResponse {
+            success: true,
+            error: None,
+        })
+    }
+}
+
+async fn wait_until<F: Fn() -> bool>(predicate: F, deadline: Duration) -> bool {
+    let started = tokio::time::Instant::now();
+    while started.elapsed() < deadline {
+        if predicate() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    predicate()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn discovers_publishes_state_and_routes_commands_over_a_real_broker() {
+    let port = free_port();
+    start_test_broker(port);
+    wait_for_broker_ready(port, Duration::from_secs(5)).await;
+
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let aggregator_task = aggregator.clone();
+    tokio::spawn(async move {
+        aggregator_task.run_with_ready(ready_tx).await;
+    });
+    ready_rx.await.expect("aggregator ready");
+
+    let adapter_registry = Arc::new(AdapterRegistry::default());
+    let recorder = Arc::new(RecordingAdapter {
+        prefix: "musicassistant",
+        received: Mutex::new(Vec::new()),
+    });
+    adapter_registry.register(recorder.clone()).await;
+
+    let publisher = Arc::new(MqttPublisher::new(
+        bus.clone(),
+        aggregator.clone(),
+        adapter_registry.clone(),
+    ));
+    publisher.set_base_url("http://uhc.test:8088".to_string());
+    publisher
+        .configure(MqttCredentialRecord {
+            host: "127.0.0.1".to_string(),
+            port,
+            tls: false,
+            username: None,
+            password: None,
+            base_topic: "unified-hifi".to_string(),
+            discovery_prefix: "homeassistant".to_string(),
+        })
+        .await;
+    publisher.set_enabled(true).await;
+    assert!(publisher.is_running().await);
+
+    let (observer_client, mut observer_loop) = connect_test_client(port, "test-observer").await;
+    // `AsyncClient::subscribe().await` only queues the request; nothing is
+    // actually sent to the broker until the event loop is polled. Driving
+    // it to each SubAck here - rather than starting to poll only inside
+    // `wait_for_publish` after the bus event below - closes a real race
+    // where the publisher's message could reach the broker before this
+    // subscriber's SUBSCRIBE packet does.
+    subscribe_and_wait(&observer_client, &mut observer_loop, "homeassistant/#").await;
+    subscribe_and_wait(&observer_client, &mut observer_loop, "unified-hifi/#").await;
+
+    // --- Availability: bridge already announced online by the time this
+    //     subscriber's SubAck arrives (retained from `announce_all_zones`
+    //     on connect). Checked here, before any zone exists, because this
+    //     retained message is delivered as part of the subscribe reply -
+    //     a later `wait_for_publish` call would never see it again, since
+    //     an earlier predicate that does not match it still consumes it
+    //     from the stream. ---
+    let availability = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic == "unified-hifi/bridge/status"
+    })
+    .await
+    .expect("availability topic published");
+    assert_eq!(availability.payload.as_ref(), b"online");
+
+    let zone_id = "musicassistant:zone1";
+    bus.publish(BusEvent::ZoneDiscovered {
+        zone: zone_fixture(zone_id, "musicassistant"),
+    });
+
+    // --- Discovery: state sensor config is retained and device-grouped ---
+    let discovery = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic.contains("/sensor/") && publish.topic.ends_with("_state/config")
+    })
+    .await
+    .expect("state sensor discovery config published");
+    // Per MQTT 3.1.1 3.3.1.3, a broker clears RETAIN on a live forward and
+    // only sets it when replaying a retained message to a *new* subscriber -
+    // this client subscribed before the publish. Retained storage itself is
+    // asserted below via a late subscriber.
+    let payload: serde_json::Value =
+        serde_json::from_slice(&discovery.payload).expect("discovery payload is JSON");
+    assert_eq!(
+        payload["device"]["identifiers"][0],
+        serde_json::json!("uhc_musicassistant_zone1")
+    );
+    assert_eq!(
+        payload["availability_topic"],
+        serde_json::json!("unified-hifi/bridge/status")
+    );
+
+    // --- State: retained payload reflects now-playing/volume/mute ---
+    let state = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic == format!("unified-hifi/media_player/{}/state", "musicassistant_zone1")
+    })
+    .await
+    .expect("state topic published");
+    let state_payload: serde_json::Value =
+        serde_json::from_slice(&state.payload).expect("state payload is JSON");
+    assert_eq!(state_payload["state"], serde_json::json!("playing"));
+    assert_eq!(state_payload["title"], serde_json::json!("Integration Song"));
+    assert_eq!(state_payload["volume"], serde_json::json!(30.0));
+    assert_eq!(state_payload["muted"], serde_json::json!(false));
+    assert_eq!(
+        state_payload["picture"],
+        serde_json::json!(
+            "http://uhc.test:8088/now_playing/image?zone_id=musicassistant%3Azone1"
+        )
+    );
+
+    // --- Retention: a brand-new subscriber gets the state immediately,
+    //     with RETAIN set, proving the broker actually stored it retained
+    //     rather than this test only ever seeing live forwards. ---
+    let (late_client, mut late_loop) = connect_test_client(port, "test-late-subscriber").await;
+    late_client
+        .subscribe("unified-hifi/media_player/musicassistant_zone1/state", QoS::AtLeastOnce)
+        .await
+        .expect("late subscribe to state topic");
+    let replayed = wait_for_publish(&mut late_loop, Duration::from_secs(15), |publish| {
+        publish.topic == "unified-hifi/media_player/musicassistant_zone1/state"
+    })
+    .await
+    .expect("retained state replayed to a fresh subscriber");
+    assert!(replayed.retain, "retained replay to a new subscriber must set RETAIN");
+
+    // --- Commands: HA -> UHC volume_set routes to the owning adapter ---
+    let command_client_id = "test-commander";
+    let (command_client, mut command_loop) = connect_test_client(port, command_client_id).await;
+    tokio::spawn(async move {
+        loop {
+            if command_loop.poll().await.is_err() {
+                break;
+            }
+        }
+    });
+    // Give the client time to complete its CONNACK before publishing.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    command_client
+        .publish(
+            "unified-hifi/media_player/musicassistant_zone1/volume/set",
+            QoS::AtLeastOnce,
+            false,
+            "42",
+        )
+        .await
+        .expect("publish volume command");
+
+    let routed = wait_until(
+        || {
+            recorder
+                .received
+                .lock()
+                .expect("recording adapter mutex")
+                .iter()
+                .any(|(zone, command)| {
+                    zone == zone_id && matches!(command, AdapterCommand::VolumeAbsolute(42))
+                })
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+    assert!(routed, "volume command should route to the recording adapter");
+
+    // --- Commands: an unbridged legacy zone is ignored gracefully ---
+    let unbridged_calls_before = recorder.received.lock().expect("mutex").len();
+    bus.publish(BusEvent::ZoneDiscovered {
+        zone: zone_fixture("roon:legacy1", "roon"),
+    });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    command_client
+        .publish(
+            "unified-hifi/media_player/roon_legacy1/play/set",
+            QoS::AtLeastOnce,
+            false,
+            "PRESS",
+        )
+        .await
+        .expect("publish play command for legacy zone");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        recorder.received.lock().expect("mutex").len(),
+        unbridged_calls_before,
+        "a zone with no registry-backed adapter must not reach any adapter"
+    );
+
+    // --- Retraction: removing a zone clears its retained discovery config ---
+    bus.publish(BusEvent::ZoneRemoved {
+        zone_id: PrefixedZoneId::parse(zone_id).expect("valid zone id"),
+    });
+    // Match on an empty payload too, not just the topic: QoS 1 can
+    // redeliver an earlier non-empty discovery config for the same topic
+    // (e.g. on a PUBACK race), and that redelivery is not the retraction
+    // this assertion cares about.
+    let retraction = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic.contains("musicassistant_zone1")
+            && publish.topic.contains("/sensor/")
+            && publish.topic.ends_with("_state/config")
+            && publish.payload.is_empty()
+    })
+    .await
+    .expect("retraction publish observed");
+    assert!(
+        retraction.payload.is_empty(),
+        "retraction must publish an empty retained payload"
+    );
+
+    publisher.shutdown().await;
+    assert!(!publisher.is_running().await);
+}
+
+/// Confirms a publisher with a broker that refuses connections keeps
+/// retrying without panicking or blocking `set_enabled`/`shutdown` - the
+/// resilience half of "off by default", where "off" also covers "broker
+/// unreachable".
+#[tokio::test(flavor = "multi_thread")]
+async fn tolerates_an_unreachable_broker() {
+    let port = free_port(); // never started - nothing listens on it
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let aggregator_task = aggregator.clone();
+    tokio::spawn(async move {
+        aggregator_task.run_with_ready(ready_tx).await;
+    });
+    ready_rx.await.expect("aggregator ready");
+    let adapter_registry = Arc::new(AdapterRegistry::default());
+
+    let publisher = MqttPublisher::new(bus.clone(), aggregator.clone(), adapter_registry);
+    publisher
+        .configure(MqttCredentialRecord {
+            host: "127.0.0.1".to_string(),
+            port,
+            tls: false,
+            username: None,
+            password: None,
+            base_topic: "unified-hifi".to_string(),
+            discovery_prefix: "homeassistant".to_string(),
+        })
+        .await;
+    publisher.set_enabled(true).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(publisher.is_running().await, "task keeps retrying, not crashed");
+
+    // Must still stop promptly even mid-retry-loop.
+    let stopped = timeout(Duration::from_secs(6), publisher.shutdown()).await;
+    assert!(stopped.is_ok(), "shutdown must not hang on an unreachable broker");
+}

--- a/tests/mqtt_integration.rs
+++ b/tests/mqtt_integration.rs
@@ -27,7 +27,22 @@ use unified_hifi_control::bus::{
     create_bus, BusEvent, NowPlaying, PlaybackState, PrefixedZoneId, VolumeControl, VolumeScale,
     Zone,
 };
+use unified_hifi_control::knobs::store::KnobStatusUpdate;
+use unified_hifi_control::knobs::KnobStore;
 use unified_hifi_control::mqtt::MqttPublisher;
+
+/// Isolate `KnobStore`'s on-disk persistence to a scratch directory shared by
+/// every test in this process, so tests never touch a real user config dir.
+fn isolated_knob_store() -> KnobStore {
+    use std::sync::OnceLock;
+    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("UHC_CONFIG_DIR", dir.path());
+        dir
+    });
+    KnobStore::new()
+}
 
 /// Bind an ephemeral port and hand its number back for `rumqttd`'s config,
 /// which does its own binding. The listener is dropped immediately before
@@ -274,6 +289,7 @@ async fn discovers_publishes_state_and_routes_commands_over_a_real_broker() {
         bus.clone(),
         aggregator.clone(),
         adapter_registry.clone(),
+        isolated_knob_store(),
     ));
     publisher.set_base_url("http://uhc.test:8088".to_string());
     publisher
@@ -476,7 +492,12 @@ async fn tolerates_an_unreachable_broker() {
     ready_rx.await.expect("aggregator ready");
     let adapter_registry = Arc::new(AdapterRegistry::default());
 
-    let publisher = MqttPublisher::new(bus.clone(), aggregator.clone(), adapter_registry);
+    let publisher = MqttPublisher::new(
+        bus.clone(),
+        aggregator.clone(),
+        adapter_registry,
+        isolated_knob_store(),
+    );
     publisher
         .configure(MqttCredentialRecord {
             host: "127.0.0.1".to_string(),
@@ -495,4 +516,184 @@ async fn tolerates_an_unreachable_broker() {
     // Must still stop promptly even mid-retry-loop.
     let stopped = timeout(Duration::from_secs(6), publisher.shutdown()).await;
     assert!(stopped.is_ok(), "shutdown must not hang on an unreachable broker");
+}
+
+/// Covers the knob-specific acceptance criteria of #523 against the same
+/// in-process broker: discovery grouped under one device keyed by knob id
+/// (not display name), retained battery/zone state, a zone-select command
+/// round trip through `KnobStore::update_config`, and discovery retraction
+/// on knob removal.
+#[tokio::test(flavor = "multi_thread")]
+async fn knob_discovery_state_and_zone_select_round_trip_over_a_real_broker() {
+    let port = free_port();
+    start_test_broker(port);
+    wait_for_broker_ready(port, Duration::from_secs(5)).await;
+
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let aggregator_task = aggregator.clone();
+    tokio::spawn(async move {
+        aggregator_task.run_with_ready(ready_tx).await;
+    });
+    ready_rx.await.expect("aggregator ready");
+
+    let adapter_registry = Arc::new(AdapterRegistry::default());
+    let knobs = isolated_knob_store();
+
+    let knob_id = "knobtest1";
+    knobs.get_or_create(knob_id, Some("1.2.3")).await;
+    knobs
+        .update_status(
+            knob_id,
+            KnobStatusUpdate {
+                battery_level: Some(77),
+                battery_charging: Some(false),
+                zone_id: Some("roon:living".to_string()),
+                ip: Some("10.0.0.5".to_string()),
+            },
+        )
+        .await;
+
+    // A zone must exist for the zone-select's options to be non-empty.
+    bus.publish(BusEvent::ZoneDiscovered {
+        zone: zone_fixture("roon:living", "roon"),
+    });
+
+    let publisher = Arc::new(MqttPublisher::new(
+        bus.clone(),
+        aggregator.clone(),
+        adapter_registry,
+        knobs.clone(),
+    ));
+    publisher.set_base_url("http://uhc.test:8088".to_string());
+    publisher
+        .configure(MqttCredentialRecord {
+            host: "127.0.0.1".to_string(),
+            port,
+            tls: false,
+            username: None,
+            password: None,
+            base_topic: "unified-hifi".to_string(),
+            discovery_prefix: "homeassistant".to_string(),
+        })
+        .await;
+    publisher.set_enabled(true).await;
+    assert!(publisher.is_running().await);
+
+    let (observer_client, mut observer_loop) = connect_test_client(port, "knob-observer").await;
+    subscribe_and_wait(&observer_client, &mut observer_loop, "homeassistant/#").await;
+    subscribe_and_wait(&observer_client, &mut observer_loop, "unified-hifi/#").await;
+
+    // --- Discovery: battery sensor is grouped under a device keyed by
+    //     knob id, not the knob's display name (which is empty here). ---
+    let battery_discovery = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic.contains("/sensor/") && publish.topic.ends_with("_battery/config")
+    })
+    .await
+    .expect("battery sensor discovery config published");
+    let payload: serde_json::Value =
+        serde_json::from_slice(&battery_discovery.payload).expect("discovery payload is JSON");
+    assert_eq!(
+        payload["device"]["identifiers"][0],
+        serde_json::json!(format!("uhc_knob_{knob_id}"))
+    );
+    assert_eq!(payload["device_class"], serde_json::json!("battery"));
+
+    // --- Discovery: the zone-select's options track the live zone list. ---
+    let select_discovery = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic.contains("/select/") && publish.topic.ends_with("_zone_select/config")
+    })
+    .await
+    .expect("zone select discovery config published");
+    let select_payload: serde_json::Value =
+        serde_json::from_slice(&select_discovery.payload).expect("select payload is JSON");
+    assert_eq!(
+        select_payload["options"],
+        serde_json::json!(["roon:living"])
+    );
+
+    // --- State: retained payload reflects battery/charging/zone/firmware. ---
+    let state = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic == format!("unified-hifi/knob/{knob_id}/state")
+    })
+    .await
+    .expect("knob state topic published");
+    let state_payload: serde_json::Value =
+        serde_json::from_slice(&state.payload).expect("state payload is JSON");
+    assert_eq!(state_payload["battery_level"], serde_json::json!(77));
+    assert_eq!(state_payload["battery_charging"], serde_json::json!(false));
+    assert_eq!(state_payload["zone_id"], serde_json::json!("roon:living"));
+    assert_eq!(state_payload["online"], serde_json::json!(true));
+    assert_eq!(state_payload["firmware_version"], serde_json::json!("1.2.3"));
+
+    // --- Command: HA -> UHC zone-select command routes through the same
+    //     `KnobStore::update_config` path the web UI uses. ---
+    let command_client_id = "knob-commander";
+    let (command_client, mut command_loop) = connect_test_client(port, command_client_id).await;
+    tokio::spawn(async move {
+        loop {
+            if command_loop.poll().await.is_err() {
+                break;
+            }
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    command_client
+        .publish(
+            format!("unified-hifi/knob/{knob_id}/zone/set"),
+            QoS::AtLeastOnce,
+            false,
+            "roon:living",
+        )
+        .await
+        .expect("publish zone-select command");
+
+    let reassigned = timeout(Duration::from_secs(5), async {
+        loop {
+            let assigned = knobs
+                .get(knob_id)
+                .await
+                .and_then(|k| k.config.assigned_zone_id);
+            if assigned.as_deref() == Some("roon:living") {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(
+        reassigned.is_ok(),
+        "zone-select command should update the knob's assigned_zone_id via update_config"
+    );
+
+    // The next state publish should reflect the reassignment.
+    let reassigned_state = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic == format!("unified-hifi/knob/{knob_id}/state")
+            && serde_json::from_slice::<serde_json::Value>(&publish.payload)
+                .ok()
+                .and_then(|v| v.get("assigned_zone_id").cloned())
+                == Some(serde_json::json!("roon:living"))
+    })
+    .await
+    .expect("state republished with the new zone assignment");
+    let _ = reassigned_state;
+
+    // --- Retraction: removing the knob clears its retained discovery config. ---
+    assert!(knobs.remove(knob_id).await, "knob should have existed");
+    let retraction = wait_for_publish(&mut observer_loop, Duration::from_secs(15), |publish| {
+        publish.topic.contains(knob_id)
+            && publish.topic.contains("/sensor/")
+            && publish.topic.ends_with("_battery/config")
+            && publish.payload.is_empty()
+    })
+    .await
+    .expect("knob discovery retraction observed");
+    assert!(
+        retraction.payload.is_empty(),
+        "retraction must publish an empty retained payload"
+    );
+
+    publisher.shutdown().await;
+    assert!(!publisher.is_running().await);
 }


### PR DESCRIPTION
Closes #523

## Base branch note

This PR targets `feat/issue-462-streaming-adapters` (not `v3`), per repo convention for this line of work.

## Dependency

This branch **includes** PR #518 (`feat(mqtt): add optional Home Assistant MQTT publisher`, branch `issue/508`) via a fast-forward merge of `origin/issue/508`, since #518 was still open (not yet merged) when this work started. **This PR must merge after #518** — once #518 lands on `feat/issue-462-streaming-adapters`, this PR's diff will shrink to just the knob-specific commit.

## Summary

Publishes each registered "knob" (S3 Knob hardware controller) as its own Home Assistant MQTT-discovery device, reusing the device-composition pattern PR #518 established for zones. Every entity type needed here is natively supported by HA MQTT discovery (unlike `media_player`), so this needed no workaround composition:

- `sensor` — battery level (`device_class: battery`)
- `binary_sensor` — charging (`device_class: battery_charging`)
- `binary_sensor` — connectivity, derived from `last_seen` staleness (5 min threshold)
- `sensor` — firmware version (diagnostic)
- `sensor` — current zone (the zone the knob is actually controlling, per its own status report)
- `select` — zone reassignment, options tracking the live zone list, entity_category `config`
- `number` — volume-step override, entity_category `config`

Power-mode curves and display rotation stay UHC-only, out of scope per the issue.

### Naming / id-stability decision (critical, per issue)

Every HA `unique_id` and MQTT topic component derives from the **knob id** (stable forever), never the knob's display name. `device.name` comes from the knob's user-assigned name and is free to change — a rename republishes the same retained discovery configs with a new `device.name`, which Home Assistant applies in place rather than recreating entities. Verified in `src/mqtt/knob_discovery.rs`'s `unique_ids_and_topics_derive_from_knob_id_not_name` test.

### Zone reassignment — no new adapter surface

The zone-select's command handler (`src/mqtt/knob_command.rs`) routes through `KnobStore::update_config` (`src/knobs/store.rs`) — the exact same knob-config path `src/knobs/routes.rs` already uses for the web UI/device-sync flow. A new `KnobConfig::assigned_zone_id` field carries the override, distinct from `KnobStatus::zone_id` (the zone the device is *currently* controlling, as it reports back over HTTP).

### Knob store has no bus events

Unlike zones, knob battery/last-seen updates land via HTTP polls from the device, not the zone event bus. Knob discovery/state is therefore re-published on a fixed 2s timer (`src/mqtt/mod.rs`'s `knob_tick`) rather than driven by `BusEvent`s. Zone add/remove events still trigger an immediate re-announce so the zone-select's options stay current without waiting for the next tick. (The timer intentionally does *not* fire at t=0 — see the code comment on a race this caused during development, fixed by using `interval_at` instead of `interval`.)

### Knob removal / retraction

UHC previously had no way to remove a registered knob at all. Added `KnobStore::remove` and `DELETE /knob/devices/{knob_id}` (admin route) so there's something for the MQTT publisher to retract discovery configs against, matching the zone-retraction pattern from #518.

## Local verification

Toolchain: rustup's rustc 1.97.1 ahead of Homebrew's on `PATH`, `RUSTC_WRAPPER=""` (sccache off), `make css` run first.

- `cargo build --lib` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo clippy --test mqtt_integration -- -D warnings` — clean
- `cargo test --lib` — 455 passed
- `cargo test --workspace --no-fail-fast` — all green except the pre-existing, unrelated `web_fullstack_runner_contract::runner_builds_matching_assets_before_it_starts_the_server` failure (documented as pre-existing; not touched by this change). The other known-intermittent test (`roon_protocol::roon_core_completes_handshake`) passed cleanly in every run here.
- `cargo test --test mqtt_integration` — 3/3 passed, including the new `knob_discovery_state_and_zone_select_round_trip_over_a_real_broker` integration test against an in-process `rumqttd` broker (discovery grouped under one device keyed by knob id, retained battery/zone state, a zone-select command round trip through `KnobStore::update_config`, and discovery retraction on knob removal) — re-ran ~8 times across serial/parallel modes with zero flakes after the `interval_at` fix above
- `cargo check --no-default-features --target wasm32-unknown-unknown` — clean (knobs/mqtt are both `#[cfg(feature = "server")]`; no shared/WASM code was touched)

## Deviations from the issue's acceptance criteria

None known. All listed entities are implemented; discovery retraction, availability/LWT reuse, and the in-process-broker integration test coverage (discovery, battery/zone state, zone-select round trip) are all present.

CI does not run on feature-branch PRs for this base and CodeRabbit is disabled here, so the above local runs are the verification record.