### PR TITLE
feat(collections): implement hifi_collections for LMS and Roon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ Two things this table does **not** claim:
 | `search` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
 | `play_by_query` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
 | `play_by_ref` | 🚧 #396 | 🚧 #396 | 🚧 #396 | 🚧 #396 | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
-| `browse` | 🚧 #399 | 🚧 #402 | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
+| `browse` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
 | `queue_read` | 🚧 #400 | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | ✅ | ✅ |
 | `queue_jump` | 🚧 #400 | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_reorder` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
@@ -223,8 +223,8 @@ Two things this table does **not** claim:
 | `play_next` | 🚧 #399 | 🚧 #403 | 🚧 #392 | 🚧 #396 | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `repeat_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
-| `saved_playlists` | 🚧 #399 | 🚧 #403 | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
-| `favorites` | 🚧 #399 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
+| `saved_playlists` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
+| `favorites` | 🚧 #531 | ✅ | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
 | `multiroom_sync` | 🚧 #360 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
 
 ✅ supported · ⛔ the provider's protocol cannot do it · 🚧 the provider can, UHC has not wired it (issue that will)
@@ -249,8 +249,6 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - 🚧 **upnp / `play_by_ref`** (#396) — the protocol can play a specific item -- UPnP AVTransport:1 takes SetAVTransportURI and SetNextAVTransportURI, OpenHome Playlist:1 takes Insert(AfterId, Uri, Metadata) -- so what is missing is UHC's ability to name one, not the device's ability to play it. Reported as a UHC gap rather than a provider limit, because a reference minted against a media server would work. Verified from the UPnP AV and OpenHome service definitions, not from a device.
 - 🚧 **hqplayer / `play_by_ref`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `play_by_ref`** (#481) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `browse`** (#399) — RoonAdapter::browse() and load() exist and POST /roon/browse exposes them; only the MCP projection is missing.
-- 🚧 **lms / `browse`** (#402) — browselibrary items and the native albums/artists/genres/years/playlists/mediafolder queries walk the whole hierarchy with native <start> <n> paging -- all verified live on Lyrion 9.1.2. The adapter never calls any of them.
 - ⛔ **openhome / `browse`** — UHC discovers OpenHome zones by their av-openhome-org Product, Transport and Volume services (src/adapters/openhome.rs) and the OpenHome service set has no library: content is resolved by a control point against a separate media server. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `browse`** — UHC discovers UPnP zones as urn:schemas-upnp-org:device:MediaRenderer:1 and speaks only AVTransport:1 and RenderingControl:1. Searching or browsing content is a ContentDirectory:1 (MediaServer) capability, which a renderer does not have and UHC does not discover. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `browse`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
@@ -313,14 +311,11 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - 🚧 **openhome / `shuffle_mode`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.
 - 🚧 **upnp / `shuffle_mode`** (#392) — AVTransport:1's SetPlayMode takes SHUFFLE and RANDOM, so shuffle is a protocol feature UHC does not use. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **applemusic / `shuffle_mode`** (#462) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `saved_playlists`** (#399) — Roon exposes Playlists as a browse hierarchy, so this arrives with browse rather than as its own protocol feature.
-- 🚧 **lms / `saved_playlists`** (#403) — playlists / playlists tracks / playlistcontrol cmd:load playlist_id / playlists new / rename / delete all exist and were verified live. playlist save additionally needs a configured playlistdir, which is unset on a stock install -- so its own answer is three-state at the server level, which is why #403 probes pref playlistdir ?.
 - ⛔ **openhome / `saved_playlists`** — the av-openhome-org service set has no playlist storage: Playlist:1 is the live queue (Read/Insert/DeleteId/DeleteAll) with no save or recall action, and stored playlists live on whatever media server the control point uses. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `saved_playlists`** — AVTransport:1 and RenderingControl:1 store nothing; a MediaRenderer has no playlist storage. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `saved_playlists`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `saved_playlists`** (#482) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `favorites`** (#399) — Roon exposes My Favorites and tags as browse hierarchies, so this arrives with browse.
-- 🚧 **lms / `favorites`** (#403) — favorites items / favorites playlist play / add / delete / exists all work; verified live. Note LMS favorites have no durable id -- only a url -- so a ref must be minted over the url.
+- 🚧 **roon / `favorites`** (#531) — Roon exposes My Favorites and tags as browse hierarchies, so this arrives with browse.
 - 🚧 **openhome / `favorites`** (#392) — OpenHome devices carry stored presets (Radio:1 presets, and a Pins service on newer firmware). UHC discovers neither. Reported as a gap rather than a limit because the per-firmware reach is unverified here.
 - ⛔ **upnp / `favorites`** — AVTransport:1 and RenderingControl:1 store nothing; a MediaRenderer has no favourites. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `favorites`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ Two things this table does **not** claim:
 | `queue_reorder` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_remove` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_clear` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
+| `queue_transfer` | ⛔ | 🚧 #400 | ⛔ | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
 | `play_next` | 🚧 #399 | 🚧 #403 | 🚧 #392 | 🚧 #396 | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `repeat_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
@@ -288,6 +289,13 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - 🚧 **hqplayer / `queue_clear`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_clear`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
 - 🚧 **spotify / `queue_clear`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **roon / `queue_transfer`** — The Roon API's transport service exposes a queue subscription and play_from_here and no mutation at all -- no move, remove or clear. The pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing further.
+- 🚧 **lms / `queue_transfer`** (#400) — sync <playerid> was verified live (#403) to merge a player into another's sync group by adopting the leader's queue, which destroys the source's queue rather than transferring it; the CLI reference names no dedicated queue-to-queue transfer command. A composite emulation -- read the source's playlist, replay it against the target with playlistcontrol, then playlist clear the source -- is buildable from primitives #400 already verified live, but is not wired.
+- ⛔ **openhome / `queue_transfer`** — OpenHome's Playlist:1 (Read/Insert/DeleteId/DeleteAll) is scoped to one room's renderer; the service set defines no action that moves one room's playlist into another's. Songcast (Sender:1/Receiver:1) relays audio to a group, it does not merge queue state. Verified from the OpenHome service definitions, not from a device.
+- ⛔ **upnp / `queue_transfer`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
+- 🚧 **hqplayer / `queue_transfer`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
+- 🚧 **applemusic / `queue_transfer`** (#462) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
+- 🚧 **spotify / `queue_transfer`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
 - 🚧 **roon / `play_next`** (#399) — Roon's browse item actions include Play Next alongside Play Now and Queue; UHC's PlayAction models only Play, Queue and Radio, so this arrives with browse rather than with the queue.
 - 🚧 **lms / `play_next`** (#403) — playlistcontrol cmd:insert places an item immediately after the current one, verified live -- and LmsPlayAction::Insert is already modelled in the adapter and simply unreachable from MCP.
 - 🚧 **openhome / `play_next`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -58,7 +58,8 @@ use tracing::{debug, info, warn};
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::lms_discovery::discover_lms_servers;
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::adapters::Startable;
 use crate::bus::runtime::{
@@ -130,6 +131,22 @@ fn lms_flag(value: Option<&Value>) -> bool {
 /// `search_library()` return an empty vec against every real server.
 fn loop_entity_id(row: &Value, entity: &str) -> Option<i64> {
     lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id"))).filter(|id| *id > 0)
+}
+
+/// The next page's offset for a `hifi_collections` page, or `None` at the
+/// end.
+///
+/// LMS's own `count` field is the total across the whole query (not just
+/// this page), so it is the source of truth when present. A response
+/// missing it (the mock's catch-all shape, or an unmodeled LMS reply) falls
+/// back to "this page was full" as the continue signal -- the same
+/// length-based heuristic Music Assistant's `collections_content` uses for
+/// its `library_items` paging.
+fn next_offset(raw: &Value, offset: usize, limit: usize, page_len: usize) -> Option<u64> {
+    match raw.get("count").and_then(Value::as_u64) {
+        Some(total) => (total > (offset + limit) as u64).then_some((offset + limit) as u64),
+        None => (page_len == limit).then_some((offset + limit) as u64),
+    }
 }
 
 /// What LMS actually does when a request fails, spelled out once.
@@ -1850,6 +1867,287 @@ impl LmsAdapter {
         Ok(results)
     }
 
+    // =========================================================================
+    // hifi_collections (#531): provider-neutral browse/playlists/favorites
+    // =========================================================================
+
+    /// Dispatch one `hifi_collections` operation to the matching taggedlist
+    /// query. `params.path` is a plain server-side collection path (never a
+    /// client-visible token -- `hifi_collections` mints/resolves the opaque
+    /// ref around it); `None`/`"root"` means the collection root.
+    ///
+    /// The wire shape returned here is LMS-specific, not the provider-neutral
+    /// `{title, subtitle, path}` shape `hifi_collections` sends to the client:
+    /// a navigable row carries `path` (a collection path for another
+    /// `collections_browse` call); a playable leaf carries `kind`+`id` (an
+    /// [`LmsPlayTarget::Library`]) or `url` (an [`LmsPlayTarget::Url`]) for
+    /// `crate::mcp::tools::collections` to mint a ref over -- mirroring the
+    /// split `LmsPlayTarget` already makes for `hifi_search`.
+    pub async fn collections_content(&self, operation: &str, params: &Value) -> Result<Value> {
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or(20)
+            .clamp(1, 50) as usize;
+        let offset = params.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize;
+        match operation {
+            "collections_browse" => {
+                let path = params
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("root");
+                self.browse_collections(path, offset, limit).await
+            }
+            "collections_playlists" => self.list_playlists(offset, limit).await,
+            "collections_favorites" => self.list_favorites(offset, limit).await,
+            _ => Err(anyhow!("unsupported LMS collection operation {operation}")),
+        }
+    }
+
+    /// Walk one level of the LMS collection hierarchy: the synthetic root
+    /// (Albums/Artists/Playlists), an album's or artist's contents, or a
+    /// playlist's tracks. Every navigable path is a plain string this adapter
+    /// invented (`"albums"`, `"album:<id>"`, ...) -- never a raw LMS id handed
+    /// back to a client uninterpreted.
+    async fn browse_collections(&self, path: &str, offset: usize, limit: usize) -> Result<Value> {
+        if path == "root" {
+            // The root menu is invented by this adapter, not read from LMS --
+            // but a caller with no LMS host configured (or one that is
+            // unreachable) must still get that failure here rather than a
+            // synthetic success that never touched the server. `serverstatus`
+            // with a zero-item request is the cheapest real round trip.
+            self.rpc
+                .execute(None, vec![json!("serverstatus"), json!(0), json!(0)])
+                .await?;
+            let categories = [("Albums", "albums"), ("Artists", "artists"), ("Playlists", "playlists")];
+            let items: Vec<Value> = categories
+                .iter()
+                .skip(offset)
+                .take(limit)
+                .map(|(title, path)| json!({"title": title, "path": path}))
+                .collect();
+            let next_offset =
+                (categories.len() > offset + limit).then_some((offset + limit) as u64);
+            return Ok(json!({"items": items, "next_offset": next_offset}));
+        }
+        if path == "albums" {
+            return self.query_albums(offset, limit, None).await;
+        }
+        if path == "artists" {
+            return self.query_artists(offset, limit).await;
+        }
+        if path == "playlists" {
+            return self.list_playlists(offset, limit).await;
+        }
+        if let Some(id) = path.strip_prefix("album:").and_then(|s| s.parse::<i64>().ok()) {
+            return self.query_tracks(offset, limit, "album_id", id).await;
+        }
+        if let Some(id) = path.strip_prefix("artist:").and_then(|s| s.parse::<i64>().ok()) {
+            return self.query_albums(offset, limit, Some(id)).await;
+        }
+        if let Some(id) = path.strip_prefix("playlist:").and_then(|s| s.parse::<i64>().ok()) {
+            return self.query_playlist_tracks(offset, limit, id).await;
+        }
+        Err(anyhow!("unknown LMS collection path {path:?}"))
+    }
+
+    /// `albums <start> <count> [artist_id:<id>]` -- the whole album library,
+    /// or one artist's albums when `artist_id` is given.
+    async fn query_albums(
+        &self,
+        offset: usize,
+        limit: usize,
+        artist_id: Option<i64>,
+    ) -> Result<Value> {
+        let mut params = vec![json!("albums"), json!(offset), json!(limit)];
+        if let Some(id) = artist_id {
+            params.push(json!(format!("artist_id:{id}")));
+        }
+        let raw = self.rpc.execute(None, params).await?;
+        let items: Vec<Value> = raw
+            .get("albums_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "album")?;
+                let title = row.get("album").and_then(Value::as_str)?.to_string();
+                let artist = row.get("artist").and_then(Value::as_str).map(String::from);
+                Some(json!({
+                    "title": title,
+                    "subtitle": artist.map(|a| format!("Album by {a}")),
+                    "path": format!("album:{id}"),
+                }))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `artists <start> <count>` -- the whole artist library.
+    async fn query_artists(&self, offset: usize, limit: usize) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(None, vec![json!("artists"), json!(offset), json!(limit)])
+            .await?;
+        let items: Vec<Value> = raw
+            .get("artists_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "artist")?;
+                let title = row.get("artist").and_then(Value::as_str)?.to_string();
+                Some(json!({"title": title, "path": format!("artist:{id}")}))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `titles <start> <count> <filter_key>:<id>` -- tracks under one album
+    /// (or, in principle, another filterable field; only album is used today).
+    async fn query_tracks(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter_key: &str,
+        filter_id: i64,
+    ) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(
+                None,
+                vec![
+                    json!("titles"),
+                    json!(offset),
+                    json!(limit),
+                    json!(format!("{filter_key}:{filter_id}")),
+                ],
+            )
+            .await?;
+        let items: Vec<Value> = raw
+            .get("titles_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "track")?;
+                let title = row.get("title").and_then(Value::as_str)?.to_string();
+                let artist = row.get("artist").and_then(Value::as_str).map(String::from);
+                Some(json!({
+                    "title": title,
+                    "subtitle": artist,
+                    "kind": "track",
+                    "id": id,
+                }))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `playlists <start> <count>` -- every saved playlist. Both
+    /// `collections_playlists` and browsing into the synthetic `"playlists"`
+    /// node use this, since LMS has exactly one playlist listing.
+    async fn list_playlists(&self, offset: usize, limit: usize) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(None, vec![json!("playlists"), json!(offset), json!(limit)])
+            .await?;
+        let items: Vec<Value> = raw
+            .get("playlists_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "playlist")?;
+                let title = row.get("playlist").and_then(Value::as_str)?.to_string();
+                Some(json!({"title": title, "path": format!("playlist:{id}")}))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `playlists tracks <start> <count> playlist_id:<id>` -- one playlist's
+    /// contents.
+    async fn query_playlist_tracks(
+        &self,
+        offset: usize,
+        limit: usize,
+        playlist_id: i64,
+    ) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(
+                None,
+                vec![
+                    json!("playlists"),
+                    json!("tracks"),
+                    json!(offset),
+                    json!(limit),
+                    json!(format!("playlist_id:{playlist_id}")),
+                ],
+            )
+            .await?;
+        let items: Vec<Value> = raw
+            .get("playlisttracks_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "track")?;
+                let title = row
+                    .get("title")
+                    .or_else(|| row.get("track"))
+                    .and_then(Value::as_str)?
+                    .to_string();
+                let artist = row.get("artist").and_then(Value::as_str).map(String::from);
+                Some(json!({
+                    "title": title,
+                    "subtitle": artist,
+                    "kind": "track",
+                    "id": id,
+                }))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `favorites items <start> <count>` -- the flat favourites list. LMS
+    /// favorites carry no durable entity id, only a `url` (verified live,
+    /// #403's gap-table note); a folder-shaped favorite (`hasitems`) is
+    /// listed but not itself browsable in this slice -- narrower than a full
+    /// walk, called out in #531's PR body rather than silently dropped.
+    async fn list_favorites(&self, offset: usize, limit: usize) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(
+                None,
+                vec![json!("favorites"), json!("items"), json!(offset), json!(limit)],
+            )
+            .await?;
+        let items: Vec<Value> = raw
+            .get("loop_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let title = row
+                    .get("name")
+                    .or_else(|| row.get("title"))
+                    .and_then(Value::as_str)?
+                    .to_string();
+                let url = row.get("url").and_then(Value::as_str)?.to_string();
+                Some(json!({"title": title, "url": url}))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
     /// Search and play the first matching result
     ///
     /// Searches using globalsearch (includes streaming services), finds the first
@@ -2108,6 +2406,37 @@ impl LmsAdapter {
             );
         }
         Ok(())
+    }
+}
+
+/// #531: routes `hifi_collections` through `AdapterRegistry::library_content`
+/// rather than a new direct `state.lms` field access from `src/mcp/tools/`
+/// (the architecture boundary #436 is closing -- see
+/// `tests/adapter_boundary_lint.rs`). `search`/`play_uri` are not
+/// meaningfully implementable through this trait's flat-URI contract --
+/// LMS's playable targets are typed (`LmsPlayTarget::{Library,Url,
+/// GlobalSearchItem}`), which is exactly why `hifi_search`/`hifi_play`
+/// already call `LmsAdapter` directly (pre-existing debt, unaffected by this
+/// registration) rather than through this trait. Only `content` is real.
+#[async_trait]
+impl LibraryAdapter for LmsAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow!(
+            "LMS search is not reachable through the generic library registry; \
+             hifi_search calls LmsAdapter directly because LMS's playable targets are typed, \
+             not a flat URI"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow!(
+            "LMS playback is not reachable through the generic library registry; \
+             hifi_play/hifi_play_ref call LmsAdapter directly for the same reason as search"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        self.collections_content(operation, params).await
     }
 }
 

--- a/src/adapters/musicassistant.rs
+++ b/src/adapters/musicassistant.rs
@@ -553,6 +553,26 @@ impl MusicAssistantAdapter {
             .ok_or_else(|| anyhow!("Music Assistant active queue had no queue_id"))
     }
 
+    /// Move `zone_id`'s active queue onto `target_zone_id`'s queue, via MA's
+    /// `player_queues/transfer` (#507). Both queue ids are read fresh
+    /// immediately before the call, matching the stale-item guard the other
+    /// queue mutations use, and the readback afterward is the target's --
+    /// that is where the transferred queue now lives.
+    async fn queue_transfer(&self, zone_id: &str, target_zone_id: &str) -> Result<Value> {
+        let source_queue_id = self.queue_id_for_zone(zone_id).await?;
+        let target_queue_id = self.queue_id_for_zone(target_zone_id).await?;
+        let _: Value = self
+            .command(
+                "player_queues/transfer",
+                Some(json!({
+                    "source_queue_id": source_queue_id,
+                    "target_queue_id": target_queue_id,
+                })),
+            )
+            .await?;
+        self.read_active_queue(target_zone_id).await
+    }
+
     async fn search_catalog(&self, query: &str, limit: usize) -> Result<Vec<LibrarySearchResult>> {
         let response: Value = self
             .command(
@@ -1131,6 +1151,21 @@ impl LibraryAdapter for MusicAssistantAdapter {
     async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
         if operation.starts_with("collections_") {
             return self.collections_content(operation, params).await;
+        }
+        if operation == "queue_transfer" {
+            let zone_id = params
+                .get("zone_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| anyhow!("Music Assistant queue transfer requires zone_id"))?;
+            let target_zone_id = params
+                .get("target_zone_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow!("Music Assistant queue transfer requires target_zone_id")
+                })?;
+            return self.queue_transfer(zone_id, target_zone_id).await;
         }
         match operation {
             "multiroom_status" => return self.multiroom_status().await,
@@ -2084,6 +2119,52 @@ mod tests {
             expected["queue_id"] = json!("group-living-room");
             assert_eq!(mutation.body["args"], expected);
         }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn queue_transfer_moves_the_active_queue_and_returns_the_targets_readback() {
+        let (config, state, server) = mock_musicassistant_server().await;
+        let adapter =
+            MusicAssistantAdapter::new(crate::bus::create_bus(), config).expect("adapter");
+        let result = adapter
+            .content(
+                "queue_transfer",
+                &json!({
+                    "zone_id": "musicassistant:sonos-kitchen",
+                    "target_zone_id": "musicassistant:sonos-office",
+                }),
+            )
+            .await
+            .expect("transfer");
+        // The readback is the target's fresh active queue.
+        assert_eq!(result["queue"]["queue_id"], "group-living-room");
+
+        let requests = state.requests.lock().expect("requests").clone();
+        let transfer = requests
+            .iter()
+            .find(|request| request.body["command"] == "player_queues/transfer")
+            .expect("transfer command sent");
+        assert_eq!(
+            transfer.body["args"],
+            json!({"source_queue_id": "group-living-room", "target_queue_id": "group-living-room"})
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn queue_transfer_requires_both_zone_ids() {
+        let (config, _state, server) = mock_musicassistant_server().await;
+        let adapter =
+            MusicAssistantAdapter::new(crate::bus::create_bus(), config).expect("adapter");
+        let error = adapter
+            .content(
+                "queue_transfer",
+                &json!({"zone_id": "musicassistant:sonos-kitchen"}),
+            )
+            .await
+            .expect_err("missing target_zone_id");
+        assert!(error.to_string().contains("target_zone_id"));
         server.abort();
     }
 

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -25,7 +25,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::bus::{
     runtime::{
@@ -1674,6 +1675,132 @@ impl RoonAdapter {
         Ok((session_key, vec![]))
     }
 
+    // =========================================================================
+    // hifi_collections (#531): the same browse/load machinery `hifi_search`
+    // already drives, exposed as hierarchy walking rather than a query.
+    // =========================================================================
+
+    /// One `hifi_collections browse` step: enter `item_key` within
+    /// `session_key` (a fresh session and the collection root when both are
+    /// `None`), then load one page. Returns the (possibly newly minted)
+    /// session key, the page's items, and the level's total count for
+    /// `next_offset`.
+    ///
+    /// Deliberately never combines `pop_all` with `item_key` in the same
+    /// request, and never sends `pop_all` when resuming an existing
+    /// session -- see [`Self::play_ref`]'s doc comment for the live evidence
+    /// that combination hangs a real Core.
+    pub async fn browse_collection(
+        &self,
+        zone_id: &str,
+        item_key: Option<&str>,
+        session_key: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(String, Vec<BrowseItem>, usize)> {
+        let bare_zone_id = strip_roon_prefix(zone_id);
+        let session_key = session_key.map(ToOwned::to_owned).unwrap_or_else(|| {
+            format!(
+                "collections_{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            )
+        });
+
+        let mut opts = BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            ..Default::default()
+        };
+        match item_key {
+            Some(key) => opts.item_key = Some(key.to_string()),
+            // Only reset the browse stack when there is nowhere to navigate
+            // from -- i.e. a brand new session at the collection root.
+            None => opts.pop_all = true,
+        }
+        self.browse(opts).await?;
+
+        let load = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                offset,
+                count: Some(limit),
+                ..Default::default()
+            })
+            .await?;
+
+        Ok((session_key, load.items, load.list.count))
+    }
+
+    /// Enter a named top-level browse node (`"Playlists"`, ...) in a fresh
+    /// session and load one page of its contents in a single call --
+    /// `hifi_collections playlists`'s whole job, since Roon exposes playlists
+    /// as a browse hierarchy rather than its own protocol feature (see the
+    /// capability table's note on this).
+    pub async fn browse_named_root_node(
+        &self,
+        zone_id: &str,
+        node_title: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(String, Vec<BrowseItem>, usize)> {
+        let bare_zone_id = strip_roon_prefix(zone_id);
+        let session_key = format!(
+            "collections_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            pop_all: true,
+            ..Default::default()
+        })
+        .await?;
+
+        let root_items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                count: Some(50),
+                ..Default::default()
+            })
+            .await?;
+
+        let node = root_items
+            .items
+            .iter()
+            .find(|item| item.title.eq_ignore_ascii_case(node_title))
+            .ok_or_else(|| anyhow::anyhow!("{node_title} not found in Roon browse root"))?;
+        let node_key = node
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("{node_title} has no item_key"))?;
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            item_key: Some(node_key),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                offset,
+                count: Some(limit),
+                ..Default::default()
+            })
+            .await?;
+
+        Ok((session_key, items.items, items.list.count))
+    }
+
     /// Search and play the first matching result
     pub async fn search_and_play(
         &self,
@@ -2265,6 +2392,100 @@ impl RoonAdapter {
         .await?;
 
         Ok(format!("{}: {}", action_title, item_title))
+    }
+}
+
+/// #531: routes `hifi_collections` through `AdapterRegistry::library_content`
+/// rather than a new direct `state.roon` field access from `src/mcp/tools/`
+/// (the architecture boundary #436 is closing -- see
+/// `tests/adapter_boundary_lint.rs`). `search`/`play_uri` are not
+/// meaningfully implementable through this trait's flat-URI contract -- a
+/// Roon playable target is an `(item_key, multi_session_key)` pair, not a
+/// portable URI (see `RoonRefTarget`'s docs) -- which is exactly why
+/// `hifi_search`/`hifi_play` already call `RoonAdapter` directly
+/// (pre-existing debt, unaffected by this registration) rather than through
+/// this trait. Only `content` is real.
+#[async_trait]
+impl LibraryAdapter for RoonAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow::anyhow!(
+            "Roon search is not reachable through the generic library registry; hifi_search \
+             calls RoonAdapter directly because a Roon item_key is scoped to the \
+             multi_session_key that minted it, not a flat URI"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow::anyhow!(
+            "Roon playback is not reachable through the generic library registry; \
+             hifi_play/hifi_play_ref call RoonAdapter directly for the same reason as search"
+        ))
+    }
+
+    /// `operation` is one of `collections_browse`/`collections_playlists`
+    /// (never `collections_favorites` -- Roon's favorites capability is not
+    /// wired, see `crate::mcp::capabilities`). The response is this
+    /// adapter's own shape, not `hifi_collections`' wire shape:
+    /// `{session_key, items: [{title, subtitle, item_key, navigable}],
+    /// next_offset}`. `crate::mcp::tools::collections::handle_roon` mints
+    /// the opaque ref (a path for `navigable`, a playable ref otherwise)
+    /// pairing `item_key` with `session_key` -- this method's job ends at
+    /// handing back an already session-scoped, already grouping-filtered
+    /// page, not at deciding what a client may address.
+    async fn content(
+        &self,
+        operation: &str,
+        params: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let zone_id = params
+            .get("zone_id")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("zone_id is required"))?;
+        let limit = params
+            .get("limit")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(20)
+            .clamp(1, 50) as usize;
+        let offset = params
+            .get("offset")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as usize;
+        let (session_key, items, total) = match operation {
+            "collections_browse" => {
+                let item_key = params.get("item_key").and_then(serde_json::Value::as_str);
+                let session_key = params.get("session_key").and_then(serde_json::Value::as_str);
+                self.browse_collection(zone_id, item_key, session_key, offset, limit)
+                    .await?
+            }
+            "collections_playlists" => {
+                self.browse_named_root_node(zone_id, "Playlists", offset, limit)
+                    .await?
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "unsupported Roon collection operation {operation}"
+                ))
+            }
+        };
+        let mapped: Vec<serde_json::Value> = items
+            .into_iter()
+            .filter(|item| !is_ungrounded_grouping(item))
+            .map(|item| {
+                let navigable = matches!(item.hint, Some(ItemHint::List));
+                serde_json::json!({
+                    "title": item.title,
+                    "subtitle": item.subtitle,
+                    "item_key": item.item_key,
+                    "navigable": navigable,
+                })
+            })
+            .collect();
+        let next_offset = (total > offset + limit).then_some((offset + limit) as u64);
+        Ok(serde_json::json!({
+            "session_key": session_key,
+            "items": mapped,
+            "next_offset": next_offset,
+        }))
     }
 }
 

--- a/src/api/browse.rs
+++ b/src/api/browse.rs
@@ -1,0 +1,86 @@
+//! HTTP surface for library browse, queue and play-ref, for the web UI (#507).
+//!
+//! # One contract, two consumers
+//!
+//! `hifi_collections`, `hifi_queue` and `hifi_play_ref` are MCP tools with a
+//! fully worked-out verb vocabulary: capability checks, opaque browse paths
+//! and playable refs (so no provider URI reaches a client), and a structured
+//! envelope describing what happened. The web UI needs exactly the same
+//! verbs -- browse a collection, transfer a queue, play or queue a browsed
+//! item -- so these handlers call the MCP tool handlers directly rather than
+//! re-implementing any of that against `AdapterRegistry` a second time.
+//!
+//! `crate::mcp::refs::RefTable` (`AppState::mcp_refs`) is a plain server-side
+//! table keyed by opaque token, not an MCP-transport concept, so a ref minted
+//! for a browse result served over this HTTP surface resolves the same way a
+//! ref minted for an MCP client would. The two consumers share one path
+//! server-side; only the transport (HTTP JSON here, JSON-RPC there) differs.
+//!
+//! Every response body is the tool's own envelope
+//! (`structuredContent`/`outcome`/`data`/`refusal`, see
+//! [`crate::mcp::envelope`]), verbatim. The HTTP status is derived from
+//! `outcome` so a browser client can branch on the status without parsing the
+//! body, while the body still carries the same detail an MCP client sees.
+
+use crate::api::AppState;
+use crate::mcp::tools::collections::{handle_collections, HifiCollectionsTool};
+use crate::mcp::tools::library::{handle_play_ref, HifiPlayRefTool};
+use crate::mcp::tools::queue::{handle_queue, HifiQueueTool};
+use axum::{extract::State, http::StatusCode, Json};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
+use serde_json::Value;
+
+/// Project a tool handler's result onto an HTTP response.
+///
+/// The body is the envelope `structuredContent` carries (or `null` if a tool
+/// somehow attached none -- unreachable today, see
+/// [`crate::mcp::envelope::Envelope::structured`]), verbatim. The HTTP status
+/// stays `200` for every envelope outcome, refusals included: `outcome` is
+/// already the machine-readable signal (`ok`/`accepted`/`unsupported`/
+/// `invalid`/`error`, see [`crate::mcp::envelope::Outcome`]) and `refusal`
+/// carries the detail, so folding that into HTTP status codes as well would
+/// just be two places for a client to check the same fact. `500` is reserved
+/// for the one case the envelope cannot describe: the MCP transport layer
+/// itself erroring before a tool ran.
+fn envelope_response(result: Result<CallToolResult, CallToolError>) -> (StatusCode, Json<Value>) {
+    match result {
+        Ok(call_result) => {
+            let body = call_result
+                .structured_content
+                .map(Value::Object)
+                .unwrap_or(Value::Null);
+            (StatusCode::OK, Json(body))
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": error.to_string()})),
+        ),
+    }
+}
+
+/// `POST /api/collections` -- browse, playlists or favorites for one zone.
+/// Same verb and paging semantics as the `hifi_collections` MCP tool.
+pub async fn collections_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiCollectionsTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_collections(&state, args).await)
+}
+
+/// `POST /api/queue` -- read, jump, reorder, remove, clear, or transfer a
+/// zone's queue. Same verb vocabulary as the `hifi_queue` MCP tool.
+pub async fn queue_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiQueueTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_queue(&state, args).await)
+}
+
+/// `POST /api/play_ref` -- play or queue a ref minted by `/api/collections`.
+/// Same verb vocabulary as the `hifi_play_ref` MCP tool.
+pub async fn play_ref_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiPlayRefTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_play_ref(&state, args).await)
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,6 +37,7 @@ use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 pub mod apple_bridge;
+pub mod browse;
 pub mod controller_auth;
 pub mod credentials;
 pub mod provider_auth;

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -208,6 +208,12 @@ pub struct Zone {
     #[serde(default)]
     pub state: Option<String>,
     pub dsp: Option<ZoneDsp>,
+    /// Whether `/api/collections` implements this zone's provider (#531).
+    /// `default`s to `false` so an older cached response (or a field this
+    /// build predates) hides the browse panel rather than showing one that
+    /// will refuse every call.
+    #[serde(default)]
+    pub browse_supported: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -250,6 +250,129 @@ pub struct NowPlaying {
 }
 
 // =============================================================================
+// Collections / queue types (#507)
+//
+// These mirror the `hifi_collections`/`hifi_queue`/`hifi_play_ref` MCP tool
+// wire shapes exactly, because `/api/collections`, `/api/queue` and
+// `/api/play_ref` (src/api/browse.rs) forward those tools' own envelope
+// verbatim -- see that module's doc comment for why. Only the fields this UI
+// renders are modelled; unknown fields are ignored by serde's default
+// behavior, so extra envelope fields (`scope`, `observed`, `params`, ...)
+// deserialize away harmlessly.
+// =============================================================================
+
+/// One item from a `hifi_collections` page: either a folder (`path` set,
+/// browse only) or a playable entry (`r#ref` set, usable with `/api/play_ref`).
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CollectionItem {
+    pub title: String,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(rename = "ref", default)]
+    pub item_ref: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CollectionPage {
+    #[serde(default)]
+    pub items: Vec<CollectionItem>,
+    #[serde(default)]
+    pub next_offset: Option<u32>,
+}
+
+/// The `reason`-tagged refusal shape from `crate::mcp::envelope::Refusal`.
+/// Every variant carries `detail`, which is all this UI shows.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct EnvelopeRefusal {
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub detail: String,
+}
+
+/// The envelope every `hifi_*` tool result carries
+/// (`crate::mcp::envelope::Envelope`), as forwarded verbatim by
+/// `src/api/browse.rs`. Generic over `data`'s shape.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Envelope<T> {
+    #[serde(default)]
+    pub outcome: String,
+    #[serde(default)]
+    pub data: Option<T>,
+    #[serde(default)]
+    pub refusal: Option<EnvelopeRefusal>,
+}
+
+impl<T> Envelope<T> {
+    pub fn is_ok(&self) -> bool {
+        matches!(self.outcome.as_str(), "ok" | "accepted")
+    }
+
+    /// A human-readable reason for a non-ok outcome, for display.
+    pub fn error_detail(&self) -> String {
+        self.refusal
+            .as_ref()
+            .map(|r| r.detail.clone())
+            .filter(|detail| !detail.is_empty())
+            .unwrap_or_else(|| format!("request did not succeed ({})", self.outcome))
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CollectionsRequest {
+    pub zone_id: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct QueueRequest {
+    pub zone_id: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_zone_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PlayRefRequest {
+    #[serde(rename = "ref")]
+    pub item_ref: String,
+    pub zone_id: String,
+    pub action: String,
+}
+
+/// `POST /api/collections`.
+pub async fn fetch_collections(
+    req: &CollectionsRequest,
+) -> Result<Envelope<CollectionPage>, String> {
+    post_json("/api/collections", req).await
+}
+
+/// `POST /api/queue`, for actions this UI drives without reading the queue
+/// contents back (transfer). The response body is ignored beyond outcome.
+pub async fn post_queue_action(req: &QueueRequest) -> Result<Envelope<serde_json::Value>, String> {
+    post_json("/api/queue", req).await
+}
+
+/// `POST /api/play_ref`.
+pub async fn post_play_ref(req: &PlayRefRequest) -> Result<Envelope<serde_json::Value>, String> {
+    post_json("/api/play_ref", req).await
+}
+
+// =============================================================================
 // LMS Types
 // =============================================================================
 

--- a/src/app/components/collections.rs
+++ b/src/app/components/collections.rs
@@ -1,0 +1,380 @@
+//! Library browse + queue transfer panel for a zone card (#507).
+//!
+//! Calls the same `/api/collections`, `/api/queue` and `/api/play_ref`
+//! endpoints the MCP tools back (see `src/api/browse.rs`), so this panel and
+//! an MCP agent see the same capability surface: browse/playlists/favorites,
+//! opaque playable refs, and queue transfer between Music Assistant zones.
+//! Only rendered for zones whose adapter advertises collections support
+//! (Music Assistant today) -- callers gate that, this component assumes it.
+
+use crate::app::api::{
+    self, CollectionItem, CollectionsRequest, PlayRefRequest, QueueRequest,
+};
+use dioxus::prelude::*;
+
+const PAGE_LIMIT: u32 = 20;
+
+#[derive(Clone, PartialEq, Props)]
+pub struct CollectionsBrowserProps {
+    /// The zone this panel browses and plays into.
+    pub zone_id: String,
+    /// Other zones a queue can be transferred to: `(zone_id, zone_name)`.
+    #[props(default)]
+    pub transfer_targets: Vec<(String, String)>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Tab {
+    Browse,
+    Playlists,
+    Favorites,
+    Radio,
+}
+
+impl Tab {
+    fn action(self) -> &'static str {
+        match self {
+            Tab::Browse => "browse",
+            Tab::Playlists => "playlists",
+            Tab::Favorites | Tab::Radio => "favorites",
+        }
+    }
+
+    fn media_type(self) -> Option<&'static str> {
+        match self {
+            Tab::Radio => Some("radio"),
+            Tab::Favorites => Some("tracks"),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Tab::Browse => "Browse",
+            Tab::Playlists => "Playlists",
+            Tab::Favorites => "Favorites",
+            Tab::Radio => "Radio",
+        }
+    }
+}
+
+const TABS: &[Tab] = &[Tab::Browse, Tab::Playlists, Tab::Favorites, Tab::Radio];
+
+/// Fetch one page of a collection and apply it to the panel's signals.
+/// A free function rather than a captured closure: `Signal<T>` is `Copy`, so
+/// this can be called from any number of independent event handlers without
+/// fighting move-closure ownership.
+#[allow(clippy::too_many_arguments)]
+async fn load_page(
+    zone_id: String,
+    action: String,
+    media_type: Option<String>,
+    path: Option<String>,
+    request_offset: u32,
+    append: bool,
+    mut items: Signal<Vec<CollectionItem>>,
+    mut next_offset: Signal<Option<u32>>,
+    mut offset: Signal<u32>,
+    mut loading: Signal<bool>,
+    mut error: Signal<Option<String>>,
+) {
+    loading.set(true);
+    error.set(None);
+    let req = CollectionsRequest {
+        zone_id,
+        action,
+        path,
+        media_type,
+        limit: Some(PAGE_LIMIT),
+        offset: Some(request_offset),
+    };
+    match api::fetch_collections(&req).await {
+        Ok(env) if env.is_ok() => {
+            let page = env.data.unwrap_or_default();
+            if append {
+                items.with_mut(|list| list.extend(page.items));
+            } else {
+                items.set(page.items);
+            }
+            next_offset.set(page.next_offset);
+            offset.set(request_offset);
+        }
+        Ok(env) => {
+            error.set(Some(env.error_detail()));
+            if !append {
+                items.set(Vec::new());
+            }
+        }
+        Err(message) => {
+            error.set(Some(message));
+            if !append {
+                items.set(Vec::new());
+            }
+        }
+    }
+    loading.set(false);
+}
+
+/// Expandable collections browser + queue transfer control for one zone.
+#[component]
+pub fn CollectionsBrowser(props: CollectionsBrowserProps) -> Element {
+    // A `Signal` is `Copy`, unlike the `String` in `props`, so every handler
+    // closure below can capture it independently without fighting move
+    // semantics over a single owned `String`.
+    let zone_id = use_signal(|| props.zone_id.clone());
+    let mut expanded = use_signal(|| false);
+    let mut tab = use_signal(|| Tab::Browse);
+    let mut path_stack = use_signal(Vec::<(String, Option<String>)>::new);
+    let items = use_signal(Vec::<CollectionItem>::new);
+    let mut offset = use_signal(|| 0u32);
+    let next_offset = use_signal(|| None::<u32>);
+    let loading = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
+    let mut status = use_signal(|| None::<String>);
+    let mut transfer_target = use_signal({
+        let first = props.transfer_targets.first().map(|(id, _)| id.clone());
+        move || first.clone()
+    });
+
+    // `use_callback` closes over props/state by reference and is itself
+    // `Copy`, so every handler below can hold and call the same instance.
+    let refresh = use_callback(move |append: bool| {
+        let zone_id = zone_id();
+        let action = tab.read().action().to_string();
+        let media_type = tab.read().media_type().map(ToOwned::to_owned);
+        let path = path_stack.read().last().and_then(|(_, p)| p.clone());
+        let request_offset = if append { offset() } else { 0 };
+        spawn(load_page(
+            zone_id,
+            action,
+            media_type,
+            path,
+            request_offset,
+            append,
+            items,
+            next_offset,
+            offset,
+            loading,
+            error,
+        ));
+    });
+
+    let toggle_open = move |_| {
+        let opening = !expanded();
+        expanded.set(opening);
+        if opening && items.read().is_empty() {
+            refresh(false);
+        }
+    };
+
+    let select_tab = use_callback(move |new_tab: Tab| {
+        tab.set(new_tab);
+        path_stack.set(Vec::new());
+        offset.set(0);
+        refresh(false);
+    });
+
+    let open_folder = use_callback(move |(title, path): (String, String)| {
+        path_stack.with_mut(|stack| stack.push((title, Some(path))));
+        offset.set(0);
+        refresh(false);
+    });
+
+    let go_back = move |_| {
+        path_stack.with_mut(|stack| {
+            stack.pop();
+        });
+        offset.set(0);
+        refresh(false);
+    };
+
+    let load_more = move |_| refresh(true);
+
+    let play_item = use_callback(move |(item_ref, action): (String, &'static str)| {
+        let zone_id = zone_id();
+        status.set(Some("Working...".to_string()));
+        spawn(async move {
+            let req = PlayRefRequest {
+                item_ref,
+                zone_id,
+                action: action.to_string(),
+            };
+            let message = match api::post_play_ref(&req).await {
+                Ok(env) if env.is_ok() => {
+                    if action == "queue" {
+                        "Added to queue".to_string()
+                    } else {
+                        "Playing".to_string()
+                    }
+                }
+                Ok(env) => env.error_detail(),
+                Err(message) => message,
+            };
+            status.set(Some(message));
+        });
+    });
+
+    let do_transfer = move |_| {
+        let Some(target) = transfer_target() else {
+            return;
+        };
+        let zone_id = zone_id();
+        status.set(Some("Transferring queue...".to_string()));
+        spawn(async move {
+            let req = QueueRequest {
+                zone_id,
+                action: "transfer".to_string(),
+                item_id: None,
+                position: None,
+                target_zone_id: Some(target),
+            };
+            let message = match api::post_queue_action(&req).await {
+                Ok(env) if env.is_ok() => "Queue transferred".to_string(),
+                Ok(env) => env.error_detail(),
+                Err(message) => message,
+            };
+            status.set(Some(message));
+        });
+    };
+
+    let breadcrumb_labels: Vec<String> = path_stack.read().iter().map(|(t, _)| t.clone()).collect();
+    let has_history = !path_stack.read().is_empty();
+    let current_tab = tab();
+    let current_items = items();
+    let is_loading = loading();
+    let current_error = error();
+    let current_status = status();
+    let can_load_more = next_offset.read().is_some();
+    let has_transfer_targets = !props.transfer_targets.is_empty();
+    let transfer_targets = props.transfer_targets.clone();
+
+    rsx! {
+        div { class: "mt-3 border-t border-subtle pt-3",
+            button {
+                class: "btn btn-ghost text-sm",
+                r#type: "button",
+                onclick: toggle_open,
+                if expanded() { "Hide library" } else { "Browse library" }
+            }
+
+            if expanded() {
+                div { class: "mt-3 space-y-3",
+                    // Tabs
+                    div { class: "flex flex-wrap gap-2",
+                        for candidate in TABS {
+                            {
+                                let candidate = *candidate;
+                                let active = candidate == current_tab;
+                                rsx! {
+                                    button {
+                                        key: "{candidate.label()}",
+                                        class: if active { "badge badge-primary" } else { "badge" },
+                                        r#type: "button",
+                                        onclick: move |_| select_tab(candidate),
+                                        "{candidate.label()}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Breadcrumb / back
+                    if has_history {
+                        div { class: "flex items-center gap-2 text-sm text-muted",
+                            button { class: "btn btn-ghost", r#type: "button", onclick: go_back, "< Back" }
+                            span { "{breadcrumb_labels.join(\" / \")}" }
+                        }
+                    }
+
+                    if let Some(message) = current_status.clone() {
+                        p { class: "text-sm text-muted", "{message}" }
+                    }
+                    if let Some(message) = current_error.clone() {
+                        p { class: "text-sm text-error", "{message}" }
+                    }
+                    if is_loading && current_items.is_empty() {
+                        p { class: "text-sm text-muted", "Loading..." }
+                    } else if current_items.is_empty() {
+                        p { class: "text-sm text-muted", "Nothing here." }
+                    } else {
+                        ul { class: "space-y-2",
+                            for item in current_items.iter().cloned() {
+                                li {
+                                    key: "{item.title}-{item.path.clone().unwrap_or_default()}-{item.item_ref.clone().unwrap_or_default()}",
+                                    class: "flex items-center justify-between gap-2",
+                                    div { class: "min-w-0",
+                                        p { class: "text-sm font-medium truncate", "{item.title}" }
+                                        if let Some(subtitle) = item.subtitle.clone() {
+                                            p { class: "text-xs text-muted truncate", "{subtitle}" }
+                                        }
+                                    }
+                                    div { class: "flex gap-2 flex-shrink-0",
+                                        if let Some(path) = item.path.clone() {
+                                            button {
+                                                class: "btn btn-ghost text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let title = item.title.clone();
+                                                    let path = path.clone();
+                                                    move |_| open_folder((title.clone(), path.clone()))
+                                                },
+                                                "Open"
+                                            }
+                                        }
+                                        if let Some(item_ref) = item.item_ref.clone() {
+                                            button {
+                                                class: "btn btn-primary text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let item_ref = item_ref.clone();
+                                                    move |_| play_item((item_ref.clone(), "play"))
+                                                },
+                                                "Play"
+                                            }
+                                            button {
+                                                class: "btn btn-ghost text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let item_ref = item_ref.clone();
+                                                    move |_| play_item((item_ref.clone(), "queue"))
+                                                },
+                                                "Queue"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if can_load_more {
+                            button {
+                                class: "btn btn-ghost text-sm",
+                                r#type: "button",
+                                onclick: load_more,
+                                "Load more"
+                            }
+                        }
+                    }
+
+                    if has_transfer_targets {
+                        div { class: "flex items-center gap-2 pt-2 border-t border-subtle",
+                            span { class: "text-sm text-muted", "Transfer queue to:" }
+                            select {
+                                class: "form-select text-sm",
+                                onchange: move |evt| transfer_target.set(Some(evt.value())),
+                                for (target_id, target_name) in transfer_targets.iter().cloned() {
+                                    option { key: "{target_id}", value: "{target_id}", "{target_name}" }
+                                }
+                            }
+                            button {
+                                class: "btn btn-ghost text-sm",
+                                r#type: "button",
+                                onclick: do_transfer,
+                                "Transfer"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -1,5 +1,6 @@
 //! Shared UI components for the Dioxus fullstack web UI.
 
+pub mod collections;
 pub mod error_alert;
 pub mod form_inputs;
 pub mod hqp_controls;
@@ -7,6 +8,7 @@ pub mod layout;
 pub mod nav;
 pub mod volume;
 
+pub use collections::CollectionsBrowser;
 pub use error_alert::ErrorAlert;
 pub use form_inputs::{PowerModeInput, ToggleInput};
 pub use hqp_controls::{HqpControlsCompact, HqpMatrixSelect, HqpProfileSelect};

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -3,7 +3,9 @@
 //! Shows all available zones using Dioxus resources.
 
 use crate::app::api::{HqpMatrixProfilesResponse, HqpProfile, NowPlaying, Zone, ZonesResponse};
-use crate::app::components::{ErrorAlert, HqpControlsCompact, Layout, VolumeControlsCompact};
+use crate::app::components::{
+    CollectionsBrowser, ErrorAlert, HqpControlsCompact, Layout, VolumeControlsCompact,
+};
 use crate::app::sse::{use_sse, SseEvent};
 use dioxus::prelude::*;
 use std::collections::HashMap;
@@ -254,6 +256,15 @@ pub fn Zones() -> Element {
     let profiles = hqp_profiles();
     let matrix = hqp_matrix();
 
+    // Music Assistant zones support library browse and queue transfer
+    // (#507); every other adapter hides the panel entirely rather than
+    // showing a browse surface that immediately refuses every call.
+    let musicassistant_zones: Vec<(String, String)> = zones_list
+        .iter()
+        .filter(|z| z.zone_id.starts_with("musicassistant:"))
+        .map(|z| (z.zone_id.clone(), z.zone_name.clone()))
+        .collect();
+
     // Group zones by source protocol
     let grouped_zones: Vec<(String, Vec<Zone>)> = {
         let mut groups: std::collections::HashMap<String, Vec<Zone>> =
@@ -305,6 +316,7 @@ pub fn Zones() -> Element {
                                 on_control: control,
                                 on_load_profile: load_profile,
                                 on_set_matrix: set_matrix,
+                                musicassistant_zones: musicassistant_zones.clone(),
                             }
                         }
                     }
@@ -345,6 +357,10 @@ fn ZoneCard(
     on_control: EventHandler<(String, String)>,
     on_load_profile: EventHandler<String>,
     on_set_matrix: EventHandler<String>,
+    /// Every Music Assistant zone, `(zone_id, zone_name)`, for the browse
+    /// panel's queue-transfer target list (#507). Empty when there are none.
+    #[props(default)]
+    musicassistant_zones: Vec<(String, String)>,
 ) -> Element {
     let zone_id = zone.zone_id.clone();
     let zone_id_prev = zone_id.clone();
@@ -494,6 +510,20 @@ fn ZoneCard(
                     volume_step: volume_step,
                     on_vol_down: move |_| on_control.call((zone_id_vol_down.clone(), "vol_down".to_string())),
                     on_vol_up: move |_| on_control.call((zone_id_vol_up.clone(), "vol_up".to_string())),
+                }
+            }
+
+            // Library browse + queue transfer (#507). Music Assistant only
+            // today; other adapters hide the panel rather than exposing a
+            // browse surface that would refuse every call.
+            if zone.zone_id.starts_with("musicassistant:") {
+                CollectionsBrowser {
+                    zone_id: zone.zone_id.clone(),
+                    transfer_targets: musicassistant_zones
+                        .iter()
+                        .filter(|(id, _)| *id != zone.zone_id)
+                        .cloned()
+                        .collect::<Vec<_>>(),
                 }
             }
         }

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -513,10 +513,14 @@ fn ZoneCard(
                 }
             }
 
-            // Library browse + queue transfer (#507). Music Assistant only
-            // today; other adapters hide the panel rather than exposing a
-            // browse surface that would refuse every call.
-            if zone.zone_id.starts_with("musicassistant:") {
+            // Library browse + queue transfer (#507, #531). Gated on the
+            // server-reported `browse_supported` -- whether `/api/collections`
+            // actually implements this zone's provider -- rather than a
+            // hardcoded prefix, so LMS and Roon zones light up as their
+            // slices land without a web change. Queue transfer itself
+            // remains Music Assistant-only (`musicassistant_zones` below);
+            // that is a separate capability (#507) this gate does not cover.
+            if zone.browse_supported {
                 CollectionsBrowser {
                     zone_id: zone.zone_id.clone(),
                     transfer_targets: musicassistant_zones

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -104,6 +104,11 @@ pub struct ZoneInfo {
     pub volume_control: Option<VolumeControl>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dsp: Option<DspInfo>,
+    /// Whether `hifi_collections`/`/api/collections` implements this zone's
+    /// provider at all (#531). The web UI's `CollectionsBrowser` panel gates
+    /// on this instead of a hardcoded `musicassistant:` prefix check, so LMS
+    /// and Roon zones light up as their slices land, without a web change.
+    pub browse_supported: bool,
 }
 
 /// GET /knob/zones response
@@ -175,6 +180,9 @@ pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
         })
         .map(|z| ZoneInfo {
             dsp: get_dsp(&z.zone_id),
+            browse_supported: crate::mcp::tools::collections::zone_supports_hifi_collections(
+                &z.zone_id,
+            ),
             zone_id: z.zone_id,
             zone_name: z.zone_name,
             source: z.source,
@@ -1580,6 +1588,7 @@ mod tests {
             state: "stopped".to_string(),
             volume_control: None,
             dsp: None,
+            browse_supported: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -740,6 +740,12 @@ mod server {
             // App settings API
             .route("/api/settings", get(api::api_settings_get_handler))
             .route("/api/settings", post(api::api_settings_post_handler))
+            // Library browse, queue and play-ref for the web UI (#507). Same
+            // verb vocabulary as the hifi_collections/hifi_queue/hifi_play_ref
+            // MCP tools -- see src/api/browse.rs.
+            .route("/api/collections", post(api::browse::collections_handler))
+            .route("/api/queue", post(api::browse::queue_handler))
+            .route("/api/play_ref", post(api::browse::play_ref_handler))
             // Event stream (SSE)
             .route("/events", get(api::events_handler))
             // Knob hardware API routes

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,6 +494,18 @@ mod server {
             );
         }
 
+        // #531: registered for `hifi_collections`' content operation only --
+        // `search`/`play_uri` refuse through this trait (see
+        // `LibraryAdapter for LmsAdapter`/`for RoonAdapter`'s docs);
+        // `hifi_search`/`hifi_play` keep calling these adapters directly.
+        state
+            .adapter_registry
+            .register_library("lms", state.lms.clone())
+            .await;
+        state
+            .adapter_registry
+            .register_library("roon", state.roon.clone())
+            .await;
         state
             .adapter_registry
             .register_with_lifecycle(spotify.clone(), spotify.clone())

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -116,6 +116,8 @@ pub enum Capability {
     QueueRemove,
     /// Empty the queue.
     QueueClear,
+    /// Move an active queue from one zone to another (#507).
+    QueueTransfer,
     /// Insert immediately after the current item.
     PlayNext,
     /// Read and set repeat mode.
@@ -148,6 +150,7 @@ impl Capability {
         Self::QueueReorder,
         Self::QueueRemove,
         Self::QueueClear,
+        Self::QueueTransfer,
         Self::PlayNext,
         Self::RepeatMode,
         Self::ShuffleMode,
@@ -172,6 +175,7 @@ impl Capability {
             Self::QueueReorder => "queue_reorder",
             Self::QueueRemove => "queue_remove",
             Self::QueueClear => "queue_clear",
+            Self::QueueTransfer => "queue_transfer",
             Self::PlayNext => "play_next",
             Self::RepeatMode => "repeat_mode",
             Self::ShuffleMode => "shuffle_mode",
@@ -358,7 +362,8 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         Capability::QueueJump
         | Capability::QueueReorder
         | Capability::QueueRemove
-        | Capability::QueueClear => target == ZoneTarget::MusicAssistant,
+        | Capability::QueueClear
+        | Capability::QueueTransfer => target == ZoneTarget::MusicAssistant,
         Capability::PlayNext => target == ZoneTarget::MusicAssistant,
         Capability::MultiroomSync => target == ZoneTarget::MusicAssistant,
         Capability::Browse | Capability::SavedPlaylists | Capability::Favorites => {
@@ -411,6 +416,14 @@ const ROON_QUEUE_IS_READ_PLUS_JUMP: &str = "The Roon API's transport service exp
     subscription and play_from_here and no mutation at all -- no move, remove or clear. The \
     pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing \
     further.";
+
+/// OpenHome's per-room `Playlist:1` has no cross-room action, and Songcast
+/// relays audio rather than queue state.
+const OPENHOME_HAS_NO_QUEUE_TRANSFER: &str = "OpenHome's Playlist:1 (Read/Insert/DeleteId/\
+    DeleteAll) is scoped to one room's renderer; the service set defines no action that moves \
+    one room's playlist into another's. Songcast (Sender:1/Receiver:1) relays audio to a group, \
+    it does not merge queue state. Verified from the OpenHome service definitions, not from a \
+    device.";
 
 /// Playing a *named* item is a different question from *finding* one, and the ship
 /// gate's dissent caught this module conflating them.
@@ -472,6 +485,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::QueueReorder, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::QueueRemove, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::QueueClear, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
+    (ZoneTarget::Roon, Capability::QueueTransfer, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::PlayNext, Gap::NotWired("#399",
         "Roon's browse item actions include Play Next alongside Play Now and Queue; UHC's \
          PlayAction models only Play, Queue and Radio, so this arrives with browse rather \
@@ -518,6 +532,13 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
         "playlist delete <index> removes one queued item; verified live.")),
     (ZoneTarget::Lms, Capability::QueueClear, Gap::NotWired("#400",
         "playlist clear empties the queue; verified live.")),
+    (ZoneTarget::Lms, Capability::QueueTransfer, Gap::NotWired("#400",
+        "sync <playerid> was verified live (#403) to merge a player into another's sync group by \
+         adopting the leader's queue, which destroys the source's queue rather than transferring \
+         it; the CLI reference names no dedicated queue-to-queue transfer command. A composite \
+         emulation -- read the source's playlist, replay it against the target with \
+         playlistcontrol, then playlist clear the source -- is buildable from primitives #400 \
+         already verified live, but is not wired.")),
     (ZoneTarget::Lms, Capability::PlayNext, Gap::NotWired("#403",
         "playlistcontrol cmd:insert places an item immediately after the current one, verified \
          live -- and LmsPlayAction::Insert is already modelled in the adapter and simply \
@@ -557,6 +578,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
          OpenHome service definitions, not from a device.")),
     (ZoneTarget::OpenHome, Capability::QueueRemove, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::QueueClear, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
+    (ZoneTarget::OpenHome, Capability::QueueTransfer, Gap::ProviderCannot(OPENHOME_HAS_NO_QUEUE_TRANSFER)),
     (ZoneTarget::OpenHome, Capability::PlayNext, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::RepeatMode, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::ShuffleMode, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
@@ -592,6 +614,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Upnp, Capability::QueueReorder, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::QueueRemove, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::QueueClear, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
+    (ZoneTarget::Upnp, Capability::QueueTransfer, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::PlayNext, Gap::NotWired("#396", PLAY_A_NAMED_URI_EXISTS)),
     (ZoneTarget::Upnp, Capability::RepeatMode, Gap::NotWired("#392",
         "AVTransport:1's SetPlayMode takes REPEAT_ONE and REPEAT_ALL, so repeat is a protocol \
@@ -633,6 +656,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::HqPlayer, Capability::QueueReorder, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::QueueRemove, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::QueueClear, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
+    (ZoneTarget::HqPlayer, Capability::QueueTransfer, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::PlayNext, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::SavedPlaylists, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::Favorites, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
@@ -822,6 +846,7 @@ mod tests {
                                 | Capability::QueueReorder
                                 | Capability::QueueRemove
                                 | Capability::QueueClear
+                                | Capability::QueueTransfer
                                 | Capability::PlayNext
                                 | Capability::SavedPlaylists
                                 | Capability::Favorites
@@ -1027,7 +1052,7 @@ mod tests {
                 capability.name()
             );
         }
-        assert_eq!(seen.len(), 18, "the vocabulary changed size: {seen:?}");
+        assert_eq!(seen.len(), 19, "the vocabulary changed size: {seen:?}");
     }
 
     /// A refusal built from a capability state must carry the same

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -366,8 +366,17 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         | Capability::QueueTransfer => target == ZoneTarget::MusicAssistant,
         Capability::PlayNext => target == ZoneTarget::MusicAssistant,
         Capability::MultiroomSync => target == ZoneTarget::MusicAssistant,
-        Capability::Browse | Capability::SavedPlaylists | Capability::Favorites => {
-            matches!(target, ZoneTarget::Spotify | ZoneTarget::MusicAssistant)
+        // #531: LMS implements all three (albums/artists/playlists/favorites
+        // queries over the CLI/jsonrpc). Roon implements browse and playlists
+        // (the same browse/load session `hifi_search` already drives);
+        // favorites remains a gap -- see `GAPS` below -- because Roon exposes
+        // it as a browse hierarchy this slice does not yet walk into.
+        Capability::Browse | Capability::SavedPlaylists => matches!(
+            target,
+            ZoneTarget::Spotify | ZoneTarget::MusicAssistant | ZoneTarget::Lms | ZoneTarget::Roon
+        ),
+        Capability::Favorites => {
+            matches!(target, ZoneTarget::Spotify | ZoneTarget::MusicAssistant | ZoneTarget::Lms)
         }
     };
     supported.then_some(Support::Supported)
@@ -473,9 +482,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::PlayByRef, Gap::NotWired("#396",
         "RoonAdapter::browse/load/play_item exist and are exposed over HTTP; MCP mints no \
          reference for a search hit to act on.")),
-    (ZoneTarget::Roon, Capability::Browse, Gap::NotWired("#399",
-        "RoonAdapter::browse() and load() exist and POST /roon/browse exposes them; only the \
-         MCP projection is missing.")),
     (ZoneTarget::Roon, Capability::QueueRead, Gap::NotWired("#400",
         "the pinned roon-api fork exposes subscribe_queue(zone, max_items), which nothing in \
          UHC calls.")),
@@ -496,10 +502,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::ShuffleMode, Gap::NotWired("#360",
         "the Roon API's transport service takes a shuffle setting; UHC drives it from no \
          surface.")),
-    (ZoneTarget::Roon, Capability::SavedPlaylists, Gap::NotWired("#399",
-        "Roon exposes Playlists as a browse hierarchy, so this arrives with browse rather \
-         than as its own protocol feature.")),
-    (ZoneTarget::Roon, Capability::Favorites, Gap::NotWired("#399",
+    (ZoneTarget::Roon, Capability::Favorites, Gap::NotWired("#531",
         "Roon exposes My Favorites and tags as browse hierarchies, so this arrives with \
          browse.")),
     (ZoneTarget::Roon, Capability::MultiroomSync, Gap::NotWired("#360",
@@ -516,10 +519,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
          that playlistcontrol accepts, verified live; MCP discards them and hands back a title. \
          Note the XMLBrowser paths (globalsearch, favorites) return positional breadcrumbs \
          instead, which is #396's safety problem, not a capability gap.")),
-    (ZoneTarget::Lms, Capability::Browse, Gap::NotWired("#402",
-        "browselibrary items and the native albums/artists/genres/years/playlists/mediafolder \
-         queries walk the whole hierarchy with native <start> <n> paging -- all \
-         verified live on Lyrion 9.1.2. The adapter never calls any of them.")),
     (ZoneTarget::Lms, Capability::QueueRead, Gap::NotWired("#400",
         "status <player> <start> <n> returns the whole current playlist with playlist_cur_index; \
          verified live.")),
@@ -549,15 +548,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Lms, Capability::ShuffleMode, Gap::NotWired("#403",
         "playlist shuffle <0|1|2> and playlist shuffle ? read and write it; verified live. \
          Setting it reshuffles the queue, so it is also a queue mutation.")),
-    (ZoneTarget::Lms, Capability::SavedPlaylists, Gap::NotWired("#403",
-        "playlists / playlists tracks / playlistcontrol cmd:load playlist_id / playlists new / \
-         rename / delete all exist and were verified live. playlist save additionally needs a \
-         configured playlistdir, which is unset on a stock install -- so its own answer is \
-         three-state at the server level, which is why #403 probes pref playlistdir ?.")),
-    (ZoneTarget::Lms, Capability::Favorites, Gap::NotWired("#403",
-        "favorites items / favorites playlist play / add / delete / exists all work; verified \
-         live. Note LMS favorites have no durable id -- only a url -- so a ref must be minted \
-         over the url.")),
     (ZoneTarget::Lms, Capability::MultiroomSync, Gap::NotWired("#403",
         "sync <playerid>, sync -, sync ? and the server-scoped syncgroups ? all work; verified \
          live. Joining is destructive to the target zone's queue, which is why #403 gates it \

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -139,6 +139,23 @@ pub enum RefTarget {
         path: String,
         title: String,
     },
+    /// An LMS browse continuation (#531): a server-side collection path
+    /// (`"albums"`, `"album:<id>"`, ...), never a raw entity id handed to a
+    /// client. Only accepted by `hifi_collections`, never `hifi_play_ref` --
+    /// same split as [`Self::MusicAssistantBrowse`].
+    LmsBrowse {
+        path: String,
+        title: String,
+    },
+    /// A Roon browse continuation (#531): the `item_key` **and**
+    /// `multi_session_key` a collection list was loaded under, so resuming it
+    /// re-enters that exact session -- same pairing requirement as
+    /// [`Self::Roon`], for the same reason (see [`RoonRefTarget`]'s docs).
+    /// Only accepted by `hifi_collections`, never `hifi_play_ref`.
+    RoonBrowse {
+        target: RoonRefTarget,
+        title: String,
+    },
     /// An Apple Music catalog/library identifier resolved by the paired native
     /// companion. Clients only receive the opaque token.
     AppleMusic {
@@ -161,6 +178,8 @@ impl RefTarget {
             Self::Spotify { .. } => Provider::Spotify,
             Self::MusicAssistant { .. } => Provider::MusicAssistant,
             Self::MusicAssistantBrowse { .. } => Provider::MusicAssistant,
+            Self::LmsBrowse { .. } => Provider::Lms,
+            Self::RoonBrowse { .. } => Provider::Roon,
             Self::AppleMusic { .. } => Provider::AppleMusic,
         }
     }
@@ -174,6 +193,8 @@ impl RefTarget {
             | Self::Spotify { title, .. }
             | Self::MusicAssistant { title, .. }
             | Self::MusicAssistantBrowse { title, .. }
+            | Self::LmsBrowse { title, .. }
+            | Self::RoonBrowse { title, .. }
             | Self::AppleMusic { title, .. } => title,
         }
     }

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -3,11 +3,25 @@
 //! The wire contract deliberately speaks only of collections, paths, pages and
 //! opaque playable refs. Provider adapters translate those concepts to their
 //! native library APIs; no provider URI or identifier is returned to a client.
+//!
+//! # #531: per-provider slices, not one blanket gate
+//!
+//! #492 wired only Music Assistant, behind a blanket "not implemented for
+//! this provider yet" refusal for every other route. That refusal did not
+//! distinguish "this provider cannot" from "UHC has not wired it" and, worse,
+//! disagreed with [`crate::mcp::capabilities`] for Spotify: `hifi_spotify`
+//! already exposes playlists/favorites/browse there, so the capability table
+//! reports `browse`/`saved_playlists`/`favorites` as `supported` for Spotify
+//! zones independent of this tool. This module now implements LMS and Roon
+//! (#531's biggest UX win -- local-library and Roon-library browsing had no
+//! neutral surface at all) and refuses Spotify and Apple Music by name,
+//! honestly: reachable through their own provider tools today, not yet wired
+//! to this one. See #531's PR body for what remains.
 
 use crate::api::AppState;
 use crate::mcp::capabilities::{support, Capability, Support};
 use crate::mcp::envelope::{Envelope, Refusal, Scope};
-use crate::mcp::refs::RefTarget;
+use crate::mcp::refs::{RefTarget, RoonRefTarget};
 use crate::mcp::routing::{LibraryRoute, ZoneTarget};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
@@ -18,9 +32,28 @@ use serde_json::{json, Value};
 
 const ACTIONS: &[&str] = &["browse", "playlists", "favorites"];
 
+/// Whether `hifi_collections` (and its HTTP mirror, `/api/collections`)
+/// implements this zone's provider at all.
+///
+/// **Narrower than "is any collections capability `supported`"**: Spotify's
+/// `browse`/`saved_playlists`/`favorites` cells read `supported` in
+/// [`crate::mcp::capabilities`] because `hifi_spotify` already implements
+/// them (see that module's `routed()`), not because this tool does. The web
+/// UI's `CollectionsBrowser` panel (`src/app/pages/zones.rs`) calls
+/// `/api/collections`, which is *this* tool -- so it must gate on this
+/// narrower question, not on the general capability table, or it would light
+/// up a panel that immediately refuses every call for a Spotify zone. See
+/// #531's PR body for Spotify and Apple Music's plan to close this gap.
+pub fn zone_supports_hifi_collections(zone_id: &str) -> bool {
+    matches!(
+        ZoneTarget::classify(zone_id).for_library(),
+        LibraryRoute::MusicAssistant | LibraryRoute::Lms | LibraryRoute::Roon
+    )
+}
+
 #[mcp_tool(
     name = "hifi_collections",
-    description = "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection."
+    description = "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection. Implemented for lms and roon zones; Music Assistant zones (see hifi_queue's provider notes); Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiCollectionsTool {
@@ -84,51 +117,59 @@ pub async fn handle_collections(
         .param_opt("limit", args.limit)
         .param_opt("offset", args.offset)
         .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
-    let prefix = match target.for_library() {
-        LibraryRoute::Roon => "roon",
-        LibraryRoute::Lms => "lms",
-        LibraryRoute::Spotify => "spotify",
-        LibraryRoute::AppleMusic => "applemusic",
-        LibraryRoute::MusicAssistant => "musicassistant",
-        LibraryRoute::Refused(_) => return env.failed("This zone has no library path"),
-    };
-    // Browse paths are server-side refs, just like playable media refs. MA's
-    // native `library://…` paths contain provider implementation details and
-    // must not become MCP client input.
-    let provider_path = match args.path.as_deref() {
-        None => None,
-        Some(token) => match state.mcp_refs.resolve(token).await {
-            Some(RefTarget::MusicAssistantBrowse { path, .. })
-                if matches!(target, ZoneTarget::MusicAssistant) => Some(path),
-            Some(_) => {
-                return env.refused(
-                    "path does not name a collection for this zone.",
-                    Refusal::invalid_parameter(
-                        "path",
-                        &["a path returned by hifi_collections for this zone"],
-                        "Browse again from this zone and use that result's path.",
-                    ),
-                )
-            }
-            None => {
-                return env.refused(
-                    "path is unknown or expired. Browse again from the collection root.",
-                    Refusal::UnknownTarget {
-                        parameter: "path",
-                        discover_with: "hifi_collections",
-                        detail: "Collection paths are short-lived opaque references. Call hifi_collections without path to start again.".to_string(),
-                    },
-                )
-            }
-        },
-    };
-    // This provider-neutral surface has a route vocabulary for every library
-    // adapter, but #492 implements the first adapter slice only. Resolve an
-    // opaque path first so a path minted for MA is never sent to another
-    // provider, even when that provider does not yet implement collections.
-    if !matches!(target, ZoneTarget::MusicAssistant) {
-        return env.failed("Collections are not implemented for this provider yet.");
+    let route = target.for_library();
+    if let LibraryRoute::Refused(_) = route {
+        return env.failed("This zone has no library path");
     }
+
+    // A `path`'s provider-boundary check runs before anything else,
+    // regardless of whether this zone's provider is wired to
+    // `hifi_collections` at all: a ref minted for one provider must never be
+    // treated as valid input for a different one, even a zone whose provider
+    // this tool cannot yet browse. Each provider handler below re-resolves
+    // the token itself to extract its specific shape; this pass only rules
+    // out "wrong provider" and "unknown token" up front.
+    if let Some(token) = args.path.as_deref() {
+        match state.mcp_refs.resolve(token).await {
+            Some(resolved) if resolved.provider() != target.provider() => {
+                return refuse_foreign_path(env);
+            }
+            None => return refuse_unknown_path(env),
+            Some(_) => {}
+        }
+    }
+
+    // Spotify and Apple Music already expose (some of) this surface through
+    // their own provider-specific tools (`hifi_spotify`, the Apple Music
+    // tools), which is why `hifi_capabilities` can report `supported` for
+    // them independent of this tool. Refusing here names that honestly
+    // instead of either lying "not implemented" for a capability the
+    // provider actually has, or silently trying an adapter operation this
+    // tool never taught it (`collections_browse` and friends) and surfacing
+    // whatever generic error falls out.
+    if matches!(route, LibraryRoute::Spotify | LibraryRoute::AppleMusic) {
+        let alternative = match route {
+            LibraryRoute::Spotify => "hifi_spotify",
+            _ => "the Apple Music companion tools",
+        };
+        return env.refused(
+            format!(
+                "hifi_collections does not reach {} zones yet; use {alternative} for this \
+                 provider's collections today.",
+                target.label()
+            ),
+            Refusal::NotImplemented {
+                operation: capability.name().to_string(),
+                tracked_by: "#531",
+                alternatives: vec![alternative.to_string()],
+                detail: format!(
+                    "{alternative} already exposes this provider's content operations; #531 \
+                     tracks adapting them behind the neutral hifi_collections contract."
+                ),
+            },
+        );
+    }
+
     if !matches!(support(target, capability), Support::Supported) {
         return env.failed(format!(
             "{} is not available for {} zones",
@@ -136,13 +177,56 @@ pub async fn handle_collections(
             target.label()
         ));
     }
+
     let limit = args.limit.unwrap_or(20).clamp(1, 50);
     let offset = args.offset.unwrap_or(0);
+
+    match route {
+        LibraryRoute::MusicAssistant => {
+            handle_music_assistant(state, env, &args, limit, offset).await
+        }
+        LibraryRoute::Lms => handle_lms(state, env, &args, limit, offset).await,
+        LibraryRoute::Roon => handle_roon(state, env, &args, limit, offset).await,
+        // Handled above; exhaustive so a new route fails to compile here
+        // rather than silently falling through.
+        LibraryRoute::Spotify | LibraryRoute::AppleMusic => env.failed(
+            "internal routing error: Spotify/Apple Music reached collections dispatch after \
+             being refused above. This is a UHC bug.",
+        ),
+        LibraryRoute::Refused(_) => env.failed(
+            "internal routing error: a refused zone reached collections dispatch. This is a \
+             UHC bug.",
+        ),
+    }
+}
+
+// =============================================================================
+// Music Assistant (#492): unchanged from before #531, minus the blanket gate.
+// =============================================================================
+
+async fn handle_music_assistant(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiCollectionsTool,
+    limit: u32,
+    offset: u32,
+) -> Result<CallToolResult, CallToolError> {
+    // Browse paths are server-side refs, just like playable media refs. MA's
+    // native `library://…` paths contain provider implementation details and
+    // must not become MCP client input.
+    let provider_path = match args.path.as_deref() {
+        None => None,
+        Some(token) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::MusicAssistantBrowse { path, .. }) => Some(path),
+            Some(_) => return refuse_foreign_path(env),
+            None => return refuse_unknown_path(env),
+        },
+    };
     let operation = format!("collections_{}", args.action);
     let response = match state
         .adapter_registry
         .library_content(
-            prefix,
+            "musicassistant",
             &operation,
             &json!({
                 "zone_id": args.zone_id,
@@ -177,8 +261,8 @@ pub async fn handle_collections(
             .get("subtitle")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
-        let path = match (target, item.get("path").and_then(Value::as_str)) {
-            (ZoneTarget::MusicAssistant, Some(path)) => Some(
+        let path = match item.get("path").and_then(Value::as_str) {
+            Some(path) => Some(
                 state
                     .mcp_refs
                     .mint(RefTarget::MusicAssistantBrowse {
@@ -187,14 +271,132 @@ pub async fn handle_collections(
                     })
                     .await,
             ),
-            _ => None,
+            None => None,
         };
-        let r#ref = match (target, item.get("uri").and_then(Value::as_str)) {
-            (ZoneTarget::MusicAssistant, Some(uri)) => Some(
+        let r#ref = match item.get("uri").and_then(Value::as_str) {
+            Some(uri) => Some(
                 state
                     .mcp_refs
                     .mint(RefTarget::MusicAssistant {
                         uri: uri.to_string(),
+                        title: title.clone(),
+                    })
+                    .await,
+            ),
+            None => None,
+        };
+        items.push(CollectionItem {
+            title,
+            subtitle,
+            path,
+            r#ref,
+        });
+    }
+    Ok(env.json_result(&CollectionPage { items, next_offset }))
+}
+
+// =============================================================================
+// LMS (#531): albums/artists/playlists/favorites over the CLI/jsonrpc the
+// adapter already speaks for search and playback.
+// =============================================================================
+
+async fn handle_lms(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiCollectionsTool,
+    limit: u32,
+    offset: u32,
+) -> Result<CallToolResult, CallToolError> {
+    // Same opaque-path split as Music Assistant: the plain collection path
+    // this adapter invents ("albums", "album:<id>", ...) never becomes
+    // client-visible; only the ref token is.
+    let provider_path = match args.path.as_deref() {
+        None => None,
+        Some(token) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::LmsBrowse { path, .. }) => Some(path),
+            Some(_) => return refuse_foreign_path(env),
+            None => return refuse_unknown_path(env),
+        },
+    };
+    let operation = format!("collections_{}", args.action);
+    let response = match state
+        .adapter_registry
+        .library_content(
+            "lms",
+            &operation,
+            &json!({
+                "path": provider_path,
+                "media_type": args.media_type,
+                "limit": limit,
+                "offset": offset,
+            }),
+        )
+        .await
+    {
+        Ok(value) => value,
+        Err(error) => return env.failed(format!("Collection error: {error}")),
+    };
+    let next_offset = response
+        .get("next_offset")
+        .and_then(Value::as_u64)
+        .map(|v| v as u32);
+    let mut items = Vec::new();
+    for item in response
+        .get("items")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("Untitled")
+            .to_string();
+        let subtitle = item
+            .get("subtitle")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        // A navigable row carries `path` (another collection to browse); a
+        // playable leaf carries either `kind`+`id` (a durable LMS entity --
+        // `LmsPlayTarget::Library`) or `url` (a favorite, which LMS gives no
+        // durable id for -- `LmsPlayTarget::Url`). At most one of the three
+        // is ever present on one row.
+        let path = match item.get("path").and_then(Value::as_str) {
+            Some(path) => Some(
+                state
+                    .mcp_refs
+                    .mint(RefTarget::LmsBrowse {
+                        path: path.to_string(),
+                        title: title.clone(),
+                    })
+                    .await,
+            ),
+            None => None,
+        };
+        let r#ref = match (
+            item.get("kind").and_then(Value::as_str),
+            item.get("id").and_then(Value::as_i64),
+            item.get("url").and_then(Value::as_str),
+        ) {
+            (Some("track"), Some(id), _) => Some(
+                state
+                    .mcp_refs
+                    .mint(RefTarget::Lms {
+                        target: crate::adapters::lms::LmsPlayTarget::Library {
+                            kind: crate::adapters::lms::LmsSearchResultType::Track,
+                            id,
+                        },
+                        title: title.clone(),
+                    })
+                    .await,
+            ),
+            (_, _, Some(url)) => Some(
+                state
+                    .mcp_refs
+                    .mint(RefTarget::Lms {
+                        target: crate::adapters::lms::LmsPlayTarget::Url {
+                            url: url.to_string(),
+                        },
                         title: title.clone(),
                     })
                     .await,
@@ -209,4 +411,168 @@ pub async fn handle_collections(
         });
     }
     Ok(env.json_result(&CollectionPage { items, next_offset }))
+}
+
+// =============================================================================
+// Roon (#531): the same browse/load session machinery `hifi_search` already
+// drives (src/adapters/roon.rs), exposed as hierarchy walking.
+// =============================================================================
+
+async fn handle_roon(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiCollectionsTool,
+    limit: u32,
+    offset: u32,
+) -> Result<CallToolResult, CallToolError> {
+    // Roon's continuation is a (item_key, multi_session_key) pair, not a flat
+    // string -- resuming it must re-enter that exact session (same reasoning
+    // as a playable Roon ref; see `RoonRefTarget`'s docs).
+    let resume = match args.path.as_deref() {
+        None => None,
+        Some(token) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::RoonBrowse { target, .. }) => Some(target),
+            Some(_) => return refuse_foreign_path(env),
+            None => return refuse_unknown_path(env),
+        },
+    };
+
+    let mut params = json!({
+        "zone_id": args.zone_id,
+        "limit": limit,
+        "offset": offset,
+    });
+    if let Some(RoonRefTarget {
+        item_key,
+        multi_session_key,
+    }) = &resume
+    {
+        params["item_key"] = json!(item_key);
+        params["session_key"] = json!(multi_session_key);
+    }
+    // Roon has no separate playlists/favorites protocol feature: both arrive
+    // as named nodes in the same browse hierarchy (see the capability
+    // table's note on this). `favorites` never reaches here -- `support()`
+    // reports it `not_implemented` for Roon and the shared check above
+    // already refused it.
+    let operation = match args.action.as_str() {
+        "browse" => "collections_browse",
+        "playlists" => "collections_playlists",
+        other => {
+            return env.failed(format!(
+                "internal routing error: unexpected hifi_collections action {other:?} reached \
+                 Roon dispatch after the capability check. This is a UHC bug."
+            ))
+        }
+    };
+    let response = match state
+        .adapter_registry
+        .library_content("roon", operation, &params)
+        .await
+    {
+        Ok(value) => value,
+        Err(error) => return env.failed(format!("Collection error: {error}")),
+    };
+
+    let Some(session_key) = response.get("session_key").and_then(Value::as_str) else {
+        return env.failed("Collection error: Roon adapter returned no session_key");
+    };
+    // `RoonAdapter::content` already dropped grouping rows (headers,
+    // result-count rows) -- see that method's docs -- so every row here is
+    // either navigable (`List` hint) or playable, and this loop only mints
+    // the ref that matches which.
+    let mut items = Vec::new();
+    for item in response
+        .get("items")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("Untitled")
+            .to_string();
+        let subtitle = item
+            .get("subtitle")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let item_key = item.get("item_key").and_then(Value::as_str);
+        let navigable = item.get("navigable").and_then(Value::as_bool).unwrap_or(false);
+        let (path, r#ref) = match item_key {
+            None => (None, None),
+            Some(item_key) => {
+                let target = RoonRefTarget {
+                    item_key: item_key.to_string(),
+                    multi_session_key: session_key.to_string(),
+                };
+                if navigable {
+                    (
+                        Some(
+                            state
+                                .mcp_refs
+                                .mint(RefTarget::RoonBrowse {
+                                    target,
+                                    title: title.clone(),
+                                })
+                                .await,
+                        ),
+                        None,
+                    )
+                } else {
+                    (
+                        None,
+                        Some(
+                            state
+                                .mcp_refs
+                                .mint(RefTarget::Roon {
+                                    target,
+                                    title: title.clone(),
+                                })
+                                .await,
+                        ),
+                    )
+                }
+            }
+        };
+        items.push(CollectionItem {
+            title,
+            subtitle,
+            path,
+            r#ref,
+        });
+    }
+    let next_offset = response
+        .get("next_offset")
+        .and_then(Value::as_u64)
+        .map(|v| v as u32);
+    Ok(env.json_result(&CollectionPage { items, next_offset }))
+}
+
+// =============================================================================
+// Shared refusals
+// =============================================================================
+
+fn refuse_foreign_path(env: Envelope) -> Result<CallToolResult, CallToolError> {
+    env.refused(
+        "path does not name a collection for this zone.",
+        Refusal::invalid_parameter(
+            "path",
+            &["a path returned by hifi_collections for this zone"],
+            "Browse again from this zone and use that result's path.",
+        ),
+    )
+}
+
+fn refuse_unknown_path(env: Envelope) -> Result<CallToolResult, CallToolError> {
+    env.refused(
+        "path is unknown or expired. Browse again from the collection root.",
+        Refusal::UnknownTarget {
+            parameter: "path",
+            discover_with: "hifi_collections",
+            detail: "Collection paths are short-lived opaque references. Call hifi_collections \
+                      without path to start again."
+                .to_string(),
+        },
+    )
 }

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -953,7 +953,9 @@ pub async fn handle_play_ref(
         (LibraryRoute::MusicAssistant, RefTarget::MusicAssistant { uri, title }) => {
             play_ref_music_assistant(state, env, &args, uri, title).await
         }
-        (LibraryRoute::MusicAssistant, RefTarget::MusicAssistantBrowse { .. }) => env.refused(
+        (LibraryRoute::MusicAssistant, RefTarget::MusicAssistantBrowse { .. })
+        | (LibraryRoute::Lms, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::Roon, RefTarget::RoonBrowse { .. }) => env.refused(
             "this ref names a browsable collection, not playable media.",
             Refusal::InvalidParameter {
                 parameter: "ref",
@@ -991,7 +993,15 @@ pub async fn handle_play_ref(
         | (LibraryRoute::MusicAssistant, RefTarget::Roon { .. })
         | (LibraryRoute::MusicAssistant, RefTarget::Lms { .. })
         | (LibraryRoute::MusicAssistant, RefTarget::Spotify { .. })
-        | (LibraryRoute::MusicAssistant, RefTarget::AppleMusic { .. }) => env.failed(
+        | (LibraryRoute::MusicAssistant, RefTarget::AppleMusic { .. })
+        | (LibraryRoute::Roon, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::Spotify, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::AppleMusic, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::MusicAssistant, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::Lms, RefTarget::RoonBrowse { .. })
+        | (LibraryRoute::Spotify, RefTarget::RoonBrowse { .. })
+        | (LibraryRoute::AppleMusic, RefTarget::RoonBrowse { .. })
+        | (LibraryRoute::MusicAssistant, RefTarget::RoonBrowse { .. }) => env.failed(
             "internal routing error: ref/zone provider mismatch reached dispatch after the \
                  capability check. This is a UHC bug.",
         ),

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -132,7 +132,7 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_search" => &["query", "zone_id", "source"],
         "hifi_play" => &["query", "zone_id", "source", "action"],
         "hifi_play_ref" => &["ref", "zone_id", "action"],
-        "hifi_queue" => &["zone_id", "action", "item_id", "position"],
+        "hifi_queue" => &["zone_id", "action", "item_id", "position", "target_zone_id"],
         "hifi_collections" => &["zone_id", "action", "path", "media_type", "limit", "offset"],
         "hifi_zone_group" => &["action", "leader_zone_id", "member_zone_ids", "confirm"],
         "hifi_spotify" => &[

--- a/src/mcp/tools/queue.rs
+++ b/src/mcp/tools/queue.rs
@@ -12,13 +12,13 @@ use serde::{Deserialize, Serialize};
 
 #[mcp_tool(
     name = "hifi_queue",
-    description = "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, and clear against its active queue; each mutation returns a fresh queue readback. Queue add is hifi_play action='queue'."
+    description = "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, clear, and transfer against its active queue; each mutation returns a fresh queue readback. transfer moves the active queue from zone_id to target_zone_id (both must be Music Assistant zones). Queue add is hifi_play action='queue'."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiQueueTool {
     /// Zone ID from hifi_zones.
     pub zone_id: String,
-    /// read (default), jump, reorder, remove, or clear.
+    /// read (default), jump, reorder, remove, clear, or transfer.
     #[serde(default = "default_action")]
     pub action: String,
     /// Queue item id for jump, reorder, or remove.
@@ -27,6 +27,9 @@ pub struct HifiQueueTool {
     /// Target zero-based position for reorder.
     #[serde(default)]
     pub position: Option<i64>,
+    /// Destination zone ID for transfer. Must belong to the same provider as zone_id.
+    #[serde(default)]
+    pub target_zone_id: Option<String>,
 }
 
 fn default_action() -> String {
@@ -44,18 +47,19 @@ pub async fn handle_queue(
         "reorder" => "queue_reorder",
         "remove" => "queue_remove",
         "clear" => "queue_clear",
+        "transfer" => "queue_transfer",
         _ => {
             return Envelope::write("hifi_queue", "queue").refused(
                 "Unknown queue action.",
                 crate::mcp::envelope::Refusal::invalid_parameter(
                     "action",
-                    &["read", "jump", "reorder", "remove", "clear"],
+                    &["read", "jump", "reorder", "remove", "clear", "transfer"],
                     "Choose a documented queue action.",
                 ),
             )
         }
     };
-    let env = if operation == "queue_read" {
+    let mut env = if operation == "queue_read" {
         Envelope::read("hifi_queue", operation)
     } else {
         Envelope::write("hifi_queue", operation)
@@ -63,11 +67,15 @@ pub async fn handle_queue(
     .param("zone_id", &*args.zone_id)
     .param("action", &*args.action)
     .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
+    if let Some(target_zone_id) = args.target_zone_id.as_deref() {
+        env = env.param("target_zone_id", target_zone_id);
+    }
     let capability = match operation {
         "queue_read" => Capability::QueueRead,
         "queue_jump" => Capability::QueueJump,
         "queue_reorder" => Capability::QueueReorder,
         "queue_remove" => Capability::QueueRemove,
+        "queue_transfer" => Capability::QueueTransfer,
         _ => Capability::QueueClear,
     };
     if !matches!(support(target, capability), Support::Supported) {
@@ -75,6 +83,46 @@ pub async fn handle_queue(
             "Queue read is not available for {} zones",
             target.label()
         ));
+    }
+    if operation == "queue_transfer" {
+        let target_zone_id = match args.target_zone_id.as_deref() {
+            Some(id) if !id.trim().is_empty() => id,
+            _ => {
+                return env.refused(
+                    "transfer requires target_zone_id.",
+                    crate::mcp::envelope::Refusal::invalid_parameter(
+                        "target_zone_id",
+                        &["a zone_id from hifi_zones"],
+                        "Provide the destination zone's zone_id.",
+                    ),
+                )
+            }
+        };
+        let target_target = ZoneTarget::classify(target_zone_id);
+        if !matches!(target.for_library(), LibraryRoute::MusicAssistant)
+            || !matches!(target_target.for_library(), LibraryRoute::MusicAssistant)
+        {
+            return env.refused(
+                "transfer requires both zones to be Music Assistant zones.",
+                crate::mcp::envelope::Refusal::invalid_parameter(
+                    "target_zone_id",
+                    &["a Music Assistant zone_id from hifi_zones"],
+                    "Queue transfer is only implemented between two Music Assistant zones.",
+                ),
+            );
+        }
+        return match state
+            .adapter_registry
+            .library_content(
+                "musicassistant",
+                operation,
+                &serde_json::json!({"zone_id": args.zone_id, "target_zone_id": target_zone_id}),
+            )
+            .await
+        {
+            Ok(value) => Ok(env.json_result(&value)),
+            Err(e) => env.failed(format!("Queue error: {e}")),
+        };
     }
     match target.for_library() {
         LibraryRoute::Spotify => match state

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -76,9 +76,12 @@ POST /api/bridges/applemusic/remove
 POST /api/bridges/applemusic/rename
 POST /api/bridges/applemusic/revoke
 POST /api/bridges/applemusic/state
+POST /api/collections
 POST /api/controller/bootstrap
+POST /api/play_ref
 POST /api/providers/{provider}/configure
 POST /api/providers/{provider}/oauth/revoke
+POST /api/queue
 POST /api/settings
 POST /control
 POST /hqp/detect

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -335,11 +335,11 @@
     }
   },
   "hifi_queue": {
-    "description": "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, and clear against its active queue; each mutation returns a fresh queue readback. Queue add is hifi_play action='queue'.",
+    "description": "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, clear, and transfer against its active queue; each mutation returns a fresh queue readback. transfer moves the active queue from zone_id to target_zone_id (both must be Music Assistant zones). Queue add is hifi_play action='queue'.",
     "inputSchema": {
       "properties": {
         "action": {
-          "description": "read (default), jump, reorder, remove, or clear.",
+          "description": "read (default), jump, reorder, remove, clear, or transfer.",
           "type": "string"
         },
         "item_id": {
@@ -351,6 +351,11 @@
           "description": "Target zero-based position for reorder.",
           "nullable": true,
           "type": "integer"
+        },
+        "target_zone_id": {
+          "description": "Destination zone ID for transfer. Must belong to the same provider as zone_id.",
+          "nullable": true,
+          "type": "string"
         },
         "zone_id": {
           "description": "Zone ID from hifi_zones.",

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -114,7 +114,7 @@
     }
   },
   "hifi_collections": {
-    "description": "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection.",
+    "description": "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection. Implemented for lms and roon zones; Music Assistant zones (see hifi_queue's provider notes); Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one.",
     "inputSchema": {
       "properties": {
         "action": {

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -800,6 +800,7 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
             ("action", true),
             ("item_id", false),
             ("position", false),
+            ("target_zone_id", false),
         ],
     ),
     (
@@ -1805,7 +1806,8 @@ async fn musicassistant_mcp_handler(
         | Some("player_queues/play_index")
         | Some("player_queues/move_item")
         | Some("player_queues/delete_item")
-        | Some("player_queues/clear") => json!({"ok": true}),
+        | Some("player_queues/clear")
+        | Some("player_queues/transfer") => json!({"ok": true}),
         Some("players/cmd/set_members") | Some("players/cmd/ungroup_many") => json!({"ok": true}),
         command => panic!("unexpected Music Assistant command: {command:?}"),
     };
@@ -2021,6 +2023,7 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
         json!({"zone_id": zone_id, "action": "reorder", "item_id": "q2", "position": 0}),
         json!({"zone_id": zone_id, "action": "remove", "item_id": "q2"}),
         json!({"zone_id": zone_id, "action": "clear"}),
+        json!({"zone_id": zone_id, "action": "transfer", "target_zone_id": "musicassistant:group-child-2"}),
     ] {
         assert_eq!(
             app.call_tool("hifi_queue", args).await["structuredContent"]["outcome"],
@@ -2034,7 +2037,8 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
             "player_queues/play_index"
             | "player_queues/move_item"
             | "player_queues/delete_item"
-            | "player_queues/clear" => Some((
+            | "player_queues/clear"
+            | "player_queues/transfer" => Some((
                 request["command"].as_str().unwrap(),
                 request["args"].clone(),
             )),
@@ -2059,6 +2063,10 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
             (
                 "player_queues/clear",
                 json!({"queue_id":"living-room-group"})
+            ),
+            (
+                "player_queues/transfer",
+                json!({"source_queue_id":"living-room-group", "target_queue_id":"living-room-group"})
             ),
         ]
     );
@@ -4831,6 +4839,7 @@ const EXPECTED_CAPABILITIES: &[&str] = &[
     "queue_reorder",
     "queue_remove",
     "queue_clear",
+    "queue_transfer",
     "play_next",
     "repeat_mode",
     "shuffle_mode",
@@ -5227,6 +5236,14 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 "hifi_queue",
                 json!({ "zone_id": zone_id, "action": "clear" }),
             )),
+            "queue_transfer" => Some((
+                "hifi_queue",
+                json!({
+                    "zone_id": zone_id,
+                    "action": "transfer",
+                    "target_zone_id": format!("{provider}:xyz"),
+                }),
+            )),
             "repeat_mode" => Some((
                 "hifi_control",
                 json!({ "zone_id": zone_id, "action": "repeat_off" }),
@@ -5279,15 +5296,16 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     }
     // The routed Spotify content and mode cells plus Music Assistant's queue
     // mutations, mode, collections, and zone-group cells add twenty-three probes to the
-    // original provider transport set.
+    // original provider transport set, plus one more for Music Assistant's
+    // queue_transfer (#507).
     // Apple Music's transport/skip/volume
     // cells remain gated until signed physical companion validation (#465).
     // Asserted exactly, not as a floor: a floor would pass while a cell silently
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 45,
-        "{proved} supported cells were proved end to end, expected 45. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 46,
+        "{proved} supported cells were proved end to end, expected 46. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -228,7 +228,7 @@ async fn build_state_with_bus(
     let startable_adapters: Vec<Arc<dyn Startable>> =
         vec![roon.clone(), lms.clone(), openhome.clone(), upnp.clone()];
 
-    AppState::new(
+    let state = AppState::new(
         roon,
         hqplayer,
         hqp_instances,
@@ -243,7 +243,20 @@ async fn build_state_with_bus(
         startable_adapters,
         Instant::now(),
         CancellationToken::new(),
-    )
+    );
+    // #531: mirrors main.rs's registration -- hifi_collections reaches LMS
+    // and Roon through the registry's `content` operation, not a direct
+    // `state.lms`/`state.roon` field access (see
+    // `tests/adapter_boundary_lint.rs`).
+    state
+        .adapter_registry
+        .register_library("lms", state.lms.clone())
+        .await;
+    state
+        .adapter_registry
+        .register_library("roon", state.roon.clone())
+        .await;
+    state
 }
 
 impl TestApp {
@@ -2248,6 +2261,194 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
                 == json!({"queue_id": "living-room-group", "media": "library://track/42", "option": "next"})
     ));
     server.abort();
+}
+
+/// #531: LMS's `hifi_collections` slice walks the synthetic root into
+/// Albums, drills into one album's tracks, and mints an opaque ref over the
+/// durable `LmsPlayTarget::Library` id -- never the raw LMS entity id.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_collections_browse_walks_albums_into_tracks() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    h.mock
+        .set_library_albums(vec![(7, "Kind of Blue", "Miles Davis")])
+        .await;
+    h.mock
+        .set_album_tracks(7, vec![(42, "So What", Some("Miles Davis"))])
+        .await;
+
+    let root = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse"}),
+        )
+        .await;
+    assert_eq!(root["structuredContent"]["outcome"], "ok");
+    let root_page: Value = serde_json::from_str(&result_text(&root)).expect("root page JSON");
+    let albums_entry = root_page["items"]
+        .as_array()
+        .expect("root items")
+        .iter()
+        .find(|item| item["title"] == "Albums")
+        .expect("root must list Albums");
+    let albums_path = albums_entry["path"].as_str().expect("Albums has a path");
+    assert!(albums_path.starts_with("ref_"));
+
+    let albums = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": albums_path}),
+        )
+        .await;
+    assert_eq!(albums["structuredContent"]["outcome"], "ok");
+    let albums_page: Value = serde_json::from_str(&result_text(&albums)).expect("albums page JSON");
+    assert_eq!(albums_page["items"][0]["title"], "Kind of Blue");
+    assert_eq!(albums_page["items"][0]["subtitle"], "Album by Miles Davis");
+    let album_path = albums_page["items"][0]["path"]
+        .as_str()
+        .expect("an album is itself browsable, into its tracks");
+
+    let tracks = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": album_path}),
+        )
+        .await;
+    assert_eq!(tracks["structuredContent"]["outcome"], "ok");
+    let tracks_page: Value = serde_json::from_str(&result_text(&tracks)).expect("tracks page JSON");
+    assert_eq!(tracks_page["items"][0]["title"], "So What");
+    let track_ref = tracks_page["items"][0]["ref"]
+        .as_str()
+        .expect("a track is playable, not a browsable path");
+    assert!(tracks_page["items"][0].get("path").is_none());
+
+    // The minted ref plays via hifi_play_ref exactly like a search hit's.
+    let play = h
+        .app
+        .call_tool(
+            "hifi_play_ref",
+            json!({"zone_id": zone_id, "ref": track_ref}),
+        )
+        .await;
+    assert_eq!(play["structuredContent"]["outcome"], "accepted");
+
+    h.stop().await;
+}
+
+/// #531: `hifi_collections playlists` lists LMS's saved playlists, and one
+/// playlist's tracks are reachable through the same opaque-path browse call.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_collections_playlists_and_favorites() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    h.mock
+        .set_library_playlists(vec![(3, "Sunday Morning")])
+        .await;
+    h.mock
+        .set_playlist_tracks(3, vec![(9, "Blue in Green", Some("Miles Davis"))])
+        .await;
+    h.mock
+        .set_favorites(vec![("Jazz FM", "http://example.com/jazzfm")])
+        .await;
+
+    let playlists = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "playlists"}),
+        )
+        .await;
+    assert_eq!(playlists["structuredContent"]["outcome"], "ok");
+    let playlists_page: Value =
+        serde_json::from_str(&result_text(&playlists)).expect("playlists page JSON");
+    assert_eq!(playlists_page["items"][0]["title"], "Sunday Morning");
+    let playlist_path = playlists_page["items"][0]["path"]
+        .as_str()
+        .expect("a playlist is browsable into its tracks");
+
+    let tracks = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": playlist_path}),
+        )
+        .await;
+    assert_eq!(tracks["structuredContent"]["outcome"], "ok");
+    let tracks_page: Value = serde_json::from_str(&result_text(&tracks)).expect("tracks page JSON");
+    assert_eq!(tracks_page["items"][0]["title"], "Blue in Green");
+
+    let favorites = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "favorites"}),
+        )
+        .await;
+    assert_eq!(favorites["structuredContent"]["outcome"], "ok");
+    let favorites_page: Value =
+        serde_json::from_str(&result_text(&favorites)).expect("favorites page JSON");
+    assert_eq!(favorites_page["items"][0]["title"], "Jazz FM");
+    let favorite_ref = favorites_page["items"][0]["ref"]
+        .as_str()
+        .expect("a favorite with a url is playable");
+    assert!(!favorite_ref.contains("jazzfm"), "the favorite's url must stay server-side");
+
+    h.stop().await;
+}
+
+/// #531: an opaque path minted for one zone's provider must never resolve
+/// against a different provider's zone -- same safety property #492 already
+/// pins for Music Assistant, now proven for LMS.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_collections_path_does_not_cross_provider_boundaries() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+    h.mock
+        .set_library_albums(vec![(1, "Album", "Artist")])
+        .await;
+
+    let root = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse"}),
+        )
+        .await;
+    let root_page: Value = serde_json::from_str(&result_text(&root)).expect("root page JSON");
+    let path = root_page["items"][0]["path"]
+        .as_str()
+        .expect("root item has a path")
+        .to_string();
+
+    let cross = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": "roon:not-lms", "action": "browse", "path": path}),
+        )
+        .await;
+    assert_eq!(cross["structuredContent"]["outcome"], "invalid", "{cross}");
+    assert_eq!(cross["structuredContent"]["refusal"]["parameter"], "path");
+
+    let stale = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": "ref_not-a-real-token"}),
+        )
+        .await;
+    assert_eq!(stale["structuredContent"]["outcome"], "invalid", "{stale}");
+    assert_eq!(stale["structuredContent"]["refusal"]["parameter"], "path");
+
+    h.stop().await;
 }
 
 /// A `TestApp` wired to a live mock LMS server, with the aggregator running so
@@ -5027,7 +5228,6 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
 
     // The named cases, spelled out so a regression names itself.
     for capability in [
-        "browse",
         "queue_read",
         "queue_jump",
         "queue_reorder",
@@ -5036,8 +5236,6 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
         "play_next",
         "repeat_mode",
         "shuffle_mode",
-        "saved_playlists",
-        "favorites",
         "multiroom_sync",
     ] {
         let entry = caps
@@ -5047,6 +5245,19 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
             support_of(entry),
             NOT_IMPLEMENTED,
             "lms/{capability} must read as not-yet-implemented until its issue lands"
+        );
+    }
+
+    // #531 wired these three to hifi_collections; LMS's protocol always
+    // supported them (that is this test's whole point), and now so does UHC.
+    for capability in ["browse", "saved_playlists", "favorites"] {
+        let entry = caps
+            .get(capability)
+            .unwrap_or_else(|| panic!("lms/{capability} missing"));
+        assert_eq!(
+            support_of(entry),
+            SUPPORTED,
+            "lms/{capability} is wired to hifi_collections since #531"
         );
     }
 }
@@ -5205,15 +5416,29 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 "hifi_play_ref",
                 json!({ "ref": "bad-ref", "zone_id": zone_id }),
             )),
-            "browse" | "saved_playlists" | "favorites" if provider == "musicassistant" => Some((
+            "browse" | "saved_playlists" | "favorites"
+                if matches!(provider, "musicassistant" | "lms") =>
+            {
+                Some((
+                    "hifi_collections",
+                    json!({
+                        "zone_id": zone_id,
+                        "action": match capability {
+                            "browse" => "browse",
+                            "saved_playlists" => "playlists",
+                            _ => "favorites",
+                        }
+                    }),
+                ))
+            }
+            // Roon's favorites cell is not (yet) supported, so only browse
+            // and saved_playlists (mapped to Playlists, its browse-hierarchy
+            // node) are probed here.
+            "browse" | "saved_playlists" if provider == "roon" => Some((
                 "hifi_collections",
                 json!({
                     "zone_id": zone_id,
-                    "action": match capability {
-                        "browse" => "browse",
-                        "saved_playlists" => "playlists",
-                        _ => "favorites",
-                    }
+                    "action": if capability == "browse" { "browse" } else { "playlists" },
                 }),
             )),
             "browse" | "saved_playlists" | "favorites" => {
@@ -5297,15 +5522,16 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     // The routed Spotify content and mode cells plus Music Assistant's queue
     // mutations, mode, collections, and zone-group cells add twenty-three probes to the
     // original provider transport set, plus one more for Music Assistant's
-    // queue_transfer (#507).
+    // queue_transfer (#507), plus five for #531's LMS (browse, saved_playlists,
+    // favorites) and Roon (browse, saved_playlists) hifi_collections cells.
     // Apple Music's transport/skip/volume
     // cells remain gated until signed physical companion validation (#465).
     // Asserted exactly, not as a floor: a floor would pass while a cell silently
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 46,
-        "{proved} supported cells were proved end to end, expected 46. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 51,
+        "{proved} supported cells were proved end to end, expected 51. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -86,6 +86,23 @@ pub struct MockLibraryItem {
     pub artist: String,
 }
 
+/// One track row for `titles` (an album's tracks) and `playlists tracks` (a
+/// playlist's tracks) -- #531's `hifi_collections` drill-down.
+#[derive(Debug, Clone)]
+pub struct MockTrack {
+    pub id: i64,
+    pub title: String,
+    pub artist: Option<String>,
+}
+
+/// One row of LMS's `favorites items` -- #531. Real LMS favorites carry no
+/// durable entity id, only a `url`; this mock mirrors that.
+#[derive(Debug, Clone)]
+pub struct MockFavorite {
+    pub name: String,
+    pub url: String,
+}
+
 /// Mock LMS server state
 struct MockLmsState {
     players: HashMap<String, MockPlayer>,
@@ -96,9 +113,18 @@ struct MockLmsState {
     /// Library items for `search` (the `search_library` fallback path) and for
     /// the `albums`/`artists`/`titles` existence checks
     /// `LmsAdapter::assert_library_id_exists` (#396) issues before a mutating
-    /// `playlistcontrol` call. Keyed by [`LmsSearchResultType`]-shaped kind:
-    /// `"album"`, `"artist"`, `"track"`.
+    /// `playlistcontrol` call, and for #531's `hifi_collections` listings.
+    /// Keyed by [`LmsSearchResultType`]-shaped kind: `"album"`, `"artist"`,
+    /// `"track"`, plus `"playlist"` for #531.
     library: HashMap<&'static str, Vec<MockLibraryItem>>,
+    /// `album_id` -> that album's tracks, for `titles <start> <count>
+    /// album_id:<id>` (#531).
+    album_tracks: HashMap<i64, Vec<MockTrack>>,
+    /// `playlist_id` -> that playlist's tracks, for `playlists tracks <start>
+    /// <count> playlist_id:<id>` (#531).
+    playlist_tracks: HashMap<i64, Vec<MockTrack>>,
+    /// The flat favourites list for `favorites items <start> <count>` (#531).
+    favorites: Vec<MockFavorite>,
 }
 
 /// Mock LMS Server
@@ -115,6 +141,9 @@ impl MockLmsServer {
             players: HashMap::new(),
             commands: Vec::new(),
             library: HashMap::new(),
+            album_tracks: HashMap::new(),
+            playlist_tracks: HashMap::new(),
+            favorites: Vec::new(),
         }));
 
         let app = Router::new()
@@ -212,6 +241,83 @@ impl MockLmsServer {
         self.state.write().await.library.insert("album", items);
     }
 
+    /// Seed the artist library `artists <start> <count>` answers from (#531).
+    pub async fn set_library_artists(&self, artists: Vec<(i64, &str)>) {
+        let items = artists
+            .into_iter()
+            .map(|(id, title)| MockLibraryItem {
+                id,
+                title: title.to_string(),
+                artist: String::new(),
+            })
+            .collect();
+        self.state.write().await.library.insert("artist", items);
+    }
+
+    /// Seed the playlist library `playlists <start> <count>` answers from
+    /// (#531).
+    pub async fn set_library_playlists(&self, playlists: Vec<(i64, &str)>) {
+        let items = playlists
+            .into_iter()
+            .map(|(id, title)| MockLibraryItem {
+                id,
+                title: title.to_string(),
+                artist: String::new(),
+            })
+            .collect();
+        self.state.write().await.library.insert("playlist", items);
+    }
+
+    /// Seed one album's tracks, for `titles <start> <count> album_id:<id>`
+    /// (#531).
+    pub async fn set_album_tracks(&self, album_id: i64, tracks: Vec<(i64, &str, Option<&str>)>) {
+        let items = tracks
+            .into_iter()
+            .map(|(id, title, artist)| MockTrack {
+                id,
+                title: title.to_string(),
+                artist: artist.map(str::to_string),
+            })
+            .collect();
+        self.state.write().await.album_tracks.insert(album_id, items);
+    }
+
+    /// Seed one playlist's tracks, for `playlists tracks <start> <count>
+    /// playlist_id:<id>` (#531).
+    pub async fn set_playlist_tracks(
+        &self,
+        playlist_id: i64,
+        tracks: Vec<(i64, &str, Option<&str>)>,
+    ) {
+        let items = tracks
+            .into_iter()
+            .map(|(id, title, artist)| MockTrack {
+                id,
+                title: title.to_string(),
+                artist: artist.map(str::to_string),
+            })
+            .collect();
+        self.state
+            .write()
+            .await
+            .playlist_tracks
+            .insert(playlist_id, items);
+    }
+
+    /// Seed the flat favourites list `favorites items <start> <count>`
+    /// answers from (#531). Real LMS favorites have no durable id, only a
+    /// `url` -- mirrored here rather than inventing one.
+    pub async fn set_favorites(&self, favorites: Vec<(&str, &str)>) {
+        let items = favorites
+            .into_iter()
+            .map(|(name, url)| MockFavorite {
+                name: name.to_string(),
+                url: url.to_string(),
+            })
+            .collect();
+        self.state.write().await.favorites = items;
+    }
+
     /// Commands received for `player_id`, excluding the read-only polling
     /// commands the adapter issues on its own schedule.
     pub async fn write_commands(&self, player_id: &str) -> Vec<Vec<String>> {
@@ -261,6 +367,23 @@ fn filter_value<'a>(commands: &'a [Value], tag: &str) -> Option<&'a str> {
         .iter()
         .filter_map(Value::as_str)
         .find_map(|s| s.strip_prefix(prefix.as_str()))
+}
+
+/// Read the `<start> <count>` pair LMS's own taggedlist queries carry at a
+/// fixed position (#531): `["albums", <start>, <count>, ...]` has them at
+/// `1, 2`; `["playlists", "tracks", <start>, <count>, ...]` has them one
+/// further out, at `2, 3`. `start_index` names where `<start>` sits.
+fn paging(commands: &[Value], start_index: usize) -> (usize, usize) {
+    let offset = commands
+        .get(start_index)
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let count = commands
+        .get(start_index + 1)
+        .and_then(Value::as_u64)
+        .map(|c| c as usize)
+        .unwrap_or(usize::MAX);
+    (offset, count)
 }
 
 /// Handle JSON-RPC requests
@@ -485,11 +608,39 @@ async fn handle_jsonrpc(
                     })
                 })
                 .collect();
-            if page.is_empty() {
-                json!({})
-            } else {
-                json!({ "albums_loop": page })
+            // #531: `LmsAdapter::assert_library_id_exists` re-searches by
+            // title before honoring a track ref minted by
+            // `hifi_collections` (same existence check #396 added for
+            // albums), so a track from an album's or a playlist's tracks
+            // must be findable here too -- by title, exactly like albums
+            // above, deduped by id since the same track can appear in both.
+            let mut seen_track_ids = std::collections::HashSet::new();
+            let track_page: Vec<Value> = state
+                .album_tracks
+                .values()
+                .chain(state.playlist_tracks.values())
+                .flatten()
+                .filter(|t| seen_track_ids.insert(t.id))
+                .filter(|t| {
+                    t.title.to_lowercase().contains(&query)
+                        || t.artist
+                            .as_deref()
+                            .unwrap_or_default()
+                            .to_lowercase()
+                            .contains(&query)
+                })
+                .skip(offset)
+                .take(count)
+                .map(|t| json!({"track_id": t.id, "track": t.title, "artist": t.artist}))
+                .collect();
+            let mut result = serde_json::Map::new();
+            if !page.is_empty() {
+                result.insert("albums_loop".to_string(), json!(page));
             }
+            if !track_page.is_empty() {
+                result.insert("tracks_loop".to_string(), json!(track_page));
+            }
+            Value::Object(result)
         }
         // The existence check `LmsAdapter::assert_library_id_exists` (#396)
         // issues before a mutating `playlistcontrol`:
@@ -498,7 +649,7 @@ async fn handle_jsonrpc(
         // album path -- they fall to the catch-all `{"count": 0}` shape via
         // `_`, which is the safe direction: an unmodeled kind reads as "not
         // found" rather than "found").
-        "albums" => {
+        "albums" if filter_value(commands, "album_id").is_some() => {
             let requested_id =
                 filter_value(commands, "album_id").and_then(|v| v.parse::<i64>().ok());
             let count = match requested_id {
@@ -512,6 +663,90 @@ async fn handle_jsonrpc(
                 None => 0,
             };
             json!({ "count": count })
+        }
+        // #531's `hifi_collections browse`: `["albums", <start>, <count>]`,
+        // the whole album library (no `album_id` filter, handled above).
+        "albums" => {
+            let (offset, count) = paging(commands, 1);
+            let all: Vec<&MockLibraryItem> = state.library.get("album").into_iter().flatten().collect();
+            let page: Vec<Value> = all
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|item| json!({"album_id": item.id, "album": item.title, "artist": item.artist}))
+                .collect();
+            json!({ "count": all.len(), "albums_loop": page })
+        }
+        // #531: `["artists", <start>, <count>]`.
+        "artists" => {
+            let (offset, count) = paging(commands, 1);
+            let all: Vec<&MockLibraryItem> = state.library.get("artist").into_iter().flatten().collect();
+            let page: Vec<Value> = all
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|item| json!({"artist_id": item.id, "artist": item.title}))
+                .collect();
+            json!({ "count": all.len(), "artists_loop": page })
+        }
+        // #531: `["titles", <start>, <count>, "album_id:<id>"]` -- one
+        // album's tracks.
+        "titles" => {
+            let (offset, count) = paging(commands, 1);
+            let album_id = filter_value(commands, "album_id").and_then(|v| v.parse::<i64>().ok());
+            let tracks = album_id
+                .and_then(|id| state.album_tracks.get(&id))
+                .cloned()
+                .unwrap_or_default();
+            let page: Vec<Value> = tracks
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|t| json!({"track_id": t.id, "title": t.title, "artist": t.artist}))
+                .collect();
+            json!({ "count": tracks.len(), "titles_loop": page })
+        }
+        // #531: `["playlists", <start>, <count>]` (the playlist library) or
+        // `["playlists", "tracks", <start>, <count>, "playlist_id:<id>"]`
+        // (one playlist's tracks).
+        "playlists" if commands.get(1).and_then(Value::as_str) == Some("tracks") => {
+            let (offset, count) = paging(commands, 2);
+            let playlist_id =
+                filter_value(commands, "playlist_id").and_then(|v| v.parse::<i64>().ok());
+            let tracks = playlist_id
+                .and_then(|id| state.playlist_tracks.get(&id))
+                .cloned()
+                .unwrap_or_default();
+            let page: Vec<Value> = tracks
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|t| json!({"id": t.id, "title": t.title, "artist": t.artist}))
+                .collect();
+            json!({ "count": tracks.len(), "playlisttracks_loop": page })
+        }
+        "playlists" => {
+            let (offset, count) = paging(commands, 1);
+            let all: Vec<&MockLibraryItem> = state.library.get("playlist").into_iter().flatten().collect();
+            let page: Vec<Value> = all
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|item| json!({"id": item.id, "playlist": item.title}))
+                .collect();
+            json!({ "count": all.len(), "playlists_loop": page })
+        }
+        // #531: `["favorites", "items", <start>, <count>]`.
+        "favorites" if commands.get(1).and_then(Value::as_str) == Some("items") => {
+            let (offset, count) = paging(commands, 2);
+            let page: Vec<Value> = state
+                .favorites
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|f| json!({"name": f.name, "url": f.url}))
+                .collect();
+            json!({ "count": state.favorites.len(), "loop_loop": page })
         }
         _ => {
             json!({})

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -1314,6 +1314,128 @@ async fn a_custom_library_is_browsable() {
 }
 
 // =============================================================================
+// hifi_collections (#531): browse_collection and browse_named_root_node
+// =============================================================================
+
+/// `browse_collection` walks two levels: a fresh root session, then resuming
+/// it with the returned `(item_key, session_key)` pair -- exactly what
+/// `hifi_collections`' `path` round-trips through a minted `RoonBrowse` ref.
+/// The second call must never send `pop_all` (see `RoonAdapter::play_ref`'s
+/// docs on why that combination hangs a real Core).
+#[tokio::test]
+async fn roon_collections_browse_walks_two_levels_without_pop_all_on_resume() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Library").with_children(vec![FakeItem::list(
+        "Genres",
+    )
+    .with_children(vec![FakeItem::list("Jazz"), FakeItem::list("Ambient")])])];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let (session, root_items, root_count) = adapter
+        .browse_collection("zone_1", None, None, 0, 20)
+        .await
+        .expect("root browse");
+    assert_eq!(root_count, 1);
+    assert_eq!(root_items[0].title, "Library");
+    let library_key = root_items[0]
+        .item_key
+        .clone()
+        .expect("Library must be keyed");
+
+    let (resumed_session, level_two, _count) = adapter
+        .browse_collection("zone_1", Some(&library_key), Some(&session), 0, 20)
+        .await
+        .expect("resumed browse");
+    assert_eq!(resumed_session, session, "resuming must reuse the session");
+    assert_eq!(
+        level_two.iter().map(|i| i.title.as_str()).collect::<Vec<_>>(),
+        vec!["Genres"]
+    );
+
+    // The resuming browse must never combine pop_all with item_key.
+    let browses = core.browse_requests().await;
+    assert_eq!(browses.len(), 2);
+    assert!(browses[0].pop_all() && browses[0].item_key().is_none());
+    assert!(!browses[1].pop_all());
+    assert_eq!(browses[1].item_key(), Some(library_key.as_str()));
+
+    core.stop().await;
+}
+
+/// `browse_collection` honors `offset`/`limit` as Roon's own `load` paging,
+/// not a client-side slice -- unlike Music Assistant's `music/browse`, Roon's
+/// `load` takes `offset`/`count` natively.
+#[tokio::test]
+async fn roon_collections_browse_pages_with_native_load_offset() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("A"), FakeItem::list("B"), FakeItem::list("C")];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let (_session, page, count) = adapter
+        .browse_collection("zone_1", None, None, 1, 1)
+        .await
+        .expect("paged root browse");
+    assert_eq!(count, 3);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].title, "B");
+
+    core.stop().await;
+}
+
+/// `hifi_collections playlists`' whole job: enter a named top-level node in
+/// one call and load its contents, without a caller ever seeing the two-hop
+/// browse/load plumbing.
+#[tokio::test]
+async fn roon_collections_playlists_enters_the_named_root_node() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        FakeItem::list("Library"),
+        FakeItem::list("Playlists").with_children(vec![
+            FakeItem::list("Sunday Morning"),
+            FakeItem::list("Focus"),
+        ]),
+    ];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let (_session, items, count) = adapter
+        .browse_named_root_node("zone_1", "Playlists", 0, 20)
+        .await
+        .expect("Playlists node must be found");
+    assert_eq!(count, 2);
+    assert_eq!(
+        items.iter().map(|i| i.title.as_str()).collect::<Vec<_>>(),
+        vec!["Sunday Morning", "Focus"]
+    );
+
+    core.stop().await;
+}
+
+/// A named node the Core's root does not have is an honest, named failure --
+/// not a hang, not an empty page pretending to be the real thing.
+#[tokio::test]
+async fn roon_collections_named_root_node_not_found_is_a_clean_error() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Library")];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let error = adapter
+        .browse_named_root_node("zone_1", "Playlists", 0, 20)
+        .await
+        .expect_err("Playlists does not exist in this root");
+    assert!(error.to_string().contains("Playlists"));
+
+    core.stop().await;
+}
+
+// =============================================================================
 // AppState for the HTTP-boundary test
 // =============================================================================
 


### PR DESCRIPTION
Progresses #531

## Dependency handling

#531 depends on PR #516 (branch `issue/507`: CollectionsBrowser web component + `/api/collections` endpoints). #516 was still open (unmerged) when this branch was created, so I branched from `feat/issue-462-streaming-adapters` and fast-forward-merged `origin/issue/507` into `issue/531` before doing any of #531's own work. If #516 merges into the base branch before this PR does, this diff should rebase/merge cleanly since it is already downstream of that content; no separate merge-after-#516 step should be required, but flagging the sequencing per the task's dependency note.

## Scope: LMS + Roon + web UI gating landed; Spotify and Apple Music deliberately deferred

This is the largest issue in its batch, and #531 explicitly permits a per-provider split when one PR would otherwise be too large to verify. This PR lands:

- **LMS**: `hifi_collections` browse/playlists/favorites over the CLI/jsonrpc the adapter already speaks for search and playback (`albums`, `artists`, `titles`, `playlists`, `playlists tracks`, `favorites items`). Browse walks a synthetic root (Albums/Artists/Playlists) into albums' and playlists' tracks. Opaque server-side paths (`RefTarget::LmsBrowse`) and playable refs (`RefTarget::Lms` over `LmsPlayTarget::Library`/`Url`) follow the same minting pattern #492 established for Music Assistant — no raw LMS entity id or favorite url ever reaches a client.
- **Roon**: browse and playlists (`saved_playlists`), reusing the exact browse/load session machinery `hifi_search` already drives (`RoonAdapter::browse`/`load`, the same "never combine `pop_all` with `item_key`" rule `play_ref` already discovered live). A new `RefTarget::RoonBrowse` pairs a browse continuation's `item_key` with the `multi_session_key` that minted it, exactly like the existing playable `RoonRefTarget`. Favorites is **not** implemented for Roon in this slice — Roon exposes it as a browse hierarchy this slice doesn't walk into, so it stays `not_implemented` (tracked by #531 itself, since the parent issue remains open).
- **Web UI**: `CollectionsBrowser` (from #516) now gates on a server-computed `browse_supported` boolean per zone — literally "does `hifi_collections` implement this zone's provider" — instead of a hardcoded `musicassistant:` prefix check. LMS and Roon zones light up automatically; queue transfer (a separate, MA-only capability from #507) is unaffected.
- The blanket "Collections are not implemented for this provider yet" refusal is removed. Spotify and Apple Music are now refused **by name**, honestly: `hifi_spotify` (and the Apple Music companion tools) already implement browse/playlists/favorites for those providers today — that's why the capability matrix already reports them `supported` independent of this tool — so `hifi_collections` refuses them with `not_implemented` (tracked by `#531`) naming the alternative tool, rather than either lying "not implemented" for a capability the provider actually has, or silently calling an adapter operation it was never taught and surfacing whatever generic error falls out.

**Remaining for #531**: adapt Spotify's and Apple Music's existing content operations behind `hifi_collections`' neutral verbs (their own dedicated tools already work; this is purely about the neutral surface). Left for a follow-up PR against this same issue rather than filed as new child issues, per the task's scope-management instruction. #531 stays open until that lands.

## Approach notes

- **Architecture boundary (#436)**: `hifi_collections` reaches LMS and Roon through `AdapterRegistry::library_content`, not a new direct `state.lms`/`state.roon` field access — `tests/adapter_boundary_lint.rs` enforces an exact, non-growing debt baseline and would have failed on a new bypass. `LmsAdapter`/`RoonAdapter` now implement `LibraryAdapter`, but only `content()` is real; `search`/`play_uri` refuse through this trait with an explanation, since `hifi_search`/`hifi_play` already call these adapters directly for reasons specific to each provider's typed targets (LMS's `LmsPlayTarget::{Library,Url,GlobalSearchItem}`, Roon's session-scoped `item_key`) that don't fit the trait's flat-URI contract. That pre-existing direct-access debt in `library.rs` is untouched.
- **Capability matrix**: flipped LMS `browse`/`saved_playlists`/`favorites` and Roon `browse`/`saved_playlists` from `not_implemented` to `supported` in `src/mcp/capabilities.rs`'s `routed()`, removed the now-stale `GAPS` rows, and regenerated `AGENTS.md` and `tests/fixtures/mcp_tools.json` via `UPDATE_MCP_FIXTURES=1 UPDATE_AGENTS_MATRIX=1 cargo test --test mcp_contract`.
- **Opaque refs**: every new path/ref follows #396/#492's existing pattern exactly — a 128-bit token naming a row in `RefTable`, never a self-describing/derivable token. Cross-provider and stale-token refusals are checked once, generically, before dispatching to a per-provider handler (matching #492's pre-existing MA-only behavior, now proven for LMS too by a dedicated test).

## Local verification

From a fresh worktree (`make css` first; `RUSTC_WRAPPER=""` with sccache off; rustup's toolchain ahead of Homebrew's on `PATH` for the wasm target):

- `cargo test` — full workspace, run three times: 100% pass except the one documented pre-existing failure, `web_fullstack_runner_contract::runner_builds_matching_assets_before_it_starts_the_server` (unrelated to this change, present on `feat/issue-462-streaming-adapters` before this PR).
- `cargo clippy -- -D warnings` — clean.
- `cargo check --no-default-features --features web --target wasm32-unknown-unknown` — clean (touches `src/app/api.rs`/`src/app/pages/zones.rs`).
- New tests added: `tests/mcp_contract.rs` (`lms_collections_browse_walks_albums_into_tracks`, `lms_collections_playlists_and_favorites`, `lms_collections_path_does_not_cross_provider_boundaries`) against a real `LmsAdapter` + extended `tests/mock_servers/lms.rs`; `tests/roon_protocol.rs` (`roon_collections_browse_walks_two_levels_without_pop_all_on_resume`, `roon_collections_browse_pages_with_native_load_offset`, `roon_collections_playlists_enters_the_named_root_node`, `roon_collections_named_root_node_not_found_is_a_clean_error`) against `RoonAdapter` + `FakeRoonCore`. Updated the existing `every_supported_capability_reaches_that_providers_own_adapter` and `lms_never_reports_a_uhc_gap_as_a_provider_limitation` contract tests for the newly-supported cells.

## Deviations from #531's acceptance criteria

- Spotify and Apple Music slices are not implemented in this PR (see "Remaining for #531" above) — explicitly permitted by the issue's own split guidance.
- Roon `favorites` is not implemented in this slice (stays `not_implemented`, tracked by `#531`) — Roon exposes it as a browse hierarchy this slice doesn't walk into; browse and playlists (the biggest UX win, per the issue's own prioritization) are implemented.
- LMS favorites folders (`hasitems`) are listed but not drillable in this slice — narrower than a full walk, called out here rather than silently dropped.