### PR TITLE
HACS integration: implement browse_media and join/unjoin

### DIFF
--- a/.github/workflows/ha-integration.yml
+++ b/.github/workflows/ha-integration.yml
@@ -1,0 +1,74 @@
+name: Home Assistant integration
+
+# Tests for the HACS custom_components/unified_hifi_control Python
+# package. This job is intentionally independent of the Rust crate's
+# build/CI (build.yml) since it has its own toolchain and dependencies.
+#
+# Note: feature-branch PRs in this repo do not currently run CI checks
+# (see AGENTS.md / stacked-PR workflow notes); this workflow becomes
+# active once merged to v3.
+
+on:
+  push:
+    branches: [v3]
+    paths:
+      - "custom_components/unified_hifi_control/**"
+      - "hacs.json"
+      - "pyproject.toml"
+      - ".github/workflows/ha-integration.yml"
+  pull_request:
+    branches: [v3]
+    paths:
+      - "custom_components/unified_hifi_control/**"
+      - "hacs.json"
+      - "pyproject.toml"
+      - ".github/workflows/ha-integration.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: custom_components/unified_hifi_control/requirements_test.txt
+
+      - name: Install test dependencies
+        run: pip install -r custom_components/unified_hifi_control/requirements_test.txt
+
+      - name: Work around aiodns/pycares thread-leak false positive
+        # homeassistant depends on aiodns/pycares, whose AsyncResolver
+        # spins up a background c-ares thread the first time any test
+        # constructs a real aiohttp connector. pytest-homeassistant-
+        # custom-component's per-test thread-leak check then flags that
+        # thread against whichever test happened to run first, even
+        # though every HTTP call in this suite goes through
+        # aioclient_mock and never touches a real connector. Since our
+        # tests never need real DNS resolution, removing pycares avoids
+        # the false positive without weakening the check itself.
+        run: pip uninstall -y aiodns pycares
+
+      - name: Run pytest
+        run: pytest custom_components/unified_hifi_control/tests -v
+
+  hacs-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ public/tailwind.css
 # Note: public/dx-components-theme.css is hand-authored, NOT generated
 .worktrees/
 .impeccable/critique/
+
+# Python (Home Assistant integration test env)
+__pycache__/
+*.pyc
+.venv*/
+.pytest_cache/
+.ruff_cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ Two things this table does **not** claim:
 | `search` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
 | `play_by_query` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
 | `play_by_ref` | 🚧 #396 | 🚧 #396 | 🚧 #396 | 🚧 #396 | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
-| `browse` | 🚧 #399 | 🚧 #402 | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
+| `browse` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
 | `queue_read` | 🚧 #400 | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | ✅ | ✅ |
 | `queue_jump` | 🚧 #400 | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_reorder` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
@@ -223,8 +223,8 @@ Two things this table does **not** claim:
 | `play_next` | 🚧 #399 | 🚧 #403 | 🚧 #392 | 🚧 #396 | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `repeat_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
-| `saved_playlists` | 🚧 #399 | 🚧 #403 | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
-| `favorites` | 🚧 #399 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
+| `saved_playlists` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
+| `favorites` | 🚧 #531 | ✅ | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
 | `multiroom_sync` | 🚧 #360 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
 
 ✅ supported · ⛔ the provider's protocol cannot do it · 🚧 the provider can, UHC has not wired it (issue that will)
@@ -249,8 +249,6 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - 🚧 **upnp / `play_by_ref`** (#396) — the protocol can play a specific item -- UPnP AVTransport:1 takes SetAVTransportURI and SetNextAVTransportURI, OpenHome Playlist:1 takes Insert(AfterId, Uri, Metadata) -- so what is missing is UHC's ability to name one, not the device's ability to play it. Reported as a UHC gap rather than a provider limit, because a reference minted against a media server would work. Verified from the UPnP AV and OpenHome service definitions, not from a device.
 - 🚧 **hqplayer / `play_by_ref`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `play_by_ref`** (#481) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `browse`** (#399) — RoonAdapter::browse() and load() exist and POST /roon/browse exposes them; only the MCP projection is missing.
-- 🚧 **lms / `browse`** (#402) — browselibrary items and the native albums/artists/genres/years/playlists/mediafolder queries walk the whole hierarchy with native <start> <n> paging -- all verified live on Lyrion 9.1.2. The adapter never calls any of them.
 - ⛔ **openhome / `browse`** — UHC discovers OpenHome zones by their av-openhome-org Product, Transport and Volume services (src/adapters/openhome.rs) and the OpenHome service set has no library: content is resolved by a control point against a separate media server. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `browse`** — UHC discovers UPnP zones as urn:schemas-upnp-org:device:MediaRenderer:1 and speaks only AVTransport:1 and RenderingControl:1. Searching or browsing content is a ContentDirectory:1 (MediaServer) capability, which a renderer does not have and UHC does not discover. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `browse`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
@@ -313,14 +311,11 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - 🚧 **openhome / `shuffle_mode`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.
 - 🚧 **upnp / `shuffle_mode`** (#392) — AVTransport:1's SetPlayMode takes SHUFFLE and RANDOM, so shuffle is a protocol feature UHC does not use. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **applemusic / `shuffle_mode`** (#462) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `saved_playlists`** (#399) — Roon exposes Playlists as a browse hierarchy, so this arrives with browse rather than as its own protocol feature.
-- 🚧 **lms / `saved_playlists`** (#403) — playlists / playlists tracks / playlistcontrol cmd:load playlist_id / playlists new / rename / delete all exist and were verified live. playlist save additionally needs a configured playlistdir, which is unset on a stock install -- so its own answer is three-state at the server level, which is why #403 probes pref playlistdir ?.
 - ⛔ **openhome / `saved_playlists`** — the av-openhome-org service set has no playlist storage: Playlist:1 is the live queue (Read/Insert/DeleteId/DeleteAll) with no save or recall action, and stored playlists live on whatever media server the control point uses. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `saved_playlists`** — AVTransport:1 and RenderingControl:1 store nothing; a MediaRenderer has no playlist storage. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `saved_playlists`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `saved_playlists`** (#482) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `favorites`** (#399) — Roon exposes My Favorites and tags as browse hierarchies, so this arrives with browse.
-- 🚧 **lms / `favorites`** (#403) — favorites items / favorites playlist play / add / delete / exists all work; verified live. Note LMS favorites have no durable id -- only a url -- so a ref must be minted over the url.
+- 🚧 **roon / `favorites`** (#531) — Roon exposes My Favorites and tags as browse hierarchies, so this arrives with browse.
 - 🚧 **openhome / `favorites`** (#392) — OpenHome devices carry stored presets (Radio:1 presets, and a Pins service on newer firmware). UHC discovers neither. Reported as a gap rather than a limit because the per-firmware reach is unverified here.
 - ⛔ **upnp / `favorites`** — AVTransport:1 and RenderingControl:1 store nothing; a MediaRenderer has no favourites. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `favorites`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ Two things this table does **not** claim:
 | `queue_reorder` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_remove` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `queue_clear` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
+| `queue_transfer` | ⛔ | 🚧 #400 | ⛔ | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
 | `play_next` | 🚧 #399 | 🚧 #403 | 🚧 #392 | 🚧 #396 | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
 | `repeat_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
@@ -288,6 +289,13 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - 🚧 **hqplayer / `queue_clear`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_clear`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
 - 🚧 **spotify / `queue_clear`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **roon / `queue_transfer`** — The Roon API's transport service exposes a queue subscription and play_from_here and no mutation at all -- no move, remove or clear. The pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing further.
+- 🚧 **lms / `queue_transfer`** (#400) — sync <playerid> was verified live (#403) to merge a player into another's sync group by adopting the leader's queue, which destroys the source's queue rather than transferring it; the CLI reference names no dedicated queue-to-queue transfer command. A composite emulation -- read the source's playlist, replay it against the target with playlistcontrol, then playlist clear the source -- is buildable from primitives #400 already verified live, but is not wired.
+- ⛔ **openhome / `queue_transfer`** — OpenHome's Playlist:1 (Read/Insert/DeleteId/DeleteAll) is scoped to one room's renderer; the service set defines no action that moves one room's playlist into another's. Songcast (Sender:1/Receiver:1) relays audio to a group, it does not merge queue state. Verified from the OpenHome service definitions, not from a device.
+- ⛔ **upnp / `queue_transfer`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
+- 🚧 **hqplayer / `queue_transfer`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
+- 🚧 **applemusic / `queue_transfer`** (#462) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
+- 🚧 **spotify / `queue_transfer`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
 - 🚧 **roon / `play_next`** (#399) — Roon's browse item actions include Play Next alongside Play Now and Queue; UHC's PlayAction models only Play, Queue and Radio, so this arrives with browse rather than with the queue.
 - 🚧 **lms / `play_next`** (#403) — playlistcontrol cmd:insert places an item immediately after the current one, verified live -- and LmsPlayAction::Insert is already modelled in the adapter and simply unreachable from MCP.
 - 🚧 **openhome / `play_next`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ Two things this table does **not** claim:
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `saved_playlists` | 🚧 #399 | 🚧 #403 | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
 | `favorites` | 🚧 #399 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
-| `multiroom_sync` | 🚧 #360 | 🚧 #403 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
+| `multiroom_sync` | ✅ | ✅ | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
 
 ✅ supported · ⛔ the provider's protocol cannot do it · 🚧 the provider can, UHC has not wired it (issue that will)
 
@@ -317,8 +317,6 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - ⛔ **upnp / `favorites`** — AVTransport:1 and RenderingControl:1 store nothing; a MediaRenderer has no favourites. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `favorites`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `favorites`** (#482) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **roon / `multiroom_sync`** (#360) — the Roon API's transport service groups and ungroups outputs; UHC exposes no grouping on any surface.
-- 🚧 **lms / `multiroom_sync`** (#403) — sync <playerid>, sync -, sync ? and the server-scoped syncgroups ? all work; verified live. Joining is destructive to the target zone's queue, which is why #403 gates it behind confirmation.
 - 🚧 **openhome / `multiroom_sync`** (#392) — OpenHome's Sender:1 and Receiver:1 services are Songcast multiroom -- exactly this capability. UHC discovers neither. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `multiroom_sync`** — UPnP AV defines no synchronised-playback service; multiroom on UPnP renderers is vendor-specific and outside the two services UHC speaks. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `multiroom_sync`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.

--- a/custom_components/unified_hifi_control/__init__.py
+++ b/custom_components/unified_hifi_control/__init__.py
@@ -1,0 +1,45 @@
+"""The Unified Hifi Control integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .api import UnifiedHifiControlApiClient
+from .const import CONF_BASE_URL, DOMAIN
+from .coordinator import UnifiedHifiControlCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Unified Hifi Control from a config entry."""
+    session = async_get_clientsession(hass)
+    client = UnifiedHifiControlApiClient(session, entry.data[CONF_BASE_URL])
+    coordinator = UnifiedHifiControlCoordinator(hass, client)
+
+    await coordinator.async_config_entry_first_refresh()
+
+    coordinator.start_event_listener()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    entry.async_on_unload(coordinator.stop_event_listener)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        coordinator: UnifiedHifiControlCoordinator = hass.data[DOMAIN].pop(
+            entry.entry_id
+        )
+        coordinator.stop_event_listener()
+    return unload_ok

--- a/custom_components/unified_hifi_control/api.py
+++ b/custom_components/unified_hifi_control/api.py
@@ -19,11 +19,13 @@ from typing import Any
 import aiohttp
 
 from .const import (
+    PATH_COLLECTIONS,
     PATH_CONTROL,
     PATH_EVENTS,
     PATH_MCP,
     PATH_NOW_PLAYING,
     PATH_NOW_PLAYING_IMAGE,
+    PATH_PLAY_REF,
     PATH_ZONES,
     REQUEST_TIMEOUT,
 )
@@ -124,6 +126,93 @@ class UnifiedHifiControlApiClient:
             raise UnifiedHifiControlApiError(
                 f"hifi_zone_group failed: {result['error']!r}"
             )
+
+    async def async_browse_collections(
+        self,
+        zone_id: str,
+        action: str,
+        *,
+        path: str | None = None,
+        media_type: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> dict[str, Any]:
+        """POST /api/collections; browse/playlists/favorites for one zone.
+
+        Mirrors the ``hifi_collections`` MCP tool's verb and paging
+        semantics (see ``src/mcp/tools/collections.rs``). Returns the tool's
+        own envelope verbatim (``outcome``/``data``/``refusal``, ...) rather
+        than raising on a refusal: a provider or action UHC has not wired
+        yet (e.g. Roon favorites) answers with an ``unsupported``/``invalid``
+        outcome, which is a normal read result for this contract, not a
+        transport failure. Callers must check ``outcome`` themselves.
+        """
+        body: dict[str, Any] = {"zone_id": zone_id, "action": action}
+        if path is not None:
+            body["path"] = path
+        if media_type is not None:
+            body["media_type"] = media_type
+        if limit is not None:
+            body["limit"] = limit
+        if offset is not None:
+            body["offset"] = offset
+        return await self._request("POST", PATH_COLLECTIONS, json=body)
+
+    async def async_play_ref(
+        self, ref: str, zone_id: str, action: str | None = None
+    ) -> dict[str, Any]:
+        """POST /api/play_ref; play or queue a ref minted by /api/collections.
+
+        Same verb vocabulary as ``hifi_play_ref`` (``play``, ``queue``,
+        ``radio`` on Roon, ``next`` on LMS). Returns the tool's own envelope
+        verbatim, like :meth:`async_browse_collections`.
+        """
+        body: dict[str, Any] = {"ref": ref, "zone_id": zone_id}
+        if action is not None:
+            body["action"] = action
+        return await self._request("POST", PATH_PLAY_REF, json=body)
+
+    async def async_zone_group_status(
+        self, zone_id: str | None = None
+    ) -> dict[str, Any]:
+        """Call ``hifi_zone_group`` action=status and return its ``data``.
+
+        Scoped to one provider when ``zone_id`` is given (``{"groups": [...]}``),
+        or aggregated across every grouping-capable provider when omitted
+        (``{"groups": [...], "errors": [...]}`` -- a provider that cannot be
+        reached is reported in ``errors`` rather than failing the whole
+        call). Each group entry carries ``leader_zone_id`` and
+        ``member_zone_ids``; Roon's members are ``roon:<output_id>`` and
+        LMS's groups are leaderless, per ``src/mcp/tools/groups.rs``.
+        """
+        arguments: dict[str, Any] = {"action": "status"}
+        if zone_id is not None:
+            arguments["zone_id"] = zone_id
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "hifi_zone_group", "arguments": arguments},
+        }
+        response = await self._request("POST", PATH_MCP, json=payload)
+        if isinstance(response, dict) and response.get("error"):
+            raise UnifiedHifiControlApiError(
+                f"hifi_zone_group status failed: {response['error']!r}"
+            )
+        result = response.get("result") if isinstance(response, dict) else None
+        structured = (
+            result.get("structuredContent") if isinstance(result, dict) else None
+        )
+        if not isinstance(structured, dict):
+            raise UnifiedHifiControlApiError(
+                f"hifi_zone_group status returned no structuredContent: {response!r}"
+            )
+        if structured.get("refusal"):
+            raise UnifiedHifiControlApiError(
+                f"hifi_zone_group status refused: {structured['refusal']!r}"
+            )
+        data = structured.get("data")
+        return data if isinstance(data, dict) else {}
 
     async def async_ping(self) -> None:
         """Raise if the server is unreachable. Used by the config flow."""

--- a/custom_components/unified_hifi_control/api.py
+++ b/custom_components/unified_hifi_control/api.py
@@ -1,0 +1,218 @@
+"""Thin async HTTP client for the Unified Hifi Control (UHC) server.
+
+Wraps the routes documented in ``src/knobs/routes.rs`` (unified,
+cross-provider zone/transport surface) plus the MCP JSON-RPC endpoint for
+functionality (zone grouping) that has no plain-REST route yet.
+
+UHC's own docs (``docs/protocol.md``) are explicit that this HTTP API is
+internal and may change without notice. This client is intentionally
+narrow and defensive so a route-shape change fails loudly (an
+``UnifiedHifiControlApiError``) rather than corrupting entity state.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable, Coroutine
+from typing import Any
+
+import aiohttp
+
+from .const import (
+    PATH_CONTROL,
+    PATH_EVENTS,
+    PATH_MCP,
+    PATH_NOW_PLAYING,
+    PATH_NOW_PLAYING_IMAGE,
+    PATH_ZONES,
+    REQUEST_TIMEOUT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class UnifiedHifiControlApiError(Exception):
+    """Base error for UHC API failures."""
+
+
+class UnifiedHifiControlConnectionError(UnifiedHifiControlApiError):
+    """Raised when the UHC server cannot be reached at all."""
+
+
+class UnifiedHifiControlAuthError(UnifiedHifiControlApiError):
+    """Raised when the UHC server rejects the request as unauthenticated.
+
+    Only relevant when the server is run with
+    ``UHC_REQUIRE_CONTROLLER_AUTH=1`` -- see docs/controller-auth.md. This
+    integration does not implement the bootstrap-cookie handshake; users
+    running with that flag set must front UHC with a reverse proxy that
+    supplies the required cookie/CSRF pair, or disable the flag for the
+    interface this integration talks to.
+    """
+
+
+class UnifiedHifiControlApiClient:
+    """Client for a single UHC server instance."""
+
+    def __init__(self, session: aiohttp.ClientSession, base_url: str) -> None:
+        self._session = session
+        self._base_url = base_url.rstrip("/")
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    async def async_get_zones(self) -> list[dict[str, Any]]:
+        """Return the unified zone list from GET /knob/zones."""
+        data = await self._request("GET", PATH_ZONES)
+        zones = data.get("zones")
+        if not isinstance(zones, list):
+            raise UnifiedHifiControlApiError(
+                f"Unexpected /knob/zones response shape: {data!r}"
+            )
+        return zones
+
+    async def async_get_now_playing(self, zone_id: str) -> dict[str, Any]:
+        """Return now-playing state for a single zone."""
+        return await self._request(
+            "GET", PATH_NOW_PLAYING, params={"zone_id": zone_id}
+        )
+
+    async def async_control(
+        self, zone_id: str, action: str, value: Any | None = None
+    ) -> None:
+        """POST a transport/volume action to /knob/control."""
+        body: dict[str, Any] = {"zone_id": zone_id, "action": action}
+        if value is not None:
+            body["value"] = value
+        await self._request("POST", PATH_CONTROL, json=body)
+
+    def image_url(self, zone_id: str) -> str:
+        """Build the direct URL for a zone's now-playing artwork."""
+        return f"{self._base_url}{PATH_NOW_PLAYING_IMAGE}?zone_id={zone_id}"
+
+    async def async_zone_group(
+        self,
+        action: str,
+        leader_zone_id: str,
+        member_zone_ids: list[str] | None = None,
+    ) -> None:
+        """Call the ``hifi_zone_group`` MCP tool (join/leave).
+
+        Grouping has no plain-REST route as of this writing; it is only
+        reachable through the MCP JSON-RPC transport at /mcp. See
+        docs/home_assistant_integration.md for the tracking note.
+        """
+        params: dict[str, Any] = {
+            "name": "hifi_zone_group",
+            "arguments": {
+                "action": action,
+                "leader_zone_id": leader_zone_id,
+                "confirm": True,
+            },
+        }
+        if member_zone_ids is not None:
+            params["arguments"]["member_zone_ids"] = member_zone_ids
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": params,
+        }
+        result = await self._request("POST", PATH_MCP, json=payload)
+        if isinstance(result, dict) and result.get("error"):
+            raise UnifiedHifiControlApiError(
+                f"hifi_zone_group failed: {result['error']!r}"
+            )
+
+    async def async_ping(self) -> None:
+        """Raise if the server is unreachable. Used by the config flow."""
+        await self.async_get_zones()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self._base_url}{path}"
+        try:
+            async with asyncio.timeout(REQUEST_TIMEOUT):
+                async with self._session.request(
+                    method, url, params=params, json=json
+                ) as resp:
+                    if resp.status == 401 or resp.status == 403:
+                        raise UnifiedHifiControlAuthError(
+                            f"{method} {path} -> {resp.status}"
+                        )
+                    if resp.status >= 400:
+                        text = await resp.text()
+                        raise UnifiedHifiControlApiError(
+                            f"{method} {path} -> {resp.status}: {text}"
+                        )
+                    return await resp.json(content_type=None)
+        except UnifiedHifiControlApiError:
+            raise
+        except TimeoutError as err:
+            raise UnifiedHifiControlConnectionError(
+                f"Timed out calling {method} {path}"
+            ) from err
+        except aiohttp.ClientError as err:
+            raise UnifiedHifiControlConnectionError(
+                f"Error calling {method} {path}: {err}"
+            ) from err
+
+    async def async_listen_events(
+        self,
+        on_event: Callable[[str, dict[str, Any]], Coroutine[Any, Any, None]],
+    ) -> None:
+        """Hold a connection to GET /events and dispatch SSE frames.
+
+        Runs until cancelled. Callers are expected to wrap this in a
+        reconnect loop (see coordinator.py) since any single connection
+        may drop.
+        """
+        url = f"{self._base_url}{PATH_EVENTS}"
+        async with self._session.get(
+            url, headers={"Accept": "text/event-stream"}
+        ) as resp:
+            if resp.status >= 400:
+                raise UnifiedHifiControlApiError(f"GET /events -> {resp.status}")
+            async for event_type, data in _parse_sse(resp.content):
+                await on_event(event_type, data)
+
+
+async def _parse_sse(
+    content: aiohttp.StreamReader,
+) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+    """Minimal Server-Sent-Events parser.
+
+    UHC's /events handler (src/api/mod.rs::events_handler) emits plain
+    ``data: <json>`` frames (one JSON object per BusEvent, tagged with a
+    "type" field) separated by blank lines, plus periodic ``: ping``
+    keep-alive comments. We only care about ``data:`` lines.
+    """
+    import json as json_module
+
+    buffer: list[str] = []
+    async for raw_line in content:
+        line = raw_line.decode("utf-8", errors="replace").rstrip("\n").rstrip("\r")
+        if line == "":
+            if buffer:
+                payload = "\n".join(buffer)
+                buffer = []
+                try:
+                    parsed = json_module.loads(payload)
+                except ValueError:
+                    _LOGGER.debug("Ignoring non-JSON SSE frame: %s", payload)
+                    continue
+                event_type = parsed.get("type", "")
+                data = parsed.get("payload", parsed)
+                yield event_type, data
+            continue
+        if line.startswith(":"):
+            continue  # comment / keep-alive
+        if line.startswith("data:"):
+            buffer.append(line[len("data:") :].lstrip())

--- a/custom_components/unified_hifi_control/config_flow.py
+++ b/custom_components/unified_hifi_control/config_flow.py
@@ -1,0 +1,113 @@
+"""Config flow for Unified Hifi Control."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+if TYPE_CHECKING:
+    # Only needed for type hints. The actual module path has moved
+    # across Home Assistant versions (helpers.service_info.zeroconf in
+    # 2025.x+, components.zeroconf before that, and the latter requires
+    # the optional `zeroconf` PyPI package to even import). Since this
+    # file uses `from __future__ import annotations`, annotations are
+    # never evaluated at runtime, so we can avoid importing either at
+    # import time and only pay the cost when a real zeroconf discovery
+    # actually happens.
+    from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .api import (
+    UnifiedHifiControlApiClient,
+    UnifiedHifiControlApiError,
+    UnifiedHifiControlAuthError,
+    UnifiedHifiControlConnectionError,
+)
+from .const import CONF_BASE_URL, DEFAULT_NAME, DEFAULT_PORT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_BASE_URL): cv.string})
+
+
+def _normalize_base_url(value: str) -> str:
+    value = value.strip().rstrip("/")
+    if not value.startswith(("http://", "https://")):
+        value = f"http://{value}"
+    return value
+
+
+class UnifiedHifiControlConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Unified Hifi Control."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        self._discovered_base_url: str | None = None
+
+    async def _async_validate(self, base_url: str) -> dict[str, str]:
+        """Return a dict of errors (empty on success)."""
+        session = async_get_clientsession(self.hass)
+        client = UnifiedHifiControlApiClient(session, base_url)
+        try:
+            await client.async_ping()
+        except UnifiedHifiControlAuthError:
+            return {"base": "auth_required"}
+        except UnifiedHifiControlConnectionError:
+            return {"base": "cannot_connect"}
+        except UnifiedHifiControlApiError:
+            return {"base": "unknown"}
+        return {}
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            base_url = _normalize_base_url(user_input[CONF_BASE_URL])
+            errors = await self._async_validate(base_url)
+            if not errors:
+                await self.async_set_unique_id(base_url)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=DEFAULT_NAME, data={CONF_BASE_URL: base_url}
+                )
+
+        schema = STEP_USER_DATA_SCHEMA
+        if self._discovered_base_url:
+            schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_BASE_URL, default=self._discovered_base_url
+                    ): cv.string
+                }
+            )
+        return self.async_show_form(
+            step_id="user", data_schema=schema, errors=errors
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery of a UHC server (_uhc._tcp.local.)."""
+        base_url = discovery_info.properties.get("base")
+        if not base_url:
+            host = discovery_info.host
+            port = discovery_info.port or DEFAULT_PORT
+            base_url = f"http://{host}:{port}"
+        base_url = _normalize_base_url(base_url)
+
+        await self.async_set_unique_id(base_url)
+        self._abort_if_unique_id_configured()
+
+        errors = await self._async_validate(base_url)
+        if errors:
+            return self.async_abort(reason="cannot_connect")
+
+        self._discovered_base_url = base_url
+        self.context["title_placeholders"] = {"base_url": base_url}
+        return await self.async_step_user()

--- a/custom_components/unified_hifi_control/const.py
+++ b/custom_components/unified_hifi_control/const.py
@@ -20,6 +20,12 @@ PATH_NOW_PLAYING_IMAGE = "/knob/now_playing/image"
 PATH_CONTROL = "/knob/control"
 PATH_EVENTS = "/events"
 PATH_MCP = "/mcp"
+# Plain-REST mirrors of the hifi_collections/hifi_play_ref MCP tools
+# (src/api/browse.rs, PR #516/#531). Unlike grouping, these forward the same
+# envelope shape a client would get from /mcp without paying for the
+# JSON-RPC transport.
+PATH_COLLECTIONS = "/api/collections"
+PATH_PLAY_REF = "/api/play_ref"
 
 # Poll interval used as a safety-net fallback in case the SSE stream to
 # /events silently drops without the underlying connection erroring out.
@@ -30,11 +36,23 @@ FALLBACK_POLL_INTERVAL = timedelta(seconds=60)
 # validation and coordinator refreshes.
 REQUEST_TIMEOUT = 10
 
-# Providers known to implement the multiroom join/leave verbs today.
-# Roon and LMS grouping work landed on a sibling branch (issue #517 /
-# PR #521) that had not merged into this integration's base branch at
-# the time this was written -- see docs/home_assistant_integration.md.
-GROUPING_CAPABLE_PROVIDERS: set[str] = {"musicassistant"}
+# Providers that implement the multiroom join/leave verbs (issue #517 /
+# PR #521, plus Music Assistant's original wiring): `hifi_zone_group`
+# routes join/leave/status to whichever of the three owns the zone prefix.
+# Roon reports grouped members as roon:<output_id> (its own zone ids churn
+# on merge); LMS sync groups are leaderless. Both conventions are tolerated
+# verbatim in group_members rather than normalized -- see
+# src/mcp/tools/groups.rs's module docs.
+GROUPING_CAPABLE_PROVIDERS: set[str] = {"musicassistant", "roon", "lms"}
+
+# Top-level hifi_collections/`/api/collections` entry points, in menu order.
+# (content_id, title) pairs surfaced at the root of async_browse_media.
+BROWSE_ROOT_ID = "root"
+BROWSE_TOP_LEVEL: tuple[tuple[str, str], ...] = (
+    ("top:browse", "Browse Library"),
+    ("top:playlists", "Playlists"),
+    ("top:favorites", "Favorites"),
+)
 
 # Providers whose adapters explicitly refuse next/previous (see
 # src/adapters/upnp.rs::REFUSED_TRANSPORT_ACTIONS).

--- a/custom_components/unified_hifi_control/const.py
+++ b/custom_components/unified_hifi_control/const.py
@@ -1,0 +1,55 @@
+"""Constants for the Unified Hifi Control integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+
+DOMAIN = "unified_hifi_control"
+
+CONF_BASE_URL = "base_url"
+
+DEFAULT_PORT = 8088
+DEFAULT_NAME = "Unified Hifi Control"
+
+# Zeroconf service type advertised by the UHC server (src/mdns.rs).
+ZEROCONF_SERVICE_TYPE = "_uhc._tcp.local."
+
+# UHC HTTP API paths (see src/knobs/routes.rs).
+PATH_ZONES = "/knob/zones"
+PATH_NOW_PLAYING = "/knob/now_playing"
+PATH_NOW_PLAYING_IMAGE = "/knob/now_playing/image"
+PATH_CONTROL = "/knob/control"
+PATH_EVENTS = "/events"
+PATH_MCP = "/mcp"
+
+# Poll interval used as a safety-net fallback in case the SSE stream to
+# /events silently drops without the underlying connection erroring out.
+# Real-time updates normally arrive via SSE well before this fires.
+FALLBACK_POLL_INTERVAL = timedelta(seconds=60)
+
+# How long to wait for the initial HTTP round-trip during config flow
+# validation and coordinator refreshes.
+REQUEST_TIMEOUT = 10
+
+# Providers known to implement the multiroom join/leave verbs today.
+# Roon and LMS grouping work landed on a sibling branch (issue #517 /
+# PR #521) that had not merged into this integration's base branch at
+# the time this was written -- see docs/home_assistant_integration.md.
+GROUPING_CAPABLE_PROVIDERS: set[str] = {"musicassistant"}
+
+# Providers whose adapters explicitly refuse next/previous (see
+# src/adapters/upnp.rs::REFUSED_TRANSPORT_ACTIONS).
+NO_SKIP_PROVIDERS: set[str] = {"upnp"}
+
+# Providers where transport/volume control is not yet reliably wired
+# end-to-end (see AGENTS.md capability matrix, e.g. AppleMusic #465).
+NO_TRANSPORT_PROVIDERS: set[str] = {"applemusic"}
+
+STATE_MAP = {
+    "playing": "playing",
+    "paused": "paused",
+    "stopped": "idle",
+    "loading": "buffering",
+    "buffering": "buffering",
+}
+
+MANUFACTURER = "Unified Hifi Control"

--- a/custom_components/unified_hifi_control/coordinator.py
+++ b/custom_components/unified_hifi_control/coordinator.py
@@ -1,0 +1,261 @@
+"""Data coordination for the Unified Hifi Control integration.
+
+State updates are push-based: a background task holds a connection to
+UHC's ``/events`` Server-Sent-Events stream (backed by a real
+``tokio::sync::broadcast`` bus on the server, see src/api/mod.rs and
+src/bus/mod.rs) and applies incremental updates to zone state as
+``NowPlayingChanged`` / ``VolumeChanged`` / ``SeekPositionChanged`` /
+``ZoneUpdated`` / ``ZoneDiscovered`` / ``ZoneRemoved`` events arrive.
+
+A slow periodic poll (``FALLBACK_POLL_INTERVAL``) runs alongside the SSE
+listener purely as a safety net in case a connection drops silently
+without erroring (some proxies/NAT setups swallow TCP resets on idle
+long-lived connections). Under normal operation the poll is a no-op
+because SSE has already kept state current.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import UnifiedHifiControlApiClient, UnifiedHifiControlApiError
+from .const import DOMAIN, FALLBACK_POLL_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+# Reconnect backoff for the SSE listener.
+_SSE_RECONNECT_MIN = 2
+_SSE_RECONNECT_MAX = 60
+
+
+@dataclass
+class ZoneState:
+    """In-memory state for a single UHC zone."""
+
+    zone_id: str
+    zone_name: str
+    source: str
+    state: str = "unknown"
+    volume: float | None = None
+    volume_min: float | None = None
+    volume_max: float | None = None
+    volume_step: float | None = None
+    is_muted: bool | None = None
+    title: str | None = None
+    artist: str | None = None
+    album: str | None = None
+    image_key: str | None = None
+    seek_position: int | None = None
+    length: int | None = None
+    is_play_allowed: bool = True
+    is_pause_allowed: bool = True
+    is_next_allowed: bool = True
+    is_previous_allowed: bool = True
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+class UnifiedHifiControlCoordinator(DataUpdateCoordinator[dict[str, ZoneState]]):
+    """Owns zone state for one UHC server and keeps it current."""
+
+    def __init__(self, hass: HomeAssistant, client: UnifiedHifiControlApiClient) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=FALLBACK_POLL_INTERVAL,
+        )
+        self.client = client
+        self._sse_task: asyncio.Task | None = None
+        self.sse_connected = False
+
+    async def _async_update_data(self) -> dict[str, ZoneState]:
+        """Full poll: fetch zones + now-playing for each. Fallback path."""
+        try:
+            zones = await self.client.async_get_zones()
+        except UnifiedHifiControlApiError as err:
+            raise UpdateFailed(f"Could not reach UHC server: {err}") from err
+
+        result: dict[str, ZoneState] = {}
+        for zone in zones:
+            zone_id = zone.get("zone_id")
+            if not zone_id:
+                continue
+            existing = self.data.get(zone_id) if self.data else None
+            zs = ZoneState(
+                zone_id=zone_id,
+                zone_name=zone.get("zone_name", zone_id),
+                source=zone.get("source", "unknown"),
+            )
+            if existing is not None:
+                # Preserve push-derived fields (mute, now-playing) that
+                # aren't present on the lightweight zones list.
+                zs.volume = existing.volume
+                zs.volume_min = existing.volume_min
+                zs.volume_max = existing.volume_max
+                zs.volume_step = existing.volume_step
+                zs.is_muted = existing.is_muted
+                zs.title = existing.title
+                zs.artist = existing.artist
+                zs.album = existing.album
+                zs.image_key = existing.image_key
+                zs.seek_position = existing.seek_position
+                zs.length = existing.length
+            zs.state = zone.get("state", zs.state)
+            vc = zone.get("volume_control") or {}
+            if vc:
+                zs.volume = vc.get("value", zs.volume)
+                zs.volume_min = vc.get("min", zs.volume_min)
+                zs.volume_max = vc.get("max", zs.volume_max)
+                zs.volume_step = vc.get("step", zs.volume_step)
+            zs.raw = zone
+            try:
+                now_playing = await self.client.async_get_now_playing(zone_id)
+            except UnifiedHifiControlApiError as err:
+                _LOGGER.debug("now_playing failed for %s: %s", zone_id, err)
+                now_playing = {}
+            if now_playing:
+                zs.title = now_playing.get("line1", zs.title)
+                zs.artist = now_playing.get("line2", zs.artist)
+                zs.album = now_playing.get("line3", zs.album)
+                zs.image_key = now_playing.get("image_key", zs.image_key)
+                zs.seek_position = now_playing.get("seek_position", zs.seek_position)
+                zs.length = now_playing.get("length", zs.length)
+                zs.is_play_allowed = now_playing.get("is_play_allowed", True)
+                zs.is_pause_allowed = now_playing.get("is_pause_allowed", True)
+                zs.is_next_allowed = now_playing.get("is_next_allowed", True)
+                zs.is_previous_allowed = now_playing.get("is_previous_allowed", True)
+                if now_playing.get("volume") is not None:
+                    zs.volume = now_playing.get("volume")
+                    zs.volume_min = now_playing.get("volume_min", zs.volume_min)
+                    zs.volume_max = now_playing.get("volume_max", zs.volume_max)
+                    zs.volume_step = now_playing.get("volume_step", zs.volume_step)
+            result[zone_id] = zs
+        return result
+
+    def start_event_listener(self) -> None:
+        """Start the background SSE listener task."""
+        if self._sse_task is None or self._sse_task.done():
+            self._sse_task = self.hass.loop.create_task(self._event_listener_loop())
+
+    def stop_event_listener(self) -> None:
+        if self._sse_task is not None:
+            self._sse_task.cancel()
+            self._sse_task = None
+
+    async def _event_listener_loop(self) -> None:
+        backoff = _SSE_RECONNECT_MIN
+        loop = self.hass.loop
+        while True:
+            started_at = loop.time()
+            try:
+                self.sse_connected = True
+                await self.client.async_listen_events(self._handle_event)
+            except asyncio.CancelledError:
+                self.sse_connected = False
+                raise
+            except UnifiedHifiControlApiError as err:
+                _LOGGER.debug("SSE connection error, will retry: %s", err)
+            except Exception:  # keep the listener alive on unexpected errors
+                _LOGGER.exception("Unexpected error in UHC event listener")
+            self.sse_connected = False
+            # A connection that stayed up for a while was healthy; reset
+            # backoff so a brief blip doesn't leave us waiting a full
+            # minute to reconnect next time.
+            if loop.time() - started_at >= 5:
+                backoff = _SSE_RECONNECT_MIN
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, _SSE_RECONNECT_MAX)
+
+    async def _handle_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        data = dict(self.data) if self.data else {}
+        handler = _EVENT_HANDLERS.get(event_type)
+        if handler is None:
+            return
+        changed = handler(data, payload)
+        if changed:
+            self.async_set_updated_data(data)
+
+
+def _zone_id_from(payload: dict[str, Any], key: str = "zone_id") -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _h_now_playing_changed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    zs.title = payload.get("title", zs.title)
+    zs.artist = payload.get("artist", zs.artist)
+    zs.album = payload.get("album", zs.album)
+    zs.image_key = payload.get("image_key", zs.image_key)
+    return True
+
+
+def _h_volume_changed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload, "output_id") or _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    if "value" in payload:
+        zs.volume = payload["value"]
+    if "is_muted" in payload:
+        zs.is_muted = payload["is_muted"]
+    return True
+
+
+def _h_seek_changed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    zs.seek_position = payload.get("position", zs.seek_position)
+    return True
+
+
+def _h_zone_updated(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    zs = data.get(zone_id) if zone_id else None
+    if zs is None:
+        return False
+    zs.zone_name = payload.get("display_name", zs.zone_name)
+    zs.state = payload.get("state", zs.state)
+    return True
+
+
+def _h_zone_removed(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone_id = _zone_id_from(payload)
+    if zone_id and zone_id in data:
+        del data[zone_id]
+        return True
+    return False
+
+
+def _h_zone_discovered(data: dict[str, ZoneState], payload: dict[str, Any]) -> bool:
+    zone = payload.get("zone") if isinstance(payload.get("zone"), dict) else payload
+    zone_id = _zone_id_from(zone)
+    if not zone_id or zone_id in data:
+        return False
+    data[zone_id] = ZoneState(
+        zone_id=zone_id,
+        zone_name=zone.get("zone_name", zone_id),
+        source=zone.get("source", "unknown"),
+        state=zone.get("state", "unknown"),
+    )
+    return True
+
+
+_EVENT_HANDLERS = {
+    "NowPlayingChanged": _h_now_playing_changed,
+    "VolumeChanged": _h_volume_changed,
+    "SeekPositionChanged": _h_seek_changed,
+    "ZoneUpdated": _h_zone_updated,
+    "ZoneRemoved": _h_zone_removed,
+    "ZoneDiscovered": _h_zone_discovered,
+}

--- a/custom_components/unified_hifi_control/coordinator.py
+++ b/custom_components/unified_hifi_control/coordinator.py
@@ -24,7 +24,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import UnifiedHifiControlApiClient, UnifiedHifiControlApiError
-from .const import DOMAIN, FALLBACK_POLL_INTERVAL
+from .const import DOMAIN, FALLBACK_POLL_INTERVAL, GROUPING_CAPABLE_PROVIDERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,6 +56,14 @@ class ZoneState:
     is_pause_allowed: bool = True
     is_next_allowed: bool = True
     is_previous_allowed: bool = True
+    # Server-reported: whether /api/collections (hifi_collections) implements
+    # this zone's provider at all (see src/mcp/tools/collections.rs's
+    # zone_supports_hifi_collections, surfaced on /knob/zones since #533).
+    browse_supported: bool = False
+    # This zone's multiroom group membership (this zone included), from the
+    # most recent hifi_zone_group status poll. Empty when ungrouped or when
+    # this zone's provider does not support grouping.
+    group_members: list[str] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
 
 
@@ -134,8 +142,36 @@ class UnifiedHifiControlCoordinator(DataUpdateCoordinator[dict[str, ZoneState]])
                     zs.volume_min = now_playing.get("volume_min", zs.volume_min)
                     zs.volume_max = now_playing.get("volume_max", zs.volume_max)
                     zs.volume_step = now_playing.get("volume_step", zs.volume_step)
+            zs.browse_supported = zone.get("browse_supported", False)
             result[zone_id] = zs
+        await self._refresh_group_members(result)
         return result
+
+    async def _refresh_group_members(self, zones: dict[str, ZoneState]) -> None:
+        """Populate ``group_members`` for every grouping-capable zone.
+
+        One aggregate ``hifi_zone_group`` status call covers every provider;
+        a provider that cannot be reached is reported in the aggregate's
+        ``errors`` rather than raising, so its zones are simply left
+        ungrouped for this poll rather than failing the whole refresh.
+        """
+        if not any(zs.source in GROUPING_CAPABLE_PROVIDERS for zs in zones.values()):
+            return
+        try:
+            status = await self.client.async_zone_group_status()
+        except UnifiedHifiControlApiError as err:
+            _LOGGER.debug("hifi_zone_group status failed, leaving groups as-is: %s", err)
+            return
+        for group in status.get("groups") or []:
+            leader = group.get("leader_zone_id")
+            members = group.get("member_zone_ids") or []
+            if not isinstance(leader, str):
+                continue
+            all_ids = [leader, *[m for m in members if isinstance(m, str)]]
+            for zone_id in all_ids:
+                zs = zones.get(zone_id)
+                if zs is not None:
+                    zs.group_members = all_ids
 
     def start_event_listener(self) -> None:
         """Start the background SSE listener task."""
@@ -247,6 +283,7 @@ def _h_zone_discovered(data: dict[str, ZoneState], payload: dict[str, Any]) -> b
         zone_name=zone.get("zone_name", zone_id),
         source=zone.get("source", "unknown"),
         state=zone.get("state", "unknown"),
+        browse_supported=zone.get("browse_supported", False),
     )
     return True
 

--- a/custom_components/unified_hifi_control/manifest.json
+++ b/custom_components/unified_hifi_control/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "unified_hifi_control",
+  "name": "Unified Hifi Control",
+  "codeowners": ["@muness"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/open-horizon-labs/unified-hifi-control/blob/v3/docs/home_assistant_integration.md",
+  "integration_type": "hub",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/open-horizon-labs/unified-hifi-control/issues",
+  "requirements": [],
+  "version": "0.1.0",
+  "zeroconf": ["_uhc._tcp.local."]
+}

--- a/custom_components/unified_hifi_control/media_player.py
+++ b/custom_components/unified_hifi_control/media_player.py
@@ -1,0 +1,268 @@
+"""Media player platform for Unified Hifi Control zones."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api import UnifiedHifiControlApiError
+from .const import (
+    DOMAIN,
+    GROUPING_CAPABLE_PROVIDERS,
+    MANUFACTURER,
+    NO_SKIP_PROVIDERS,
+    NO_TRANSPORT_PROVIDERS,
+    STATE_MAP,
+)
+from .coordinator import UnifiedHifiControlCoordinator, ZoneState
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up media_player entities for each known UHC zone."""
+    coordinator: UnifiedHifiControlCoordinator = hass.data[DOMAIN][entry.entry_id]
+    known_zone_ids: set[str] = set()
+
+    def _add_new_entities() -> None:
+        new_entities = []
+        for zone_id in coordinator.data:
+            if zone_id in known_zone_ids:
+                continue
+            known_zone_ids.add(zone_id)
+            new_entities.append(UnifiedHifiControlMediaPlayer(coordinator, zone_id))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_new_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
+
+
+def _supported_features(zone: ZoneState) -> MediaPlayerEntityFeature:
+    if zone.source in NO_TRANSPORT_PROVIDERS:
+        return MediaPlayerEntityFeature(0)
+
+    features = (
+        MediaPlayerEntityFeature.PLAY
+        | MediaPlayerEntityFeature.PAUSE
+        | MediaPlayerEntityFeature.STOP
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.SEEK
+    )
+    if zone.source not in NO_SKIP_PROVIDERS:
+        features |= (
+            MediaPlayerEntityFeature.NEXT_TRACK
+            | MediaPlayerEntityFeature.PREVIOUS_TRACK
+        )
+    if zone.source in GROUPING_CAPABLE_PROVIDERS:
+        features |= (
+            MediaPlayerEntityFeature.GROUPING
+        )
+    return features
+
+
+class UnifiedHifiControlMediaPlayer(
+    CoordinatorEntity[UnifiedHifiControlCoordinator], MediaPlayerEntity
+):
+    """A media_player entity backed by a single UHC zone."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+
+    def __init__(
+        self, coordinator: UnifiedHifiControlCoordinator, zone_id: str
+    ) -> None:
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        # UHC's zone ids are provider-prefixed (e.g. "roon:<zone_id>",
+        # "lms:<mac>") and stable for the lifetime of that zone on the
+        # server. One documented exception: Roon's own zone_id can churn
+        # when outputs are grouped/ungrouped in Roon itself (see PR
+        # #515's discussion of the roon:<output_id> convention) -- that
+        # churn is inherent to Roon's zone model and outside UHC/this
+        # integration's control.
+        self._attr_unique_id = zone_id
+        zone = coordinator.data.get(zone_id)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, zone_id)},
+            name=zone.zone_name if zone else zone_id,
+            manufacturer=MANUFACTURER,
+            model=zone.source if zone else None,
+        )
+        self._attr_supported_features = (
+            _supported_features(zone) if zone else MediaPlayerEntityFeature(0)
+        )
+
+    @property
+    def _zone(self) -> ZoneState | None:
+        return self.coordinator.data.get(self._zone_id)
+
+    @property
+    def available(self) -> bool:
+        return super().available and self._zone is not None
+
+    @property
+    def name(self) -> str | None:
+        zone = self._zone
+        return zone.zone_name if zone else self._zone_id
+
+    @property
+    def state(self) -> MediaPlayerState | None:
+        zone = self._zone
+        if zone is None:
+            return None
+        return MediaPlayerState(STATE_MAP.get(zone.state, "idle"))
+
+    @property
+    def media_title(self) -> str | None:
+        zone = self._zone
+        return zone.title if zone else None
+
+    @property
+    def media_artist(self) -> str | None:
+        zone = self._zone
+        return zone.artist if zone else None
+
+    @property
+    def media_album_name(self) -> str | None:
+        zone = self._zone
+        return zone.album if zone else None
+
+    @property
+    def media_duration(self) -> int | None:
+        zone = self._zone
+        return zone.length if zone else None
+
+    @property
+    def media_position(self) -> int | None:
+        zone = self._zone
+        return zone.seek_position if zone else None
+
+    @property
+    def media_image_url(self) -> str | None:
+        zone = self._zone
+        if zone is None or not zone.image_key:
+            return None
+        return self.coordinator.client.image_url(self._zone_id)
+
+    @property
+    def media_image_hash(self) -> str | None:
+        zone = self._zone
+        return zone.image_key if zone else None
+
+    @property
+    def volume_level(self) -> float | None:
+        zone = self._zone
+        if zone is None or zone.volume is None:
+            return None
+        vmin = zone.volume_min if zone.volume_min is not None else 0.0
+        vmax = zone.volume_max if zone.volume_max is not None else 100.0
+        if vmax <= vmin:
+            return None
+        return max(0.0, min(1.0, (zone.volume - vmin) / (vmax - vmin)))
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        zone = self._zone
+        # UHC's now_playing payload does not report mute state; this is
+        # only known once at least one VolumeChanged SSE event with
+        # is_muted has been observed for this zone.
+        return zone.is_muted if zone else None
+
+    async def async_media_play(self) -> None:
+        await self._async_control("play")
+
+    async def async_media_pause(self) -> None:
+        await self._async_control("pause")
+
+    async def async_media_stop(self) -> None:
+        await self._async_control("stop")
+
+    async def async_media_next_track(self) -> None:
+        await self._async_control("next")
+
+    async def async_media_previous_track(self) -> None:
+        await self._async_control("previous")
+
+    async def async_media_seek(self, position: float) -> None:
+        await self._async_control("seek", value=position)
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        zone = self._zone
+        if zone is None:
+            raise HomeAssistantError(f"Zone {self._zone_id} is unavailable")
+        vmin = zone.volume_min if zone.volume_min is not None else 0.0
+        vmax = zone.volume_max if zone.volume_max is not None else 100.0
+        absolute = vmin + volume * (vmax - vmin)
+        await self._async_control("vol_abs", value=absolute)
+
+    async def async_volume_up(self) -> None:
+        await self._async_control("vol_up")
+
+    async def async_volume_down(self) -> None:
+        await self._async_control("vol_down")
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        # Best-effort: not every provider has confirmed mute/unmute
+        # wiring through /knob/control (see docs/home_assistant_integration.md).
+        await self._async_control("mute", value=mute)
+
+    async def _async_control(self, action: str, value: Any | None = None) -> None:
+        try:
+            await self.coordinator.client.async_control(
+                self._zone_id, action, value
+            )
+        except UnifiedHifiControlApiError as err:
+            raise HomeAssistantError(
+                f"Failed to send '{action}' to zone {self._zone_id}: {err}"
+            ) from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_join_players(self, group_members: list[str]) -> None:
+        zone = self._zone
+        if zone is None or zone.source not in GROUPING_CAPABLE_PROVIDERS:
+            source = zone.source if zone else "unknown"
+            raise HomeAssistantError(
+                f"Grouping is not supported for provider '{source}' yet "
+                "(tracked in unified-hifi-control issue #517/#521)."
+            )
+        try:
+            await self.coordinator.client.async_zone_group(
+                "join", self._zone_id, member_zone_ids=group_members
+            )
+        except UnifiedHifiControlApiError as err:
+            raise HomeAssistantError(f"Failed to join players: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_unjoin_player(self) -> None:
+        zone = self._zone
+        if zone is None or zone.source not in GROUPING_CAPABLE_PROVIDERS:
+            source = zone.source if zone else "unknown"
+            raise HomeAssistantError(
+                f"Grouping is not supported for provider '{source}' yet "
+                "(tracked in unified-hifi-control issue #517/#521)."
+            )
+        try:
+            await self.coordinator.client.async_zone_group(
+                "leave", self._zone_id, member_zone_ids=[self._zone_id]
+            )
+        except UnifiedHifiControlApiError as err:
+            raise HomeAssistantError(f"Failed to unjoin player: {err}") from err
+        await self.coordinator.async_request_refresh()

--- a/custom_components/unified_hifi_control/media_player.py
+++ b/custom_components/unified_hifi_control/media_player.py
@@ -5,9 +5,14 @@ import logging
 from typing import Any
 
 from homeassistant.components.media_player import (
+    BrowseError,
+    BrowseMedia,
+    MediaClass,
+    MediaPlayerEnqueue,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
+    MediaType,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -18,6 +23,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .api import UnifiedHifiControlApiError
 from .const import (
+    BROWSE_ROOT_ID,
+    BROWSE_TOP_LEVEL,
     DOMAIN,
     GROUPING_CAPABLE_PROVIDERS,
     MANUFACTURER,
@@ -28,6 +35,18 @@ from .const import (
 from .coordinator import UnifiedHifiControlCoordinator, ZoneState
 
 _LOGGER = logging.getLogger(__name__)
+
+# media_content_id prefixes used by async_browse_media/async_play_media.
+# "top:<action>" is one of hifi_collections' three entry points (browse,
+# playlists, favorites); "path:<token>" is an opaque browse-continuation ref
+# minted by a previous /api/collections call (always re-entered with
+# action=browse -- see src/mcp/tools/collections.rs's path-resolution
+# comments); "ref:<token>" is an opaque playable ref for /api/play_ref.
+_TOP_PREFIX = "top:"
+_PATH_PREFIX = "path:"
+_REF_PREFIX = "ref:"
+
+_TOP_LEVEL_TITLES = dict(BROWSE_TOP_LEVEL)
 
 
 async def async_setup_entry(
@@ -74,6 +93,12 @@ def _supported_features(zone: ZoneState) -> MediaPlayerEntityFeature:
     if zone.source in GROUPING_CAPABLE_PROVIDERS:
         features |= (
             MediaPlayerEntityFeature.GROUPING
+        )
+    if zone.browse_supported:
+        features |= (
+            MediaPlayerEntityFeature.BROWSE_MEDIA
+            | MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.MEDIA_ENQUEUE
         )
     return features
 
@@ -186,6 +211,14 @@ class UnifiedHifiControlMediaPlayer(
         # is_muted has been observed for this zone.
         return zone.is_muted if zone else None
 
+    @property
+    def group_members(self) -> list[str]:
+        # UHC zone ids double as this integration's unique_id, so the group
+        # is expressed the same way async_join_players/async_unjoin_player
+        # already accept it (see those methods below), not as HA entity_ids.
+        zone = self._zone
+        return zone.group_members if zone else []
+
     async def async_media_play(self) -> None:
         await self._async_control("play")
 
@@ -240,8 +273,18 @@ class UnifiedHifiControlMediaPlayer(
         if zone is None or zone.source not in GROUPING_CAPABLE_PROVIDERS:
             source = zone.source if zone else "unknown"
             raise HomeAssistantError(
-                f"Grouping is not supported for provider '{source}' yet "
-                "(tracked in unified-hifi-control issue #517/#521)."
+                f"Grouping is not supported for provider '{source}'."
+            )
+        foreign = [
+            member_id
+            for member_id in group_members
+            if not member_id.startswith(f"{zone.source}:")
+        ]
+        if foreign:
+            raise HomeAssistantError(
+                f"Cannot group zone {self._zone_id} ({zone.source}) with "
+                f"{foreign}: UHC has no protocol that groups zones across "
+                "providers. Join zones from the same provider only."
             )
         try:
             await self.coordinator.client.async_zone_group(
@@ -256,8 +299,7 @@ class UnifiedHifiControlMediaPlayer(
         if zone is None or zone.source not in GROUPING_CAPABLE_PROVIDERS:
             source = zone.source if zone else "unknown"
             raise HomeAssistantError(
-                f"Grouping is not supported for provider '{source}' yet "
-                "(tracked in unified-hifi-control issue #517/#521)."
+                f"Grouping is not supported for provider '{source}'."
             )
         try:
             await self.coordinator.client.async_zone_group(
@@ -265,4 +307,144 @@ class UnifiedHifiControlMediaPlayer(
             )
         except UnifiedHifiControlApiError as err:
             raise HomeAssistantError(f"Failed to unjoin player: {err}") from err
+        await self.coordinator.async_request_refresh()
+
+    async def async_browse_media(
+        self,
+        media_content_type: str | None = None,
+        media_content_id: str | None = None,
+    ) -> BrowseMedia:
+        zone = self._zone
+        if zone is None or not zone.browse_supported:
+            raise BrowseError(
+                f"Zone {self._zone_id} does not support browsing its library."
+            )
+
+        if media_content_id in (None, "", BROWSE_ROOT_ID):
+            return BrowseMedia(
+                media_class=MediaClass.DIRECTORY,
+                media_content_id=BROWSE_ROOT_ID,
+                media_content_type=MediaType.MUSIC,
+                title=zone.zone_name,
+                can_play=False,
+                can_expand=True,
+                children_media_class=MediaClass.DIRECTORY,
+                children=[
+                    BrowseMedia(
+                        media_class=MediaClass.DIRECTORY,
+                        media_content_id=content_id,
+                        media_content_type=MediaType.MUSIC,
+                        title=title,
+                        can_play=False,
+                        can_expand=True,
+                    )
+                    for content_id, title in BROWSE_TOP_LEVEL
+                ],
+            )
+
+        if media_content_id.startswith(_TOP_PREFIX):
+            action = media_content_id[len(_TOP_PREFIX) :]
+            path = None
+            title = _TOP_LEVEL_TITLES.get(media_content_id, action.title())
+        elif media_content_id.startswith(_PATH_PREFIX):
+            # A browse continuation always re-enters as action=browse,
+            # regardless of which top-level entry point minted the path
+            # token -- see the module-level comment on _PATH_PREFIX.
+            action = "browse"
+            path = media_content_id[len(_PATH_PREFIX) :]
+            title = "Library"
+        else:
+            raise BrowseError(f"Cannot browse media_content_id {media_content_id!r}")
+
+        try:
+            envelope = await self.coordinator.client.async_browse_collections(
+                self._zone_id, action, path=path
+            )
+        except UnifiedHifiControlApiError as err:
+            raise BrowseError(f"Failed to browse zone {self._zone_id}: {err}") from err
+
+        if envelope.get("outcome") != "ok":
+            refusal = envelope.get("refusal") or {}
+            detail = refusal.get("message") or envelope.get("outcome", "unknown error")
+            raise BrowseError(
+                f"{action} is not available for zone {self._zone_id}: {detail}"
+            )
+
+        data = envelope.get("data") or {}
+        children: list[BrowseMedia] = []
+        for item in data.get("items") or []:
+            item_title = item.get("title") or "Untitled"
+            item_path = item.get("path")
+            item_ref = item.get("ref")
+            if item_path:
+                children.append(
+                    BrowseMedia(
+                        media_class=MediaClass.DIRECTORY,
+                        media_content_id=f"{_PATH_PREFIX}{item_path}",
+                        media_content_type=MediaType.MUSIC,
+                        title=item_title,
+                        can_play=False,
+                        can_expand=True,
+                    )
+                )
+            elif item_ref:
+                children.append(
+                    BrowseMedia(
+                        media_class=MediaClass.TRACK,
+                        media_content_id=f"{_REF_PREFIX}{item_ref}",
+                        media_content_type=MediaType.MUSIC,
+                        title=item_title,
+                        can_play=True,
+                        can_expand=False,
+                    )
+                )
+            # A row with neither path nor ref (e.g. #396's known LMS
+            # XMLBrowser gap) carries nothing this integration can act on;
+            # it is silently omitted rather than shown as dead-end.
+
+        return BrowseMedia(
+            media_class=MediaClass.DIRECTORY,
+            media_content_id=media_content_id,
+            media_content_type=MediaType.MUSIC,
+            title=title,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MediaClass.DIRECTORY,
+            children=children,
+        )
+
+    async def async_play_media(
+        self, media_type: str, media_id: str, **kwargs: Any
+    ) -> None:
+        zone = self._zone
+        if zone is None or not zone.browse_supported:
+            raise HomeAssistantError(
+                f"Zone {self._zone_id} does not support playing browsed media."
+            )
+        if not media_id.startswith(_REF_PREFIX):
+            raise HomeAssistantError(
+                f"Cannot play media_id {media_id!r}: only items returned by "
+                "browsing this zone's library can be played."
+            )
+        ref = media_id[len(_REF_PREFIX) :]
+        enqueue = kwargs.get("enqueue")
+        if enqueue in (None, MediaPlayerEnqueue.PLAY):
+            action = "play"
+        elif enqueue == MediaPlayerEnqueue.NEXT:
+            action = "next"
+        else:
+            # ADD / REPLACE: UHC's hifi_play_ref has no distinct "replace the
+            # queue" verb, so both fall back to appending -- see
+            # docs/home_assistant_integration.md.
+            action = "queue"
+        try:
+            envelope = await self.coordinator.client.async_play_ref(
+                ref, self._zone_id, action=action
+            )
+        except UnifiedHifiControlApiError as err:
+            raise HomeAssistantError(f"Failed to play media: {err}") from err
+        if envelope.get("outcome") not in ("ok", "accepted"):
+            refusal = envelope.get("refusal") or {}
+            detail = refusal.get("message") or envelope.get("outcome", "unknown error")
+            raise HomeAssistantError(f"Failed to play media: {detail}")
         await self.coordinator.async_request_refresh()

--- a/custom_components/unified_hifi_control/requirements_test.txt
+++ b/custom_components/unified_hifi_control/requirements_test.txt
@@ -1,0 +1,5 @@
+homeassistant>=2024.1.0
+pytest>=7.4.0
+pytest-asyncio>=0.23.0
+pytest-homeassistant-custom-component>=0.13.0
+aiohttp>=3.9.0

--- a/custom_components/unified_hifi_control/strings.json
+++ b/custom_components/unified_hifi_control/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Unified Hifi Control",
+        "description": "Enter the base URL of your UHC server, e.g. http://192.168.1.50:8088",
+        "data": {
+          "base_url": "Base URL"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Could not connect to the UHC server at that address.",
+      "auth_required": "This UHC server requires controller authentication, which this integration does not yet support. Disable UHC_REQUIRE_CONTROLLER_AUTH or front it with a proxy that supplies the session cookie.",
+      "unknown": "Unexpected error communicating with UHC."
+    },
+    "abort": {
+      "already_configured": "This UHC server is already configured.",
+      "cannot_connect": "Could not connect to the discovered UHC server."
+    }
+  }
+}

--- a/custom_components/unified_hifi_control/tests/__init__.py
+++ b/custom_components/unified_hifi_control/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the unified_hifi_control custom component."""

--- a/custom_components/unified_hifi_control/tests/conftest.py
+++ b/custom_components/unified_hifi_control/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Fixtures for unified_hifi_control tests."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations for every test (pytest-homeassistant-custom-component)."""
+    yield

--- a/custom_components/unified_hifi_control/tests/test_api.py
+++ b/custom_components/unified_hifi_control/tests/test_api.py
@@ -127,3 +127,121 @@ def test_image_url_builds_expected_path():
         api.image_url("roon:1")
         == "http://uhc.local:8088/knob/now_playing/image?zone_id=roon:1"
     )
+
+
+@pytest.mark.asyncio
+async def test_browse_collections_posts_expected_body(hass, aioclient_mock):
+    aioclient_mock.post(
+        f"{BASE_URL}/api/collections",
+        json={"outcome": "ok", "data": {"items": []}},
+    )
+    result = await _client(hass).async_browse_collections(
+        "lms:aa", "browse", path="tok", limit=10, offset=5
+    )
+    assert result == {"outcome": "ok", "data": {"items": []}}
+    assert aioclient_mock.mock_calls[0][2] == {
+        "zone_id": "lms:aa",
+        "action": "browse",
+        "path": "tok",
+        "limit": 10,
+        "offset": 5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_browse_collections_omits_absent_optional_fields(hass, aioclient_mock):
+    aioclient_mock.post(
+        f"{BASE_URL}/api/collections", json={"outcome": "ok", "data": {}}
+    )
+    await _client(hass).async_browse_collections("lms:aa", "playlists")
+    assert aioclient_mock.mock_calls[0][2] == {
+        "zone_id": "lms:aa",
+        "action": "playlists",
+    }
+
+
+@pytest.mark.asyncio
+async def test_play_ref_posts_expected_body(hass, aioclient_mock):
+    aioclient_mock.post(
+        f"{BASE_URL}/api/play_ref", json={"outcome": "accepted"}
+    )
+    result = await _client(hass).async_play_ref("tok", "lms:aa", action="queue")
+    assert result == {"outcome": "accepted"}
+    assert aioclient_mock.mock_calls[0][2] == {
+        "ref": "tok",
+        "zone_id": "lms:aa",
+        "action": "queue",
+    }
+
+
+@pytest.mark.asyncio
+async def test_zone_group_status_scoped_to_one_provider(hass, aioclient_mock):
+    aioclient_mock.post(
+        f"{BASE_URL}/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "structuredContent": {
+                    "data": {
+                        "groups": [
+                            {
+                                "leader_zone_id": "roon:1",
+                                "member_zone_ids": ["roon:2"],
+                            }
+                        ]
+                    }
+                }
+            },
+        },
+    )
+    result = await _client(hass).async_zone_group_status("roon:1")
+    assert result == {
+        "groups": [{"leader_zone_id": "roon:1", "member_zone_ids": ["roon:2"]}]
+    }
+    body = aioclient_mock.mock_calls[0][2]
+    assert body["params"]["arguments"] == {"action": "status", "zone_id": "roon:1"}
+
+
+@pytest.mark.asyncio
+async def test_zone_group_status_aggregate_omits_zone_id(hass, aioclient_mock):
+    aioclient_mock.post(
+        f"{BASE_URL}/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"structuredContent": {"data": {"groups": [], "errors": []}}},
+        },
+    )
+    result = await _client(hass).async_zone_group_status()
+    assert result == {"groups": [], "errors": []}
+    body = aioclient_mock.mock_calls[0][2]
+    assert body["params"]["arguments"] == {"action": "status"}
+
+
+@pytest.mark.asyncio
+async def test_zone_group_status_raises_on_transport_error(hass, aioclient_mock):
+    aioclient_mock.post(
+        f"{BASE_URL}/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "error": {"message": "boom"}},
+    )
+    with pytest.raises(UnifiedHifiControlApiError):
+        await _client(hass).async_zone_group_status()
+
+
+@pytest.mark.asyncio
+async def test_zone_group_status_raises_on_refusal(hass, aioclient_mock):
+    aioclient_mock.post(
+        f"{BASE_URL}/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "structuredContent": {
+                    "refusal": {"message": "zone_id must be from a provider..."}
+                }
+            },
+        },
+    )
+    with pytest.raises(UnifiedHifiControlApiError):
+        await _client(hass).async_zone_group_status("upnp:1")

--- a/custom_components/unified_hifi_control/tests/test_api.py
+++ b/custom_components/unified_hifi_control/tests/test_api.py
@@ -1,0 +1,129 @@
+"""Tests for the UHC API client, including the SSE frame parser.
+
+Uses Home Assistant's ``aioclient_mock`` fixture (an aiohttp session
+mock) rather than a real TestServer/socket, since the pytest-socket
+plugin bundled with pytest-homeassistant-custom-component blocks real
+network sockets by default.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.unified_hifi_control.api import (
+    UnifiedHifiControlApiClient,
+    UnifiedHifiControlApiError,
+    UnifiedHifiControlAuthError,
+    UnifiedHifiControlConnectionError,
+    _parse_sse,
+)
+
+BASE_URL = "http://uhc.local:8088"
+
+
+async def _fake_content_lines(lines: list[bytes]):
+    for line in lines:
+        yield line
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_single_event():
+    lines = [
+        b'data: {"type":"VolumeChanged","payload":{"output_id":"roon:1","value":42,"is_muted":false}}\n',
+        b"\n",
+    ]
+    events = [e async for e in _parse_sse(_fake_content_lines(lines))]
+    assert events == [
+        ("VolumeChanged", {"output_id": "roon:1", "value": 42, "is_muted": False})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_ignores_comments_and_multiple_frames():
+    lines = [
+        b": ping\n",
+        b'data: {"type":"NowPlayingChanged","payload":{"zone_id":"lms:aa","title":"Song"}}\n',
+        b"\n",
+        b'data: {"type":"SeekPositionChanged","payload":{"zone_id":"lms:aa","position":10}}\n',
+        b"\n",
+    ]
+    events = [e async for e in _parse_sse(_fake_content_lines(lines))]
+    assert events[0][0] == "NowPlayingChanged"
+    assert events[1][0] == "SeekPositionChanged"
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_skips_invalid_json():
+    lines = [b"data: {not valid json\n", b"\n"]
+    events = [e async for e in _parse_sse(_fake_content_lines(lines))]
+    assert events == []
+
+
+def _client(hass) -> UnifiedHifiControlApiClient:
+    """Build a client using HA's managed, test-harness-owned session.
+
+    Using homeassistant.helpers.aiohttp_client.async_get_clientsession
+    (routed through aioclient_mock by the test harness) rather than a
+    raw aiohttp.ClientSession avoids leaking background resolver
+    threads that the harness's cleanup fixture would otherwise flag.
+    """
+    from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+    return UnifiedHifiControlApiClient(async_get_clientsession(hass), BASE_URL)
+
+
+@pytest.mark.asyncio
+async def test_get_zones(hass, aioclient_mock):
+    aioclient_mock.get(
+        f"{BASE_URL}/knob/zones",
+        json={"zones": [{"zone_id": "roon:1", "zone_name": "Kitchen"}]},
+    )
+    zones = await _client(hass).async_get_zones()
+    assert zones == [{"zone_id": "roon:1", "zone_name": "Kitchen"}]
+
+
+@pytest.mark.asyncio
+async def test_get_zones_bad_shape_raises(hass, aioclient_mock):
+    aioclient_mock.get(f"{BASE_URL}/knob/zones", json={"unexpected": True})
+    with pytest.raises(UnifiedHifiControlApiError):
+        await _client(hass).async_get_zones()
+
+
+@pytest.mark.asyncio
+async def test_control_posts_expected_body(hass, aioclient_mock):
+    aioclient_mock.post(f"{BASE_URL}/knob/control", json={"ok": True})
+    await _client(hass).async_control("roon:1", "vol_abs", value=50)
+    assert aioclient_mock.mock_calls[0][2] == {
+        "zone_id": "roon:1",
+        "action": "vol_abs",
+        "value": 50,
+    }
+
+
+@pytest.mark.asyncio
+async def test_auth_error_raised_on_401(hass, aioclient_mock):
+    aioclient_mock.get(f"{BASE_URL}/knob/zones", status=401, json={"error": "no"})
+    with pytest.raises(UnifiedHifiControlAuthError):
+        await _client(hass).async_get_zones()
+
+
+@pytest.mark.asyncio
+async def test_connection_error_wraps_client_exceptions(hass, aioclient_mock):
+    import aiohttp
+
+    aioclient_mock.get(
+        f"{BASE_URL}/knob/zones",
+        exc=aiohttp.ClientConnectionError("boom"),
+    )
+    with pytest.raises(UnifiedHifiControlConnectionError):
+        await _client(hass).async_get_zones()
+
+
+def test_image_url_builds_expected_path():
+    class _FakeSession:
+        pass
+
+    api = UnifiedHifiControlApiClient(_FakeSession(), "http://uhc.local:8088/")
+    assert (
+        api.image_url("roon:1")
+        == "http://uhc.local:8088/knob/now_playing/image?zone_id=roon:1"
+    )

--- a/custom_components/unified_hifi_control/tests/test_config_flow.py
+++ b/custom_components/unified_hifi_control/tests/test_config_flow.py
@@ -1,0 +1,61 @@
+"""Tests for the config flow."""
+from __future__ import annotations
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.unified_hifi_control.const import CONF_BASE_URL, DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_user_flow_success(hass: HomeAssistant, aioclient_mock) -> None:
+    aioclient_mock.get(
+        "http://192.168.1.50:8088/knob/zones",
+        json={"zones": [{"zone_id": "roon:1", "zone_name": "Kitchen"}]},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_BASE_URL: "192.168.1.50:8088"}
+    )
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_BASE_URL] == "http://192.168.1.50:8088"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_cannot_connect(hass: HomeAssistant, aioclient_mock) -> None:
+    import aiohttp
+
+    aioclient_mock.get(
+        "http://192.168.1.50:8088/knob/zones",
+        exc=aiohttp.ClientConnectionError("boom"),
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_BASE_URL: "http://192.168.1.50:8088"}
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.asyncio
+async def test_user_flow_auth_required(hass: HomeAssistant, aioclient_mock) -> None:
+    aioclient_mock.get("http://192.168.1.50:8088/knob/zones", status=401)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_BASE_URL: "http://192.168.1.50:8088"}
+    )
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "auth_required"}

--- a/custom_components/unified_hifi_control/tests/test_coordinator.py
+++ b/custom_components/unified_hifi_control/tests/test_coordinator.py
@@ -1,7 +1,13 @@
 """Tests for coordinator event handling."""
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.unified_hifi_control.api import UnifiedHifiControlApiError
 from custom_components.unified_hifi_control.coordinator import (
+    UnifiedHifiControlCoordinator,
     ZoneState,
     _h_now_playing_changed,
     _h_seek_changed,
@@ -93,3 +99,77 @@ def test_zone_discovered_existing_zone_is_noop():
     )
     assert not changed
     assert data["roon:1"].zone_name == "Kitchen"
+
+
+def test_zone_discovered_carries_browse_supported():
+    data: dict[str, ZoneState] = {}
+    _h_zone_discovered(
+        data,
+        {
+            "zone": {
+                "zone_id": "lms:aa",
+                "zone_name": "Bedroom",
+                "source": "lms",
+                "browse_supported": True,
+            }
+        },
+    )
+    assert data["lms:aa"].browse_supported is True
+
+
+def _coordinator_with_client(client) -> UnifiedHifiControlCoordinator:
+    """A coordinator instance with only `.client` set.
+
+    `_refresh_group_members` only touches `self.client`, so this avoids
+    wiring up the full `DataUpdateCoordinator`/hass machinery just to test
+    it.
+    """
+    coordinator = object.__new__(UnifiedHifiControlCoordinator)
+    coordinator.client = client
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_refresh_group_members_populates_leader_and_members():
+    client = AsyncMock()
+    client.async_zone_group_status = AsyncMock(
+        return_value={
+            "groups": [
+                {"leader_zone_id": "roon:1", "member_zone_ids": ["roon:2", "roon:3"]}
+            ]
+        }
+    )
+    coordinator = _coordinator_with_client(client)
+    zones = {
+        "roon:1": _zone(zone_id="roon:1"),
+        "roon:2": _zone(zone_id="roon:2"),
+        "roon:3": _zone(zone_id="roon:3"),
+    }
+    await coordinator._refresh_group_members(zones)
+    assert zones["roon:1"].group_members == ["roon:1", "roon:2", "roon:3"]
+    assert zones["roon:2"].group_members == ["roon:1", "roon:2", "roon:3"]
+    assert zones["roon:3"].group_members == ["roon:1", "roon:2", "roon:3"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_group_members_skips_when_no_grouping_capable_zone():
+    client = AsyncMock()
+    client.async_zone_group_status = AsyncMock()
+    coordinator = _coordinator_with_client(client)
+    zones = {"upnp:1": _zone(zone_id="upnp:1")}
+    zones["upnp:1"].source = "upnp"
+    await coordinator._refresh_group_members(zones)
+    client.async_zone_group_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_group_members_tolerates_status_failure():
+    client = AsyncMock()
+    client.async_zone_group_status = AsyncMock(
+        side_effect=UnifiedHifiControlApiError("unreachable")
+    )
+    coordinator = _coordinator_with_client(client)
+    zones = {"roon:1": _zone(zone_id="roon:1")}
+    # Must not raise.
+    await coordinator._refresh_group_members(zones)
+    assert zones["roon:1"].group_members == []

--- a/custom_components/unified_hifi_control/tests/test_coordinator.py
+++ b/custom_components/unified_hifi_control/tests/test_coordinator.py
@@ -1,0 +1,95 @@
+"""Tests for coordinator event handling."""
+from __future__ import annotations
+
+from custom_components.unified_hifi_control.coordinator import (
+    ZoneState,
+    _h_now_playing_changed,
+    _h_seek_changed,
+    _h_volume_changed,
+    _h_zone_discovered,
+    _h_zone_removed,
+    _h_zone_updated,
+)
+
+
+def _zone(zone_id="roon:1", zone_name="Kitchen", **kw):
+    return ZoneState(zone_id=zone_id, zone_name=zone_name, source="roon", **kw)
+
+
+def test_now_playing_changed_updates_metadata():
+    data = {"roon:1": _zone()}
+    changed = _h_now_playing_changed(
+        data, {"zone_id": "roon:1", "title": "Song", "artist": "Artist"}
+    )
+    assert changed
+    assert data["roon:1"].title == "Song"
+    assert data["roon:1"].artist == "Artist"
+
+
+def test_now_playing_changed_unknown_zone_is_noop():
+    data = {"roon:1": _zone()}
+    changed = _h_now_playing_changed(data, {"zone_id": "roon:999", "title": "Song"})
+    assert not changed
+    assert data["roon:1"].title is None
+
+
+def test_volume_changed_uses_output_id():
+    data = {"roon:1": _zone()}
+    changed = _h_volume_changed(
+        data, {"output_id": "roon:1", "value": 33, "is_muted": True}
+    )
+    assert changed
+    assert data["roon:1"].volume == 33
+    assert data["roon:1"].is_muted is True
+
+
+def test_seek_changed_updates_position():
+    data = {"roon:1": _zone()}
+    assert _h_seek_changed(data, {"zone_id": "roon:1", "position": 42})
+    assert data["roon:1"].seek_position == 42
+
+
+def test_zone_updated_changes_name_and_state():
+    data = {"roon:1": _zone()}
+    assert _h_zone_updated(
+        data, {"zone_id": "roon:1", "display_name": "Den", "state": "playing"}
+    )
+    assert data["roon:1"].zone_name == "Den"
+    assert data["roon:1"].state == "playing"
+
+
+def test_zone_removed_deletes_entry():
+    data = {"roon:1": _zone()}
+    assert _h_zone_removed(data, {"zone_id": "roon:1"})
+    assert "roon:1" not in data
+
+
+def test_zone_removed_unknown_zone_is_noop():
+    data = {"roon:1": _zone()}
+    assert not _h_zone_removed(data, {"zone_id": "roon:999"})
+
+
+def test_zone_discovered_adds_new_zone():
+    data: dict[str, ZoneState] = {}
+    changed = _h_zone_discovered(
+        data,
+        {
+            "zone": {
+                "zone_id": "lms:aa",
+                "zone_name": "Bedroom",
+                "source": "lms",
+                "state": "stopped",
+            }
+        },
+    )
+    assert changed
+    assert data["lms:aa"].zone_name == "Bedroom"
+
+
+def test_zone_discovered_existing_zone_is_noop():
+    data = {"roon:1": _zone(zone_name="Kitchen")}
+    changed = _h_zone_discovered(
+        data, {"zone": {"zone_id": "roon:1", "zone_name": "Renamed"}}
+    )
+    assert not changed
+    assert data["roon:1"].zone_name == "Kitchen"

--- a/custom_components/unified_hifi_control/tests/test_media_player.py
+++ b/custom_components/unified_hifi_control/tests/test_media_player.py
@@ -1,10 +1,21 @@
 """Tests for capability mapping in media_player.py."""
 from __future__ import annotations
 
-from homeassistant.components.media_player import MediaPlayerEntityFeature
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.components.media_player import (
+    BrowseError,
+    MediaPlayerEnqueue,
+    MediaPlayerEntityFeature,
+)
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.unified_hifi_control.coordinator import ZoneState
-from custom_components.unified_hifi_control.media_player import _supported_features
+from custom_components.unified_hifi_control.media_player import (
+    UnifiedHifiControlMediaPlayer,
+    _supported_features,
+)
 
 
 def test_roon_zone_gets_full_transport_and_skip():
@@ -13,7 +24,8 @@ def test_roon_zone_gets_full_transport_and_skip():
     assert features & MediaPlayerEntityFeature.NEXT_TRACK
     assert features & MediaPlayerEntityFeature.PREVIOUS_TRACK
     assert features & MediaPlayerEntityFeature.VOLUME_SET
-    assert not (features & MediaPlayerEntityFeature.GROUPING)
+    # Roon grouping landed with issue #517 / PR #521.
+    assert features & MediaPlayerEntityFeature.GROUPING
 
 
 def test_upnp_zone_has_no_skip_per_adapter_refusal():
@@ -38,8 +50,261 @@ def test_applemusic_zone_has_no_transport_features_yet():
     assert features == MediaPlayerEntityFeature(0)
 
 
-def test_lms_zone_has_no_grouping_on_this_branch():
+def test_lms_zone_gets_grouping():
     zone = ZoneState(zone_id="lms:aa", zone_name="Bedroom", source="lms")
     features = _supported_features(zone)
-    assert not (features & MediaPlayerEntityFeature.GROUPING)
+    # LMS sync-group grouping landed with issue #517 / PR #521.
+    assert features & MediaPlayerEntityFeature.GROUPING
     assert features & MediaPlayerEntityFeature.NEXT_TRACK
+
+
+def test_browse_supported_zone_gets_browse_and_play_media():
+    zone = ZoneState(
+        zone_id="musicassistant:1",
+        zone_name="Living Room",
+        source="musicassistant",
+        browse_supported=True,
+    )
+    features = _supported_features(zone)
+    assert features & MediaPlayerEntityFeature.BROWSE_MEDIA
+    assert features & MediaPlayerEntityFeature.PLAY_MEDIA
+    assert features & MediaPlayerEntityFeature.MEDIA_ENQUEUE
+
+
+def test_browse_unsupported_zone_has_no_browse_features():
+    zone = ZoneState(
+        zone_id="applemusic:1",
+        zone_name="Phone",
+        source="applemusic",
+        browse_supported=False,
+    )
+    features = _supported_features(zone)
+    assert not (features & MediaPlayerEntityFeature.BROWSE_MEDIA)
+    assert not (features & MediaPlayerEntityFeature.PLAY_MEDIA)
+
+
+class _FakeCoordinator:
+    """Minimal coordinator double: just what CoordinatorEntity/media_player need."""
+
+    def __init__(self, zones: dict[str, ZoneState]) -> None:
+        self.data = zones
+        self.client = AsyncMock()
+        self.async_request_refresh = AsyncMock()
+
+
+def _player(zone: ZoneState) -> UnifiedHifiControlMediaPlayer:
+    coordinator = _FakeCoordinator({zone.zone_id: zone})
+    return UnifiedHifiControlMediaPlayer(coordinator, zone.zone_id)
+
+
+def _ok_envelope(data: dict) -> dict:
+    return {"outcome": "ok", "data": data}
+
+
+def _accepted_envelope() -> dict:
+    return {"outcome": "accepted"}
+
+
+def _refused_envelope(message: str) -> dict:
+    return {"outcome": "unsupported", "refusal": {"message": message}}
+
+
+@pytest.mark.asyncio
+async def test_browse_media_root_lists_three_entry_points():
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    result = await player.async_browse_media()
+    assert result.can_expand
+    ids = [child.media_content_id for child in result.children]
+    assert ids == ["top:browse", "top:playlists", "top:favorites"]
+
+
+@pytest.mark.asyncio
+async def test_browse_media_raises_for_zone_without_browse_support():
+    zone = ZoneState(
+        zone_id="applemusic:1", zone_name="Phone", source="applemusic", browse_supported=False
+    )
+    player = _player(zone)
+    with pytest.raises(BrowseError):
+        await player.async_browse_media()
+
+
+@pytest.mark.asyncio
+async def test_browse_media_top_level_walks_into_collections_browse():
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    player.coordinator.client.async_browse_collections = AsyncMock(
+        return_value=_ok_envelope(
+            {
+                "items": [
+                    {"title": "Albums", "path": "browse-token-albums"},
+                    {"title": "Some Track", "ref": "play-token-1"},
+                ]
+            }
+        )
+    )
+    result = await player.async_browse_media(media_content_id="top:browse")
+    player.coordinator.client.async_browse_collections.assert_awaited_once_with(
+        "lms:aa", "browse", path=None
+    )
+    assert [c.media_content_id for c in result.children] == [
+        "path:browse-token-albums",
+        "ref:play-token-1",
+    ]
+    assert result.children[0].can_expand and not result.children[0].can_play
+    assert result.children[1].can_play and not result.children[1].can_expand
+
+
+@pytest.mark.asyncio
+async def test_browse_media_path_continuation_always_uses_browse_action():
+    zone = ZoneState(
+        zone_id="roon:1", zone_name="Kitchen", source="roon", browse_supported=True
+    )
+    player = _player(zone)
+    player.coordinator.client.async_browse_collections = AsyncMock(
+        return_value=_ok_envelope({"items": []})
+    )
+    await player.async_browse_media(media_content_id="path:some-token")
+    player.coordinator.client.async_browse_collections.assert_awaited_once_with(
+        "roon:1", "browse", path="some-token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_browse_media_refusal_raises_browse_error():
+    zone = ZoneState(
+        zone_id="roon:1", zone_name="Kitchen", source="roon", browse_supported=True
+    )
+    player = _player(zone)
+    player.coordinator.client.async_browse_collections = AsyncMock(
+        return_value=_refused_envelope("favorites is not available for roon zones")
+    )
+    with pytest.raises(BrowseError, match="favorites is not available"):
+        await player.async_browse_media(media_content_id="top:favorites")
+
+
+@pytest.mark.asyncio
+async def test_browse_media_rejects_unknown_content_id():
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    with pytest.raises(BrowseError):
+        await player.async_browse_media(media_content_id="nonsense:1")
+
+
+@pytest.mark.asyncio
+async def test_play_media_plays_a_browsed_ref():
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    player.coordinator.client.async_play_ref = AsyncMock(
+        return_value=_accepted_envelope()
+    )
+    await player.async_play_media("music", "ref:play-token-1")
+    player.coordinator.client.async_play_ref.assert_awaited_once_with(
+        "play-token-1", "lms:aa", action="play"
+    )
+    player.coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_play_media_honors_enqueue():
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    player.coordinator.client.async_play_ref = AsyncMock(
+        return_value=_accepted_envelope()
+    )
+    await player.async_play_media(
+        "music", "ref:play-token-1", enqueue=MediaPlayerEnqueue.ADD
+    )
+    player.coordinator.client.async_play_ref.assert_awaited_once_with(
+        "play-token-1", "lms:aa", action="queue"
+    )
+
+
+@pytest.mark.asyncio
+async def test_play_media_rejects_a_non_ref_media_id():
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    with pytest.raises(HomeAssistantError):
+        await player.async_play_media("music", "some-raw-id")
+
+
+@pytest.mark.asyncio
+async def test_play_media_refusal_raises_home_assistant_error():
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    player.coordinator.client.async_play_ref = AsyncMock(
+        return_value=_refused_envelope("ref expired")
+    )
+    with pytest.raises(HomeAssistantError, match="ref expired"):
+        await player.async_play_media("music", "ref:stale-token")
+
+
+@pytest.mark.asyncio
+async def test_join_players_refuses_cross_provider_members():
+    zone = ZoneState(zone_id="roon:1", zone_name="Kitchen", source="roon")
+    player = _player(zone)
+    with pytest.raises(HomeAssistantError, match="across providers"):
+        await player.async_join_players(["lms:aa"])
+    player.coordinator.client.async_zone_group.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_join_players_refuses_ungrouping_capable_provider():
+    zone = ZoneState(zone_id="upnp:1", zone_name="Office", source="upnp")
+    player = _player(zone)
+    with pytest.raises(HomeAssistantError, match="not supported"):
+        await player.async_join_players(["upnp:2"])
+
+
+@pytest.mark.asyncio
+async def test_join_players_calls_client_for_same_provider_members():
+    zone = ZoneState(zone_id="roon:1", zone_name="Kitchen", source="roon")
+    player = _player(zone)
+    player.coordinator.client.async_zone_group = AsyncMock()
+    await player.async_join_players(["roon:2", "roon:3"])
+    player.coordinator.client.async_zone_group.assert_awaited_once_with(
+        "join", "roon:1", member_zone_ids=["roon:2", "roon:3"]
+    )
+    player.coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unjoin_player_calls_client_leave():
+    zone = ZoneState(zone_id="lms:aa", zone_name="Bedroom", source="lms")
+    player = _player(zone)
+    player.coordinator.client.async_zone_group = AsyncMock()
+    await player.async_unjoin_player()
+    player.coordinator.client.async_zone_group.assert_awaited_once_with(
+        "leave", "lms:aa", member_zone_ids=["lms:aa"]
+    )
+
+
+def test_group_members_reflects_zone_state():
+    zone = ZoneState(
+        zone_id="roon:1",
+        zone_name="Kitchen",
+        source="roon",
+        group_members=["roon:1", "roon:2"],
+    )
+    player = _player(zone)
+    assert player.group_members == ["roon:1", "roon:2"]
+
+
+def test_group_members_empty_for_unavailable_zone():
+    coordinator = _FakeCoordinator({})
+    player = UnifiedHifiControlMediaPlayer(coordinator, "roon:missing")
+    assert player.group_members == []

--- a/custom_components/unified_hifi_control/tests/test_media_player.py
+++ b/custom_components/unified_hifi_control/tests/test_media_player.py
@@ -1,0 +1,45 @@
+"""Tests for capability mapping in media_player.py."""
+from __future__ import annotations
+
+from homeassistant.components.media_player import MediaPlayerEntityFeature
+
+from custom_components.unified_hifi_control.coordinator import ZoneState
+from custom_components.unified_hifi_control.media_player import _supported_features
+
+
+def test_roon_zone_gets_full_transport_and_skip():
+    zone = ZoneState(zone_id="roon:1", zone_name="Kitchen", source="roon")
+    features = _supported_features(zone)
+    assert features & MediaPlayerEntityFeature.NEXT_TRACK
+    assert features & MediaPlayerEntityFeature.PREVIOUS_TRACK
+    assert features & MediaPlayerEntityFeature.VOLUME_SET
+    assert not (features & MediaPlayerEntityFeature.GROUPING)
+
+
+def test_upnp_zone_has_no_skip_per_adapter_refusal():
+    zone = ZoneState(zone_id="upnp:1", zone_name="Office", source="upnp")
+    features = _supported_features(zone)
+    assert not (features & MediaPlayerEntityFeature.NEXT_TRACK)
+    assert not (features & MediaPlayerEntityFeature.PREVIOUS_TRACK)
+    # Transport/volume are still supported for UPnP.
+    assert features & MediaPlayerEntityFeature.PLAY
+    assert features & MediaPlayerEntityFeature.VOLUME_SET
+
+
+def test_musicassistant_zone_gets_grouping():
+    zone = ZoneState(zone_id="musicassistant:1", zone_name="Living Room", source="musicassistant")
+    features = _supported_features(zone)
+    assert features & MediaPlayerEntityFeature.GROUPING
+
+
+def test_applemusic_zone_has_no_transport_features_yet():
+    zone = ZoneState(zone_id="applemusic:1", zone_name="Phone", source="applemusic")
+    features = _supported_features(zone)
+    assert features == MediaPlayerEntityFeature(0)
+
+
+def test_lms_zone_has_no_grouping_on_this_branch():
+    zone = ZoneState(zone_id="lms:aa", zone_name="Bedroom", source="lms")
+    features = _supported_features(zone)
+    assert not (features & MediaPlayerEntityFeature.GROUPING)
+    assert features & MediaPlayerEntityFeature.NEXT_TRACK

--- a/custom_components/unified_hifi_control/translations/en.json
+++ b/custom_components/unified_hifi_control/translations/en.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Unified Hifi Control",
+        "description": "Enter the base URL of your UHC server, e.g. http://192.168.1.50:8088",
+        "data": {
+          "base_url": "Base URL"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Could not connect to the UHC server at that address.",
+      "auth_required": "This UHC server requires controller authentication, which this integration does not yet support. Disable UHC_REQUIRE_CONTROLLER_AUTH or front it with a proxy that supplies the session cookie.",
+      "unknown": "Unexpected error communicating with UHC."
+    },
+    "abort": {
+      "already_configured": "This UHC server is already configured.",
+      "cannot_connect": "Could not connect to the discovered UHC server."
+    }
+  }
+}

--- a/docs/home_assistant_integration.md
+++ b/docs/home_assistant_integration.md
@@ -69,17 +69,51 @@ subdirectory. Rationale:
   - Next/previous: all providers except UPnP, whose adapter explicitly
     refuses skip actions (`src/adapters/upnp.rs::REFUSED_TRANSPORT_ACTIONS`).
   - Grouping (`MediaPlayerEntityFeature.GROUPING`, wired to
-    `async_join_players`/`async_unjoin_player`): **Music Assistant
-    only** on this branch, matching `Capability::MultiroomSync` in
-    `src/mcp/capabilities.rs` (the only provider marked `Supported`
-    there). Roon/LMS grouping work exists on branch `issue/517`
-    (feeding PR #521) but had not merged into this integration's base
-    branch as of this PR — calling join/unjoin on any other provider
-    raises a `HomeAssistantError` naming the tracking issues instead of
-    silently failing.
+    `async_join_players`/`async_unjoin_player`): **Music Assistant,
+    Roon and LMS**, matching `Capability::MultiroomSync` in
+    `src/mcp/capabilities.rs` (issue #517 / PR #521). Calling join/unjoin
+    on any other provider's zone raises a `HomeAssistantError`, as does
+    passing `group_members` whose zone ids belong to a different
+    provider than the target zone — UHC has no protocol that groups
+    zones across providers, so cross-provider joins are refused
+    client-side before any adapter call. `group_members` is populated
+    from a periodic aggregate `hifi_zone_group` status poll
+    (`UnifiedHifiControlCoordinator._refresh_group_members`), run
+    alongside the fallback poll; a provider that cannot be reached for
+    that poll is simply skipped rather than failing the whole refresh.
+    Two provider-specific conventions are tolerated verbatim in
+    `group_members`, per `src/mcp/tools/groups.rs`: Roon reports grouped
+    members as `roon:<output_id>` (its own zone ids churn when outputs
+    are grouped/ungrouped in Roon itself), and LMS sync groups are
+    leaderless (the reported "leader" is UHC's stable-but-arbitrary pick
+    of the first member, not an LMS fact).
   - Grouping itself is implemented over the `/mcp` JSON-RPC endpoint
     (`hifi_zone_group` tool) because grouping has no plain-REST route
-    yet; everything else in this integration is plain REST.
+    yet; browsing (`/api/collections`, `/api/play_ref`) and everything
+    else in this integration is plain REST.
+  - Browsing (`MediaPlayerEntityFeature.BROWSE_MEDIA` /
+    `PLAY_MEDIA` / `MEDIA_ENQUEUE`, wired to `async_browse_media`/
+    `async_play_media`): gated per-zone on the server-reported
+    `browse_supported` flag (`/knob/zones`, PR #533's
+    `zone_supports_hifi_collections`) rather than a hardcoded provider
+    set, so it tracks whichever providers `hifi_collections` implements
+    (Music Assistant, Roon, LMS as of #531) without a client-side
+    update. `async_browse_media` presents three root entries mirroring
+    `hifi_collections`' actions (Browse Library, Playlists, Favorites);
+    navigating into a subfolder always re-enters with `action=browse`
+    and the previous page's opaque `path` token, since a browse
+    continuation is provider-generic regardless of which entry point
+    minted it (see `src/mcp/tools/collections.rs`'s path-resolution
+    comments). `async_play_media` only accepts a `media_id` that
+    `async_browse_media` itself returned (an opaque `ref:` token) and
+    forwards it to `/api/play_ref`; an `enqueue` value HA passes maps to
+    `hifi_play_ref`'s `queue`/`next`/`play` actions where a distinct verb
+    exists, and to `queue` otherwise (UHC has no separate "replace the
+    queue" verb). **Artwork caveat**: `hifi_collections` items carry no
+    per-item artwork field today (only now-playing state does, via
+    `/knob/now_playing/image`), so browsed folders and tracks render
+    without thumbnails — `BrowseMedia.thumbnail` is left unset rather
+    than guessing at one.
 - **Mute caveat**: UHC's `/knob/now_playing` response does not include
   mute state, and not every provider has confirmed `mute`/`unmute`
   wiring through `/knob/control` end-to-end (only HQPlayer's handler was
@@ -152,11 +186,17 @@ becomes active once this lands on `v3`.
 
 ## Known follow-ups
 
-- No plain-REST route exists for zone grouping, collections, queue, or
-  play-by-ref — they're MCP-only today. This integration only uses MCP
-  for grouping; a UHC-side push endpoint or plain-REST equivalents for
-  the rest would let a future version add queue/collections support
-  without embedding an MCP client for everything.
-- Extending grouping support to Roon/LMS once `issue/517`'s work lands
-  on this integration's base branch is a follow-up, not blocking this
-  PR (the code already refuses cleanly for those providers today).
+- No plain-REST route exists for zone grouping itself (`hifi_zone_group`)
+  — it's MCP-only today, unlike `/api/collections`/`/api/play_ref`
+  (PR #516/#531), which already got plain-REST mirrors. A UHC-side
+  plain-REST equivalent for grouping (mirroring `src/api/browse.rs`'s
+  pattern) would let this integration drop its one remaining MCP
+  JSON-RPC call.
+- `hifi_collections` items carry no per-item artwork, so browsed
+  folders/tracks show no thumbnail in the HA browse UI (see the
+  Architecture section's browsing note). Adding artwork to the
+  provider-neutral collections contract is tracked separately.
+- Queue management (`hifi_queue`: read/reorder/remove/transfer) is not
+  exposed through this integration yet — only browse-and-play. A future
+  version could surface it via `async_get_media_source`/a
+  queue-specific service, once there's a concrete HA UX for it.

--- a/docs/home_assistant_integration.md
+++ b/docs/home_assistant_integration.md
@@ -1,0 +1,162 @@
+# Home Assistant integration (`custom_components/unified_hifi_control`)
+
+A HACS-installable custom integration that exposes every UHC zone as a
+`media_player` entity, giving Home Assistant native voice control
+("pause the kitchen"), media-player dashboard cards, and `media_player.*`
+service calls — beyond what the MQTT device-composition path (PR #518,
+issue #508) can offer, since HA's built-in MQTT integration has no
+`media_player` platform.
+
+## Repo location
+
+Lives at the repository root (`custom_components/unified_hifi_control/`
+plus a root-level `hacs.json`), not in a sibling repo or a nested
+subdirectory. Rationale:
+
+- HACS's "integration" category expects `custom_components/<domain>/`
+  and `hacs.json` at the **root** of the repository it's pointed at.
+  Nesting the integration under e.g. `ha_integration/` would require
+  either a second HACS-visible repo or an unsupported layout; keeping it
+  at repo root lets users add
+  `https://github.com/open-horizon-labs/unified-hifi-control` directly
+  as a HACS custom repository today, with zero extra hosting.
+- This mirrors how several other server+integration monorepos ship (the
+  Rust crate and the Python integration are independent build/test
+  units that happen to share a repo and an issue tracker).
+- A sibling repo was considered but rejected for this PR: it would
+  require creating and maintaining a second GitHub repository, which
+  isn't something this change can do unattended, and would separate the
+  integration's issue history from the UHC server changes it depends
+  on (capability matrix, zone id conventions, event bus shape).
+
+## Architecture
+
+- **Transport**: plain HTTP against UHC's unified `/knob/*` routes
+  (`src/knobs/routes.rs`) — `GET /knob/zones`, `GET /knob/now_playing`,
+  `POST /knob/control`, `GET /knob/now_playing/image`. These work across
+  every adapter (Roon, LMS, HQPlayer, OpenHome, UPnP, Music Assistant)
+  without per-provider client code.
+- **State updates**: push-based via Server-Sent Events. UHC's
+  `GET /events` (`src/api/mod.rs::events_handler`) streams every
+  `BusEvent` off a real `tokio::sync::broadcast` channel
+  (`src/bus/mod.rs`). The coordinator (`coordinator.py`) holds a
+  long-lived connection and applies `NowPlayingChanged`,
+  `VolumeChanged`, `SeekPositionChanged`, `ZoneUpdated`,
+  `ZoneDiscovered`, and `ZoneRemoved` events directly to in-memory zone
+  state, then pushes updates to entities via
+  `DataUpdateCoordinator.async_set_updated_data` — no polling delay for
+  ordinary playback changes.
+  - **Documented polling fallback**: a 60-second periodic poll
+    (`FALLBACK_POLL_INTERVAL`) runs alongside the SSE listener as a
+    safety net for connections that go idle-dead without erroring
+    (some NAT/proxy setups swallow resets on long-lived idle TCP
+    connections). Under normal operation this poll observes no changes
+    because SSE already applied them.
+  - The SSE listener reconnects with exponential backoff (2s-60s) on
+    any disconnect and resets to the minimum backoff once a connection
+    has stayed up for 5+ seconds.
+- **Unavailability**: entities report unavailable when the coordinator's
+  last poll failed (`UpdateFailed`) or when their zone_id has been
+  removed from the coordinator's zone map (e.g. after a `ZoneRemoved`
+  event, or the zone no longer appears in a poll).
+- **Capability mapping**: `media_player.py::_supported_features` derives
+  `MediaPlayerEntityFeature` flags from the zone's provider using the
+  same facts as `src/mcp/capabilities.rs` / AGENTS.md's capability
+  matrix on this branch:
+  - Transport (play/pause/stop) and volume: all providers except
+    AppleMusic, which is gated behind #465 pending physical-device
+    validation on the UHC side.
+  - Next/previous: all providers except UPnP, whose adapter explicitly
+    refuses skip actions (`src/adapters/upnp.rs::REFUSED_TRANSPORT_ACTIONS`).
+  - Grouping (`MediaPlayerEntityFeature.GROUPING`, wired to
+    `async_join_players`/`async_unjoin_player`): **Music Assistant
+    only** on this branch, matching `Capability::MultiroomSync` in
+    `src/mcp/capabilities.rs` (the only provider marked `Supported`
+    there). Roon/LMS grouping work exists on branch `issue/517`
+    (feeding PR #521) but had not merged into this integration's base
+    branch as of this PR — calling join/unjoin on any other provider
+    raises a `HomeAssistantError` naming the tracking issues instead of
+    silently failing.
+  - Grouping itself is implemented over the `/mcp` JSON-RPC endpoint
+    (`hifi_zone_group` tool) because grouping has no plain-REST route
+    yet; everything else in this integration is plain REST.
+- **Mute caveat**: UHC's `/knob/now_playing` response does not include
+  mute state, and not every provider has confirmed `mute`/`unmute`
+  wiring through `/knob/control` end-to-end (only HQPlayer's handler was
+  found to set `Command::Mute` explicitly during research for this
+  integration). `media_player.is_volume_muted` is therefore `None`
+  (unknown) until a `VolumeChanged` SSE event with `is_muted` has been
+  observed for that zone, and `async_mute_volume` is a best-effort call
+  that surfaces a `HomeAssistantError` if UHC rejects it rather than
+  failing silently.
+- **Zone id stability**: unique_id is UHC's provider-prefixed zone id
+  (`roon:<id>`, `lms:<mac>`, `hqplayer:<instance>`,
+  `musicassistant:<id>`, etc. — see `PrefixedZoneId` in
+  `src/bus/events.rs`). These are stable for the lifetime of a zone on
+  the UHC server, with one known exception: Roon's own zone_id can
+  change when a user regroups outputs inside Roon itself, since Roon's
+  zone model — not UHC — owns that identity. That churn is inherent to
+  Roon and out of this integration's control; it shows up in Home
+  Assistant as the old entity going unavailable and a new one appearing
+  after a Roon-side regroup.
+- **Auth**: this integration talks to UHC assuming the default,
+  unauthenticated-on-LAN posture. If a server is run with
+  `UHC_REQUIRE_CONTROLLER_AUTH=1` (see `docs/controller-auth.md`), most
+  `/knob/*` and provider routes become protected by a cookie+CSRF
+  session this integration does not implement; the config flow surfaces
+  a clear "auth_required" error in that case rather than silently
+  failing. Front such a server with a reverse proxy that supplies the
+  session, or leave the flag unset for the interface this integration
+  is pointed at.
+
+## Choosing MQTT vs. this integration
+
+- Use the MQTT path (PR #518 / issue #508) for lightweight dashboards
+  and automations without installing a custom component, or when HA and
+  UHC can't reach each other over plain HTTP but already share an MQTT
+  broker.
+- Use this integration for real `media_player` entities: Assist voice
+  control, media-player dashboard cards, and `media_player.*` service
+  calls (play/pause/volume/seek/grouping) — none of which HA's MQTT
+  integration can provide, since it has no `media_player` platform.
+  Both can be installed side by side; they don't conflict.
+
+## Testing
+
+`custom_components/unified_hifi_control/tests/` uses
+`pytest-homeassistant-custom-component`. Run locally with:
+
+```
+pip install -r custom_components/unified_hifi_control/requirements_test.txt
+pip uninstall -y aiodns pycares  # see note below
+pytest custom_components/unified_hifi_control/tests -v
+```
+
+The `aiodns`/`pycares` uninstall works around a false-positive thread-leak
+failure: `homeassistant` depends on `aiodns`, whose `AsyncResolver` spins
+up a background c-ares thread the first time any test constructs a real
+aiohttp connector, and pytest-homeassistant-custom-component's per-test
+thread-leak check then flags that thread against whichever test happens
+to run first — even though every HTTP call in this suite goes through
+`aioclient_mock` and never builds a real connector. Since the suite never
+needs real DNS resolution, removing `pycares` avoids the false positive
+without weakening the check for genuine leaks.
+
+CI: `.github/workflows/ha-integration.yml` runs the test suite plus
+`hacs/action` (HACS repository validation) and
+`home-assistant/actions/hassfest` (manifest/schema validation) on pushes
+and PRs to `v3` that touch the integration. Per this repo's stacked-PR
+convention, feature-branch-based PRs (including the one that introduced
+this integration) do not run CI — the workflow was verified locally and
+becomes active once this lands on `v3`.
+
+## Known follow-ups
+
+- No plain-REST route exists for zone grouping, collections, queue, or
+  play-by-ref — they're MCP-only today. This integration only uses MCP
+  for grouping; a UHC-side push endpoint or plain-REST equivalents for
+  the rest would let a future version add queue/collections support
+  without embedding an MCP client for everything.
+- Extending grouping support to Roon/LMS once `issue/517`'s work lands
+  on this integration's base branch is a follow-up, not blocking this
+  PR (the code already refuses cleanly for those providers today).

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Unified Hifi Control",
+  "render_readme": true,
+  "homeassistant": "2024.1.0"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.pytest.ini_options]
+testpaths = ["custom_components/unified_hifi_control/tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+include = ["custom_components/unified_hifi_control/**/*.py"]

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -2578,37 +2578,6 @@ impl LmsAdapter {
     }
 }
 
-/// #531: routes `hifi_collections` through `AdapterRegistry::library_content`
-/// rather than a new direct `state.lms` field access from `src/mcp/tools/`
-/// (the architecture boundary #436 is closing -- see
-/// `tests/adapter_boundary_lint.rs`). `search`/`play_uri` are not
-/// meaningfully implementable through this trait's flat-URI contract --
-/// LMS's playable targets are typed (`LmsPlayTarget::{Library,Url,
-/// GlobalSearchItem}`), which is exactly why `hifi_search`/`hifi_play`
-/// already call `LmsAdapter` directly (pre-existing debt, unaffected by this
-/// registration) rather than through this trait. Only `content` is real.
-#[async_trait]
-impl LibraryAdapter for LmsAdapter {
-    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
-        Err(anyhow!(
-            "LMS search is not reachable through the generic library registry; \
-             hifi_search calls LmsAdapter directly because LMS's playable targets are typed, \
-             not a flat URI"
-        ))
-    }
-
-    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
-        Err(anyhow!(
-            "LMS playback is not reachable through the generic library registry; \
-             hifi_play/hifi_play_ref call LmsAdapter directly for the same reason as search"
-        ))
-    }
-
-    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
-        self.collections_content(operation, params).await
-    }
-}
-
 /// Convert an LMS player to a unified Zone representation
 fn lms_player_to_zone(player: &LmsPlayer) -> Zone {
     let zone_id = PrefixedZoneId::lms(&player.playerid).to_string();
@@ -3584,25 +3553,34 @@ async fn run_lms_command_endpoint(
     }
 }
 
-/// Content-library surface (#510): only the multiroom sync-group operations
-/// are implemented here. LMS's own search/play surfaces are reached through
-/// their dedicated paths (`LmsAdapter::search`, `LmsAdapter::control`, ...);
-/// this trait is what lets the provider-neutral MCP registry
+/// Content-library surface: the multiroom sync-group operations (#510) and
+/// the `hifi_collections` browse operations (#531) are both implemented
+/// here. LMS's own search/play surfaces are reached through their
+/// dedicated paths (`LmsAdapter::search`, `LmsAdapter::control`, ...)
+/// rather than through this trait's `search`/`play_uri` -- LMS's playable
+/// targets are typed (`LmsPlayTarget::{Library,Url,GlobalSearchItem}`),
+/// which is exactly why `hifi_search`/`hifi_play` already call `LmsAdapter`
+/// directly (pre-existing debt, unaffected by this registration). `content`
+/// is what lets the provider-neutral MCP registry
 /// (`AdapterRegistry::library_content`) dispatch `multiroom_status`,
-/// `multiroom_set_members` and `multiroom_ungroup` to LMS the same way it
-/// already dispatches them to Music Assistant
+/// `multiroom_set_members`, `multiroom_ungroup`, `collections_browse`,
+/// `collections_playlists` and `collections_favorites` to LMS the same way
+/// it already dispatches the multiroom operations to Music Assistant
 /// (`src/adapters/musicassistant.rs`).
 #[async_trait]
 impl LibraryAdapter for LmsAdapter {
     async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
         Err(anyhow!(
-            "LMS search is not implemented via the generic content-library surface (see #396/#402)"
+            "LMS search is not reachable through the generic library registry; \
+             hifi_search calls LmsAdapter directly because LMS's playable targets are typed, \
+             not a flat URI"
         ))
     }
 
     async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
         Err(anyhow!(
-            "LMS play-by-uri is not implemented via the generic content-library surface (see #396)"
+            "LMS playback is not reachable through the generic library registry; \
+             hifi_play/hifi_play_ref call LmsAdapter directly for the same reason as search"
         ))
     }
 
@@ -3646,6 +3624,9 @@ impl LibraryAdapter for LmsAdapter {
                     .map(ToOwned::to_owned)
                     .collect::<Vec<_>>();
                 self.ungroup_members(&members).await
+            }
+            "collections_browse" | "collections_playlists" | "collections_favorites" => {
+                self.collections_content(operation, params).await
             }
             _ => Err(anyhow!("LMS content operation `{operation}` is not supported")),
         }

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -58,7 +58,8 @@ use tracing::{debug, info, warn};
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::lms_discovery::discover_lms_servers;
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::adapters::Startable;
 use crate::bus::runtime::{
@@ -130,6 +131,22 @@ fn lms_flag(value: Option<&Value>) -> bool {
 /// `search_library()` return an empty vec against every real server.
 fn loop_entity_id(row: &Value, entity: &str) -> Option<i64> {
     lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id"))).filter(|id| *id > 0)
+}
+
+/// The next page's offset for a `hifi_collections` page, or `None` at the
+/// end.
+///
+/// LMS's own `count` field is the total across the whole query (not just
+/// this page), so it is the source of truth when present. A response
+/// missing it (the mock's catch-all shape, or an unmodeled LMS reply) falls
+/// back to "this page was full" as the continue signal -- the same
+/// length-based heuristic Music Assistant's `collections_content` uses for
+/// its `library_items` paging.
+fn next_offset(raw: &Value, offset: usize, limit: usize, page_len: usize) -> Option<u64> {
+    match raw.get("count").and_then(Value::as_u64) {
+        Some(total) => (total > (offset + limit) as u64).then_some((offset + limit) as u64),
+        None => (page_len == limit).then_some((offset + limit) as u64),
+    }
 }
 
 /// What LMS actually does when a request fails, spelled out once.
@@ -1850,6 +1867,287 @@ impl LmsAdapter {
         Ok(results)
     }
 
+    // =========================================================================
+    // hifi_collections (#531): provider-neutral browse/playlists/favorites
+    // =========================================================================
+
+    /// Dispatch one `hifi_collections` operation to the matching taggedlist
+    /// query. `params.path` is a plain server-side collection path (never a
+    /// client-visible token -- `hifi_collections` mints/resolves the opaque
+    /// ref around it); `None`/`"root"` means the collection root.
+    ///
+    /// The wire shape returned here is LMS-specific, not the provider-neutral
+    /// `{title, subtitle, path}` shape `hifi_collections` sends to the client:
+    /// a navigable row carries `path` (a collection path for another
+    /// `collections_browse` call); a playable leaf carries `kind`+`id` (an
+    /// [`LmsPlayTarget::Library`]) or `url` (an [`LmsPlayTarget::Url`]) for
+    /// `crate::mcp::tools::collections` to mint a ref over -- mirroring the
+    /// split `LmsPlayTarget` already makes for `hifi_search`.
+    pub async fn collections_content(&self, operation: &str, params: &Value) -> Result<Value> {
+        let limit = params
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or(20)
+            .clamp(1, 50) as usize;
+        let offset = params.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize;
+        match operation {
+            "collections_browse" => {
+                let path = params
+                    .get("path")
+                    .and_then(Value::as_str)
+                    .unwrap_or("root");
+                self.browse_collections(path, offset, limit).await
+            }
+            "collections_playlists" => self.list_playlists(offset, limit).await,
+            "collections_favorites" => self.list_favorites(offset, limit).await,
+            _ => Err(anyhow!("unsupported LMS collection operation {operation}")),
+        }
+    }
+
+    /// Walk one level of the LMS collection hierarchy: the synthetic root
+    /// (Albums/Artists/Playlists), an album's or artist's contents, or a
+    /// playlist's tracks. Every navigable path is a plain string this adapter
+    /// invented (`"albums"`, `"album:<id>"`, ...) -- never a raw LMS id handed
+    /// back to a client uninterpreted.
+    async fn browse_collections(&self, path: &str, offset: usize, limit: usize) -> Result<Value> {
+        if path == "root" {
+            // The root menu is invented by this adapter, not read from LMS --
+            // but a caller with no LMS host configured (or one that is
+            // unreachable) must still get that failure here rather than a
+            // synthetic success that never touched the server. `serverstatus`
+            // with a zero-item request is the cheapest real round trip.
+            self.rpc
+                .execute(None, vec![json!("serverstatus"), json!(0), json!(0)])
+                .await?;
+            let categories = [("Albums", "albums"), ("Artists", "artists"), ("Playlists", "playlists")];
+            let items: Vec<Value> = categories
+                .iter()
+                .skip(offset)
+                .take(limit)
+                .map(|(title, path)| json!({"title": title, "path": path}))
+                .collect();
+            let next_offset =
+                (categories.len() > offset + limit).then_some((offset + limit) as u64);
+            return Ok(json!({"items": items, "next_offset": next_offset}));
+        }
+        if path == "albums" {
+            return self.query_albums(offset, limit, None).await;
+        }
+        if path == "artists" {
+            return self.query_artists(offset, limit).await;
+        }
+        if path == "playlists" {
+            return self.list_playlists(offset, limit).await;
+        }
+        if let Some(id) = path.strip_prefix("album:").and_then(|s| s.parse::<i64>().ok()) {
+            return self.query_tracks(offset, limit, "album_id", id).await;
+        }
+        if let Some(id) = path.strip_prefix("artist:").and_then(|s| s.parse::<i64>().ok()) {
+            return self.query_albums(offset, limit, Some(id)).await;
+        }
+        if let Some(id) = path.strip_prefix("playlist:").and_then(|s| s.parse::<i64>().ok()) {
+            return self.query_playlist_tracks(offset, limit, id).await;
+        }
+        Err(anyhow!("unknown LMS collection path {path:?}"))
+    }
+
+    /// `albums <start> <count> [artist_id:<id>]` -- the whole album library,
+    /// or one artist's albums when `artist_id` is given.
+    async fn query_albums(
+        &self,
+        offset: usize,
+        limit: usize,
+        artist_id: Option<i64>,
+    ) -> Result<Value> {
+        let mut params = vec![json!("albums"), json!(offset), json!(limit)];
+        if let Some(id) = artist_id {
+            params.push(json!(format!("artist_id:{id}")));
+        }
+        let raw = self.rpc.execute(None, params).await?;
+        let items: Vec<Value> = raw
+            .get("albums_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "album")?;
+                let title = row.get("album").and_then(Value::as_str)?.to_string();
+                let artist = row.get("artist").and_then(Value::as_str).map(String::from);
+                Some(json!({
+                    "title": title,
+                    "subtitle": artist.map(|a| format!("Album by {a}")),
+                    "path": format!("album:{id}"),
+                }))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `artists <start> <count>` -- the whole artist library.
+    async fn query_artists(&self, offset: usize, limit: usize) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(None, vec![json!("artists"), json!(offset), json!(limit)])
+            .await?;
+        let items: Vec<Value> = raw
+            .get("artists_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "artist")?;
+                let title = row.get("artist").and_then(Value::as_str)?.to_string();
+                Some(json!({"title": title, "path": format!("artist:{id}")}))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `titles <start> <count> <filter_key>:<id>` -- tracks under one album
+    /// (or, in principle, another filterable field; only album is used today).
+    async fn query_tracks(
+        &self,
+        offset: usize,
+        limit: usize,
+        filter_key: &str,
+        filter_id: i64,
+    ) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(
+                None,
+                vec![
+                    json!("titles"),
+                    json!(offset),
+                    json!(limit),
+                    json!(format!("{filter_key}:{filter_id}")),
+                ],
+            )
+            .await?;
+        let items: Vec<Value> = raw
+            .get("titles_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "track")?;
+                let title = row.get("title").and_then(Value::as_str)?.to_string();
+                let artist = row.get("artist").and_then(Value::as_str).map(String::from);
+                Some(json!({
+                    "title": title,
+                    "subtitle": artist,
+                    "kind": "track",
+                    "id": id,
+                }))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `playlists <start> <count>` -- every saved playlist. Both
+    /// `collections_playlists` and browsing into the synthetic `"playlists"`
+    /// node use this, since LMS has exactly one playlist listing.
+    async fn list_playlists(&self, offset: usize, limit: usize) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(None, vec![json!("playlists"), json!(offset), json!(limit)])
+            .await?;
+        let items: Vec<Value> = raw
+            .get("playlists_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "playlist")?;
+                let title = row.get("playlist").and_then(Value::as_str)?.to_string();
+                Some(json!({"title": title, "path": format!("playlist:{id}")}))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `playlists tracks <start> <count> playlist_id:<id>` -- one playlist's
+    /// contents.
+    async fn query_playlist_tracks(
+        &self,
+        offset: usize,
+        limit: usize,
+        playlist_id: i64,
+    ) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(
+                None,
+                vec![
+                    json!("playlists"),
+                    json!("tracks"),
+                    json!(offset),
+                    json!(limit),
+                    json!(format!("playlist_id:{playlist_id}")),
+                ],
+            )
+            .await?;
+        let items: Vec<Value> = raw
+            .get("playlisttracks_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let id = loop_entity_id(row, "track")?;
+                let title = row
+                    .get("title")
+                    .or_else(|| row.get("track"))
+                    .and_then(Value::as_str)?
+                    .to_string();
+                let artist = row.get("artist").and_then(Value::as_str).map(String::from);
+                Some(json!({
+                    "title": title,
+                    "subtitle": artist,
+                    "kind": "track",
+                    "id": id,
+                }))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `favorites items <start> <count>` -- the flat favourites list. LMS
+    /// favorites carry no durable entity id, only a `url` (verified live,
+    /// #403's gap-table note); a folder-shaped favorite (`hasitems`) is
+    /// listed but not itself browsable in this slice -- narrower than a full
+    /// walk, called out in #531's PR body rather than silently dropped.
+    async fn list_favorites(&self, offset: usize, limit: usize) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(
+                None,
+                vec![json!("favorites"), json!("items"), json!(offset), json!(limit)],
+            )
+            .await?;
+        let items: Vec<Value> = raw
+            .get("loop_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let title = row
+                    .get("name")
+                    .or_else(|| row.get("title"))
+                    .and_then(Value::as_str)?
+                    .to_string();
+                let url = row.get("url").and_then(Value::as_str)?.to_string();
+                Some(json!({"title": title, "url": url}))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
     /// Search and play the first matching result
     ///
     /// Searches using globalsearch (includes streaming services), finds the first
@@ -2108,6 +2406,37 @@ impl LmsAdapter {
             );
         }
         Ok(())
+    }
+}
+
+/// #531: routes `hifi_collections` through `AdapterRegistry::library_content`
+/// rather than a new direct `state.lms` field access from `src/mcp/tools/`
+/// (the architecture boundary #436 is closing -- see
+/// `tests/adapter_boundary_lint.rs`). `search`/`play_uri` are not
+/// meaningfully implementable through this trait's flat-URI contract --
+/// LMS's playable targets are typed (`LmsPlayTarget::{Library,Url,
+/// GlobalSearchItem}`), which is exactly why `hifi_search`/`hifi_play`
+/// already call `LmsAdapter` directly (pre-existing debt, unaffected by this
+/// registration) rather than through this trait. Only `content` is real.
+#[async_trait]
+impl LibraryAdapter for LmsAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow!(
+            "LMS search is not reachable through the generic library registry; \
+             hifi_search calls LmsAdapter directly because LMS's playable targets are typed, \
+             not a flat URI"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow!(
+            "LMS playback is not reachable through the generic library registry; \
+             hifi_play/hifi_play_ref call LmsAdapter directly for the same reason as search"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        self.collections_content(operation, params).await
     }
 }
 

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -58,7 +58,8 @@ use tracing::{debug, info, warn};
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::lms_discovery::discover_lms_servers;
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::adapters::Startable;
 use crate::bus::runtime::{
@@ -85,6 +86,33 @@ const LMS_MUTE_PREF: &str = "mute";
 /// MCP and aggregator use prefixed IDs (e.g., "lms:00:11:22:33:44:55"), but LMS API expects bare IDs.
 fn strip_lms_prefix(id: &str) -> &str {
     id.strip_prefix("lms:").unwrap_or(id)
+}
+
+/// Require a properly-prefixed LMS zone id and return its bare player id.
+///
+/// Unlike Music Assistant's ids, LMS player ids are MAC addresses and
+/// legitimately contain colons, so (unlike `musicassistant_player_id`) this
+/// does not reject a remainder containing `:`.
+fn lms_player_id(zone_id: &str, parameter: &str) -> Result<String> {
+    zone_id
+        .strip_prefix("lms:")
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("{parameter} must be an LMS zone id"))
+}
+
+/// [`lms_player_id`] over a list, rejecting duplicates the same way the
+/// Music Assistant multiroom contract does.
+fn lms_player_ids(zone_ids: &[String], parameter: &str) -> Result<Vec<String>> {
+    let mut ids = Vec::with_capacity(zone_ids.len());
+    for zone_id in zone_ids {
+        let id = lms_player_id(zone_id, parameter)?;
+        if ids.contains(&id) {
+            return Err(anyhow!("{parameter} must not contain duplicate zones"));
+        }
+        ids.push(id);
+    }
+    Ok(ids)
 }
 
 /// Read an integer that LMS may emit as either a JSON number or a JSON string.
@@ -1243,6 +1271,148 @@ impl LmsAdapter {
     pub async fn get_player_status(&self, player_id: &str) -> Result<LmsPlayer> {
         let player_id = strip_lms_prefix(player_id);
         self.rpc.get_player_status(player_id).await
+    }
+
+    // -------------------------------------------------------------------------
+    // Sync groups (#510): LMS's native Squeezebox multi-room, wired to the
+    // multiroom_status / multiroom_set_members / multiroom_ungroup contract
+    // the Music Assistant adapter already implements
+    // (`src/adapters/musicassistant.rs`).
+    //
+    // LMS sync is peer-based -- a group is just a set of players playing the
+    // same stream in lockstep, with no server-side concept of a leader. The
+    // contract, however, is leader/member shaped. This adapter resolves that
+    // mismatch by treating "join the leader's group" literally: every add
+    // is sent as `<leader> sync <member>`. Verified live against Lyrion 9.1.2
+    // (issue #403's investigation): the **addressed** player in a `sync`
+    // command becomes/stays the sync master, and the **argument** player
+    // adopts the addressed player's queue, repeat and shuffle -- destroying
+    // its own. Addressing the leader therefore keeps the leader's queue
+    // intact and makes the member fall in behind it, exactly the semantics
+    // `multiroom_set_members`'s `leader_zone_id` implies. Removal is
+    // leader-independent: `<member> sync -` unsyncs that one player from
+    // whatever group it is currently in.
+    //
+    // Because there is no server-side leader, `multiroom_status` cannot
+    // recover *which* player was originally addressed -- only current group
+    // membership via `syncgroups ?`. This adapter picks the first id LMS
+    // reports for each group as that group's leader for display purposes.
+    // That is a stable-but-arbitrary UHC convention, not an LMS fact.
+
+    /// Read every active LMS sync group from `syncgroups ?` as a raw member
+    /// list (no leader/member split yet). Groups of fewer than two players
+    /// are not sync groups and are dropped.
+    async fn read_sync_groups(&self) -> Result<Vec<Vec<String>>> {
+        let result = self
+            .rpc
+            .execute(None, vec![json!("syncgroups"), json!("?")])
+            .await?;
+        let groups_loop = result
+            .get("syncgroups_loop")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        Ok(groups_loop
+            .iter()
+            .filter_map(|group| group.get("sync_members").and_then(Value::as_str))
+            .map(|members| {
+                members
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|members| members.len() >= 2)
+            .collect())
+    }
+
+    /// Report every active LMS sync group in the multiroom contract's shape.
+    ///
+    /// `can_set_members` is always `true`: unlike Music Assistant's per-leader
+    /// `SET_MEMBERS` feature flag, every LMS player accepts `sync`
+    /// unconditionally, so there is no per-group capability to check.
+    pub async fn multiroom_status(&self) -> Result<Value> {
+        let groups = self.read_sync_groups().await?;
+        let groups = groups
+            .into_iter()
+            .filter_map(|members| {
+                let (leader, rest) = members.split_first()?;
+                Some(json!({
+                    "leader_zone_id": PrefixedZoneId::lms(leader).to_string(),
+                    "member_zone_ids": rest
+                        .iter()
+                        .map(|id| PrefixedZoneId::lms(id).to_string())
+                        .collect::<Vec<_>>(),
+                    "can_set_members": true,
+                }))
+            })
+            .collect::<Vec<_>>();
+        Ok(json!({ "groups": groups }))
+    }
+
+    /// Sync `add_zone_ids` into `leader_zone_id`'s group and unsync
+    /// `remove_zone_ids`, then return the refreshed `multiroom_status`.
+    pub async fn set_group_members(
+        &self,
+        leader_zone_id: &str,
+        add_zone_ids: &[String],
+        remove_zone_ids: &[String],
+    ) -> Result<Value> {
+        if add_zone_ids.is_empty() && remove_zone_ids.is_empty() {
+            return Err(anyhow!("LMS group membership needs at least one member"));
+        }
+        let leader_id = lms_player_id(leader_zone_id, "leader_zone_id")?;
+        let add_ids = lms_player_ids(add_zone_ids, "member_zone_ids_to_add")?;
+        let remove_ids = lms_player_ids(remove_zone_ids, "member_zone_ids_to_remove")?;
+        let players = self.rpc.get_players().await?;
+        let player_exists = |id: &str| players.iter().any(|player| player.playerid == id);
+        if !player_exists(&leader_id) {
+            return Err(anyhow!("LMS group leader was not found"));
+        }
+        for player_id in add_ids.iter().chain(remove_ids.iter()) {
+            if player_id == &leader_id {
+                return Err(anyhow!(
+                    "LMS group leader cannot be its own member input"
+                ));
+            }
+            if !player_exists(player_id) {
+                return Err(anyhow!("LMS group member was not found"));
+            }
+        }
+        for member_id in &add_ids {
+            self.rpc
+                .execute(Some(&leader_id), vec![json!("sync"), json!(member_id)])
+                .await?;
+        }
+        for member_id in &remove_ids {
+            self.rpc
+                .execute(Some(member_id), vec![json!("sync"), json!("-")])
+                .await?;
+        }
+        self.multiroom_status().await
+    }
+
+    /// Unsync each of `member_zone_ids` via its own `sync -`, independent of
+    /// which group (if any) it currently belongs to, then return the
+    /// refreshed `multiroom_status`.
+    pub async fn ungroup_members(&self, member_zone_ids: &[String]) -> Result<Value> {
+        let member_ids = lms_player_ids(member_zone_ids, "member_zone_ids")?;
+        if member_ids.is_empty() {
+            return Err(anyhow!("LMS ungroup needs at least one member"));
+        }
+        let players = self.rpc.get_players().await?;
+        for member_id in &member_ids {
+            if !players.iter().any(|player| player.playerid == *member_id) {
+                return Err(anyhow!("LMS group member was not found"));
+            }
+        }
+        for member_id in &member_ids {
+            self.rpc
+                .execute(Some(member_id), vec![json!("sync"), json!("-")])
+                .await?;
+        }
+        self.multiroom_status().await
     }
 
     /// Start polling for player updates (internal - use Startable trait)
@@ -3082,6 +3252,74 @@ async fn run_lms_command_endpoint(
                 // deadline; the command may have applied even though LMS did not serve readback.
                 tracing::warn!(%error, command_id = command_id.get(), "LMS native write accepted but coherent player readback failed");
             }
+        }
+    }
+}
+
+/// Content-library surface (#510): only the multiroom sync-group operations
+/// are implemented here. LMS's own search/play surfaces are reached through
+/// their dedicated paths (`LmsAdapter::search`, `LmsAdapter::control`, ...);
+/// this trait is what lets the provider-neutral MCP registry
+/// (`AdapterRegistry::library_content`) dispatch `multiroom_status`,
+/// `multiroom_set_members` and `multiroom_ungroup` to LMS the same way it
+/// already dispatches them to Music Assistant
+/// (`src/adapters/musicassistant.rs`).
+#[async_trait]
+impl LibraryAdapter for LmsAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow!(
+            "LMS search is not implemented via the generic content-library surface (see #396/#402)"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow!(
+            "LMS play-by-uri is not implemented via the generic content-library surface (see #396)"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        match operation {
+            "multiroom_status" => self.multiroom_status().await,
+            "multiroom_set_members" => {
+                let leader = params
+                    .get("leader_zone_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("LMS group operation requires leader_zone_id"))?;
+                let add = params
+                    .get("member_zone_ids_to_add")
+                    .or_else(|| params.get("member_zone_ids"))
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow!("LMS group operation requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                let remove = params
+                    .get("member_zone_ids_to_remove")
+                    .and_then(Value::as_array)
+                    .map(|members| {
+                        members
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                self.set_group_members(leader, &add, &remove).await
+            }
+            "multiroom_ungroup" => {
+                let members = params
+                    .get("member_zone_ids")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow!("LMS ungroup requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                self.ungroup_members(&members).await
+            }
+            _ => Err(anyhow!("LMS content operation `{operation}` is not supported")),
         }
     }
 }

--- a/src/adapters/musicassistant.rs
+++ b/src/adapters/musicassistant.rs
@@ -553,6 +553,26 @@ impl MusicAssistantAdapter {
             .ok_or_else(|| anyhow!("Music Assistant active queue had no queue_id"))
     }
 
+    /// Move `zone_id`'s active queue onto `target_zone_id`'s queue, via MA's
+    /// `player_queues/transfer` (#507). Both queue ids are read fresh
+    /// immediately before the call, matching the stale-item guard the other
+    /// queue mutations use, and the readback afterward is the target's --
+    /// that is where the transferred queue now lives.
+    async fn queue_transfer(&self, zone_id: &str, target_zone_id: &str) -> Result<Value> {
+        let source_queue_id = self.queue_id_for_zone(zone_id).await?;
+        let target_queue_id = self.queue_id_for_zone(target_zone_id).await?;
+        let _: Value = self
+            .command(
+                "player_queues/transfer",
+                Some(json!({
+                    "source_queue_id": source_queue_id,
+                    "target_queue_id": target_queue_id,
+                })),
+            )
+            .await?;
+        self.read_active_queue(target_zone_id).await
+    }
+
     async fn search_catalog(&self, query: &str, limit: usize) -> Result<Vec<LibrarySearchResult>> {
         let response: Value = self
             .command(
@@ -1131,6 +1151,21 @@ impl LibraryAdapter for MusicAssistantAdapter {
     async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
         if operation.starts_with("collections_") {
             return self.collections_content(operation, params).await;
+        }
+        if operation == "queue_transfer" {
+            let zone_id = params
+                .get("zone_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| anyhow!("Music Assistant queue transfer requires zone_id"))?;
+            let target_zone_id = params
+                .get("target_zone_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow!("Music Assistant queue transfer requires target_zone_id")
+                })?;
+            return self.queue_transfer(zone_id, target_zone_id).await;
         }
         match operation {
             "multiroom_status" => return self.multiroom_status().await,
@@ -2084,6 +2119,52 @@ mod tests {
             expected["queue_id"] = json!("group-living-room");
             assert_eq!(mutation.body["args"], expected);
         }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn queue_transfer_moves_the_active_queue_and_returns_the_targets_readback() {
+        let (config, state, server) = mock_musicassistant_server().await;
+        let adapter =
+            MusicAssistantAdapter::new(crate::bus::create_bus(), config).expect("adapter");
+        let result = adapter
+            .content(
+                "queue_transfer",
+                &json!({
+                    "zone_id": "musicassistant:sonos-kitchen",
+                    "target_zone_id": "musicassistant:sonos-office",
+                }),
+            )
+            .await
+            .expect("transfer");
+        // The readback is the target's fresh active queue.
+        assert_eq!(result["queue"]["queue_id"], "group-living-room");
+
+        let requests = state.requests.lock().expect("requests").clone();
+        let transfer = requests
+            .iter()
+            .find(|request| request.body["command"] == "player_queues/transfer")
+            .expect("transfer command sent");
+        assert_eq!(
+            transfer.body["args"],
+            json!({"source_queue_id": "group-living-room", "target_queue_id": "group-living-room"})
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn queue_transfer_requires_both_zone_ids() {
+        let (config, _state, server) = mock_musicassistant_server().await;
+        let adapter =
+            MusicAssistantAdapter::new(crate::bus::create_bus(), config).expect("adapter");
+        let error = adapter
+            .content(
+                "queue_transfer",
+                &json!({"zone_id": "musicassistant:sonos-kitchen"}),
+            )
+            .await
+            .expect_err("missing target_zone_id");
+        assert!(error.to_string().contains("target_zone_id"));
         server.abort();
     }
 

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -14,6 +14,7 @@ use roon_api::{
     CoreEvent, Info, Parsed, RoonApi, RoonApiError, Services, Svc,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -25,7 +26,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::bus::{
     runtime::{
@@ -172,6 +174,35 @@ pub(crate) fn is_ungrounded_grouping(item: &BrowseItem) -> bool {
 /// MCP and aggregator use prefixed IDs (e.g., "roon:zone_123"), but Roon API expects bare IDs.
 fn strip_roon_prefix(id: &str) -> &str {
     id.strip_prefix("roon:").unwrap_or(id)
+}
+
+/// Require a properly-prefixed Roon zone id and return its bare id.
+///
+/// Unlike [`strip_roon_prefix`] (used by the pre-existing transport paths,
+/// which tolerate a bare id for backward compatibility), the multiroom
+/// grouping surface (#509) is new and follows the stricter validation the
+/// Music Assistant and LMS adapters already apply to their own multiroom
+/// parameters (`musicassistant_player_id`, `lms_player_id`).
+fn roon_zone_id(zone_id: &str, parameter: &str) -> Result<String> {
+    zone_id
+        .strip_prefix("roon:")
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("{parameter} must be a Roon zone id"))
+}
+
+/// [`roon_zone_id`] over a list, rejecting duplicates the same way the
+/// Music Assistant and LMS multiroom contracts do.
+fn roon_zone_ids(zone_ids: &[String], parameter: &str) -> Result<Vec<String>> {
+    let mut ids = Vec::with_capacity(zone_ids.len());
+    for zone_id in zone_ids {
+        let id = roon_zone_id(zone_id, parameter)?;
+        if ids.contains(&id) {
+            return Err(anyhow::anyhow!("{parameter} must not contain duplicate zones"));
+        }
+        ids.push(id);
+    }
+    Ok(ids)
 }
 
 /// Pending image request - stores the oneshot sender to deliver the result
@@ -630,6 +661,14 @@ pub struct Output {
     pub output_id: String,
     pub display_name: String,
     pub volume: Option<VolumeInfo>,
+    /// Output ids this output can be grouped with, straight from the Core
+    /// (`transport::Output::can_group_with_output_ids`). Roon only groups
+    /// outputs that share a streaming protocol (RAAT with RAAT, AirPlay with
+    /// AirPlay, etc); this is the Core's own compatibility list, so grouping
+    /// (#509) refuses upfront against it instead of guessing at protocol
+    /// names the wire format never exposes.
+    #[serde(default)]
+    pub can_group_with_output_ids: Vec<String>,
 }
 
 /// Volume information
@@ -1372,6 +1411,213 @@ impl RoonAdapter {
         };
         transport.mute(&output_id, &how).await;
         Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiroom grouping (#509): `Transport::group_outputs` / `ungroup_outputs`
+    // wired to the `multiroom_status` / `multiroom_set_members` /
+    // `multiroom_ungroup` contract the Music Assistant adapter already
+    // implements (`src/adapters/musicassistant.rs`).
+    //
+    // Roon groups *outputs*, not zones. Grouping merges every named zone's
+    // outputs into a single zone; the Core keeps the leader's zone_id and
+    // retires the other zones (their outputs move under the leader's
+    // zone_id in the next zone update). This adapter resolves each zone
+    // argument to one representative output -- the same first-output
+    // resolution `change_volume` (above) already uses for multi-output
+    // zones -- and lets the ordinary zone-event pipeline in `run()`
+    // (`Parsed::Zones` / `Parsed::ZonesRemoved`, already unconditional for
+    // every zone change) publish the resulting `ZoneUpdated` /
+    // `ZoneRemoved` bus events. No special-case bus code is needed for
+    // grouping: from the bus's perspective a merge is just an ordinary zone
+    // update plus zone removal.
+    //
+    // Because member zone ids do not survive a merge, this adapter reports
+    // (and accepts back) *outputs* as members once a group exists: for a
+    // zone with more than one output, `multiroom_status` treats the first
+    // output as the "leader" and the rest as members, addressed as
+    // `roon:<output_id>` rather than a zone id. That is a stable-but-
+    // arbitrary UHC display convention (mirroring the same call LMS's
+    // adapter documents for its own leaderless sync groups), not a Roon
+    // fact: `resolve_roon_output` accepts either a live zone id or a bare
+    // output id, so a caller can always name a group member whether or not
+    // it currently has its own zone.
+
+    /// Resolve `id` (bare, no "roon:" prefix) to one Roon output: either the
+    /// first output of a zone with this id, or -- for a member of an
+    /// existing group, whose original zone id was retired by the merge --
+    /// the output with this id directly.
+    async fn resolve_roon_output(&self, id: &str) -> Result<Output> {
+        let state = self.state.read().await;
+        if let Some(zone) = state.zones.get(id) {
+            return zone
+                .outputs
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Zone has no outputs: {id}"));
+        }
+        state
+            .zones
+            .values()
+            .find_map(|zone| zone.outputs.iter().find(|o| o.output_id == id).cloned())
+            .ok_or_else(|| anyhow::anyhow!("Roon zone or output was not found: {id}"))
+    }
+
+    /// Report every Roon zone with more than one output as a group.
+    ///
+    /// `can_set_members` is always `true`: every Roon output accepts
+    /// `group_outputs`/`ungroup_outputs` unconditionally, so there is no
+    /// per-group capability to check (unlike Music Assistant's per-leader
+    /// `SET_MEMBERS` feature flag).
+    pub async fn multiroom_status(&self) -> Result<Value> {
+        let state = self.state.read().await;
+        let groups: Vec<Value> = state
+            .zones
+            .values()
+            .filter(|zone| zone.outputs.len() > 1)
+            .filter_map(|zone| {
+                let (_leader_output, member_outputs) = zone.outputs.split_first()?;
+                Some(json!({
+                    "leader_zone_id": PrefixedZoneId::roon(&zone.zone_id).to_string(),
+                    "member_zone_ids": member_outputs
+                        .iter()
+                        .map(|o| PrefixedZoneId::roon(&o.output_id).to_string())
+                        .collect::<Vec<_>>(),
+                    "can_set_members": true,
+                }))
+            })
+            .collect();
+        Ok(json!({ "groups": groups }))
+    }
+
+    /// Group `add_zone_ids` (and any current members of `leader_zone_id`'s
+    /// group) together via `group_outputs`, and ungroup `remove_zone_ids` via
+    /// `ungroup_outputs`, then return the current `multiroom_status`.
+    ///
+    /// Roon confirms grouping asynchronously through the ordinary zone
+    /// subscription rather than a synchronous RPC reply (the same is true of
+    /// `change_volume`/`mute`/`control` above), so -- unlike the Music
+    /// Assistant and LMS adapters, whose underlying protocols are
+    /// request/response -- the status returned here is a snapshot of
+    /// current knowledge, not a guaranteed post-condition. Callers that need
+    /// the authoritative outcome should watch the zone bus, exactly as they
+    /// already must for every other Roon transport command.
+    pub async fn set_group_members(
+        &self,
+        leader_zone_id: &str,
+        add_zone_ids: &[String],
+        remove_zone_ids: &[String],
+    ) -> Result<Value> {
+        if add_zone_ids.is_empty() && remove_zone_ids.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Roon group membership needs at least one member"
+            ));
+        }
+        let leader_id = roon_zone_id(leader_zone_id, "leader_zone_id")?;
+        let add_ids = roon_zone_ids(add_zone_ids, "member_zone_ids_to_add")?;
+        let remove_ids = roon_zone_ids(remove_zone_ids, "member_zone_ids_to_remove")?;
+        for id in add_ids.iter().chain(remove_ids.iter()) {
+            if id == &leader_id {
+                return Err(anyhow::anyhow!(
+                    "Roon group leader cannot be its own member input"
+                ));
+            }
+        }
+
+        let leader_output = self
+            .resolve_roon_output(&leader_id)
+            .await
+            .map_err(|_| anyhow::anyhow!("Roon group leader was not found"))?;
+        let mut add_outputs = Vec::with_capacity(add_ids.len());
+        for id in &add_ids {
+            add_outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+        let mut remove_outputs = Vec::with_capacity(remove_ids.len());
+        for id in &remove_ids {
+            remove_outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+
+        // Roon only groups outputs that share a streaming protocol. The Core
+        // does not expose a queryable protocol name, but `can_group_with_output_ids`
+        // *is* the Core's own compatibility list for the leader's output, so a
+        // mismatch here is refused cleanly instead of being sent to the Core
+        // to fail (or be silently ignored) in some undocumented way.
+        for output in &add_outputs {
+            if !leader_output
+                .can_group_with_output_ids
+                .iter()
+                .any(|id| id == &output.output_id)
+            {
+                return Err(anyhow::anyhow!(
+                    "Cannot group '{}' with '{}': they do not share a compatible streaming protocol",
+                    output.display_name,
+                    leader_output.display_name
+                ));
+            }
+        }
+
+        let transport = {
+            let state = self.state.read().await;
+            state
+                .transport
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Not connected to Roon"))?
+        };
+
+        if !add_outputs.is_empty() {
+            let mut output_ids: Vec<&str> = vec![leader_output.output_id.as_str()];
+            output_ids.extend(add_outputs.iter().map(|o| o.output_id.as_str()));
+            transport.group_outputs(output_ids).await;
+        }
+        for output in &remove_outputs {
+            transport
+                .ungroup_outputs(vec![output.output_id.as_str()])
+                .await;
+        }
+
+        self.multiroom_status().await
+    }
+
+    /// Ungroup each of `member_zone_ids` via `ungroup_outputs`, then return
+    /// the current `multiroom_status`. See [`Self::set_group_members`] for
+    /// why the returned status is a snapshot rather than a guaranteed
+    /// post-condition.
+    pub async fn ungroup_members(&self, member_zone_ids: &[String]) -> Result<Value> {
+        let member_ids = roon_zone_ids(member_zone_ids, "member_zone_ids")?;
+        if member_ids.is_empty() {
+            return Err(anyhow::anyhow!("Roon ungroup needs at least one member"));
+        }
+        let mut outputs = Vec::with_capacity(member_ids.len());
+        for id in &member_ids {
+            outputs.push(
+                self.resolve_roon_output(id)
+                    .await
+                    .map_err(|_| anyhow::anyhow!("Roon group member was not found"))?,
+            );
+        }
+
+        let transport = {
+            let state = self.state.read().await;
+            state
+                .transport
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Not connected to Roon"))?
+        };
+        for output in &outputs {
+            transport
+                .ungroup_outputs(vec![output.output_id.as_str()])
+                .await;
+        }
+
+        self.multiroom_status().await
     }
 
     /// Get album art image
@@ -2268,6 +2514,76 @@ impl RoonAdapter {
     }
 }
 
+/// Content-library surface (#509): only the multiroom grouping operations
+/// are implemented here. Roon's own search/play surfaces are reached
+/// through their dedicated paths (`RoonAdapter::search`, `RoonAdapter::play_item`,
+/// ...); this trait is what lets the provider-neutral MCP registry
+/// (`AdapterRegistry::library_content`) dispatch `multiroom_status`,
+/// `multiroom_set_members` and `multiroom_ungroup` to Roon the same way it
+/// already dispatches them to Music Assistant
+/// (`src/adapters/musicassistant.rs`).
+#[async_trait]
+impl LibraryAdapter for RoonAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow::anyhow!(
+            "Roon search is not implemented via the generic content-library surface (see #396/#402)"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow::anyhow!(
+            "Roon play-by-uri is not implemented via the generic content-library surface (see #396)"
+        ))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> Result<Value> {
+        match operation {
+            "multiroom_status" => self.multiroom_status().await,
+            "multiroom_set_members" => {
+                let leader = params
+                    .get("leader_zone_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("Roon group operation requires leader_zone_id"))?;
+                let add = params
+                    .get("member_zone_ids_to_add")
+                    .or_else(|| params.get("member_zone_ids"))
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow::anyhow!("Roon group operation requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                let remove = params
+                    .get("member_zone_ids_to_remove")
+                    .and_then(Value::as_array)
+                    .map(|members| {
+                        members
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(ToOwned::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                self.set_group_members(leader, &add, &remove).await
+            }
+            "multiroom_ungroup" => {
+                let members = params
+                    .get("member_zone_ids")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| anyhow::anyhow!("Roon ungroup requires member_zone_ids"))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<Vec<_>>();
+                self.ungroup_members(&members).await
+            }
+            _ => Err(anyhow::anyhow!(
+                "Roon content operation `{operation}` is not supported"
+            )),
+        }
+    }
+}
+
 #[async_trait]
 impl AdapterLogic for RoonAdapter {
     fn prefix(&self) -> &'static str {
@@ -2604,6 +2920,7 @@ fn convert_zone(roon_zone: &RoonZone) -> Zone {
                 is_muted: v.is_muted,
                 step: v.step,
             }),
+            can_group_with_output_ids: o.can_group_with_output_ids.clone(),
         })
         .collect();
 
@@ -3383,6 +3700,7 @@ mod tests {
                     is_muted: None,
                     step: None,
                 }),
+                can_group_with_output_ids: Vec::new(),
             }],
         }
     }
@@ -3448,6 +3766,7 @@ mod tests {
                 output_id: "output-no-vol".to_string(),
                 display_name: "No Volume Output".to_string(),
                 volume: None,
+                can_group_with_output_ids: Vec::new(),
             }],
         };
         let bus_zone = roon_zone_to_bus_zone(&zone);

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -25,7 +25,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::adapters::handle::{AdapterHandle, RetryConfig};
 use crate::adapters::traits::{
-    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic,
+    AdapterCommand, AdapterCommandResponse, AdapterContext, AdapterLogic, LibraryAdapter,
+    LibrarySearchResult,
 };
 use crate::bus::{
     runtime::{
@@ -1674,6 +1675,132 @@ impl RoonAdapter {
         Ok((session_key, vec![]))
     }
 
+    // =========================================================================
+    // hifi_collections (#531): the same browse/load machinery `hifi_search`
+    // already drives, exposed as hierarchy walking rather than a query.
+    // =========================================================================
+
+    /// One `hifi_collections browse` step: enter `item_key` within
+    /// `session_key` (a fresh session and the collection root when both are
+    /// `None`), then load one page. Returns the (possibly newly minted)
+    /// session key, the page's items, and the level's total count for
+    /// `next_offset`.
+    ///
+    /// Deliberately never combines `pop_all` with `item_key` in the same
+    /// request, and never sends `pop_all` when resuming an existing
+    /// session -- see [`Self::play_ref`]'s doc comment for the live evidence
+    /// that combination hangs a real Core.
+    pub async fn browse_collection(
+        &self,
+        zone_id: &str,
+        item_key: Option<&str>,
+        session_key: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(String, Vec<BrowseItem>, usize)> {
+        let bare_zone_id = strip_roon_prefix(zone_id);
+        let session_key = session_key.map(ToOwned::to_owned).unwrap_or_else(|| {
+            format!(
+                "collections_{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            )
+        });
+
+        let mut opts = BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            ..Default::default()
+        };
+        match item_key {
+            Some(key) => opts.item_key = Some(key.to_string()),
+            // Only reset the browse stack when there is nowhere to navigate
+            // from -- i.e. a brand new session at the collection root.
+            None => opts.pop_all = true,
+        }
+        self.browse(opts).await?;
+
+        let load = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                offset,
+                count: Some(limit),
+                ..Default::default()
+            })
+            .await?;
+
+        Ok((session_key, load.items, load.list.count))
+    }
+
+    /// Enter a named top-level browse node (`"Playlists"`, ...) in a fresh
+    /// session and load one page of its contents in a single call --
+    /// `hifi_collections playlists`'s whole job, since Roon exposes playlists
+    /// as a browse hierarchy rather than its own protocol feature (see the
+    /// capability table's note on this).
+    pub async fn browse_named_root_node(
+        &self,
+        zone_id: &str,
+        node_title: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(String, Vec<BrowseItem>, usize)> {
+        let bare_zone_id = strip_roon_prefix(zone_id);
+        let session_key = format!(
+            "collections_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            pop_all: true,
+            ..Default::default()
+        })
+        .await?;
+
+        let root_items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                count: Some(50),
+                ..Default::default()
+            })
+            .await?;
+
+        let node = root_items
+            .items
+            .iter()
+            .find(|item| item.title.eq_ignore_ascii_case(node_title))
+            .ok_or_else(|| anyhow::anyhow!("{node_title} not found in Roon browse root"))?;
+        let node_key = node
+            .item_key
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("{node_title} has no item_key"))?;
+
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            item_key: Some(node_key),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            ..Default::default()
+        })
+        .await?;
+
+        let items = self
+            .load(LoadOpts {
+                multi_session_key: Some(session_key.clone()),
+                offset,
+                count: Some(limit),
+                ..Default::default()
+            })
+            .await?;
+
+        Ok((session_key, items.items, items.list.count))
+    }
+
     /// Search and play the first matching result
     pub async fn search_and_play(
         &self,
@@ -2265,6 +2392,100 @@ impl RoonAdapter {
         .await?;
 
         Ok(format!("{}: {}", action_title, item_title))
+    }
+}
+
+/// #531: routes `hifi_collections` through `AdapterRegistry::library_content`
+/// rather than a new direct `state.roon` field access from `src/mcp/tools/`
+/// (the architecture boundary #436 is closing -- see
+/// `tests/adapter_boundary_lint.rs`). `search`/`play_uri` are not
+/// meaningfully implementable through this trait's flat-URI contract -- a
+/// Roon playable target is an `(item_key, multi_session_key)` pair, not a
+/// portable URI (see `RoonRefTarget`'s docs) -- which is exactly why
+/// `hifi_search`/`hifi_play` already call `RoonAdapter` directly
+/// (pre-existing debt, unaffected by this registration) rather than through
+/// this trait. Only `content` is real.
+#[async_trait]
+impl LibraryAdapter for RoonAdapter {
+    async fn search(&self, _query: &str, _limit: usize) -> Result<Vec<LibrarySearchResult>> {
+        Err(anyhow::anyhow!(
+            "Roon search is not reachable through the generic library registry; hifi_search \
+             calls RoonAdapter directly because a Roon item_key is scoped to the \
+             multi_session_key that minted it, not a flat URI"
+        ))
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> Result<String> {
+        Err(anyhow::anyhow!(
+            "Roon playback is not reachable through the generic library registry; \
+             hifi_play/hifi_play_ref call RoonAdapter directly for the same reason as search"
+        ))
+    }
+
+    /// `operation` is one of `collections_browse`/`collections_playlists`
+    /// (never `collections_favorites` -- Roon's favorites capability is not
+    /// wired, see `crate::mcp::capabilities`). The response is this
+    /// adapter's own shape, not `hifi_collections`' wire shape:
+    /// `{session_key, items: [{title, subtitle, item_key, navigable}],
+    /// next_offset}`. `crate::mcp::tools::collections::handle_roon` mints
+    /// the opaque ref (a path for `navigable`, a playable ref otherwise)
+    /// pairing `item_key` with `session_key` -- this method's job ends at
+    /// handing back an already session-scoped, already grouping-filtered
+    /// page, not at deciding what a client may address.
+    async fn content(
+        &self,
+        operation: &str,
+        params: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let zone_id = params
+            .get("zone_id")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("zone_id is required"))?;
+        let limit = params
+            .get("limit")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(20)
+            .clamp(1, 50) as usize;
+        let offset = params
+            .get("offset")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as usize;
+        let (session_key, items, total) = match operation {
+            "collections_browse" => {
+                let item_key = params.get("item_key").and_then(serde_json::Value::as_str);
+                let session_key = params.get("session_key").and_then(serde_json::Value::as_str);
+                self.browse_collection(zone_id, item_key, session_key, offset, limit)
+                    .await?
+            }
+            "collections_playlists" => {
+                self.browse_named_root_node(zone_id, "Playlists", offset, limit)
+                    .await?
+            }
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "unsupported Roon collection operation {operation}"
+                ))
+            }
+        };
+        let mapped: Vec<serde_json::Value> = items
+            .into_iter()
+            .filter(|item| !is_ungrounded_grouping(item))
+            .map(|item| {
+                let navigable = matches!(item.hint, Some(ItemHint::List));
+                serde_json::json!({
+                    "title": item.title,
+                    "subtitle": item.subtitle,
+                    "item_key": item.item_key,
+                    "navigable": navigable,
+                })
+            })
+            .collect();
+        let next_offset = (total > offset + limit).then_some((offset + limit) as u64);
+        Ok(serde_json::json!({
+            "session_key": session_key,
+            "items": mapped,
+            "next_offset": next_offset,
+        }))
     }
 }
 

--- a/src/api/browse.rs
+++ b/src/api/browse.rs
@@ -1,0 +1,86 @@
+//! HTTP surface for library browse, queue and play-ref, for the web UI (#507).
+//!
+//! # One contract, two consumers
+//!
+//! `hifi_collections`, `hifi_queue` and `hifi_play_ref` are MCP tools with a
+//! fully worked-out verb vocabulary: capability checks, opaque browse paths
+//! and playable refs (so no provider URI reaches a client), and a structured
+//! envelope describing what happened. The web UI needs exactly the same
+//! verbs -- browse a collection, transfer a queue, play or queue a browsed
+//! item -- so these handlers call the MCP tool handlers directly rather than
+//! re-implementing any of that against `AdapterRegistry` a second time.
+//!
+//! `crate::mcp::refs::RefTable` (`AppState::mcp_refs`) is a plain server-side
+//! table keyed by opaque token, not an MCP-transport concept, so a ref minted
+//! for a browse result served over this HTTP surface resolves the same way a
+//! ref minted for an MCP client would. The two consumers share one path
+//! server-side; only the transport (HTTP JSON here, JSON-RPC there) differs.
+//!
+//! Every response body is the tool's own envelope
+//! (`structuredContent`/`outcome`/`data`/`refusal`, see
+//! [`crate::mcp::envelope`]), verbatim. The HTTP status is derived from
+//! `outcome` so a browser client can branch on the status without parsing the
+//! body, while the body still carries the same detail an MCP client sees.
+
+use crate::api::AppState;
+use crate::mcp::tools::collections::{handle_collections, HifiCollectionsTool};
+use crate::mcp::tools::library::{handle_play_ref, HifiPlayRefTool};
+use crate::mcp::tools::queue::{handle_queue, HifiQueueTool};
+use axum::{extract::State, http::StatusCode, Json};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
+use serde_json::Value;
+
+/// Project a tool handler's result onto an HTTP response.
+///
+/// The body is the envelope `structuredContent` carries (or `null` if a tool
+/// somehow attached none -- unreachable today, see
+/// [`crate::mcp::envelope::Envelope::structured`]), verbatim. The HTTP status
+/// stays `200` for every envelope outcome, refusals included: `outcome` is
+/// already the machine-readable signal (`ok`/`accepted`/`unsupported`/
+/// `invalid`/`error`, see [`crate::mcp::envelope::Outcome`]) and `refusal`
+/// carries the detail, so folding that into HTTP status codes as well would
+/// just be two places for a client to check the same fact. `500` is reserved
+/// for the one case the envelope cannot describe: the MCP transport layer
+/// itself erroring before a tool ran.
+fn envelope_response(result: Result<CallToolResult, CallToolError>) -> (StatusCode, Json<Value>) {
+    match result {
+        Ok(call_result) => {
+            let body = call_result
+                .structured_content
+                .map(Value::Object)
+                .unwrap_or(Value::Null);
+            (StatusCode::OK, Json(body))
+        }
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": error.to_string()})),
+        ),
+    }
+}
+
+/// `POST /api/collections` -- browse, playlists or favorites for one zone.
+/// Same verb and paging semantics as the `hifi_collections` MCP tool.
+pub async fn collections_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiCollectionsTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_collections(&state, args).await)
+}
+
+/// `POST /api/queue` -- read, jump, reorder, remove, clear, or transfer a
+/// zone's queue. Same verb vocabulary as the `hifi_queue` MCP tool.
+pub async fn queue_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiQueueTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_queue(&state, args).await)
+}
+
+/// `POST /api/play_ref` -- play or queue a ref minted by `/api/collections`.
+/// Same verb vocabulary as the `hifi_play_ref` MCP tool.
+pub async fn play_ref_handler(
+    State(state): State<AppState>,
+    Json(args): Json<HifiPlayRefTool>,
+) -> (StatusCode, Json<Value>) {
+    envelope_response(handle_play_ref(&state, args).await)
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,6 +37,7 @@ use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 
 pub mod apple_bridge;
+pub mod browse;
 pub mod controller_auth;
 pub mod credentials;
 pub mod provider_auth;

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -208,6 +208,12 @@ pub struct Zone {
     #[serde(default)]
     pub state: Option<String>,
     pub dsp: Option<ZoneDsp>,
+    /// Whether `/api/collections` implements this zone's provider (#531).
+    /// `default`s to `false` so an older cached response (or a field this
+    /// build predates) hides the browse panel rather than showing one that
+    /// will refuse every call.
+    #[serde(default)]
+    pub browse_supported: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -250,6 +250,129 @@ pub struct NowPlaying {
 }
 
 // =============================================================================
+// Collections / queue types (#507)
+//
+// These mirror the `hifi_collections`/`hifi_queue`/`hifi_play_ref` MCP tool
+// wire shapes exactly, because `/api/collections`, `/api/queue` and
+// `/api/play_ref` (src/api/browse.rs) forward those tools' own envelope
+// verbatim -- see that module's doc comment for why. Only the fields this UI
+// renders are modelled; unknown fields are ignored by serde's default
+// behavior, so extra envelope fields (`scope`, `observed`, `params`, ...)
+// deserialize away harmlessly.
+// =============================================================================
+
+/// One item from a `hifi_collections` page: either a folder (`path` set,
+/// browse only) or a playable entry (`r#ref` set, usable with `/api/play_ref`).
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CollectionItem {
+    pub title: String,
+    #[serde(default)]
+    pub subtitle: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(rename = "ref", default)]
+    pub item_ref: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CollectionPage {
+    #[serde(default)]
+    pub items: Vec<CollectionItem>,
+    #[serde(default)]
+    pub next_offset: Option<u32>,
+}
+
+/// The `reason`-tagged refusal shape from `crate::mcp::envelope::Refusal`.
+/// Every variant carries `detail`, which is all this UI shows.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct EnvelopeRefusal {
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub detail: String,
+}
+
+/// The envelope every `hifi_*` tool result carries
+/// (`crate::mcp::envelope::Envelope`), as forwarded verbatim by
+/// `src/api/browse.rs`. Generic over `data`'s shape.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Envelope<T> {
+    #[serde(default)]
+    pub outcome: String,
+    #[serde(default)]
+    pub data: Option<T>,
+    #[serde(default)]
+    pub refusal: Option<EnvelopeRefusal>,
+}
+
+impl<T> Envelope<T> {
+    pub fn is_ok(&self) -> bool {
+        matches!(self.outcome.as_str(), "ok" | "accepted")
+    }
+
+    /// A human-readable reason for a non-ok outcome, for display.
+    pub fn error_detail(&self) -> String {
+        self.refusal
+            .as_ref()
+            .map(|r| r.detail.clone())
+            .filter(|detail| !detail.is_empty())
+            .unwrap_or_else(|| format!("request did not succeed ({})", self.outcome))
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CollectionsRequest {
+    pub zone_id: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct QueueRequest {
+    pub zone_id: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_zone_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PlayRefRequest {
+    #[serde(rename = "ref")]
+    pub item_ref: String,
+    pub zone_id: String,
+    pub action: String,
+}
+
+/// `POST /api/collections`.
+pub async fn fetch_collections(
+    req: &CollectionsRequest,
+) -> Result<Envelope<CollectionPage>, String> {
+    post_json("/api/collections", req).await
+}
+
+/// `POST /api/queue`, for actions this UI drives without reading the queue
+/// contents back (transfer). The response body is ignored beyond outcome.
+pub async fn post_queue_action(req: &QueueRequest) -> Result<Envelope<serde_json::Value>, String> {
+    post_json("/api/queue", req).await
+}
+
+/// `POST /api/play_ref`.
+pub async fn post_play_ref(req: &PlayRefRequest) -> Result<Envelope<serde_json::Value>, String> {
+    post_json("/api/play_ref", req).await
+}
+
+// =============================================================================
 // LMS Types
 // =============================================================================
 

--- a/src/app/components/collections.rs
+++ b/src/app/components/collections.rs
@@ -1,0 +1,380 @@
+//! Library browse + queue transfer panel for a zone card (#507).
+//!
+//! Calls the same `/api/collections`, `/api/queue` and `/api/play_ref`
+//! endpoints the MCP tools back (see `src/api/browse.rs`), so this panel and
+//! an MCP agent see the same capability surface: browse/playlists/favorites,
+//! opaque playable refs, and queue transfer between Music Assistant zones.
+//! Only rendered for zones whose adapter advertises collections support
+//! (Music Assistant today) -- callers gate that, this component assumes it.
+
+use crate::app::api::{
+    self, CollectionItem, CollectionsRequest, PlayRefRequest, QueueRequest,
+};
+use dioxus::prelude::*;
+
+const PAGE_LIMIT: u32 = 20;
+
+#[derive(Clone, PartialEq, Props)]
+pub struct CollectionsBrowserProps {
+    /// The zone this panel browses and plays into.
+    pub zone_id: String,
+    /// Other zones a queue can be transferred to: `(zone_id, zone_name)`.
+    #[props(default)]
+    pub transfer_targets: Vec<(String, String)>,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Tab {
+    Browse,
+    Playlists,
+    Favorites,
+    Radio,
+}
+
+impl Tab {
+    fn action(self) -> &'static str {
+        match self {
+            Tab::Browse => "browse",
+            Tab::Playlists => "playlists",
+            Tab::Favorites | Tab::Radio => "favorites",
+        }
+    }
+
+    fn media_type(self) -> Option<&'static str> {
+        match self {
+            Tab::Radio => Some("radio"),
+            Tab::Favorites => Some("tracks"),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Tab::Browse => "Browse",
+            Tab::Playlists => "Playlists",
+            Tab::Favorites => "Favorites",
+            Tab::Radio => "Radio",
+        }
+    }
+}
+
+const TABS: &[Tab] = &[Tab::Browse, Tab::Playlists, Tab::Favorites, Tab::Radio];
+
+/// Fetch one page of a collection and apply it to the panel's signals.
+/// A free function rather than a captured closure: `Signal<T>` is `Copy`, so
+/// this can be called from any number of independent event handlers without
+/// fighting move-closure ownership.
+#[allow(clippy::too_many_arguments)]
+async fn load_page(
+    zone_id: String,
+    action: String,
+    media_type: Option<String>,
+    path: Option<String>,
+    request_offset: u32,
+    append: bool,
+    mut items: Signal<Vec<CollectionItem>>,
+    mut next_offset: Signal<Option<u32>>,
+    mut offset: Signal<u32>,
+    mut loading: Signal<bool>,
+    mut error: Signal<Option<String>>,
+) {
+    loading.set(true);
+    error.set(None);
+    let req = CollectionsRequest {
+        zone_id,
+        action,
+        path,
+        media_type,
+        limit: Some(PAGE_LIMIT),
+        offset: Some(request_offset),
+    };
+    match api::fetch_collections(&req).await {
+        Ok(env) if env.is_ok() => {
+            let page = env.data.unwrap_or_default();
+            if append {
+                items.with_mut(|list| list.extend(page.items));
+            } else {
+                items.set(page.items);
+            }
+            next_offset.set(page.next_offset);
+            offset.set(request_offset);
+        }
+        Ok(env) => {
+            error.set(Some(env.error_detail()));
+            if !append {
+                items.set(Vec::new());
+            }
+        }
+        Err(message) => {
+            error.set(Some(message));
+            if !append {
+                items.set(Vec::new());
+            }
+        }
+    }
+    loading.set(false);
+}
+
+/// Expandable collections browser + queue transfer control for one zone.
+#[component]
+pub fn CollectionsBrowser(props: CollectionsBrowserProps) -> Element {
+    // A `Signal` is `Copy`, unlike the `String` in `props`, so every handler
+    // closure below can capture it independently without fighting move
+    // semantics over a single owned `String`.
+    let zone_id = use_signal(|| props.zone_id.clone());
+    let mut expanded = use_signal(|| false);
+    let mut tab = use_signal(|| Tab::Browse);
+    let mut path_stack = use_signal(Vec::<(String, Option<String>)>::new);
+    let items = use_signal(Vec::<CollectionItem>::new);
+    let mut offset = use_signal(|| 0u32);
+    let next_offset = use_signal(|| None::<u32>);
+    let loading = use_signal(|| false);
+    let error = use_signal(|| None::<String>);
+    let mut status = use_signal(|| None::<String>);
+    let mut transfer_target = use_signal({
+        let first = props.transfer_targets.first().map(|(id, _)| id.clone());
+        move || first.clone()
+    });
+
+    // `use_callback` closes over props/state by reference and is itself
+    // `Copy`, so every handler below can hold and call the same instance.
+    let refresh = use_callback(move |append: bool| {
+        let zone_id = zone_id();
+        let action = tab.read().action().to_string();
+        let media_type = tab.read().media_type().map(ToOwned::to_owned);
+        let path = path_stack.read().last().and_then(|(_, p)| p.clone());
+        let request_offset = if append { offset() } else { 0 };
+        spawn(load_page(
+            zone_id,
+            action,
+            media_type,
+            path,
+            request_offset,
+            append,
+            items,
+            next_offset,
+            offset,
+            loading,
+            error,
+        ));
+    });
+
+    let toggle_open = move |_| {
+        let opening = !expanded();
+        expanded.set(opening);
+        if opening && items.read().is_empty() {
+            refresh(false);
+        }
+    };
+
+    let select_tab = use_callback(move |new_tab: Tab| {
+        tab.set(new_tab);
+        path_stack.set(Vec::new());
+        offset.set(0);
+        refresh(false);
+    });
+
+    let open_folder = use_callback(move |(title, path): (String, String)| {
+        path_stack.with_mut(|stack| stack.push((title, Some(path))));
+        offset.set(0);
+        refresh(false);
+    });
+
+    let go_back = move |_| {
+        path_stack.with_mut(|stack| {
+            stack.pop();
+        });
+        offset.set(0);
+        refresh(false);
+    };
+
+    let load_more = move |_| refresh(true);
+
+    let play_item = use_callback(move |(item_ref, action): (String, &'static str)| {
+        let zone_id = zone_id();
+        status.set(Some("Working...".to_string()));
+        spawn(async move {
+            let req = PlayRefRequest {
+                item_ref,
+                zone_id,
+                action: action.to_string(),
+            };
+            let message = match api::post_play_ref(&req).await {
+                Ok(env) if env.is_ok() => {
+                    if action == "queue" {
+                        "Added to queue".to_string()
+                    } else {
+                        "Playing".to_string()
+                    }
+                }
+                Ok(env) => env.error_detail(),
+                Err(message) => message,
+            };
+            status.set(Some(message));
+        });
+    });
+
+    let do_transfer = move |_| {
+        let Some(target) = transfer_target() else {
+            return;
+        };
+        let zone_id = zone_id();
+        status.set(Some("Transferring queue...".to_string()));
+        spawn(async move {
+            let req = QueueRequest {
+                zone_id,
+                action: "transfer".to_string(),
+                item_id: None,
+                position: None,
+                target_zone_id: Some(target),
+            };
+            let message = match api::post_queue_action(&req).await {
+                Ok(env) if env.is_ok() => "Queue transferred".to_string(),
+                Ok(env) => env.error_detail(),
+                Err(message) => message,
+            };
+            status.set(Some(message));
+        });
+    };
+
+    let breadcrumb_labels: Vec<String> = path_stack.read().iter().map(|(t, _)| t.clone()).collect();
+    let has_history = !path_stack.read().is_empty();
+    let current_tab = tab();
+    let current_items = items();
+    let is_loading = loading();
+    let current_error = error();
+    let current_status = status();
+    let can_load_more = next_offset.read().is_some();
+    let has_transfer_targets = !props.transfer_targets.is_empty();
+    let transfer_targets = props.transfer_targets.clone();
+
+    rsx! {
+        div { class: "mt-3 border-t border-subtle pt-3",
+            button {
+                class: "btn btn-ghost text-sm",
+                r#type: "button",
+                onclick: toggle_open,
+                if expanded() { "Hide library" } else { "Browse library" }
+            }
+
+            if expanded() {
+                div { class: "mt-3 space-y-3",
+                    // Tabs
+                    div { class: "flex flex-wrap gap-2",
+                        for candidate in TABS {
+                            {
+                                let candidate = *candidate;
+                                let active = candidate == current_tab;
+                                rsx! {
+                                    button {
+                                        key: "{candidate.label()}",
+                                        class: if active { "badge badge-primary" } else { "badge" },
+                                        r#type: "button",
+                                        onclick: move |_| select_tab(candidate),
+                                        "{candidate.label()}"
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Breadcrumb / back
+                    if has_history {
+                        div { class: "flex items-center gap-2 text-sm text-muted",
+                            button { class: "btn btn-ghost", r#type: "button", onclick: go_back, "< Back" }
+                            span { "{breadcrumb_labels.join(\" / \")}" }
+                        }
+                    }
+
+                    if let Some(message) = current_status.clone() {
+                        p { class: "text-sm text-muted", "{message}" }
+                    }
+                    if let Some(message) = current_error.clone() {
+                        p { class: "text-sm text-error", "{message}" }
+                    }
+                    if is_loading && current_items.is_empty() {
+                        p { class: "text-sm text-muted", "Loading..." }
+                    } else if current_items.is_empty() {
+                        p { class: "text-sm text-muted", "Nothing here." }
+                    } else {
+                        ul { class: "space-y-2",
+                            for item in current_items.iter().cloned() {
+                                li {
+                                    key: "{item.title}-{item.path.clone().unwrap_or_default()}-{item.item_ref.clone().unwrap_or_default()}",
+                                    class: "flex items-center justify-between gap-2",
+                                    div { class: "min-w-0",
+                                        p { class: "text-sm font-medium truncate", "{item.title}" }
+                                        if let Some(subtitle) = item.subtitle.clone() {
+                                            p { class: "text-xs text-muted truncate", "{subtitle}" }
+                                        }
+                                    }
+                                    div { class: "flex gap-2 flex-shrink-0",
+                                        if let Some(path) = item.path.clone() {
+                                            button {
+                                                class: "btn btn-ghost text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let title = item.title.clone();
+                                                    let path = path.clone();
+                                                    move |_| open_folder((title.clone(), path.clone()))
+                                                },
+                                                "Open"
+                                            }
+                                        }
+                                        if let Some(item_ref) = item.item_ref.clone() {
+                                            button {
+                                                class: "btn btn-primary text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let item_ref = item_ref.clone();
+                                                    move |_| play_item((item_ref.clone(), "play"))
+                                                },
+                                                "Play"
+                                            }
+                                            button {
+                                                class: "btn btn-ghost text-sm",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let item_ref = item_ref.clone();
+                                                    move |_| play_item((item_ref.clone(), "queue"))
+                                                },
+                                                "Queue"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if can_load_more {
+                            button {
+                                class: "btn btn-ghost text-sm",
+                                r#type: "button",
+                                onclick: load_more,
+                                "Load more"
+                            }
+                        }
+                    }
+
+                    if has_transfer_targets {
+                        div { class: "flex items-center gap-2 pt-2 border-t border-subtle",
+                            span { class: "text-sm text-muted", "Transfer queue to:" }
+                            select {
+                                class: "form-select text-sm",
+                                onchange: move |evt| transfer_target.set(Some(evt.value())),
+                                for (target_id, target_name) in transfer_targets.iter().cloned() {
+                                    option { key: "{target_id}", value: "{target_id}", "{target_name}" }
+                                }
+                            }
+                            button {
+                                class: "btn btn-ghost text-sm",
+                                r#type: "button",
+                                onclick: do_transfer,
+                                "Transfer"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -1,5 +1,6 @@
 //! Shared UI components for the Dioxus fullstack web UI.
 
+pub mod collections;
 pub mod error_alert;
 pub mod form_inputs;
 pub mod hqp_controls;
@@ -7,6 +8,7 @@ pub mod layout;
 pub mod nav;
 pub mod volume;
 
+pub use collections::CollectionsBrowser;
 pub use error_alert::ErrorAlert;
 pub use form_inputs::{PowerModeInput, ToggleInput};
 pub use hqp_controls::{HqpControlsCompact, HqpMatrixSelect, HqpProfileSelect};

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -3,7 +3,9 @@
 //! Shows all available zones using Dioxus resources.
 
 use crate::app::api::{HqpMatrixProfilesResponse, HqpProfile, NowPlaying, Zone, ZonesResponse};
-use crate::app::components::{ErrorAlert, HqpControlsCompact, Layout, VolumeControlsCompact};
+use crate::app::components::{
+    CollectionsBrowser, ErrorAlert, HqpControlsCompact, Layout, VolumeControlsCompact,
+};
 use crate::app::sse::{use_sse, SseEvent};
 use dioxus::prelude::*;
 use std::collections::HashMap;
@@ -254,6 +256,15 @@ pub fn Zones() -> Element {
     let profiles = hqp_profiles();
     let matrix = hqp_matrix();
 
+    // Music Assistant zones support library browse and queue transfer
+    // (#507); every other adapter hides the panel entirely rather than
+    // showing a browse surface that immediately refuses every call.
+    let musicassistant_zones: Vec<(String, String)> = zones_list
+        .iter()
+        .filter(|z| z.zone_id.starts_with("musicassistant:"))
+        .map(|z| (z.zone_id.clone(), z.zone_name.clone()))
+        .collect();
+
     // Group zones by source protocol
     let grouped_zones: Vec<(String, Vec<Zone>)> = {
         let mut groups: std::collections::HashMap<String, Vec<Zone>> =
@@ -305,6 +316,7 @@ pub fn Zones() -> Element {
                                 on_control: control,
                                 on_load_profile: load_profile,
                                 on_set_matrix: set_matrix,
+                                musicassistant_zones: musicassistant_zones.clone(),
                             }
                         }
                     }
@@ -345,6 +357,10 @@ fn ZoneCard(
     on_control: EventHandler<(String, String)>,
     on_load_profile: EventHandler<String>,
     on_set_matrix: EventHandler<String>,
+    /// Every Music Assistant zone, `(zone_id, zone_name)`, for the browse
+    /// panel's queue-transfer target list (#507). Empty when there are none.
+    #[props(default)]
+    musicassistant_zones: Vec<(String, String)>,
 ) -> Element {
     let zone_id = zone.zone_id.clone();
     let zone_id_prev = zone_id.clone();
@@ -494,6 +510,20 @@ fn ZoneCard(
                     volume_step: volume_step,
                     on_vol_down: move |_| on_control.call((zone_id_vol_down.clone(), "vol_down".to_string())),
                     on_vol_up: move |_| on_control.call((zone_id_vol_up.clone(), "vol_up".to_string())),
+                }
+            }
+
+            // Library browse + queue transfer (#507). Music Assistant only
+            // today; other adapters hide the panel rather than exposing a
+            // browse surface that would refuse every call.
+            if zone.zone_id.starts_with("musicassistant:") {
+                CollectionsBrowser {
+                    zone_id: zone.zone_id.clone(),
+                    transfer_targets: musicassistant_zones
+                        .iter()
+                        .filter(|(id, _)| *id != zone.zone_id)
+                        .cloned()
+                        .collect::<Vec<_>>(),
                 }
             }
         }

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -513,10 +513,14 @@ fn ZoneCard(
                 }
             }
 
-            // Library browse + queue transfer (#507). Music Assistant only
-            // today; other adapters hide the panel rather than exposing a
-            // browse surface that would refuse every call.
-            if zone.zone_id.starts_with("musicassistant:") {
+            // Library browse + queue transfer (#507, #531). Gated on the
+            // server-reported `browse_supported` -- whether `/api/collections`
+            // actually implements this zone's provider -- rather than a
+            // hardcoded prefix, so LMS and Roon zones light up as their
+            // slices land without a web change. Queue transfer itself
+            // remains Music Assistant-only (`musicassistant_zones` below);
+            // that is a separate capability (#507) this gate does not cover.
+            if zone.browse_supported {
                 CollectionsBrowser {
                     zone_id: zone.zone_id.clone(),
                     transfer_targets: musicassistant_zones

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -104,6 +104,11 @@ pub struct ZoneInfo {
     pub volume_control: Option<VolumeControl>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dsp: Option<DspInfo>,
+    /// Whether `hifi_collections`/`/api/collections` implements this zone's
+    /// provider at all (#531). The web UI's `CollectionsBrowser` panel gates
+    /// on this instead of a hardcoded `musicassistant:` prefix check, so LMS
+    /// and Roon zones light up as their slices land, without a web change.
+    pub browse_supported: bool,
 }
 
 /// GET /knob/zones response
@@ -175,6 +180,9 @@ pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
         })
         .map(|z| ZoneInfo {
             dsp: get_dsp(&z.zone_id),
+            browse_supported: crate::mcp::tools::collections::zone_supports_hifi_collections(
+                &z.zone_id,
+            ),
             zone_id: z.zone_id,
             zone_name: z.zone_name,
             source: z.source,
@@ -1580,6 +1588,7 @@ mod tests {
             state: "stopped".to_string(),
             volume_control: None,
             dsp: None,
+            browse_supported: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,6 +502,14 @@ mod server {
             .adapter_registry
             .register_library("spotify", spotify.clone())
             .await;
+        // Roon's transport commands keep going through the dedicated
+        // `state.roon` field/routes; this registration only exposes the
+        // provider-neutral content-library surface (#509's multiroom
+        // grouping operations) via `AdapterRegistry::library_content("roon", ...)`.
+        state
+            .adapter_registry
+            .register_library("roon", state.roon.clone())
+            .await;
         state.provider_auth.attach_spotify(spotify.clone()).await;
         state
             .provider_auth

--- a/src/main.rs
+++ b/src/main.rs
@@ -740,6 +740,12 @@ mod server {
             // App settings API
             .route("/api/settings", get(api::api_settings_get_handler))
             .route("/api/settings", post(api::api_settings_post_handler))
+            // Library browse, queue and play-ref for the web UI (#507). Same
+            // verb vocabulary as the hifi_collections/hifi_queue/hifi_play_ref
+            // MCP tools -- see src/api/browse.rs.
+            .route("/api/collections", post(api::browse::collections_handler))
+            .route("/api/queue", post(api::browse::queue_handler))
+            .route("/api/play_ref", post(api::browse::play_ref_handler))
             // Event stream (SSE)
             .route("/events", get(api::events_handler))
             // Knob hardware API routes

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,6 +502,14 @@ mod server {
             .adapter_registry
             .register_library("spotify", spotify.clone())
             .await;
+        // LMS's transport commands keep going through the dedicated `state.lms`
+        // field/routes; this registration only exposes the provider-neutral
+        // content-library surface (#510's multiroom sync-group operations) via
+        // `AdapterRegistry::library_content("lms", ...)`.
+        state
+            .adapter_registry
+            .register_library("lms", state.lms.clone())
+            .await;
         state.provider_auth.attach_spotify(spotify.clone()).await;
         state
             .provider_auth

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,6 +494,18 @@ mod server {
             );
         }
 
+        // #531: registered for `hifi_collections`' content operation only --
+        // `search`/`play_uri` refuse through this trait (see
+        // `LibraryAdapter for LmsAdapter`/`for RoonAdapter`'s docs);
+        // `hifi_search`/`hifi_play` keep calling these adapters directly.
+        state
+            .adapter_registry
+            .register_library("lms", state.lms.clone())
+            .await;
+        state
+            .adapter_registry
+            .register_library("roon", state.roon.clone())
+            .await;
         state
             .adapter_registry
             .register_with_lifecycle(spotify.clone(), spotify.clone())

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -360,7 +360,15 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         | Capability::QueueRemove
         | Capability::QueueClear => target == ZoneTarget::MusicAssistant,
         Capability::PlayNext => target == ZoneTarget::MusicAssistant,
-        Capability::MultiroomSync => target == ZoneTarget::MusicAssistant,
+        // #517: LMS (#513) and Roon (#515) both implement the
+        // multiroom_status/multiroom_set_members/multiroom_ungroup contract at
+        // the adapter layer, exactly like Music Assistant. `hifi_zone_group`
+        // routes join/leave/status to whichever of the three owns the zone
+        // prefix (`src/mcp/tools/groups.rs`), so all three are routed here.
+        Capability::MultiroomSync => matches!(
+            target,
+            ZoneTarget::MusicAssistant | ZoneTarget::Roon | ZoneTarget::Lms
+        ),
         Capability::Browse | Capability::SavedPlaylists | Capability::Favorites => {
             matches!(target, ZoneTarget::Spotify | ZoneTarget::MusicAssistant)
         }
@@ -455,7 +463,8 @@ const HQPLAYER_CONTENT_UNVERIFIED: &str = "UHC's HQPlayer adapter speaks transpo
 #[rustfmt::skip]
 const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     // -------------------------------------------------------------------------
-    // Roon. Transport, volume, search and play-by-query are routed.
+    // Roon. Transport, volume, search, play-by-query and (since #517)
+    // multiroom_sync are routed.
     // -------------------------------------------------------------------------
     (ZoneTarget::Roon, Capability::PlayByRef, Gap::NotWired("#396",
         "RoonAdapter::browse/load/play_item exist and are exposed over HTTP; MCP mints no \
@@ -488,9 +497,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::Favorites, Gap::NotWired("#399",
         "Roon exposes My Favorites and tags as browse hierarchies, so this arrives with \
          browse.")),
-    (ZoneTarget::Roon, Capability::MultiroomSync, Gap::NotWired("#360",
-        "the Roon API's transport service groups and ungroups outputs; UHC exposes no \
-         grouping on any surface.")),
 
     // -------------------------------------------------------------------------
     // LMS. **Not one ProviderCannot** -- every gap here is UHC's, verified live
@@ -537,10 +543,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
         "favorites items / favorites playlist play / add / delete / exists all work; verified \
          live. Note LMS favorites have no durable id -- only a url -- so a ref must be minted \
          over the url.")),
-    (ZoneTarget::Lms, Capability::MultiroomSync, Gap::NotWired("#403",
-        "sync <playerid>, sync -, sync ? and the server-scoped syncgroups ? all work; verified \
-         live. Joining is destructive to the target zone's queue, which is why #403 gates it \
-         behind confirmation.")),
 
     // -------------------------------------------------------------------------
     // OpenHome. Transport, skip and (since #398) volume are routed.

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -116,6 +116,8 @@ pub enum Capability {
     QueueRemove,
     /// Empty the queue.
     QueueClear,
+    /// Move an active queue from one zone to another (#507).
+    QueueTransfer,
     /// Insert immediately after the current item.
     PlayNext,
     /// Read and set repeat mode.
@@ -148,6 +150,7 @@ impl Capability {
         Self::QueueReorder,
         Self::QueueRemove,
         Self::QueueClear,
+        Self::QueueTransfer,
         Self::PlayNext,
         Self::RepeatMode,
         Self::ShuffleMode,
@@ -172,6 +175,7 @@ impl Capability {
             Self::QueueReorder => "queue_reorder",
             Self::QueueRemove => "queue_remove",
             Self::QueueClear => "queue_clear",
+            Self::QueueTransfer => "queue_transfer",
             Self::PlayNext => "play_next",
             Self::RepeatMode => "repeat_mode",
             Self::ShuffleMode => "shuffle_mode",
@@ -358,7 +362,8 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         Capability::QueueJump
         | Capability::QueueReorder
         | Capability::QueueRemove
-        | Capability::QueueClear => target == ZoneTarget::MusicAssistant,
+        | Capability::QueueClear
+        | Capability::QueueTransfer => target == ZoneTarget::MusicAssistant,
         Capability::PlayNext => target == ZoneTarget::MusicAssistant,
         Capability::MultiroomSync => target == ZoneTarget::MusicAssistant,
         Capability::Browse | Capability::SavedPlaylists | Capability::Favorites => {
@@ -411,6 +416,14 @@ const ROON_QUEUE_IS_READ_PLUS_JUMP: &str = "The Roon API's transport service exp
     subscription and play_from_here and no mutation at all -- no move, remove or clear. The \
     pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing \
     further.";
+
+/// OpenHome's per-room `Playlist:1` has no cross-room action, and Songcast
+/// relays audio rather than queue state.
+const OPENHOME_HAS_NO_QUEUE_TRANSFER: &str = "OpenHome's Playlist:1 (Read/Insert/DeleteId/\
+    DeleteAll) is scoped to one room's renderer; the service set defines no action that moves \
+    one room's playlist into another's. Songcast (Sender:1/Receiver:1) relays audio to a group, \
+    it does not merge queue state. Verified from the OpenHome service definitions, not from a \
+    device.";
 
 /// Playing a *named* item is a different question from *finding* one, and the ship
 /// gate's dissent caught this module conflating them.
@@ -472,6 +485,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::QueueReorder, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::QueueRemove, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::QueueClear, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
+    (ZoneTarget::Roon, Capability::QueueTransfer, Gap::ProviderCannot(ROON_QUEUE_IS_READ_PLUS_JUMP)),
     (ZoneTarget::Roon, Capability::PlayNext, Gap::NotWired("#399",
         "Roon's browse item actions include Play Next alongside Play Now and Queue; UHC's \
          PlayAction models only Play, Queue and Radio, so this arrives with browse rather \
@@ -518,6 +532,13 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
         "playlist delete <index> removes one queued item; verified live.")),
     (ZoneTarget::Lms, Capability::QueueClear, Gap::NotWired("#400",
         "playlist clear empties the queue; verified live.")),
+    (ZoneTarget::Lms, Capability::QueueTransfer, Gap::NotWired("#400",
+        "sync <playerid> was verified live (#403) to merge a player into another's sync group by \
+         adopting the leader's queue, which destroys the source's queue rather than transferring \
+         it; the CLI reference names no dedicated queue-to-queue transfer command. A composite \
+         emulation -- read the source's playlist, replay it against the target with \
+         playlistcontrol, then playlist clear the source -- is buildable from primitives #400 \
+         already verified live, but is not wired.")),
     (ZoneTarget::Lms, Capability::PlayNext, Gap::NotWired("#403",
         "playlistcontrol cmd:insert places an item immediately after the current one, verified \
          live -- and LmsPlayAction::Insert is already modelled in the adapter and simply \
@@ -557,6 +578,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
          OpenHome service definitions, not from a device.")),
     (ZoneTarget::OpenHome, Capability::QueueRemove, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::QueueClear, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
+    (ZoneTarget::OpenHome, Capability::QueueTransfer, Gap::ProviderCannot(OPENHOME_HAS_NO_QUEUE_TRANSFER)),
     (ZoneTarget::OpenHome, Capability::PlayNext, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::RepeatMode, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
     (ZoneTarget::OpenHome, Capability::ShuffleMode, Gap::NotWired("#392", OPENHOME_PLAYLIST_SERVICE_UNUSED)),
@@ -592,6 +614,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Upnp, Capability::QueueReorder, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::QueueRemove, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::QueueClear, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
+    (ZoneTarget::Upnp, Capability::QueueTransfer, Gap::ProviderCannot(UPNP_HAS_NO_QUEUE)),
     (ZoneTarget::Upnp, Capability::PlayNext, Gap::NotWired("#396", PLAY_A_NAMED_URI_EXISTS)),
     (ZoneTarget::Upnp, Capability::RepeatMode, Gap::NotWired("#392",
         "AVTransport:1's SetPlayMode takes REPEAT_ONE and REPEAT_ALL, so repeat is a protocol \
@@ -633,6 +656,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::HqPlayer, Capability::QueueReorder, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::QueueRemove, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::QueueClear, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
+    (ZoneTarget::HqPlayer, Capability::QueueTransfer, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::PlayNext, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::SavedPlaylists, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
     (ZoneTarget::HqPlayer, Capability::Favorites, Gap::NotWired("#209", HQPLAYER_CONTENT_UNVERIFIED)),
@@ -822,6 +846,7 @@ mod tests {
                                 | Capability::QueueReorder
                                 | Capability::QueueRemove
                                 | Capability::QueueClear
+                                | Capability::QueueTransfer
                                 | Capability::PlayNext
                                 | Capability::SavedPlaylists
                                 | Capability::Favorites
@@ -1027,7 +1052,7 @@ mod tests {
                 capability.name()
             );
         }
-        assert_eq!(seen.len(), 18, "the vocabulary changed size: {seen:?}");
+        assert_eq!(seen.len(), 19, "the vocabulary changed size: {seen:?}");
     }
 
     /// A refusal built from a capability state must carry the same

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -366,8 +366,17 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         | Capability::QueueTransfer => target == ZoneTarget::MusicAssistant,
         Capability::PlayNext => target == ZoneTarget::MusicAssistant,
         Capability::MultiroomSync => target == ZoneTarget::MusicAssistant,
-        Capability::Browse | Capability::SavedPlaylists | Capability::Favorites => {
-            matches!(target, ZoneTarget::Spotify | ZoneTarget::MusicAssistant)
+        // #531: LMS implements all three (albums/artists/playlists/favorites
+        // queries over the CLI/jsonrpc). Roon implements browse and playlists
+        // (the same browse/load session `hifi_search` already drives);
+        // favorites remains a gap -- see `GAPS` below -- because Roon exposes
+        // it as a browse hierarchy this slice does not yet walk into.
+        Capability::Browse | Capability::SavedPlaylists => matches!(
+            target,
+            ZoneTarget::Spotify | ZoneTarget::MusicAssistant | ZoneTarget::Lms | ZoneTarget::Roon
+        ),
+        Capability::Favorites => {
+            matches!(target, ZoneTarget::Spotify | ZoneTarget::MusicAssistant | ZoneTarget::Lms)
         }
     };
     supported.then_some(Support::Supported)
@@ -473,9 +482,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::PlayByRef, Gap::NotWired("#396",
         "RoonAdapter::browse/load/play_item exist and are exposed over HTTP; MCP mints no \
          reference for a search hit to act on.")),
-    (ZoneTarget::Roon, Capability::Browse, Gap::NotWired("#399",
-        "RoonAdapter::browse() and load() exist and POST /roon/browse exposes them; only the \
-         MCP projection is missing.")),
     (ZoneTarget::Roon, Capability::QueueRead, Gap::NotWired("#400",
         "the pinned roon-api fork exposes subscribe_queue(zone, max_items), which nothing in \
          UHC calls.")),
@@ -496,10 +502,7 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Roon, Capability::ShuffleMode, Gap::NotWired("#360",
         "the Roon API's transport service takes a shuffle setting; UHC drives it from no \
          surface.")),
-    (ZoneTarget::Roon, Capability::SavedPlaylists, Gap::NotWired("#399",
-        "Roon exposes Playlists as a browse hierarchy, so this arrives with browse rather \
-         than as its own protocol feature.")),
-    (ZoneTarget::Roon, Capability::Favorites, Gap::NotWired("#399",
+    (ZoneTarget::Roon, Capability::Favorites, Gap::NotWired("#531",
         "Roon exposes My Favorites and tags as browse hierarchies, so this arrives with \
          browse.")),
     (ZoneTarget::Roon, Capability::MultiroomSync, Gap::NotWired("#360",
@@ -516,10 +519,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
          that playlistcontrol accepts, verified live; MCP discards them and hands back a title. \
          Note the XMLBrowser paths (globalsearch, favorites) return positional breadcrumbs \
          instead, which is #396's safety problem, not a capability gap.")),
-    (ZoneTarget::Lms, Capability::Browse, Gap::NotWired("#402",
-        "browselibrary items and the native albums/artists/genres/years/playlists/mediafolder \
-         queries walk the whole hierarchy with native <start> <n> paging -- all \
-         verified live on Lyrion 9.1.2. The adapter never calls any of them.")),
     (ZoneTarget::Lms, Capability::QueueRead, Gap::NotWired("#400",
         "status <player> <start> <n> returns the whole current playlist with playlist_cur_index; \
          verified live.")),
@@ -549,15 +548,6 @@ const GAPS: &[(ZoneTarget, Capability, Gap)] = &[
     (ZoneTarget::Lms, Capability::ShuffleMode, Gap::NotWired("#403",
         "playlist shuffle <0|1|2> and playlist shuffle ? read and write it; verified live. \
          Setting it reshuffles the queue, so it is also a queue mutation.")),
-    (ZoneTarget::Lms, Capability::SavedPlaylists, Gap::NotWired("#403",
-        "playlists / playlists tracks / playlistcontrol cmd:load playlist_id / playlists new / \
-         rename / delete all exist and were verified live. playlist save additionally needs a \
-         configured playlistdir, which is unset on a stock install -- so its own answer is \
-         three-state at the server level, which is why #403 probes pref playlistdir ?.")),
-    (ZoneTarget::Lms, Capability::Favorites, Gap::NotWired("#403",
-        "favorites items / favorites playlist play / add / delete / exists all work; verified \
-         live. Note LMS favorites have no durable id -- only a url -- so a ref must be minted \
-         over the url.")),
     (ZoneTarget::Lms, Capability::MultiroomSync, Gap::NotWired("#403",
         "sync <playerid>, sync -, sync ? and the server-scoped syncgroups ? all work; verified \
          live. Joining is destructive to the target zone's queue, which is why #403 gates it \

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -139,6 +139,23 @@ pub enum RefTarget {
         path: String,
         title: String,
     },
+    /// An LMS browse continuation (#531): a server-side collection path
+    /// (`"albums"`, `"album:<id>"`, ...), never a raw entity id handed to a
+    /// client. Only accepted by `hifi_collections`, never `hifi_play_ref` --
+    /// same split as [`Self::MusicAssistantBrowse`].
+    LmsBrowse {
+        path: String,
+        title: String,
+    },
+    /// A Roon browse continuation (#531): the `item_key` **and**
+    /// `multi_session_key` a collection list was loaded under, so resuming it
+    /// re-enters that exact session -- same pairing requirement as
+    /// [`Self::Roon`], for the same reason (see [`RoonRefTarget`]'s docs).
+    /// Only accepted by `hifi_collections`, never `hifi_play_ref`.
+    RoonBrowse {
+        target: RoonRefTarget,
+        title: String,
+    },
     /// An Apple Music catalog/library identifier resolved by the paired native
     /// companion. Clients only receive the opaque token.
     AppleMusic {
@@ -161,6 +178,8 @@ impl RefTarget {
             Self::Spotify { .. } => Provider::Spotify,
             Self::MusicAssistant { .. } => Provider::MusicAssistant,
             Self::MusicAssistantBrowse { .. } => Provider::MusicAssistant,
+            Self::LmsBrowse { .. } => Provider::Lms,
+            Self::RoonBrowse { .. } => Provider::Roon,
             Self::AppleMusic { .. } => Provider::AppleMusic,
         }
     }
@@ -174,6 +193,8 @@ impl RefTarget {
             | Self::Spotify { title, .. }
             | Self::MusicAssistant { title, .. }
             | Self::MusicAssistantBrowse { title, .. }
+            | Self::LmsBrowse { title, .. }
+            | Self::RoonBrowse { title, .. }
             | Self::AppleMusic { title, .. } => title,
         }
     }

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -3,11 +3,25 @@
 //! The wire contract deliberately speaks only of collections, paths, pages and
 //! opaque playable refs. Provider adapters translate those concepts to their
 //! native library APIs; no provider URI or identifier is returned to a client.
+//!
+//! # #531: per-provider slices, not one blanket gate
+//!
+//! #492 wired only Music Assistant, behind a blanket "not implemented for
+//! this provider yet" refusal for every other route. That refusal did not
+//! distinguish "this provider cannot" from "UHC has not wired it" and, worse,
+//! disagreed with [`crate::mcp::capabilities`] for Spotify: `hifi_spotify`
+//! already exposes playlists/favorites/browse there, so the capability table
+//! reports `browse`/`saved_playlists`/`favorites` as `supported` for Spotify
+//! zones independent of this tool. This module now implements LMS and Roon
+//! (#531's biggest UX win -- local-library and Roon-library browsing had no
+//! neutral surface at all) and refuses Spotify and Apple Music by name,
+//! honestly: reachable through their own provider tools today, not yet wired
+//! to this one. See #531's PR body for what remains.
 
 use crate::api::AppState;
 use crate::mcp::capabilities::{support, Capability, Support};
 use crate::mcp::envelope::{Envelope, Refusal, Scope};
-use crate::mcp::refs::RefTarget;
+use crate::mcp::refs::{RefTarget, RoonRefTarget};
 use crate::mcp::routing::{LibraryRoute, ZoneTarget};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
@@ -18,9 +32,28 @@ use serde_json::{json, Value};
 
 const ACTIONS: &[&str] = &["browse", "playlists", "favorites"];
 
+/// Whether `hifi_collections` (and its HTTP mirror, `/api/collections`)
+/// implements this zone's provider at all.
+///
+/// **Narrower than "is any collections capability `supported`"**: Spotify's
+/// `browse`/`saved_playlists`/`favorites` cells read `supported` in
+/// [`crate::mcp::capabilities`] because `hifi_spotify` already implements
+/// them (see that module's `routed()`), not because this tool does. The web
+/// UI's `CollectionsBrowser` panel (`src/app/pages/zones.rs`) calls
+/// `/api/collections`, which is *this* tool -- so it must gate on this
+/// narrower question, not on the general capability table, or it would light
+/// up a panel that immediately refuses every call for a Spotify zone. See
+/// #531's PR body for Spotify and Apple Music's plan to close this gap.
+pub fn zone_supports_hifi_collections(zone_id: &str) -> bool {
+    matches!(
+        ZoneTarget::classify(zone_id).for_library(),
+        LibraryRoute::MusicAssistant | LibraryRoute::Lms | LibraryRoute::Roon
+    )
+}
+
 #[mcp_tool(
     name = "hifi_collections",
-    description = "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection."
+    description = "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection. Implemented for lms and roon zones; Music Assistant zones (see hifi_queue's provider notes); Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiCollectionsTool {
@@ -84,51 +117,59 @@ pub async fn handle_collections(
         .param_opt("limit", args.limit)
         .param_opt("offset", args.offset)
         .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
-    let prefix = match target.for_library() {
-        LibraryRoute::Roon => "roon",
-        LibraryRoute::Lms => "lms",
-        LibraryRoute::Spotify => "spotify",
-        LibraryRoute::AppleMusic => "applemusic",
-        LibraryRoute::MusicAssistant => "musicassistant",
-        LibraryRoute::Refused(_) => return env.failed("This zone has no library path"),
-    };
-    // Browse paths are server-side refs, just like playable media refs. MA's
-    // native `library://…` paths contain provider implementation details and
-    // must not become MCP client input.
-    let provider_path = match args.path.as_deref() {
-        None => None,
-        Some(token) => match state.mcp_refs.resolve(token).await {
-            Some(RefTarget::MusicAssistantBrowse { path, .. })
-                if matches!(target, ZoneTarget::MusicAssistant) => Some(path),
-            Some(_) => {
-                return env.refused(
-                    "path does not name a collection for this zone.",
-                    Refusal::invalid_parameter(
-                        "path",
-                        &["a path returned by hifi_collections for this zone"],
-                        "Browse again from this zone and use that result's path.",
-                    ),
-                )
-            }
-            None => {
-                return env.refused(
-                    "path is unknown or expired. Browse again from the collection root.",
-                    Refusal::UnknownTarget {
-                        parameter: "path",
-                        discover_with: "hifi_collections",
-                        detail: "Collection paths are short-lived opaque references. Call hifi_collections without path to start again.".to_string(),
-                    },
-                )
-            }
-        },
-    };
-    // This provider-neutral surface has a route vocabulary for every library
-    // adapter, but #492 implements the first adapter slice only. Resolve an
-    // opaque path first so a path minted for MA is never sent to another
-    // provider, even when that provider does not yet implement collections.
-    if !matches!(target, ZoneTarget::MusicAssistant) {
-        return env.failed("Collections are not implemented for this provider yet.");
+    let route = target.for_library();
+    if let LibraryRoute::Refused(_) = route {
+        return env.failed("This zone has no library path");
     }
+
+    // A `path`'s provider-boundary check runs before anything else,
+    // regardless of whether this zone's provider is wired to
+    // `hifi_collections` at all: a ref minted for one provider must never be
+    // treated as valid input for a different one, even a zone whose provider
+    // this tool cannot yet browse. Each provider handler below re-resolves
+    // the token itself to extract its specific shape; this pass only rules
+    // out "wrong provider" and "unknown token" up front.
+    if let Some(token) = args.path.as_deref() {
+        match state.mcp_refs.resolve(token).await {
+            Some(resolved) if resolved.provider() != target.provider() => {
+                return refuse_foreign_path(env);
+            }
+            None => return refuse_unknown_path(env),
+            Some(_) => {}
+        }
+    }
+
+    // Spotify and Apple Music already expose (some of) this surface through
+    // their own provider-specific tools (`hifi_spotify`, the Apple Music
+    // tools), which is why `hifi_capabilities` can report `supported` for
+    // them independent of this tool. Refusing here names that honestly
+    // instead of either lying "not implemented" for a capability the
+    // provider actually has, or silently trying an adapter operation this
+    // tool never taught it (`collections_browse` and friends) and surfacing
+    // whatever generic error falls out.
+    if matches!(route, LibraryRoute::Spotify | LibraryRoute::AppleMusic) {
+        let alternative = match route {
+            LibraryRoute::Spotify => "hifi_spotify",
+            _ => "the Apple Music companion tools",
+        };
+        return env.refused(
+            format!(
+                "hifi_collections does not reach {} zones yet; use {alternative} for this \
+                 provider's collections today.",
+                target.label()
+            ),
+            Refusal::NotImplemented {
+                operation: capability.name().to_string(),
+                tracked_by: "#531",
+                alternatives: vec![alternative.to_string()],
+                detail: format!(
+                    "{alternative} already exposes this provider's content operations; #531 \
+                     tracks adapting them behind the neutral hifi_collections contract."
+                ),
+            },
+        );
+    }
+
     if !matches!(support(target, capability), Support::Supported) {
         return env.failed(format!(
             "{} is not available for {} zones",
@@ -136,13 +177,56 @@ pub async fn handle_collections(
             target.label()
         ));
     }
+
     let limit = args.limit.unwrap_or(20).clamp(1, 50);
     let offset = args.offset.unwrap_or(0);
+
+    match route {
+        LibraryRoute::MusicAssistant => {
+            handle_music_assistant(state, env, &args, limit, offset).await
+        }
+        LibraryRoute::Lms => handle_lms(state, env, &args, limit, offset).await,
+        LibraryRoute::Roon => handle_roon(state, env, &args, limit, offset).await,
+        // Handled above; exhaustive so a new route fails to compile here
+        // rather than silently falling through.
+        LibraryRoute::Spotify | LibraryRoute::AppleMusic => env.failed(
+            "internal routing error: Spotify/Apple Music reached collections dispatch after \
+             being refused above. This is a UHC bug.",
+        ),
+        LibraryRoute::Refused(_) => env.failed(
+            "internal routing error: a refused zone reached collections dispatch. This is a \
+             UHC bug.",
+        ),
+    }
+}
+
+// =============================================================================
+// Music Assistant (#492): unchanged from before #531, minus the blanket gate.
+// =============================================================================
+
+async fn handle_music_assistant(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiCollectionsTool,
+    limit: u32,
+    offset: u32,
+) -> Result<CallToolResult, CallToolError> {
+    // Browse paths are server-side refs, just like playable media refs. MA's
+    // native `library://…` paths contain provider implementation details and
+    // must not become MCP client input.
+    let provider_path = match args.path.as_deref() {
+        None => None,
+        Some(token) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::MusicAssistantBrowse { path, .. }) => Some(path),
+            Some(_) => return refuse_foreign_path(env),
+            None => return refuse_unknown_path(env),
+        },
+    };
     let operation = format!("collections_{}", args.action);
     let response = match state
         .adapter_registry
         .library_content(
-            prefix,
+            "musicassistant",
             &operation,
             &json!({
                 "zone_id": args.zone_id,
@@ -177,8 +261,8 @@ pub async fn handle_collections(
             .get("subtitle")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
-        let path = match (target, item.get("path").and_then(Value::as_str)) {
-            (ZoneTarget::MusicAssistant, Some(path)) => Some(
+        let path = match item.get("path").and_then(Value::as_str) {
+            Some(path) => Some(
                 state
                     .mcp_refs
                     .mint(RefTarget::MusicAssistantBrowse {
@@ -187,14 +271,132 @@ pub async fn handle_collections(
                     })
                     .await,
             ),
-            _ => None,
+            None => None,
         };
-        let r#ref = match (target, item.get("uri").and_then(Value::as_str)) {
-            (ZoneTarget::MusicAssistant, Some(uri)) => Some(
+        let r#ref = match item.get("uri").and_then(Value::as_str) {
+            Some(uri) => Some(
                 state
                     .mcp_refs
                     .mint(RefTarget::MusicAssistant {
                         uri: uri.to_string(),
+                        title: title.clone(),
+                    })
+                    .await,
+            ),
+            None => None,
+        };
+        items.push(CollectionItem {
+            title,
+            subtitle,
+            path,
+            r#ref,
+        });
+    }
+    Ok(env.json_result(&CollectionPage { items, next_offset }))
+}
+
+// =============================================================================
+// LMS (#531): albums/artists/playlists/favorites over the CLI/jsonrpc the
+// adapter already speaks for search and playback.
+// =============================================================================
+
+async fn handle_lms(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiCollectionsTool,
+    limit: u32,
+    offset: u32,
+) -> Result<CallToolResult, CallToolError> {
+    // Same opaque-path split as Music Assistant: the plain collection path
+    // this adapter invents ("albums", "album:<id>", ...) never becomes
+    // client-visible; only the ref token is.
+    let provider_path = match args.path.as_deref() {
+        None => None,
+        Some(token) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::LmsBrowse { path, .. }) => Some(path),
+            Some(_) => return refuse_foreign_path(env),
+            None => return refuse_unknown_path(env),
+        },
+    };
+    let operation = format!("collections_{}", args.action);
+    let response = match state
+        .adapter_registry
+        .library_content(
+            "lms",
+            &operation,
+            &json!({
+                "path": provider_path,
+                "media_type": args.media_type,
+                "limit": limit,
+                "offset": offset,
+            }),
+        )
+        .await
+    {
+        Ok(value) => value,
+        Err(error) => return env.failed(format!("Collection error: {error}")),
+    };
+    let next_offset = response
+        .get("next_offset")
+        .and_then(Value::as_u64)
+        .map(|v| v as u32);
+    let mut items = Vec::new();
+    for item in response
+        .get("items")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("Untitled")
+            .to_string();
+        let subtitle = item
+            .get("subtitle")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        // A navigable row carries `path` (another collection to browse); a
+        // playable leaf carries either `kind`+`id` (a durable LMS entity --
+        // `LmsPlayTarget::Library`) or `url` (a favorite, which LMS gives no
+        // durable id for -- `LmsPlayTarget::Url`). At most one of the three
+        // is ever present on one row.
+        let path = match item.get("path").and_then(Value::as_str) {
+            Some(path) => Some(
+                state
+                    .mcp_refs
+                    .mint(RefTarget::LmsBrowse {
+                        path: path.to_string(),
+                        title: title.clone(),
+                    })
+                    .await,
+            ),
+            None => None,
+        };
+        let r#ref = match (
+            item.get("kind").and_then(Value::as_str),
+            item.get("id").and_then(Value::as_i64),
+            item.get("url").and_then(Value::as_str),
+        ) {
+            (Some("track"), Some(id), _) => Some(
+                state
+                    .mcp_refs
+                    .mint(RefTarget::Lms {
+                        target: crate::adapters::lms::LmsPlayTarget::Library {
+                            kind: crate::adapters::lms::LmsSearchResultType::Track,
+                            id,
+                        },
+                        title: title.clone(),
+                    })
+                    .await,
+            ),
+            (_, _, Some(url)) => Some(
+                state
+                    .mcp_refs
+                    .mint(RefTarget::Lms {
+                        target: crate::adapters::lms::LmsPlayTarget::Url {
+                            url: url.to_string(),
+                        },
                         title: title.clone(),
                     })
                     .await,
@@ -209,4 +411,168 @@ pub async fn handle_collections(
         });
     }
     Ok(env.json_result(&CollectionPage { items, next_offset }))
+}
+
+// =============================================================================
+// Roon (#531): the same browse/load session machinery `hifi_search` already
+// drives (src/adapters/roon.rs), exposed as hierarchy walking.
+// =============================================================================
+
+async fn handle_roon(
+    state: &AppState,
+    env: Envelope,
+    args: &HifiCollectionsTool,
+    limit: u32,
+    offset: u32,
+) -> Result<CallToolResult, CallToolError> {
+    // Roon's continuation is a (item_key, multi_session_key) pair, not a flat
+    // string -- resuming it must re-enter that exact session (same reasoning
+    // as a playable Roon ref; see `RoonRefTarget`'s docs).
+    let resume = match args.path.as_deref() {
+        None => None,
+        Some(token) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::RoonBrowse { target, .. }) => Some(target),
+            Some(_) => return refuse_foreign_path(env),
+            None => return refuse_unknown_path(env),
+        },
+    };
+
+    let mut params = json!({
+        "zone_id": args.zone_id,
+        "limit": limit,
+        "offset": offset,
+    });
+    if let Some(RoonRefTarget {
+        item_key,
+        multi_session_key,
+    }) = &resume
+    {
+        params["item_key"] = json!(item_key);
+        params["session_key"] = json!(multi_session_key);
+    }
+    // Roon has no separate playlists/favorites protocol feature: both arrive
+    // as named nodes in the same browse hierarchy (see the capability
+    // table's note on this). `favorites` never reaches here -- `support()`
+    // reports it `not_implemented` for Roon and the shared check above
+    // already refused it.
+    let operation = match args.action.as_str() {
+        "browse" => "collections_browse",
+        "playlists" => "collections_playlists",
+        other => {
+            return env.failed(format!(
+                "internal routing error: unexpected hifi_collections action {other:?} reached \
+                 Roon dispatch after the capability check. This is a UHC bug."
+            ))
+        }
+    };
+    let response = match state
+        .adapter_registry
+        .library_content("roon", operation, &params)
+        .await
+    {
+        Ok(value) => value,
+        Err(error) => return env.failed(format!("Collection error: {error}")),
+    };
+
+    let Some(session_key) = response.get("session_key").and_then(Value::as_str) else {
+        return env.failed("Collection error: Roon adapter returned no session_key");
+    };
+    // `RoonAdapter::content` already dropped grouping rows (headers,
+    // result-count rows) -- see that method's docs -- so every row here is
+    // either navigable (`List` hint) or playable, and this loop only mints
+    // the ref that matches which.
+    let mut items = Vec::new();
+    for item in response
+        .get("items")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("Untitled")
+            .to_string();
+        let subtitle = item
+            .get("subtitle")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let item_key = item.get("item_key").and_then(Value::as_str);
+        let navigable = item.get("navigable").and_then(Value::as_bool).unwrap_or(false);
+        let (path, r#ref) = match item_key {
+            None => (None, None),
+            Some(item_key) => {
+                let target = RoonRefTarget {
+                    item_key: item_key.to_string(),
+                    multi_session_key: session_key.to_string(),
+                };
+                if navigable {
+                    (
+                        Some(
+                            state
+                                .mcp_refs
+                                .mint(RefTarget::RoonBrowse {
+                                    target,
+                                    title: title.clone(),
+                                })
+                                .await,
+                        ),
+                        None,
+                    )
+                } else {
+                    (
+                        None,
+                        Some(
+                            state
+                                .mcp_refs
+                                .mint(RefTarget::Roon {
+                                    target,
+                                    title: title.clone(),
+                                })
+                                .await,
+                        ),
+                    )
+                }
+            }
+        };
+        items.push(CollectionItem {
+            title,
+            subtitle,
+            path,
+            r#ref,
+        });
+    }
+    let next_offset = response
+        .get("next_offset")
+        .and_then(Value::as_u64)
+        .map(|v| v as u32);
+    Ok(env.json_result(&CollectionPage { items, next_offset }))
+}
+
+// =============================================================================
+// Shared refusals
+// =============================================================================
+
+fn refuse_foreign_path(env: Envelope) -> Result<CallToolResult, CallToolError> {
+    env.refused(
+        "path does not name a collection for this zone.",
+        Refusal::invalid_parameter(
+            "path",
+            &["a path returned by hifi_collections for this zone"],
+            "Browse again from this zone and use that result's path.",
+        ),
+    )
+}
+
+fn refuse_unknown_path(env: Envelope) -> Result<CallToolResult, CallToolError> {
+    env.refused(
+        "path is unknown or expired. Browse again from the collection root.",
+        Refusal::UnknownTarget {
+            parameter: "path",
+            discover_with: "hifi_collections",
+            detail: "Collection paths are short-lived opaque references. Call hifi_collections \
+                      without path to start again."
+                .to_string(),
+        },
+    )
 }

--- a/src/mcp/tools/groups.rs
+++ b/src/mcp/tools/groups.rs
@@ -1,24 +1,125 @@
+//! `hifi_zone_group`: multiroom grouping, generalized across every adapter that
+//! implements the `multiroom_status` / `multiroom_set_members` /
+//! `multiroom_ungroup` contract (issue #517).
+//!
+//! # Three providers, one contract
+//!
+//! Music Assistant, Roon (#509/#515) and LMS (#510/#513) each implement the
+//! same three-operation content-library contract
+//! (`src/adapters/{musicassistant,roon,lms}.rs`, `impl LibraryAdapter for
+//! ...::content`). This module owns the provider-neutral routing that used to
+//! be hardwired to Music Assistant alone: `join`/`leave` resolve the owning
+//! adapter from the zone id's prefix via [`ZoneTarget`], exactly like every
+//! other MCP tool.
+//!
+//! # The `status` design decision
+//!
+//! Before #517, `status` took no zone id at all, which implicitly assumed a
+//! single grouping-capable provider. With three, that question has two honest
+//! answers and this tool supports both explicitly rather than picking one at
+//! the cost of the other:
+//!
+//! - **`zone_id` present**: scoped to that zone's provider, exactly like every
+//!   other zone-scoped tool infers its provider. Refused if the zone's prefix
+//!   names no multiroom-capable provider.
+//! - **`zone_id` absent**: aggregate every provider's groups into one
+//!   `groups` list, each entry tagged with its `provider`. A provider whose
+//!   call fails (not configured, not connected, ...) is reported in `errors`
+//!   rather than failing the whole read — one backend being unreachable must
+//!   not hide the other two's groups. `errors` is omitted entirely when every
+//!   provider answered.
+//!
+//! Aggregation is the default (no `zone_id`) because `status` is the one
+//! read-only action here and a client asking "what is grouped right now"
+//! almost always means "everywhere", not "guess which provider I meant". The
+//! explicit `zone_id` form exists for a client that already knows which
+//! provider it cares about and does not want to pay for the other two calls
+//! (or parse `errors` for a provider it does not use).
+//!
+//! # Two member-id conventions, tolerated not normalized
+//!
+//! `multiroom_status`'s `member_zone_ids` mean different things per adapter,
+//! and this tool passes them through verbatim rather than pretending they
+//! agree:
+//!
+//! - **Roon** merges outputs into one zone on grouping and retires the
+//!   member zones' own ids, so a member is reported (and must be addressed
+//!   again) as `roon:<output_id>`, not a zone id `hifi_zones` ever listed
+//!   independently once grouped.
+//! - **LMS** sync groups are leaderless — Squeezebox sync has no
+//!   server-side concept of "leader" — so `leader_zone_id` in an LMS group is
+//!   a stable-but-arbitrary UHC convention (the first id LMS's `syncgroups ?`
+//!   reports for that group), not an LMS fact.
+//!
+//! Both are documented on the tool description below so a client does not
+//! read either as a UHC bug.
+//!
+//! # Cross-provider grouping is refused, not attempted
+//!
+//! `join` and `leave` require every zone id involved (leader plus every
+//! member) to classify to the *same* multiroom-capable provider. Mixing
+//! providers is refused as an invalid parameter before any adapter is
+//! called — there is no protocol that groups a Roon output with an LMS
+//! player, so attempting it would only surface as a confusing adapter-side
+//! failure instead of a clear client-side one.
+
 use crate::api::AppState;
-use crate::mcp::envelope::{Envelope, Refusal};
+use crate::mcp::envelope::{Envelope, Refusal, Scope};
 use crate::mcp::routing::ZoneTarget;
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     schema::{schema_utils::CallToolError, CallToolResult},
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Every [`ZoneTarget`] that implements the multiroom contract, in the order
+/// `status`'s aggregate reports them.
+const MULTIROOM_TARGETS: &[ZoneTarget] = &[
+    ZoneTarget::Roon,
+    ZoneTarget::Lms,
+    ZoneTarget::MusicAssistant,
+];
+
+/// The accepted zone-id prefixes, for refusals that must say what a valid
+/// input looks like.
+const MULTIROOM_PREFIXES: &[&str] = &["roon:", "lms:", "musicassistant:"];
+
+/// Classify `zone_id` and accept it only if its provider implements the
+/// multiroom contract.
+fn multiroom_target(zone_id: &str) -> Option<ZoneTarget> {
+    let target = ZoneTarget::classify(zone_id);
+    MULTIROOM_TARGETS.contains(&target).then_some(target)
+}
 
 #[mcp_tool(
     name = "hifi_zone_group",
-    description = "Inspect or change Music Assistant zone groups. action=status is read-only. join and leave require confirm=true because grouping changes playback topology."
+    description = "Inspect or change multiroom zone groups for any provider that supports \
+                    synchronised playback (Roon, LMS, Music Assistant). action=status is \
+                    read-only: pass zone_id to scope it to one provider, or omit zone_id to \
+                    aggregate every provider's groups (a provider that cannot be reached is \
+                    reported in `errors` rather than failing the whole read). join and leave \
+                    require confirm=true because grouping changes playback topology, and every \
+                    zone id involved (leader plus every member) must belong to the same \
+                    provider -- cross-provider groups are refused. Two provider-specific member \
+                    conventions: Roon retires a grouped zone's own id and reports/accepts its \
+                    members as roon:<output_id>; LMS sync groups are leaderless, so \
+                    leader_zone_id there is UHC's stable-but-arbitrary pick of the first member \
+                    id, not an LMS fact."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiZoneGroupTool {
     /// status, join, or leave.
     pub action: String,
-    /// Music Assistant leader zone for join.
+    /// Scopes action=status to one provider. Omit to aggregate every
+    /// multiroom-capable provider's groups.
+    #[serde(default)]
+    pub zone_id: Option<String>,
+    /// Leader zone for join. Must be the same provider as every member_zone_id.
     #[serde(default)]
     pub leader_zone_id: Option<String>,
-    /// Music Assistant member zones to add or leave.
+    /// Member zones to add (join) or remove (leave). Must all share one
+    /// provider, matching leader_zone_id for join.
     #[serde(default)]
     pub member_zone_ids: Option<Vec<String>>,
     /// Required true for topology-changing join and leave actions.
@@ -52,59 +153,219 @@ pub async fn handle_zone_group(
             "join and leave require at least one member_zone_id.",
             Refusal::invalid_parameter(
                 "member_zone_ids",
-                &["musicassistant:<player>"],
-                "Specify one or more Music Assistant zones to change.",
+                MULTIROOM_PREFIXES,
+                "Specify one or more zones to change, all from the same provider.",
             ),
         );
     }
-    let operation = match args.action.as_str() {
-        "status" => "multiroom_status",
-        "join" => "multiroom_set_members",
-        "leave" => "multiroom_ungroup",
-        _ => {
+    match args.action.as_str() {
+        "status" => handle_status(state, env, args.zone_id).await,
+        "join" => handle_join(state, env, args.leader_zone_id, member_zone_ids).await,
+        "leave" => handle_leave(state, env, member_zone_ids).await,
+        _ => env.refused(
+            "Unknown zone group action.",
+            Refusal::invalid_parameter(
+                "action",
+                &["status", "join", "leave"],
+                "Choose a documented zone group action.",
+            ),
+        ),
+    }
+}
+
+async fn handle_join(
+    state: &AppState,
+    env: Envelope,
+    leader_zone_id: Option<String>,
+    member_zone_ids: Vec<String>,
+) -> Result<CallToolResult, CallToolError> {
+    let leader_zone_id = match leader_zone_id.filter(|id| !id.is_empty()) {
+        Some(id) => id,
+        None => {
             return env.refused(
-                "Unknown zone group action.",
+                "join requires a leader_zone_id.",
                 Refusal::invalid_parameter(
-                    "action",
-                    &["status", "join", "leave"],
-                    "Choose a documented zone group action.",
+                    "leader_zone_id",
+                    MULTIROOM_PREFIXES,
+                    "Groups are addressed by the leader's zone id.",
                 ),
             )
         }
     };
-    if args.action == "join"
-        && args.leader_zone_id.as_deref().map(ZoneTarget::classify)
-            != Some(ZoneTarget::MusicAssistant)
-    {
-        return env.refused(
-            "join requires a musicassistant: leader_zone_id.",
-            Refusal::invalid_parameter(
-                "leader_zone_id",
-                &["musicassistant:<player>"],
-                "Groups are owned by Music Assistant.",
+    let leader_target =
+        match multiroom_target(&leader_zone_id) {
+            Some(target) => target,
+            None => return env.refused(
+                "join requires a leader_zone_id from a provider that supports multiroom \
+                 grouping.",
+                Refusal::invalid_parameter(
+                    "leader_zone_id",
+                    MULTIROOM_PREFIXES,
+                    "Groups are owned by Roon, LMS or Music Assistant; other zone types cannot \
+                     lead a group.",
+                ),
             ),
-        );
-    }
+        };
     if member_zone_ids
         .iter()
-        .any(|id| ZoneTarget::classify(id) != ZoneTarget::MusicAssistant)
+        .any(|id| ZoneTarget::classify(id) != leader_target)
     {
         return env.refused(
-            "Every member_zone_id must be a Music Assistant zone.",
+            format!(
+                "Every member_zone_id must be a {} zone, matching the leader.",
+                leader_target.label()
+            ),
             Refusal::invalid_parameter(
                 "member_zone_ids",
-                &["musicassistant:<player>"],
+                &[leader_target.prefix().unwrap_or_default()],
                 "Cross-provider zone groups are not supported.",
             ),
         );
     }
-    let params = serde_json::json!({"leader_zone_id": args.leader_zone_id, "member_zone_ids": member_zone_ids});
+    let params =
+        serde_json::json!({"leader_zone_id": leader_zone_id, "member_zone_ids": member_zone_ids});
     match state
         .adapter_registry
-        .library_content("musicassistant", operation, &params)
+        .library_content(leader_target.label(), "multiroom_set_members", &params)
         .await
     {
-        Ok(value) => Ok(env.json_result(&value)),
+        Ok(value) => Ok(env
+            .scope(Scope::provider_only(leader_target.provider()))
+            .json_result(&value)),
         Err(error) => env.failed(format!("Zone group error: {error}")),
+    }
+}
+
+async fn handle_leave(
+    state: &AppState,
+    env: Envelope,
+    member_zone_ids: Vec<String>,
+) -> Result<CallToolResult, CallToolError> {
+    let first_target =
+        match member_zone_ids.first().and_then(|id| multiroom_target(id)) {
+            Some(target) => target,
+            None => return env.refused(
+                "leave requires member_zone_ids from a provider that supports multiroom \
+                 grouping.",
+                Refusal::invalid_parameter(
+                    "member_zone_ids",
+                    MULTIROOM_PREFIXES,
+                    "Groups are owned by Roon, LMS or Music Assistant; other zone types cannot \
+                     be group members.",
+                ),
+            ),
+        };
+    if member_zone_ids
+        .iter()
+        .any(|id| ZoneTarget::classify(id) != first_target)
+    {
+        return env.refused(
+            format!(
+                "Every member_zone_id must be a {} zone.",
+                first_target.label()
+            ),
+            Refusal::invalid_parameter(
+                "member_zone_ids",
+                &[first_target.prefix().unwrap_or_default()],
+                "Cross-provider zone groups are not supported.",
+            ),
+        );
+    }
+    let params = serde_json::json!({"member_zone_ids": member_zone_ids});
+    match state
+        .adapter_registry
+        .library_content(first_target.label(), "multiroom_ungroup", &params)
+        .await
+    {
+        Ok(value) => Ok(env
+            .scope(Scope::provider_only(first_target.provider()))
+            .json_result(&value)),
+        Err(error) => env.failed(format!("Zone group error: {error}")),
+    }
+}
+
+/// One provider's `multiroom_status` call failing during aggregation. Reported
+/// alongside the groups every other provider did answer, rather than failing
+/// the whole read for one unreachable backend.
+#[derive(Debug, Serialize)]
+struct ProviderError {
+    provider: &'static str,
+    detail: String,
+}
+
+/// The aggregate payload for `status` with no `zone_id`: every reachable
+/// provider's groups, each tagged with `provider`, plus the providers that
+/// could not be reached.
+#[derive(Debug, Serialize)]
+struct AggregateMultiroomStatus {
+    groups: Vec<Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    errors: Vec<ProviderError>,
+}
+
+async fn handle_status(
+    state: &AppState,
+    env: Envelope,
+    zone_id: Option<String>,
+) -> Result<CallToolResult, CallToolError> {
+    match zone_id.filter(|id| !id.is_empty()) {
+        Some(zone_id) => {
+            let target = match multiroom_target(&zone_id) {
+                Some(target) => target,
+                None => {
+                    return env.refused(
+                        "zone_id must be from a provider that supports multiroom grouping.",
+                        Refusal::invalid_parameter(
+                            "zone_id",
+                            MULTIROOM_PREFIXES,
+                            "Only Roon, LMS and Music Assistant zones report multiroom status.",
+                        ),
+                    )
+                }
+            };
+            match state
+                .adapter_registry
+                .library_content(target.label(), "multiroom_status", &serde_json::json!({}))
+                .await
+            {
+                Ok(value) => Ok(env
+                    .scope(Scope::provider_only(target.provider()))
+                    .json_result(&value)),
+                Err(error) => env.failed(format!("Zone group error: {error}")),
+            }
+        }
+        None => {
+            let mut groups = Vec::new();
+            let mut errors = Vec::new();
+            for target in MULTIROOM_TARGETS {
+                match state
+                    .adapter_registry
+                    .library_content(target.label(), "multiroom_status", &serde_json::json!({}))
+                    .await
+                {
+                    Ok(value) => {
+                        let provider_groups = value
+                            .get("groups")
+                            .and_then(Value::as_array)
+                            .cloned()
+                            .unwrap_or_default();
+                        for mut group in provider_groups {
+                            if let Value::Object(map) = &mut group {
+                                map.insert(
+                                    "provider".to_string(),
+                                    Value::String(target.label().to_string()),
+                                );
+                            }
+                            groups.push(group);
+                        }
+                    }
+                    Err(error) => errors.push(ProviderError {
+                        provider: target.label(),
+                        detail: error.to_string(),
+                    }),
+                }
+            }
+            Ok(env.json_result(&AggregateMultiroomStatus { groups, errors }))
+        }
     }
 }

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -953,7 +953,9 @@ pub async fn handle_play_ref(
         (LibraryRoute::MusicAssistant, RefTarget::MusicAssistant { uri, title }) => {
             play_ref_music_assistant(state, env, &args, uri, title).await
         }
-        (LibraryRoute::MusicAssistant, RefTarget::MusicAssistantBrowse { .. }) => env.refused(
+        (LibraryRoute::MusicAssistant, RefTarget::MusicAssistantBrowse { .. })
+        | (LibraryRoute::Lms, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::Roon, RefTarget::RoonBrowse { .. }) => env.refused(
             "this ref names a browsable collection, not playable media.",
             Refusal::InvalidParameter {
                 parameter: "ref",
@@ -991,7 +993,15 @@ pub async fn handle_play_ref(
         | (LibraryRoute::MusicAssistant, RefTarget::Roon { .. })
         | (LibraryRoute::MusicAssistant, RefTarget::Lms { .. })
         | (LibraryRoute::MusicAssistant, RefTarget::Spotify { .. })
-        | (LibraryRoute::MusicAssistant, RefTarget::AppleMusic { .. }) => env.failed(
+        | (LibraryRoute::MusicAssistant, RefTarget::AppleMusic { .. })
+        | (LibraryRoute::Roon, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::Spotify, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::AppleMusic, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::MusicAssistant, RefTarget::LmsBrowse { .. })
+        | (LibraryRoute::Lms, RefTarget::RoonBrowse { .. })
+        | (LibraryRoute::Spotify, RefTarget::RoonBrowse { .. })
+        | (LibraryRoute::AppleMusic, RefTarget::RoonBrowse { .. })
+        | (LibraryRoute::MusicAssistant, RefTarget::RoonBrowse { .. }) => env.failed(
             "internal routing error: ref/zone provider mismatch reached dispatch after the \
                  capability check. This is a UHC bug.",
         ),

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -134,7 +134,13 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_play_ref" => &["ref", "zone_id", "action"],
         "hifi_queue" => &["zone_id", "action", "item_id", "position"],
         "hifi_collections" => &["zone_id", "action", "path", "media_type", "limit", "offset"],
-        "hifi_zone_group" => &["action", "leader_zone_id", "member_zone_ids", "confirm"],
+        "hifi_zone_group" => &[
+            "action",
+            "zone_id",
+            "leader_zone_id",
+            "member_zone_ids",
+            "confirm",
+        ],
         "hifi_spotify" => &[
             "action",
             "playlist_id",

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -132,7 +132,7 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_search" => &["query", "zone_id", "source"],
         "hifi_play" => &["query", "zone_id", "source", "action"],
         "hifi_play_ref" => &["ref", "zone_id", "action"],
-        "hifi_queue" => &["zone_id", "action", "item_id", "position"],
+        "hifi_queue" => &["zone_id", "action", "item_id", "position", "target_zone_id"],
         "hifi_collections" => &["zone_id", "action", "path", "media_type", "limit", "offset"],
         "hifi_zone_group" => &["action", "leader_zone_id", "member_zone_ids", "confirm"],
         "hifi_spotify" => &[

--- a/src/mcp/tools/queue.rs
+++ b/src/mcp/tools/queue.rs
@@ -12,13 +12,13 @@ use serde::{Deserialize, Serialize};
 
 #[mcp_tool(
     name = "hifi_queue",
-    description = "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, and clear against its active queue; each mutation returns a fresh queue readback. Queue add is hifi_play action='queue'."
+    description = "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, clear, and transfer against its active queue; each mutation returns a fresh queue readback. transfer moves the active queue from zone_id to target_zone_id (both must be Music Assistant zones). Queue add is hifi_play action='queue'."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiQueueTool {
     /// Zone ID from hifi_zones.
     pub zone_id: String,
-    /// read (default), jump, reorder, remove, or clear.
+    /// read (default), jump, reorder, remove, clear, or transfer.
     #[serde(default = "default_action")]
     pub action: String,
     /// Queue item id for jump, reorder, or remove.
@@ -27,6 +27,9 @@ pub struct HifiQueueTool {
     /// Target zero-based position for reorder.
     #[serde(default)]
     pub position: Option<i64>,
+    /// Destination zone ID for transfer. Must belong to the same provider as zone_id.
+    #[serde(default)]
+    pub target_zone_id: Option<String>,
 }
 
 fn default_action() -> String {
@@ -44,18 +47,19 @@ pub async fn handle_queue(
         "reorder" => "queue_reorder",
         "remove" => "queue_remove",
         "clear" => "queue_clear",
+        "transfer" => "queue_transfer",
         _ => {
             return Envelope::write("hifi_queue", "queue").refused(
                 "Unknown queue action.",
                 crate::mcp::envelope::Refusal::invalid_parameter(
                     "action",
-                    &["read", "jump", "reorder", "remove", "clear"],
+                    &["read", "jump", "reorder", "remove", "clear", "transfer"],
                     "Choose a documented queue action.",
                 ),
             )
         }
     };
-    let env = if operation == "queue_read" {
+    let mut env = if operation == "queue_read" {
         Envelope::read("hifi_queue", operation)
     } else {
         Envelope::write("hifi_queue", operation)
@@ -63,11 +67,15 @@ pub async fn handle_queue(
     .param("zone_id", &*args.zone_id)
     .param("action", &*args.action)
     .scope(Scope::for_zone(state, &args.zone_id, target.provider()).await);
+    if let Some(target_zone_id) = args.target_zone_id.as_deref() {
+        env = env.param("target_zone_id", target_zone_id);
+    }
     let capability = match operation {
         "queue_read" => Capability::QueueRead,
         "queue_jump" => Capability::QueueJump,
         "queue_reorder" => Capability::QueueReorder,
         "queue_remove" => Capability::QueueRemove,
+        "queue_transfer" => Capability::QueueTransfer,
         _ => Capability::QueueClear,
     };
     if !matches!(support(target, capability), Support::Supported) {
@@ -75,6 +83,46 @@ pub async fn handle_queue(
             "Queue read is not available for {} zones",
             target.label()
         ));
+    }
+    if operation == "queue_transfer" {
+        let target_zone_id = match args.target_zone_id.as_deref() {
+            Some(id) if !id.trim().is_empty() => id,
+            _ => {
+                return env.refused(
+                    "transfer requires target_zone_id.",
+                    crate::mcp::envelope::Refusal::invalid_parameter(
+                        "target_zone_id",
+                        &["a zone_id from hifi_zones"],
+                        "Provide the destination zone's zone_id.",
+                    ),
+                )
+            }
+        };
+        let target_target = ZoneTarget::classify(target_zone_id);
+        if !matches!(target.for_library(), LibraryRoute::MusicAssistant)
+            || !matches!(target_target.for_library(), LibraryRoute::MusicAssistant)
+        {
+            return env.refused(
+                "transfer requires both zones to be Music Assistant zones.",
+                crate::mcp::envelope::Refusal::invalid_parameter(
+                    "target_zone_id",
+                    &["a Music Assistant zone_id from hifi_zones"],
+                    "Queue transfer is only implemented between two Music Assistant zones.",
+                ),
+            );
+        }
+        return match state
+            .adapter_registry
+            .library_content(
+                "musicassistant",
+                operation,
+                &serde_json::json!({"zone_id": args.zone_id, "target_zone_id": target_zone_id}),
+            )
+            .await
+        {
+            Ok(value) => Ok(env.json_result(&value)),
+            Err(e) => env.failed(format!("Queue error: {e}")),
+        };
     }
     match target.for_library() {
         LibraryRoute::Spotify => match state

--- a/tests/adapter_integration.rs
+++ b/tests/adapter_integration.rs
@@ -780,4 +780,186 @@ mod mock_server_tests {
         adapter.stop().await;
         mock.stop().await;
     }
+
+    // -------------------------------------------------------------------------
+    // LMS sync groups (#510): multiroom_status / set_group_members /
+    // ungroup_members over the mock server's `sync` / `syncgroups ?` support.
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_status_reports_no_groups_before_syncing() {
+        let mock = MockLmsServer::start().await;
+        mock.add_player("aa:bb:cc:dd:ee:ff", "Living Room").await;
+        mock.add_player("11:22:33:44:55:66", "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+
+        let status = adapter.multiroom_status().await.unwrap();
+        assert_eq!(
+            status["groups"].as_array().unwrap().len(),
+            0,
+            "no players are synced yet"
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_set_members_syncs_member_into_leaders_group() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        let member = "11:22:33:44:55:66";
+        mock.add_player(leader, "Living Room").await;
+        mock.add_player(member, "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+        mock.clear_commands().await;
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let member_zone = PrefixedZoneId::lms(member).to_string();
+        let result = adapter
+            .set_group_members(&leader_zone, &[member_zone.clone()], &[])
+            .await
+            .expect("set_group_members should succeed");
+
+        let groups = result["groups"].as_array().expect("groups array");
+        assert_eq!(groups.len(), 1, "one group after syncing one member");
+        assert_eq!(groups[0]["leader_zone_id"], serde_json::json!(leader_zone));
+        assert_eq!(groups[0]["member_zone_ids"], serde_json::json!([member_zone]));
+        assert_eq!(groups[0]["can_set_members"], serde_json::json!(true));
+
+        // The leader is addressed, the member is the argument -- verified live
+        // (#403) to make the *addressed* player the sync master and keep its
+        // queue, which is why the leader (not the member) issues the command.
+        let leader_commands = mock.write_commands(leader).await;
+        assert!(
+            leader_commands.contains(&vec!["sync".to_string(), member.to_string()]),
+            "expected `sync {member}` addressed to the leader, got {leader_commands:?}"
+        );
+
+        assert_eq!(
+            mock.sync_groups().await,
+            vec![vec![leader.to_string(), member.to_string()]]
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_ungroup_unsyncs_member() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        let member = "11:22:33:44:55:66";
+        mock.add_player(leader, "Living Room").await;
+        mock.add_player(member, "Kitchen").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let member_zone = PrefixedZoneId::lms(member).to_string();
+        adapter
+            .set_group_members(&leader_zone, &[member_zone.clone()], &[])
+            .await
+            .expect("initial sync should succeed");
+        mock.clear_commands().await;
+
+        let result = adapter
+            .ungroup_members(&[member_zone])
+            .await
+            .expect("ungroup_members should succeed");
+        assert_eq!(
+            result["groups"].as_array().unwrap().len(),
+            0,
+            "the group dissolves once its only member leaves"
+        );
+
+        let member_commands = mock.write_commands(member).await;
+        assert_eq!(
+            member_commands,
+            vec![vec!["sync".to_string(), "-".to_string()]],
+            "the member is addressed directly to unsync itself"
+        );
+
+        assert!(
+            mock.sync_groups().await.is_empty(),
+            "server-side group state must also be gone"
+        );
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(lms_config)]
+    async fn lms_multiroom_set_members_rejects_unknown_player_before_any_sync_call() {
+        let mock = MockLmsServer::start().await;
+        let leader = "aa:bb:cc:dd:ee:ff";
+        mock.add_player(leader, "Living Room").await;
+
+        let (bus, _rx) = test_bus();
+        let adapter = LmsAdapter::new(bus);
+        adapter
+            .configure(
+                mock.addr().ip().to_string(),
+                Some(mock.addr().port()),
+                None,
+                None,
+            )
+            .await;
+        adapter.start().await.unwrap();
+        mock.clear_commands().await;
+
+        let leader_zone = PrefixedZoneId::lms(leader).to_string();
+        let unknown_zone = PrefixedZoneId::lms("00:00:00:00:00:00").to_string();
+        let result = adapter
+            .set_group_members(&leader_zone, &[unknown_zone], &[])
+            .await;
+        assert!(
+            result.is_err(),
+            "an unknown member must be refused, not synced"
+        );
+        assert!(
+            mock.write_commands(leader).await.is_empty(),
+            "no sync command should reach LMS once validation fails"
+        );
+        assert!(mock.sync_groups().await.is_empty());
+
+        adapter.stop().await;
+        mock.stop().await;
+    }
 }

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -76,9 +76,12 @@ POST /api/bridges/applemusic/remove
 POST /api/bridges/applemusic/rename
 POST /api/bridges/applemusic/revoke
 POST /api/bridges/applemusic/state
+POST /api/collections
 POST /api/controller/bootstrap
+POST /api/play_ref
 POST /api/providers/{provider}/configure
 POST /api/providers/{provider}/oauth/revoke
+POST /api/queue
 POST /api/settings
 POST /control
 POST /hqp/detect

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -335,11 +335,11 @@
     }
   },
   "hifi_queue": {
-    "description": "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, and clear against its active queue; each mutation returns a fresh queue readback. Queue add is hifi_play action='queue'.",
+    "description": "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, clear, and transfer against its active queue; each mutation returns a fresh queue readback. transfer moves the active queue from zone_id to target_zone_id (both must be Music Assistant zones). Queue add is hifi_play action='queue'.",
     "inputSchema": {
       "properties": {
         "action": {
-          "description": "read (default), jump, reorder, remove, or clear.",
+          "description": "read (default), jump, reorder, remove, clear, or transfer.",
           "type": "string"
         },
         "item_id": {
@@ -351,6 +351,11 @@
           "description": "Target zero-based position for reorder.",
           "nullable": true,
           "type": "integer"
+        },
+        "target_zone_id": {
+          "description": "Destination zone ID for transfer. Must belong to the same provider as zone_id.",
+          "nullable": true,
+          "type": "string"
         },
         "zone_id": {
           "description": "Zone ID from hifi_zones.",

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -114,7 +114,7 @@
     }
   },
   "hifi_collections": {
-    "description": "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection.",
+    "description": "Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection. Implemented for lms and roon zones; Music Assistant zones (see hifi_queue's provider notes); Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one.",
     "inputSchema": {
       "properties": {
         "action": {

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -458,7 +458,7 @@
     }
   },
   "hifi_zone_group": {
-    "description": "Inspect or change Music Assistant zone groups. action=status is read-only. join and leave require confirm=true because grouping changes playback topology.",
+    "description": "Inspect or change multiroom zone groups for any provider that supports synchronised playback (Roon, LMS, Music Assistant). action=status is read-only: pass zone_id to scope it to one provider, or omit zone_id to aggregate every provider's groups (a provider that cannot be reached is reported in `errors` rather than failing the whole read). join and leave require confirm=true because grouping changes playback topology, and every zone id involved (leader plus every member) must belong to the same provider -- cross-provider groups are refused. Two provider-specific member conventions: Roon retires a grouped zone's own id and reports/accepts its members as roon:<output_id>; LMS sync groups are leaderless, so leader_zone_id there is UHC's stable-but-arbitrary pick of the first member id, not an LMS fact.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -471,17 +471,22 @@
           "type": "boolean"
         },
         "leader_zone_id": {
-          "description": "Music Assistant leader zone for join.",
+          "description": "Leader zone for join. Must be the same provider as every member_zone_id.",
           "nullable": true,
           "type": "string"
         },
         "member_zone_ids": {
-          "description": "Music Assistant member zones to add or leave.",
+          "description": "Member zones to add (join) or remove (leave). Must all share one\nprovider, matching leader_zone_id for join.",
           "items": {
             "type": "string"
           },
           "nullable": true,
           "type": "array"
+        },
+        "zone_id": {
+          "description": "Scopes action=status to one provider. Omit to aggregate every\nmultiroom-capable provider's groups.",
+          "nullable": true,
+          "type": "string"
         }
       },
       "required": [

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -800,6 +800,7 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
             ("action", true),
             ("item_id", false),
             ("position", false),
+            ("target_zone_id", false),
         ],
     ),
     (
@@ -1805,7 +1806,8 @@ async fn musicassistant_mcp_handler(
         | Some("player_queues/play_index")
         | Some("player_queues/move_item")
         | Some("player_queues/delete_item")
-        | Some("player_queues/clear") => json!({"ok": true}),
+        | Some("player_queues/clear")
+        | Some("player_queues/transfer") => json!({"ok": true}),
         Some("players/cmd/set_members") | Some("players/cmd/ungroup_many") => json!({"ok": true}),
         command => panic!("unexpected Music Assistant command: {command:?}"),
     };
@@ -2021,6 +2023,7 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
         json!({"zone_id": zone_id, "action": "reorder", "item_id": "q2", "position": 0}),
         json!({"zone_id": zone_id, "action": "remove", "item_id": "q2"}),
         json!({"zone_id": zone_id, "action": "clear"}),
+        json!({"zone_id": zone_id, "action": "transfer", "target_zone_id": "musicassistant:group-child-2"}),
     ] {
         assert_eq!(
             app.call_tool("hifi_queue", args).await["structuredContent"]["outcome"],
@@ -2034,7 +2037,8 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
             "player_queues/play_index"
             | "player_queues/move_item"
             | "player_queues/delete_item"
-            | "player_queues/clear" => Some((
+            | "player_queues/clear"
+            | "player_queues/transfer" => Some((
                 request["command"].as_str().unwrap(),
                 request["args"].clone(),
             )),
@@ -2059,6 +2063,10 @@ async fn musicassistant_queue_mutations_use_documented_wire_commands() {
             (
                 "player_queues/clear",
                 json!({"queue_id":"living-room-group"})
+            ),
+            (
+                "player_queues/transfer",
+                json!({"source_queue_id":"living-room-group", "target_queue_id":"living-room-group"})
             ),
         ]
     );
@@ -4831,6 +4839,7 @@ const EXPECTED_CAPABILITIES: &[&str] = &[
     "queue_reorder",
     "queue_remove",
     "queue_clear",
+    "queue_transfer",
     "play_next",
     "repeat_mode",
     "shuffle_mode",
@@ -5227,6 +5236,14 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 "hifi_queue",
                 json!({ "zone_id": zone_id, "action": "clear" }),
             )),
+            "queue_transfer" => Some((
+                "hifi_queue",
+                json!({
+                    "zone_id": zone_id,
+                    "action": "transfer",
+                    "target_zone_id": format!("{provider}:xyz"),
+                }),
+            )),
             "repeat_mode" => Some((
                 "hifi_control",
                 json!({ "zone_id": zone_id, "action": "repeat_off" }),
@@ -5279,15 +5296,16 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     }
     // The routed Spotify content and mode cells plus Music Assistant's queue
     // mutations, mode, collections, and zone-group cells add twenty-three probes to the
-    // original provider transport set.
+    // original provider transport set, plus one more for Music Assistant's
+    // queue_transfer (#507).
     // Apple Music's transport/skip/volume
     // cells remain gated until signed physical companion validation (#465).
     // Asserted exactly, not as a floor: a floor would pass while a cell silently
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 45,
-        "{proved} supported cells were proved end to end, expected 45. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 46,
+        "{proved} supported cells were proved end to end, expected 46. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -228,7 +228,7 @@ async fn build_state_with_bus(
     let startable_adapters: Vec<Arc<dyn Startable>> =
         vec![roon.clone(), lms.clone(), openhome.clone(), upnp.clone()];
 
-    AppState::new(
+    let state = AppState::new(
         roon,
         hqplayer,
         hqp_instances,
@@ -243,7 +243,20 @@ async fn build_state_with_bus(
         startable_adapters,
         Instant::now(),
         CancellationToken::new(),
-    )
+    );
+    // #531: mirrors main.rs's registration -- hifi_collections reaches LMS
+    // and Roon through the registry's `content` operation, not a direct
+    // `state.lms`/`state.roon` field access (see
+    // `tests/adapter_boundary_lint.rs`).
+    state
+        .adapter_registry
+        .register_library("lms", state.lms.clone())
+        .await;
+    state
+        .adapter_registry
+        .register_library("roon", state.roon.clone())
+        .await;
+    state
 }
 
 impl TestApp {
@@ -2248,6 +2261,194 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
                 == json!({"queue_id": "living-room-group", "media": "library://track/42", "option": "next"})
     ));
     server.abort();
+}
+
+/// #531: LMS's `hifi_collections` slice walks the synthetic root into
+/// Albums, drills into one album's tracks, and mints an opaque ref over the
+/// durable `LmsPlayTarget::Library` id -- never the raw LMS entity id.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_collections_browse_walks_albums_into_tracks() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    h.mock
+        .set_library_albums(vec![(7, "Kind of Blue", "Miles Davis")])
+        .await;
+    h.mock
+        .set_album_tracks(7, vec![(42, "So What", Some("Miles Davis"))])
+        .await;
+
+    let root = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse"}),
+        )
+        .await;
+    assert_eq!(root["structuredContent"]["outcome"], "ok");
+    let root_page: Value = serde_json::from_str(&result_text(&root)).expect("root page JSON");
+    let albums_entry = root_page["items"]
+        .as_array()
+        .expect("root items")
+        .iter()
+        .find(|item| item["title"] == "Albums")
+        .expect("root must list Albums");
+    let albums_path = albums_entry["path"].as_str().expect("Albums has a path");
+    assert!(albums_path.starts_with("ref_"));
+
+    let albums = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": albums_path}),
+        )
+        .await;
+    assert_eq!(albums["structuredContent"]["outcome"], "ok");
+    let albums_page: Value = serde_json::from_str(&result_text(&albums)).expect("albums page JSON");
+    assert_eq!(albums_page["items"][0]["title"], "Kind of Blue");
+    assert_eq!(albums_page["items"][0]["subtitle"], "Album by Miles Davis");
+    let album_path = albums_page["items"][0]["path"]
+        .as_str()
+        .expect("an album is itself browsable, into its tracks");
+
+    let tracks = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": album_path}),
+        )
+        .await;
+    assert_eq!(tracks["structuredContent"]["outcome"], "ok");
+    let tracks_page: Value = serde_json::from_str(&result_text(&tracks)).expect("tracks page JSON");
+    assert_eq!(tracks_page["items"][0]["title"], "So What");
+    let track_ref = tracks_page["items"][0]["ref"]
+        .as_str()
+        .expect("a track is playable, not a browsable path");
+    assert!(tracks_page["items"][0].get("path").is_none());
+
+    // The minted ref plays via hifi_play_ref exactly like a search hit's.
+    let play = h
+        .app
+        .call_tool(
+            "hifi_play_ref",
+            json!({"zone_id": zone_id, "ref": track_ref}),
+        )
+        .await;
+    assert_eq!(play["structuredContent"]["outcome"], "accepted");
+
+    h.stop().await;
+}
+
+/// #531: `hifi_collections playlists` lists LMS's saved playlists, and one
+/// playlist's tracks are reachable through the same opaque-path browse call.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_collections_playlists_and_favorites() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+
+    h.mock
+        .set_library_playlists(vec![(3, "Sunday Morning")])
+        .await;
+    h.mock
+        .set_playlist_tracks(3, vec![(9, "Blue in Green", Some("Miles Davis"))])
+        .await;
+    h.mock
+        .set_favorites(vec![("Jazz FM", "http://example.com/jazzfm")])
+        .await;
+
+    let playlists = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "playlists"}),
+        )
+        .await;
+    assert_eq!(playlists["structuredContent"]["outcome"], "ok");
+    let playlists_page: Value =
+        serde_json::from_str(&result_text(&playlists)).expect("playlists page JSON");
+    assert_eq!(playlists_page["items"][0]["title"], "Sunday Morning");
+    let playlist_path = playlists_page["items"][0]["path"]
+        .as_str()
+        .expect("a playlist is browsable into its tracks");
+
+    let tracks = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": playlist_path}),
+        )
+        .await;
+    assert_eq!(tracks["structuredContent"]["outcome"], "ok");
+    let tracks_page: Value = serde_json::from_str(&result_text(&tracks)).expect("tracks page JSON");
+    assert_eq!(tracks_page["items"][0]["title"], "Blue in Green");
+
+    let favorites = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "favorites"}),
+        )
+        .await;
+    assert_eq!(favorites["structuredContent"]["outcome"], "ok");
+    let favorites_page: Value =
+        serde_json::from_str(&result_text(&favorites)).expect("favorites page JSON");
+    assert_eq!(favorites_page["items"][0]["title"], "Jazz FM");
+    let favorite_ref = favorites_page["items"][0]["ref"]
+        .as_str()
+        .expect("a favorite with a url is playable");
+    assert!(!favorite_ref.contains("jazzfm"), "the favorite's url must stay server-side");
+
+    h.stop().await;
+}
+
+/// #531: an opaque path minted for one zone's provider must never resolve
+/// against a different provider's zone -- same safety property #492 already
+/// pins for Music Assistant, now proven for LMS.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_collections_path_does_not_cross_provider_boundaries() {
+    let h = LmsHarness::start().await;
+    let zone_id = h.zone_id();
+    h.mock
+        .set_library_albums(vec![(1, "Album", "Artist")])
+        .await;
+
+    let root = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse"}),
+        )
+        .await;
+    let root_page: Value = serde_json::from_str(&result_text(&root)).expect("root page JSON");
+    let path = root_page["items"][0]["path"]
+        .as_str()
+        .expect("root item has a path")
+        .to_string();
+
+    let cross = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": "roon:not-lms", "action": "browse", "path": path}),
+        )
+        .await;
+    assert_eq!(cross["structuredContent"]["outcome"], "invalid", "{cross}");
+    assert_eq!(cross["structuredContent"]["refusal"]["parameter"], "path");
+
+    let stale = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": zone_id, "action": "browse", "path": "ref_not-a-real-token"}),
+        )
+        .await;
+    assert_eq!(stale["structuredContent"]["outcome"], "invalid", "{stale}");
+    assert_eq!(stale["structuredContent"]["refusal"]["parameter"], "path");
+
+    h.stop().await;
 }
 
 /// A `TestApp` wired to a live mock LMS server, with the aggregator running so
@@ -5027,7 +5228,6 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
 
     // The named cases, spelled out so a regression names itself.
     for capability in [
-        "browse",
         "queue_read",
         "queue_jump",
         "queue_reorder",
@@ -5036,8 +5236,6 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
         "play_next",
         "repeat_mode",
         "shuffle_mode",
-        "saved_playlists",
-        "favorites",
         "multiroom_sync",
     ] {
         let entry = caps
@@ -5047,6 +5245,19 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
             support_of(entry),
             NOT_IMPLEMENTED,
             "lms/{capability} must read as not-yet-implemented until its issue lands"
+        );
+    }
+
+    // #531 wired these three to hifi_collections; LMS's protocol always
+    // supported them (that is this test's whole point), and now so does UHC.
+    for capability in ["browse", "saved_playlists", "favorites"] {
+        let entry = caps
+            .get(capability)
+            .unwrap_or_else(|| panic!("lms/{capability} missing"));
+        assert_eq!(
+            support_of(entry),
+            SUPPORTED,
+            "lms/{capability} is wired to hifi_collections since #531"
         );
     }
 }
@@ -5205,15 +5416,29 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 "hifi_play_ref",
                 json!({ "ref": "bad-ref", "zone_id": zone_id }),
             )),
-            "browse" | "saved_playlists" | "favorites" if provider == "musicassistant" => Some((
+            "browse" | "saved_playlists" | "favorites"
+                if matches!(provider, "musicassistant" | "lms") =>
+            {
+                Some((
+                    "hifi_collections",
+                    json!({
+                        "zone_id": zone_id,
+                        "action": match capability {
+                            "browse" => "browse",
+                            "saved_playlists" => "playlists",
+                            _ => "favorites",
+                        }
+                    }),
+                ))
+            }
+            // Roon's favorites cell is not (yet) supported, so only browse
+            // and saved_playlists (mapped to Playlists, its browse-hierarchy
+            // node) are probed here.
+            "browse" | "saved_playlists" if provider == "roon" => Some((
                 "hifi_collections",
                 json!({
                     "zone_id": zone_id,
-                    "action": match capability {
-                        "browse" => "browse",
-                        "saved_playlists" => "playlists",
-                        _ => "favorites",
-                    }
+                    "action": if capability == "browse" { "browse" } else { "playlists" },
                 }),
             )),
             "browse" | "saved_playlists" | "favorites" => {
@@ -5297,15 +5522,16 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     // The routed Spotify content and mode cells plus Music Assistant's queue
     // mutations, mode, collections, and zone-group cells add twenty-three probes to the
     // original provider transport set, plus one more for Music Assistant's
-    // queue_transfer (#507).
+    // queue_transfer (#507), plus five for #531's LMS (browse, saved_playlists,
+    // favorites) and Roon (browse, saved_playlists) hifi_collections cells.
     // Apple Music's transport/skip/volume
     // cells remain gated until signed physical companion validation (#465).
     // Asserted exactly, not as a floor: a floor would pass while a cell silently
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 46,
-        "{proved} supported cells were proved end to end, expected 46. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 51,
+        "{proved} supported cells were proved end to end, expected 51. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -206,15 +206,16 @@ struct TestApp {
 }
 
 async fn build_state(lms: Option<Arc<LmsAdapter>>) -> AppState {
-    build_state_with_bus(create_bus(), lms).await
+    build_state_with_bus(create_bus(), lms, None).await
 }
 
 async fn build_state_with_bus(
     bus: unified_hifi_control::bus::SharedBus,
     lms: Option<Arc<LmsAdapter>>,
+    roon: Option<Arc<RoonAdapter>>,
 ) -> AppState {
     let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
-    let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
+    let roon = roon.unwrap_or_else(|| Arc::new(RoonAdapter::new_disconnected(bus.clone())));
     let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
     let hqp_instances = Arc::new(HqpInstanceManager::new_with_native_sink(
         bus.clone(),
@@ -228,12 +229,12 @@ async fn build_state_with_bus(
     let startable_adapters: Vec<Arc<dyn Startable>> =
         vec![roon.clone(), lms.clone(), openhome.clone(), upnp.clone()];
 
-    AppState::new(
-        roon,
+    let state = AppState::new(
+        roon.clone(),
         hqplayer,
         hqp_instances,
         hqp_zone_links,
-        lms,
+        lms.clone(),
         openhome,
         upnp,
         KnobStore::new(),
@@ -243,7 +244,15 @@ async fn build_state_with_bus(
         startable_adapters,
         Instant::now(),
         CancellationToken::new(),
-    )
+    );
+    // Mirror main.rs's unconditional content-library registration (#513/#515):
+    // `hifi_zone_group` (#517) dispatches multiroom_status/set_members/ungroup
+    // to Roon and LMS through `AdapterRegistry::library_content` exactly like
+    // Music Assistant, so the test harness must expose the same registry
+    // entries production wiring does.
+    state.adapter_registry.register_library("roon", roon).await;
+    state.adapter_registry.register_library("lms", lms).await;
+    state
 }
 
 impl TestApp {
@@ -853,6 +862,7 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
         "hifi_zone_group",
         &[
             ("action", true),
+            ("zone_id", false),
             ("leader_zone_id", false),
             ("member_zone_ids", false),
             ("confirm", false),
@@ -1836,7 +1846,7 @@ async fn musicassistant_mcp_app() -> (TestApp, MusicAssistantMcpMock, tokio::tas
     });
 
     let bus = create_bus();
-    let state = build_state_with_bus(bus.clone(), None).await;
+    let state = build_state_with_bus(bus.clone(), None, None).await;
     let adapter = Arc::new(
         MusicAssistantAdapter::new(
             bus,
@@ -2121,6 +2131,187 @@ async fn musicassistant_zone_group_refuses_invalid_inputs_before_ma_calls() {
     server.abort();
 }
 
+/// Cross-provider grouping is refused for every pairing among the three
+/// multiroom-capable providers (#517's acceptance criterion), not just the
+/// musicassistant/roon pair the original single-provider tests happened to
+/// cover. Nothing here needs a live backend: every case is refused by zone-id
+/// classification before any adapter is called.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn zone_group_refuses_every_cross_provider_pairing() {
+    let app = TestApp::new().await;
+    for args in [
+        // join: leader and member disagree, for every ordered pairing.
+        json!({"action":"join", "leader_zone_id":"roon:a", "member_zone_ids":["lms:b"], "confirm":true}),
+        json!({"action":"join", "leader_zone_id":"lms:a", "member_zone_ids":["roon:b"], "confirm":true}),
+        json!({"action":"join", "leader_zone_id":"roon:a", "member_zone_ids":["musicassistant:b"], "confirm":true}),
+        json!({"action":"join", "leader_zone_id":"musicassistant:a", "member_zone_ids":["lms:b"], "confirm":true}),
+        // join: a mix of matching and mismatching members must still refuse.
+        json!({"action":"join", "leader_zone_id":"roon:a", "member_zone_ids":["roon:b", "lms:c"], "confirm":true}),
+        // join: a leader from a provider that does not implement grouping at all.
+        json!({"action":"join", "leader_zone_id":"openhome:a", "member_zone_ids":["openhome:b"], "confirm":true}),
+        // leave: members from two different multiroom providers.
+        json!({"action":"leave", "member_zone_ids":["roon:a", "lms:b"], "confirm":true}),
+        json!({"action":"leave", "member_zone_ids":["lms:a", "musicassistant:b"], "confirm":true}),
+        // leave: a provider that does not implement grouping at all.
+        json!({"action":"leave", "member_zone_ids":["upnp:a"], "confirm":true}),
+        // status: a zone_id from a provider that does not implement grouping.
+        json!({"action":"status", "zone_id":"upnp:a"}),
+    ] {
+        let result = app.call_tool("hifi_zone_group", args.clone()).await;
+        assert_eq!(
+            result["structuredContent"]["outcome"], "invalid",
+            "{args} must be refused as invalid: {result}"
+        );
+        assert_eq!(
+            result["structuredContent"]["refusal"]["reason"], "invalid_parameter",
+            "{args}: {result}"
+        );
+    }
+}
+
+/// A `TestApp` wired to a real `RoonAdapter` driven against
+/// `tests/mock_servers/roon_core.rs`'s `FakeRoonCore` -- the same harness
+/// `tests/roon_protocol.rs` uses for Roon's own multiroom tests
+/// (`roon_set_group_members_merges_outputs_into_one_zone` and friends), but
+/// wrapped in the real `/mcp` route so `hifi_zone_group`'s routing (#517) is
+/// proved end to end rather than only at the adapter layer.
+async fn roon_mcp_app(core: &mock_servers::roon_core::FakeRoonCore) -> TestApp {
+    let bus = create_bus();
+    let roon = std::sync::Arc::new(RoonAdapter::new_configured(
+        bus.clone(),
+        "http://test.invalid:8088".to_string(),
+        KnobStore::new(),
+    ));
+    let runner = roon.clone();
+    let ip = core.ip();
+    let port = core.port();
+    tokio::spawn(async move {
+        let _ = runner
+            .run_event_loop_against_core_for_tests(ip, &port)
+            .await;
+    });
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if roon.is_browse_connected().await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        roon.is_browse_connected().await,
+        "RoonAdapter never connected to the fake core"
+    );
+
+    let state = build_state_with_bus(bus, None, Some(roon)).await;
+    TestApp::with_state(state)
+}
+
+/// `hifi_zone_group` routing generalized to Roon (issue #517), proved against
+/// the same `FakeRoonCore` fixture `tests/roon_protocol.rs` uses at the
+/// adapter layer -- join merges two single-output zones' outputs via
+/// `group_outputs`, status reports the merge, and leave splits them back via
+/// `ungroup_outputs`, all addressed by `roon:` zone ids with no Music
+/// Assistant or LMS involved.
+///
+/// Roon confirms grouping asynchronously through its ordinary zone
+/// subscription rather than a synchronous RPC reply (documented on
+/// `RoonAdapter::set_group_members`), so this polls `hifi_zone_group`
+/// status rather than trusting the immediate `join`/`leave` response to
+/// reflect the merge -- the same caveat #517 documents on the tool itself.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn roon_zone_group_routes_join_status_and_leave_through_the_registry() {
+    use mock_servers::roon_core::{zone_with_grouping, FakeRoonCore};
+
+    let _settings = SettingsFixture::with_hqplayer(true);
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let app = roon_mcp_app(&core).await;
+
+    // Poll status until the aggregate view either shows the expected group
+    // count or a bound is hit, so a slow merge shows what actually arrived
+    // instead of just "assertion failed".
+    async fn wait_for_group_count(app: &TestApp, expected: usize) -> Value {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let status = app
+                .call_tool(
+                    "hifi_zone_group",
+                    json!({"action": "status", "zone_id": "roon:zone_a"}),
+                )
+                .await;
+            let payload: Value =
+                serde_json::from_str(&result_text(&status)).expect("status payload JSON");
+            let count = payload["groups"].as_array().map(Vec::len).unwrap_or(0);
+            if count == expected || std::time::Instant::now() >= deadline {
+                return payload;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    let before = wait_for_group_count(&app, 0).await;
+    assert_eq!(before["groups"].as_array().unwrap().len(), 0, "{before}");
+
+    let joined = app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "join",
+                "leader_zone_id": "roon:zone_a",
+                "member_zone_ids": ["roon:zone_b"],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(joined["structuredContent"]["outcome"], "accepted");
+
+    let after = wait_for_group_count(&app, 1).await;
+    let groups = after["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 1, "{after}");
+    assert_eq!(groups[0]["leader_zone_id"], json!("roon:zone_a"));
+    assert_eq!(
+        groups[0]["member_zone_ids"],
+        json!(["roon:output_b"]),
+        "zone_b was retired by the merge, so the surviving member is named by output id: {after}"
+    );
+    let group_requests = core
+        .requests_named("com.roonlabs.transport:2/group_outputs")
+        .await;
+    assert_eq!(group_requests.len(), 1, "exactly one group_outputs call");
+
+    let left = app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "leave",
+                "member_zone_ids": ["roon:output_b"],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(left["structuredContent"]["outcome"], "accepted");
+
+    let split = wait_for_group_count(&app, 0).await;
+    assert_eq!(split["groups"].as_array().unwrap().len(), 0, "{split}");
+    let ungroup_requests = core
+        .requests_named("com.roonlabs.transport:2/ungroup_outputs")
+        .await;
+    assert_eq!(
+        ungroup_requests.len(),
+        1,
+        "exactly one ungroup_outputs call"
+    );
+
+    core.stop().await;
+}
+
 /// Collections must have one provider-neutral wire shape: no MA URI escapes,
 /// pages are explicit, paths continue browse, and playable rows use the same
 /// opaque refs as search.
@@ -2282,7 +2473,7 @@ impl LmsHarness {
         )
         .await;
 
-        let state = build_state_with_bus(bus, Some(lms.clone())).await;
+        let state = build_state_with_bus(bus, Some(lms.clone()), None).await;
 
         // The aggregator only learns about zones by consuming bus events.
         let aggregator = state.aggregator.clone();
@@ -2409,6 +2600,88 @@ async fn lms_round_trip_pins_the_action_map_and_the_volume_sign() {
              mock received {commands:?}"
         );
     }
+
+    h.stop().await;
+}
+
+/// `hifi_zone_group` routing generalized to LMS (issue #517): a real mock
+/// server, a real adapter registered as an `AdapterRegistry` library (exactly
+/// the wiring `main.rs` does for #513), and the MCP tool driven over the real
+/// `/mcp` route -- join syncs the mock's second player into the first's
+/// group, status reports it, and leave unsyncs it, all addressed by `lms:`
+/// zone ids with no Music Assistant involved.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn lms_zone_group_routes_join_status_and_leave_through_the_registry() {
+    let h = LmsHarness::start().await;
+    const MEMBER_ID: &str = "11:22:33:44:55:66";
+    h.mock.add_player(MEMBER_ID, "Kitchen").await;
+
+    let leader_zone = h.zone_id();
+    let member_zone = format!("lms:{MEMBER_ID}");
+
+    let before = h
+        .app
+        .call_tool(
+            "hifi_zone_group",
+            json!({"action": "status", "zone_id": leader_zone}),
+        )
+        .await;
+    assert_eq!(before["structuredContent"]["outcome"], "ok");
+    assert_eq!(
+        before["structuredContent"]["scope"]["provider"],
+        json!("lms"),
+        "a zone_id-scoped status must identify lms, not aggregate: {before}"
+    );
+    let before_payload: Value =
+        serde_json::from_str(&result_text(&before)).expect("status payload JSON");
+    assert_eq!(
+        before_payload["groups"].as_array().map(Vec::len),
+        Some(0),
+        "no sync group exists yet: {before_payload}"
+    );
+
+    let joined = h
+        .app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "join",
+                "leader_zone_id": leader_zone,
+                "member_zone_ids": [member_zone.clone()],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(joined["structuredContent"]["outcome"], "accepted");
+    let joined_payload: Value =
+        serde_json::from_str(&result_text(&joined)).expect("join payload JSON");
+    let groups = joined_payload["groups"].as_array().expect("groups array");
+    assert_eq!(groups.len(), 1, "{joined_payload}");
+    assert_eq!(groups[0]["leader_zone_id"], json!(leader_zone));
+    assert_eq!(groups[0]["member_zone_ids"], json!([member_zone.clone()]));
+    assert_eq!(
+        h.mock.sync_groups().await,
+        vec![vec![h.player_id.to_string(), MEMBER_ID.to_string()]],
+        "the wire command must address the leader with `sync <member>`, per #403"
+    );
+
+    let left = h
+        .app
+        .call_tool(
+            "hifi_zone_group",
+            json!({
+                "action": "leave",
+                "member_zone_ids": [member_zone],
+                "confirm": true,
+            }),
+        )
+        .await;
+    assert_eq!(left["structuredContent"]["outcome"], "accepted");
+    assert!(
+        h.mock.sync_groups().await.is_empty(),
+        "leave must unsync the member"
+    );
 
     h.stop().await;
 }
@@ -5029,7 +5302,9 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
         "shuffle_mode",
         "saved_playlists",
         "favorites",
-        "multiroom_sync",
+        // multiroom_sync is deliberately absent here: #517 wired LMS sync
+        // groups (#513) to `hifi_zone_group`, so it is `supported` and is
+        // asserted as such below rather than as not-yet-implemented.
     ] {
         let entry = caps
             .get(capability)
@@ -5040,6 +5315,13 @@ async fn lms_never_reports_a_uhc_gap_as_a_provider_limitation() {
             "lms/{capability} must read as not-yet-implemented until its issue lands"
         );
     }
+
+    assert_eq!(
+        support_of(&caps["multiroom_sync"]),
+        "supported",
+        "lms/multiroom_sync must be supported: #513 wired native sync groups and #517 routes \
+         hifi_zone_group to them"
+    );
 }
 
 /// OpenHome and UPnP volume was ❌ in AGENTS.md and `not_implemented` in #395.
@@ -5235,7 +5517,29 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 "hifi_control",
                 json!({ "zone_id": zone_id, "action": "shuffle_off" }),
             )),
-            "multiroom_sync" => Some(("hifi_zone_group", json!({ "action": "status" }))),
+            // musicassistant's "multiroom" library is never registered in this
+            // generic TestApp, so a scoped status call reaches the registry's
+            // own "not configured" wording -- the same fingerprint every other
+            // musicassistant probe above proves against.
+            "multiroom_sync" if provider == "musicassistant" => Some((
+                "hifi_zone_group",
+                json!({ "action": "status", "zone_id": zone_id }),
+            )),
+            // Roon and LMS libraries *are* registered (`build_state_with_bus`),
+            // so status would reach a live, empty adapter and succeed instead of
+            // naming it. `join` reaches deep enough into each adapter's own
+            // group-membership resolution to name the provider even while
+            // disconnected/unconfigured -- see the bespoke `expected` strings
+            // below for why status is not used here.
+            "multiroom_sync" => Some((
+                "hifi_zone_group",
+                json!({
+                    "action": "join",
+                    "leader_zone_id": zone_id,
+                    "member_zone_ids": [format!("{provider}:def")],
+                    "confirm": true,
+                }),
+            )),
             _ => None,
         }
     }
@@ -5265,6 +5569,13 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
                 && capability == "play_by_ref"
             {
                 "unknown or expired"
+            } else if *provider == "roon" && capability == "multiroom_sync" {
+                // The disconnected fake never populates a zone, so
+                // `resolve_roon_output` fails before `set_group_members` ever
+                // reaches its own "Not connected to Roon" transport check --
+                // this is still RoonAdapter's own wording, just from a step
+                // earlier in the same call.
+                "Roon group leader was not found"
             } else {
                 fingerprint(provider)
             };
@@ -5279,15 +5590,16 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     }
     // The routed Spotify content and mode cells plus Music Assistant's queue
     // mutations, mode, collections, and zone-group cells add twenty-three probes to the
-    // original provider transport set.
+    // original provider transport set. #517 adds two more: Roon and LMS
+    // multiroom_sync, generalized from the Music Assistant-only original.
     // Apple Music's transport/skip/volume
     // cells remain gated until signed physical companion validation (#465).
     // Asserted exactly, not as a floor: a floor would pass while a cell silently
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 45,
-        "{proved} supported cells were proved end to end, expected 45. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 47,
+        "{proved} supported cells were proved end to end, expected 47. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 
@@ -5841,7 +6153,7 @@ async fn now_playing_resource_agrees_with_hifi_now_playing_tool_for_a_live_zone(
 async fn a_newly_discovered_zone_is_addressable_without_a_restart() {
     let _settings = SettingsFixture::with_hqplayer(true);
     let bus = create_bus();
-    let state = build_state_with_bus(bus.clone(), None).await;
+    let state = build_state_with_bus(bus.clone(), None, None).await;
 
     let aggregator = state.aggregator.clone();
     let aggregator_task = tokio::spawn(async move { aggregator.run().await });

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -86,6 +86,23 @@ pub struct MockLibraryItem {
     pub artist: String,
 }
 
+/// One track row for `titles` (an album's tracks) and `playlists tracks` (a
+/// playlist's tracks) -- #531's `hifi_collections` drill-down.
+#[derive(Debug, Clone)]
+pub struct MockTrack {
+    pub id: i64,
+    pub title: String,
+    pub artist: Option<String>,
+}
+
+/// One row of LMS's `favorites items` -- #531. Real LMS favorites carry no
+/// durable entity id, only a `url`; this mock mirrors that.
+#[derive(Debug, Clone)]
+pub struct MockFavorite {
+    pub name: String,
+    pub url: String,
+}
+
 /// Mock LMS server state
 struct MockLmsState {
     players: HashMap<String, MockPlayer>,
@@ -96,9 +113,18 @@ struct MockLmsState {
     /// Library items for `search` (the `search_library` fallback path) and for
     /// the `albums`/`artists`/`titles` existence checks
     /// `LmsAdapter::assert_library_id_exists` (#396) issues before a mutating
-    /// `playlistcontrol` call. Keyed by [`LmsSearchResultType`]-shaped kind:
-    /// `"album"`, `"artist"`, `"track"`.
+    /// `playlistcontrol` call, and for #531's `hifi_collections` listings.
+    /// Keyed by [`LmsSearchResultType`]-shaped kind: `"album"`, `"artist"`,
+    /// `"track"`, plus `"playlist"` for #531.
     library: HashMap<&'static str, Vec<MockLibraryItem>>,
+    /// `album_id` -> that album's tracks, for `titles <start> <count>
+    /// album_id:<id>` (#531).
+    album_tracks: HashMap<i64, Vec<MockTrack>>,
+    /// `playlist_id` -> that playlist's tracks, for `playlists tracks <start>
+    /// <count> playlist_id:<id>` (#531).
+    playlist_tracks: HashMap<i64, Vec<MockTrack>>,
+    /// The flat favourites list for `favorites items <start> <count>` (#531).
+    favorites: Vec<MockFavorite>,
 }
 
 /// Mock LMS Server
@@ -115,6 +141,9 @@ impl MockLmsServer {
             players: HashMap::new(),
             commands: Vec::new(),
             library: HashMap::new(),
+            album_tracks: HashMap::new(),
+            playlist_tracks: HashMap::new(),
+            favorites: Vec::new(),
         }));
 
         let app = Router::new()
@@ -212,6 +241,83 @@ impl MockLmsServer {
         self.state.write().await.library.insert("album", items);
     }
 
+    /// Seed the artist library `artists <start> <count>` answers from (#531).
+    pub async fn set_library_artists(&self, artists: Vec<(i64, &str)>) {
+        let items = artists
+            .into_iter()
+            .map(|(id, title)| MockLibraryItem {
+                id,
+                title: title.to_string(),
+                artist: String::new(),
+            })
+            .collect();
+        self.state.write().await.library.insert("artist", items);
+    }
+
+    /// Seed the playlist library `playlists <start> <count>` answers from
+    /// (#531).
+    pub async fn set_library_playlists(&self, playlists: Vec<(i64, &str)>) {
+        let items = playlists
+            .into_iter()
+            .map(|(id, title)| MockLibraryItem {
+                id,
+                title: title.to_string(),
+                artist: String::new(),
+            })
+            .collect();
+        self.state.write().await.library.insert("playlist", items);
+    }
+
+    /// Seed one album's tracks, for `titles <start> <count> album_id:<id>`
+    /// (#531).
+    pub async fn set_album_tracks(&self, album_id: i64, tracks: Vec<(i64, &str, Option<&str>)>) {
+        let items = tracks
+            .into_iter()
+            .map(|(id, title, artist)| MockTrack {
+                id,
+                title: title.to_string(),
+                artist: artist.map(str::to_string),
+            })
+            .collect();
+        self.state.write().await.album_tracks.insert(album_id, items);
+    }
+
+    /// Seed one playlist's tracks, for `playlists tracks <start> <count>
+    /// playlist_id:<id>` (#531).
+    pub async fn set_playlist_tracks(
+        &self,
+        playlist_id: i64,
+        tracks: Vec<(i64, &str, Option<&str>)>,
+    ) {
+        let items = tracks
+            .into_iter()
+            .map(|(id, title, artist)| MockTrack {
+                id,
+                title: title.to_string(),
+                artist: artist.map(str::to_string),
+            })
+            .collect();
+        self.state
+            .write()
+            .await
+            .playlist_tracks
+            .insert(playlist_id, items);
+    }
+
+    /// Seed the flat favourites list `favorites items <start> <count>`
+    /// answers from (#531). Real LMS favorites have no durable id, only a
+    /// `url` -- mirrored here rather than inventing one.
+    pub async fn set_favorites(&self, favorites: Vec<(&str, &str)>) {
+        let items = favorites
+            .into_iter()
+            .map(|(name, url)| MockFavorite {
+                name: name.to_string(),
+                url: url.to_string(),
+            })
+            .collect();
+        self.state.write().await.favorites = items;
+    }
+
     /// Commands received for `player_id`, excluding the read-only polling
     /// commands the adapter issues on its own schedule.
     pub async fn write_commands(&self, player_id: &str) -> Vec<Vec<String>> {
@@ -261,6 +367,23 @@ fn filter_value<'a>(commands: &'a [Value], tag: &str) -> Option<&'a str> {
         .iter()
         .filter_map(Value::as_str)
         .find_map(|s| s.strip_prefix(prefix.as_str()))
+}
+
+/// Read the `<start> <count>` pair LMS's own taggedlist queries carry at a
+/// fixed position (#531): `["albums", <start>, <count>, ...]` has them at
+/// `1, 2`; `["playlists", "tracks", <start>, <count>, ...]` has them one
+/// further out, at `2, 3`. `start_index` names where `<start>` sits.
+fn paging(commands: &[Value], start_index: usize) -> (usize, usize) {
+    let offset = commands
+        .get(start_index)
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let count = commands
+        .get(start_index + 1)
+        .and_then(Value::as_u64)
+        .map(|c| c as usize)
+        .unwrap_or(usize::MAX);
+    (offset, count)
 }
 
 /// Handle JSON-RPC requests
@@ -485,11 +608,39 @@ async fn handle_jsonrpc(
                     })
                 })
                 .collect();
-            if page.is_empty() {
-                json!({})
-            } else {
-                json!({ "albums_loop": page })
+            // #531: `LmsAdapter::assert_library_id_exists` re-searches by
+            // title before honoring a track ref minted by
+            // `hifi_collections` (same existence check #396 added for
+            // albums), so a track from an album's or a playlist's tracks
+            // must be findable here too -- by title, exactly like albums
+            // above, deduped by id since the same track can appear in both.
+            let mut seen_track_ids = std::collections::HashSet::new();
+            let track_page: Vec<Value> = state
+                .album_tracks
+                .values()
+                .chain(state.playlist_tracks.values())
+                .flatten()
+                .filter(|t| seen_track_ids.insert(t.id))
+                .filter(|t| {
+                    t.title.to_lowercase().contains(&query)
+                        || t.artist
+                            .as_deref()
+                            .unwrap_or_default()
+                            .to_lowercase()
+                            .contains(&query)
+                })
+                .skip(offset)
+                .take(count)
+                .map(|t| json!({"track_id": t.id, "track": t.title, "artist": t.artist}))
+                .collect();
+            let mut result = serde_json::Map::new();
+            if !page.is_empty() {
+                result.insert("albums_loop".to_string(), json!(page));
             }
+            if !track_page.is_empty() {
+                result.insert("tracks_loop".to_string(), json!(track_page));
+            }
+            Value::Object(result)
         }
         // The existence check `LmsAdapter::assert_library_id_exists` (#396)
         // issues before a mutating `playlistcontrol`:
@@ -498,7 +649,7 @@ async fn handle_jsonrpc(
         // album path -- they fall to the catch-all `{"count": 0}` shape via
         // `_`, which is the safe direction: an unmodeled kind reads as "not
         // found" rather than "found").
-        "albums" => {
+        "albums" if filter_value(commands, "album_id").is_some() => {
             let requested_id =
                 filter_value(commands, "album_id").and_then(|v| v.parse::<i64>().ok());
             let count = match requested_id {
@@ -512,6 +663,90 @@ async fn handle_jsonrpc(
                 None => 0,
             };
             json!({ "count": count })
+        }
+        // #531's `hifi_collections browse`: `["albums", <start>, <count>]`,
+        // the whole album library (no `album_id` filter, handled above).
+        "albums" => {
+            let (offset, count) = paging(commands, 1);
+            let all: Vec<&MockLibraryItem> = state.library.get("album").into_iter().flatten().collect();
+            let page: Vec<Value> = all
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|item| json!({"album_id": item.id, "album": item.title, "artist": item.artist}))
+                .collect();
+            json!({ "count": all.len(), "albums_loop": page })
+        }
+        // #531: `["artists", <start>, <count>]`.
+        "artists" => {
+            let (offset, count) = paging(commands, 1);
+            let all: Vec<&MockLibraryItem> = state.library.get("artist").into_iter().flatten().collect();
+            let page: Vec<Value> = all
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|item| json!({"artist_id": item.id, "artist": item.title}))
+                .collect();
+            json!({ "count": all.len(), "artists_loop": page })
+        }
+        // #531: `["titles", <start>, <count>, "album_id:<id>"]` -- one
+        // album's tracks.
+        "titles" => {
+            let (offset, count) = paging(commands, 1);
+            let album_id = filter_value(commands, "album_id").and_then(|v| v.parse::<i64>().ok());
+            let tracks = album_id
+                .and_then(|id| state.album_tracks.get(&id))
+                .cloned()
+                .unwrap_or_default();
+            let page: Vec<Value> = tracks
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|t| json!({"track_id": t.id, "title": t.title, "artist": t.artist}))
+                .collect();
+            json!({ "count": tracks.len(), "titles_loop": page })
+        }
+        // #531: `["playlists", <start>, <count>]` (the playlist library) or
+        // `["playlists", "tracks", <start>, <count>, "playlist_id:<id>"]`
+        // (one playlist's tracks).
+        "playlists" if commands.get(1).and_then(Value::as_str) == Some("tracks") => {
+            let (offset, count) = paging(commands, 2);
+            let playlist_id =
+                filter_value(commands, "playlist_id").and_then(|v| v.parse::<i64>().ok());
+            let tracks = playlist_id
+                .and_then(|id| state.playlist_tracks.get(&id))
+                .cloned()
+                .unwrap_or_default();
+            let page: Vec<Value> = tracks
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|t| json!({"id": t.id, "title": t.title, "artist": t.artist}))
+                .collect();
+            json!({ "count": tracks.len(), "playlisttracks_loop": page })
+        }
+        "playlists" => {
+            let (offset, count) = paging(commands, 1);
+            let all: Vec<&MockLibraryItem> = state.library.get("playlist").into_iter().flatten().collect();
+            let page: Vec<Value> = all
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|item| json!({"id": item.id, "playlist": item.title}))
+                .collect();
+            json!({ "count": all.len(), "playlists_loop": page })
+        }
+        // #531: `["favorites", "items", <start>, <count>]`.
+        "favorites" if commands.get(1).and_then(Value::as_str) == Some("items") => {
+            let (offset, count) = paging(commands, 2);
+            let page: Vec<Value> = state
+                .favorites
+                .iter()
+                .skip(offset)
+                .take(count)
+                .map(|f| json!({"name": f.name, "url": f.url}))
+                .collect();
+            json!({ "count": state.favorites.len(), "loop_loop": page })
         }
         _ => {
             json!({})

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -99,6 +99,15 @@ struct MockLmsState {
     /// `playlistcontrol` call. Keyed by [`LmsSearchResultType`]-shaped kind:
     /// `"album"`, `"artist"`, `"track"`.
     library: HashMap<&'static str, Vec<MockLibraryItem>>,
+    /// Active sync groups (#510). Each inner `Vec` is one group's full
+    /// membership, first-added player first -- mirroring what real LMS's
+    /// `syncgroups ?` reports (a flat member list with no leader marker).
+    /// This is a simplified peer model, not a full replica of LMS's
+    /// undocumented internal master-election-on-leave behavior: `sync -`
+    /// dissolves the whole group rather than promoting a new master, which is
+    /// enough to exercise the adapter's join/leave/status calls without
+    /// claiming to model LMS's internals exactly.
+    sync_groups: Vec<Vec<String>>,
 }
 
 /// Mock LMS Server
@@ -115,6 +124,7 @@ impl MockLmsServer {
             players: HashMap::new(),
             commands: Vec::new(),
             library: HashMap::new(),
+            sync_groups: Vec::new(),
         }));
 
         let app = Router::new()
@@ -232,10 +242,53 @@ impl MockLmsServer {
             .collect()
     }
 
+    /// Current sync groups, each as its full member id list (#510). Lets a
+    /// test assert on server-side membership directly, independent of how
+    /// the adapter reports it.
+    pub async fn sync_groups(&self) -> Vec<Vec<String>> {
+        self.state.read().await.sync_groups.clone()
+    }
+
     /// Stop the mock server
     pub async fn stop(self) {
         self.handle.abort();
     }
+}
+
+/// Join `member` into `master`'s sync group (#510).
+///
+/// Mirrors the live-verified behavior (issue #403): the *addressed* player
+/// (`master`) becomes/stays the sync master, and `member` joins its group.
+/// `member` is first removed from any group it was previously in.
+fn mock_sync_join(state: &mut MockLmsState, master: &str, member: &str) {
+    mock_sync_remove(state, member);
+    if let Some(group) = state
+        .sync_groups
+        .iter_mut()
+        .find(|group| group.first().map(String::as_str) == Some(master))
+    {
+        if !group.iter().any(|id| id == member) {
+            group.push(member.to_string());
+        }
+        return;
+    }
+    // `master` was not already a group's first (leader) entry. If it was a
+    // member of some other group, leaving that group first keeps this model
+    // consistent with "the addressed player becomes master".
+    mock_sync_remove(state, master);
+    state
+        .sync_groups
+        .push(vec![master.to_string(), member.to_string()]);
+}
+
+/// Remove `player` from whatever sync group it currently belongs to, if any.
+/// A group left with fewer than two members is no longer a sync group and is
+/// dropped entirely.
+fn mock_sync_remove(state: &mut MockLmsState, player: &str) {
+    for group in state.sync_groups.iter_mut() {
+        group.retain(|id| id != player);
+    }
+    state.sync_groups.retain(|group| group.len() >= 2);
 }
 
 /// JSON-RPC request format
@@ -378,6 +431,21 @@ async fn handle_jsonrpc(
                 result: json!({}),
             }));
         }
+        // `<playerid> sync <otherplayerid>` joins a group; `<playerid> sync -`
+        // leaves whatever group it is in (#510).
+        "sync" if commands.get(1).is_some() => {
+            let target = commands.get(1).and_then(Value::as_str).unwrap_or("");
+            let mut state = state.write().await;
+            if target == "-" {
+                mock_sync_remove(&mut state, player_id);
+            } else {
+                mock_sync_join(&mut state, player_id, target);
+            }
+            return Ok(Json(JsonRpcResponse {
+                id: request.id,
+                result: json!({}),
+            }));
+        }
         _ => {}
     }
 
@@ -436,6 +504,36 @@ async fn handle_jsonrpc(
         "mixer" => {
             // Volume control - return empty success
             json!({})
+        }
+        // Server-scoped `syncgroups ?` (#510): one entry per active group,
+        // with the full membership as a comma-joined id list, matching the
+        // `sync_members`/`sync_member_names` shape verified live against
+        // Lyrion 9.1.2 (issue #403's investigation).
+        "syncgroups" => {
+            let syncgroups_loop: Vec<Value> = state
+                .sync_groups
+                .iter()
+                .map(|group| {
+                    let names: Vec<String> = group
+                        .iter()
+                        .map(|id| {
+                            state
+                                .players
+                                .get(id)
+                                .map(|p| p.name.clone())
+                                .unwrap_or_default()
+                        })
+                        .collect();
+                    json!({
+                        "sync_members": group.join(","),
+                        "sync_member_names": names.join(","),
+                    })
+                })
+                .collect();
+            json!({
+                "count": syncgroups_loop.len(),
+                "syncgroups_loop": syncgroups_loop
+            })
         }
         "playlist" => {
             // Playlist control (next/prev) - return empty success

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -562,6 +562,11 @@ struct CoreState {
     core_id: String,
     display_name: String,
     display_version: String,
+    /// The zone subscription's `(req_id, writer)`, captured when
+    /// `subscribe_zones` completes (#509). `group_outputs`/`ungroup_outputs`
+    /// push their effect on this same subscription, mirroring a real Core --
+    /// see the `SubscribeZones` handler for why it must be this req_id.
+    zone_push: Option<(usize, Writer)>,
 }
 
 // =============================================================================
@@ -611,6 +616,7 @@ impl FakeRoonCore {
             core_id: format!("fake-core-408-{}", addr.port()),
             display_name: "Fake Roon Core".to_string(),
             display_version: "2.0.408".to_string(),
+            zone_push: None,
         }));
         let root_title = library.root_title.clone();
 
@@ -951,6 +957,48 @@ pub fn default_zone(zone_id: &str, display_name: &str) -> Value {
     })
 }
 
+/// A single-output zone with an explicit output id and grouping
+/// compatibility list (issue #509), for tests that need several distinct
+/// zones whose outputs can (or deliberately cannot) be grouped together.
+/// `default_zone` above always derives `"{zone_id}_output"` and leaves
+/// `can_group_with_output_ids` empty, which cannot express either.
+pub fn zone_with_grouping(
+    zone_id: &str,
+    display_name: &str,
+    output_id: &str,
+    can_group_with_output_ids: &[&str],
+) -> Value {
+    json!({
+        "zone_id": zone_id,
+        "display_name": display_name,
+        "state": "stopped",
+        "is_next_allowed": true,
+        "is_previous_allowed": true,
+        "is_pause_allowed": false,
+        "is_play_allowed": true,
+        "is_seek_allowed": false,
+        "queue_items_remaining": 0,
+        "queue_time_remaining": 0,
+        "now_playing": null,
+        "settings": { "loop": "disabled", "shuffle": false, "auto_radio": false },
+        "outputs": [{
+            "output_id": output_id,
+            "zone_id": zone_id,
+            "can_group_with_output_ids": can_group_with_output_ids,
+            "display_name": display_name,
+            "source_controls": null,
+            "volume": {
+                "type": "number",
+                "min": 0.0,
+                "max": 100.0,
+                "value": 50.0,
+                "step": 1.0,
+                "is_muted": false
+            }
+        }]
+    })
+}
+
 // =============================================================================
 // MOO framing
 // =============================================================================
@@ -1186,6 +1234,14 @@ async fn handle_request(
         }
         RequestKind::SubscribeZones => {
             let body = json!({ "zones": core.read().await.zones.clone() });
+            // Remember this request id and connection so group_outputs /
+            // ungroup_outputs (#509) can push a later `CONTINUE Changed` on
+            // the same subscription -- exactly how a real Core reports the
+            // effect of grouping, per the fork's own `parse_msg`
+            // (`transport.rs:457-484`): it only recognises `zones_changed` /
+            // `zones_added` / `zones_removed` arriving on the *subscription's*
+            // `req_id`, not a fresh one.
+            core.write().await.zone_push = Some((req_id, writer.clone()));
             // FROM FORK: transport.rs:479 accepts name "Subscribed"; a
             // subscription stays open, hence CONTINUE.
             respond(
@@ -1203,6 +1259,8 @@ async fn handle_request(
         }
         RequestKind::Browse => handle_browse(req_id, &body, &core, &writer, &root_title).await,
         RequestKind::Load => handle_load(req_id, &body, &core, &writer).await,
+        RequestKind::GroupOutputs => handle_group_outputs(req_id, &body, &core, &writer).await,
+        RequestKind::UngroupOutputs => handle_ungroup_outputs(req_id, &body, &core, &writer).await,
         RequestKind::Unknown => {
             // Mirrors the fork's own reply to an unknown service (lib.rs:588-592).
             // FROM ROONLABS' PUBLISHED API: `InvalidRequest` with an `error` string
@@ -1232,6 +1290,8 @@ enum RequestKind {
     Browse,
     Load,
     Ping,
+    GroupOutputs,
+    UngroupOutputs,
     Unknown,
 }
 
@@ -1245,6 +1305,9 @@ impl RequestKind {
             "com.roonlabs.browse:1/browse" => Self::Browse,
             "com.roonlabs.browse:1/load" => Self::Load,
             "com.roonlabs.ping:1/ping" => Self::Ping,
+            // FROM FORK: transport.rs:334,343 -- both send only `output_ids`.
+            "com.roonlabs.transport:2/group_outputs" => Self::GroupOutputs,
+            "com.roonlabs.transport:2/ungroup_outputs" => Self::UngroupOutputs,
             _ => Self::Unknown,
         }
     }
@@ -1496,6 +1559,231 @@ async fn handle_load(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>,
     // FROM FORK: browse.rs:93-98 LoadResult { items, offset, list } — all required.
     let body = json!({ "items": items, "offset": offset, "list": list });
     respond(core, writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+}
+
+// =============================================================================
+// Grouping: group_outputs / ungroup_outputs (issue #509)
+// =============================================================================
+//
+// FROM FORK: `transport.rs:334-350` sends only `{"output_ids": [...]}` and
+// reads no reply body at all -- `Transport::group_outputs`/`ungroup_outputs`
+// return the raw `Option<usize>` request id, not a parsed result. So the
+// client observes the *effect* of grouping only through the zone
+// subscription's `Changed` push, exactly like every other Roon transport
+// write in this fake (`control`, `mute`, `change_volume` get the same
+// body-less `COMPLETE Success`). This fake's own zone-merge/split semantics
+// below are a simplified model, not a documented Core behavior: real Roon's
+// exact index/ordering rules for a merged zone's `outputs` list are
+// unpublished. What is load-bearing is that a merge (a) keeps the leader's
+// zone_id, (b) unions the outputs, and (c) retires any source zone left with
+// none -- which is exactly what issue #509's acceptance criteria describe.
+
+async fn handle_group_outputs(req_id: usize, body: &Value, core: &Arc<RwLock<CoreState>>, writer: &Writer) {
+    let output_ids = string_array(body, "output_ids");
+    respond(core, writer, "COMPLETE", "Success", req_id, None).await;
+
+    let (merge, push) = {
+        let mut state = core.write().await;
+        let merge = merge_zone_outputs(&mut state.zones, &output_ids);
+        (merge, state.zone_push.clone())
+    };
+    let Some((merged_zone, removed_zone_ids)) = merge else {
+        return;
+    };
+    if let Some((sub_req_id, sub_writer)) = push {
+        let mut change = json!({ "zones_changed": [merged_zone] });
+        if !removed_zone_ids.is_empty() {
+            change["zones_removed"] = json!(removed_zone_ids);
+        }
+        send(&sub_writer, "CONTINUE", "Changed", sub_req_id, Some(&change)).await;
+    }
+}
+
+async fn handle_ungroup_outputs(
+    req_id: usize,
+    body: &Value,
+    core: &Arc<RwLock<CoreState>>,
+    writer: &Writer,
+) {
+    let output_ids = string_array(body, "output_ids");
+    respond(core, writer, "COMPLETE", "Success", req_id, None).await;
+
+    let (changed, added, removed, push) = {
+        let mut state = core.write().await;
+        let (changed, added, removed) = split_zone_outputs(&mut state.zones, &output_ids);
+        (changed, added, removed, state.zone_push.clone())
+    };
+    if changed.is_empty() && added.is_empty() && removed.is_empty() {
+        return;
+    }
+    if let Some((sub_req_id, sub_writer)) = push {
+        let mut zones_changed = changed;
+        zones_changed.extend(added);
+        let mut change = json!({});
+        if !zones_changed.is_empty() {
+            change["zones_changed"] = json!(zones_changed);
+        }
+        if !removed.is_empty() {
+            change["zones_removed"] = json!(removed);
+        }
+        send(&sub_writer, "CONTINUE", "Changed", sub_req_id, Some(&change)).await;
+    }
+}
+
+fn string_array(body: &Value, field: &str) -> Vec<String> {
+    body.get(field)
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The `(zone index, output index)` of the zone currently holding `output_id`.
+fn zone_output_index(zones: &[Value], output_id: &str) -> Option<(usize, usize)> {
+    zones.iter().enumerate().find_map(|(zi, zone)| {
+        let outs = zone.get("outputs")?.as_array()?;
+        let oi = outs
+            .iter()
+            .position(|o| o.get("output_id").and_then(Value::as_str) == Some(output_id))?;
+        Some((zi, oi))
+    })
+}
+
+/// Merge every output in `output_ids` into the zone holding the first id.
+/// Returns the merged zone's full JSON and the zone_ids of any source zones
+/// that lost their last output and were retired as a result. `None` when
+/// there was nothing to merge (the leader output was not found, or every
+/// other requested output already belongs to the leader's zone).
+fn merge_zone_outputs(zones: &mut Vec<Value>, output_ids: &[String]) -> Option<(Value, Vec<String>)> {
+    let leader_output_id = output_ids.first()?;
+    let (leader_zi, _) = zone_output_index(zones, leader_output_id)?;
+    let leader_zone_id = zones[leader_zi]["zone_id"].as_str()?.to_string();
+
+    let mut moved_from = Vec::new();
+    let mut moved_outputs = Vec::new();
+    for output_id in &output_ids[1..] {
+        let Some((zi, _)) = zone_output_index(zones, output_id) else {
+            continue;
+        };
+        if zi == leader_zi {
+            continue; // already part of the leader's zone
+        }
+        let outs = zones[zi]["outputs"].as_array_mut()?;
+        let Some(pos) = outs
+            .iter()
+            .position(|o| o["output_id"].as_str() == Some(output_id.as_str()))
+        else {
+            continue;
+        };
+        let mut out = outs.remove(pos);
+        out["zone_id"] = json!(leader_zone_id);
+        moved_from.push(zi);
+        moved_outputs.push(out);
+    }
+    if moved_outputs.is_empty() {
+        return None;
+    }
+
+    // Retire any source zone that lost its last output. Removing in
+    // descending index order keeps the remaining indices (including
+    // `leader_zi`, adjusted below) valid.
+    let mut emptied: Vec<usize> = moved_from;
+    emptied.sort_unstable();
+    emptied.dedup();
+    let mut removed_zone_ids = Vec::new();
+    let mut leader_zi = leader_zi;
+    for zi in emptied.into_iter().rev() {
+        if zones[zi]["outputs"]
+            .as_array()
+            .is_some_and(|outs| outs.is_empty())
+        {
+            removed_zone_ids.push(zones[zi]["zone_id"].as_str().unwrap_or_default().to_string());
+            zones.remove(zi);
+            if zi < leader_zi {
+                leader_zi -= 1;
+            }
+        }
+    }
+
+    let leader_outputs = zones[leader_zi]["outputs"].as_array_mut()?;
+    leader_outputs.extend(moved_outputs);
+
+    Some((zones[leader_zi].clone(), removed_zone_ids))
+}
+
+/// Pull every output in `output_ids` out of its current zone into its own
+/// standalone zone. Returns `(zones_changed, zones_added, zones_removed)`:
+/// a source zone that keeps at least one output after losing this one is
+/// `zones_changed`; a source zone left empty is retired into `zones_removed`.
+/// An output already alone in its zone is left untouched (not returned in
+/// any of the three).
+fn split_zone_outputs(
+    zones: &mut Vec<Value>,
+    output_ids: &[String],
+) -> (Vec<Value>, Vec<Value>, Vec<String>) {
+    let mut zones_changed = Vec::new();
+    let mut zones_added = Vec::new();
+    let mut zones_removed = Vec::new();
+
+    for output_id in output_ids {
+        let Some((zi, _)) = zone_output_index(zones, output_id) else {
+            continue;
+        };
+        let output_count = zones[zi]["outputs"].as_array().map_or(0, Vec::len);
+        if output_count <= 1 {
+            continue; // already standalone
+        }
+        let outs = zones[zi]["outputs"].as_array_mut().unwrap();
+        let pos = outs
+            .iter()
+            .position(|o| o["output_id"].as_str() == Some(output_id.as_str()))
+            .unwrap();
+        let mut out = outs.remove(pos);
+
+        let new_zone_id = format!("ungrouped-{output_id}");
+        out["zone_id"] = json!(new_zone_id);
+        let new_zone = standalone_zone_from_output(&new_zone_id, out);
+        zones.push(new_zone.clone());
+        zones_added.push(new_zone);
+
+        if zones[zi]["outputs"].as_array().unwrap().is_empty() {
+            zones_removed.push(zones[zi]["zone_id"].as_str().unwrap_or_default().to_string());
+        } else {
+            zones_changed.push(zones[zi].clone());
+        }
+    }
+    if !zones_removed.is_empty() {
+        zones.retain(|z| {
+            !zones_removed.contains(&z["zone_id"].as_str().unwrap_or_default().to_string())
+        });
+    }
+    (zones_changed, zones_added, zones_removed)
+}
+
+/// Build a minimal, fully-populated standalone zone (every field
+/// `roon_api`'s `transport::Zone` requires, same as [`default_zone`]) around
+/// one output that just left a group.
+fn standalone_zone_from_output(zone_id: &str, output: Value) -> Value {
+    json!({
+        "zone_id": zone_id,
+        "display_name": output["display_name"],
+        "state": "stopped",
+        "is_next_allowed": true,
+        "is_previous_allowed": true,
+        "is_pause_allowed": false,
+        "is_play_allowed": true,
+        "is_seek_allowed": false,
+        "queue_items_remaining": 0,
+        "queue_time_remaining": 0,
+        "now_playing": null,
+        "settings": { "loop": "disabled", "shuffle": false, "auto_radio": false },
+        "outputs": [output],
+    })
 }
 
 fn current_list(state: &CoreState, session_key: &str) -> Value {

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -1314,6 +1314,128 @@ async fn a_custom_library_is_browsable() {
 }
 
 // =============================================================================
+// hifi_collections (#531): browse_collection and browse_named_root_node
+// =============================================================================
+
+/// `browse_collection` walks two levels: a fresh root session, then resuming
+/// it with the returned `(item_key, session_key)` pair -- exactly what
+/// `hifi_collections`' `path` round-trips through a minted `RoonBrowse` ref.
+/// The second call must never send `pop_all` (see `RoonAdapter::play_ref`'s
+/// docs on why that combination hangs a real Core).
+#[tokio::test]
+async fn roon_collections_browse_walks_two_levels_without_pop_all_on_resume() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Library").with_children(vec![FakeItem::list(
+        "Genres",
+    )
+    .with_children(vec![FakeItem::list("Jazz"), FakeItem::list("Ambient")])])];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let (session, root_items, root_count) = adapter
+        .browse_collection("zone_1", None, None, 0, 20)
+        .await
+        .expect("root browse");
+    assert_eq!(root_count, 1);
+    assert_eq!(root_items[0].title, "Library");
+    let library_key = root_items[0]
+        .item_key
+        .clone()
+        .expect("Library must be keyed");
+
+    let (resumed_session, level_two, _count) = adapter
+        .browse_collection("zone_1", Some(&library_key), Some(&session), 0, 20)
+        .await
+        .expect("resumed browse");
+    assert_eq!(resumed_session, session, "resuming must reuse the session");
+    assert_eq!(
+        level_two.iter().map(|i| i.title.as_str()).collect::<Vec<_>>(),
+        vec!["Genres"]
+    );
+
+    // The resuming browse must never combine pop_all with item_key.
+    let browses = core.browse_requests().await;
+    assert_eq!(browses.len(), 2);
+    assert!(browses[0].pop_all() && browses[0].item_key().is_none());
+    assert!(!browses[1].pop_all());
+    assert_eq!(browses[1].item_key(), Some(library_key.as_str()));
+
+    core.stop().await;
+}
+
+/// `browse_collection` honors `offset`/`limit` as Roon's own `load` paging,
+/// not a client-side slice -- unlike Music Assistant's `music/browse`, Roon's
+/// `load` takes `offset`/`count` natively.
+#[tokio::test]
+async fn roon_collections_browse_pages_with_native_load_offset() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("A"), FakeItem::list("B"), FakeItem::list("C")];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let (_session, page, count) = adapter
+        .browse_collection("zone_1", None, None, 1, 1)
+        .await
+        .expect("paged root browse");
+    assert_eq!(count, 3);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].title, "B");
+
+    core.stop().await;
+}
+
+/// `hifi_collections playlists`' whole job: enter a named top-level node in
+/// one call and load its contents, without a caller ever seeing the two-hop
+/// browse/load plumbing.
+#[tokio::test]
+async fn roon_collections_playlists_enters_the_named_root_node() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        FakeItem::list("Library"),
+        FakeItem::list("Playlists").with_children(vec![
+            FakeItem::list("Sunday Morning"),
+            FakeItem::list("Focus"),
+        ]),
+    ];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let (_session, items, count) = adapter
+        .browse_named_root_node("zone_1", "Playlists", 0, 20)
+        .await
+        .expect("Playlists node must be found");
+    assert_eq!(count, 2);
+    assert_eq!(
+        items.iter().map(|i| i.title.as_str()).collect::<Vec<_>>(),
+        vec!["Sunday Morning", "Focus"]
+    );
+
+    core.stop().await;
+}
+
+/// A named node the Core's root does not have is an honest, named failure --
+/// not a hang, not an empty page pretending to be the real thing.
+#[tokio::test]
+async fn roon_collections_named_root_node_not_found_is_a_clean_error() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Library")];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let error = adapter
+        .browse_named_root_node("zone_1", "Playlists", 0, 20)
+        .await
+        .expect_err("Playlists does not exist in this root");
+    assert!(error.to_string().contains("Playlists"));
+
+    core.stop().await;
+}
+
+// =============================================================================
 // AppState for the HTTP-boundary test
 // =============================================================================
 

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -30,7 +30,9 @@ mod mock_servers;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use mock_servers::roon_core::{album, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope};
+use mock_servers::roon_core::{
+    album, zone_with_grouping, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
+};
 use roon_api::browse::{BrowseOpts, LoadOpts};
 use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
 use unified_hifi_control::bus::create_bus;
@@ -1602,6 +1604,216 @@ async fn a_shared_session_key_is_one_level_stack_however_well_results_correlate(
         Some(&here.list.title),
         levels.last(),
         "a following load pages the level that landed last, whoever asked for it"
+    );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// Multiroom grouping: group_outputs / ungroup_outputs (issue #509)
+// =============================================================================
+//
+// Roon confirms grouping asynchronously through the ordinary zone
+// subscription (`RoonAdapter::set_group_members`'s own docs explain why), so
+// these tests poll `RoonAdapter::get_zones` rather than asserting on the
+// instant `set_group_members`/`ungroup_members` return.
+
+/// Poll `RoonAdapter::get_zones` until it reports exactly `expected` zones or
+/// a bound is hit, then return the last observation either way -- so a
+/// failing assertion downstream shows what actually arrived instead of just
+/// "timed out".
+async fn wait_for_zone_count(
+    adapter: &RoonAdapter,
+    expected: usize,
+) -> Vec<unified_hifi_control::adapters::roon::Zone> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let zones = adapter.get_zones().await;
+        if zones.len() == expected || Instant::now() >= deadline {
+            return zones;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn roon_multiroom_status_reports_no_groups_for_single_output_zones() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    // `connected()` only waits for Browse to register; the zone subscription
+    // it triggers as a side effect can still be in flight, so wait for both
+    // configured zones to have actually arrived before trusting the status
+    // below to mean anything.
+    wait_for_zone_count(&adapter, 2).await;
+
+    let status = adapter.multiroom_status().await.unwrap();
+    assert_eq!(
+        status["groups"].as_array().unwrap().len(),
+        0,
+        "no zone has more than one output yet"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_set_group_members_merges_outputs_into_one_zone() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    // See the status test above: wait for both zones before grouping them.
+    wait_for_zone_count(&adapter, 2).await;
+
+    adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await
+        .expect("set_group_members should succeed");
+
+    // Merging is confirmed asynchronously (the Core's `group_outputs` handler
+    // runs in its own spawned task, and the merge itself is only visible once
+    // its zone push round-trips back to the adapter), so wait for that before
+    // inspecting either the wire log or the adapter's own zone state.
+    let zones = wait_for_zone_count(&adapter, 1).await;
+    assert_eq!(
+        zones.len(),
+        1,
+        "the two zones merge into one once the Core's push arrives"
+    );
+
+    // The wire request the Core actually saw: `group_outputs` addressed by
+    // output id, leader first, exactly as `Transport::group_outputs`
+    // (`transport.rs:334-341`) sends it.
+    let group_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/group_outputs")
+        .collect();
+    assert_eq!(group_requests.len(), 1, "exactly one group_outputs call");
+    assert_eq!(
+        group_requests[0].body["output_ids"],
+        serde_json::json!(["output_a", "output_b"])
+    );
+    let merged = &zones[0];
+    assert_eq!(merged.zone_id, "zone_a", "the leader's zone_id survives");
+    let mut output_ids: Vec<&str> = merged.outputs.iter().map(|o| o.output_id.as_str()).collect();
+    output_ids.sort_unstable();
+    assert_eq!(output_ids, vec!["output_a", "output_b"]);
+
+    let status = adapter.multiroom_status().await.unwrap();
+    let groups = status["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 1, "the merged zone reports as one group");
+    assert_eq!(groups[0]["leader_zone_id"], serde_json::json!("roon:zone_a"));
+    assert_eq!(
+        groups[0]["member_zone_ids"],
+        serde_json::json!(["roon:output_b"]),
+        "member zone_a was retired, so the surviving member is named by output id"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_ungroup_members_splits_outputs_back_into_separate_zones() {
+    let core = FakeRoonCore::start().await;
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &["output_b"]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &["output_a"]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    wait_for_zone_count(&adapter, 2).await;
+
+    adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await
+        .expect("initial grouping should succeed");
+    wait_for_zone_count(&adapter, 1).await;
+
+    adapter
+        .ungroup_members(&["roon:output_b".to_string()])
+        .await
+        .expect("ungroup_members should succeed");
+
+    // See the merge test above for why this waits before inspecting either
+    // the wire log or the adapter's own zone state.
+    let zones = wait_for_zone_count(&adapter, 2).await;
+    assert_eq!(
+        zones.len(),
+        2,
+        "output_b splits back into its own zone once the Core's push arrives"
+    );
+
+    let ungroup_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/ungroup_outputs")
+        .collect();
+    assert_eq!(ungroup_requests.len(), 1, "exactly one ungroup_outputs call");
+    assert_eq!(
+        ungroup_requests[0].body["output_ids"],
+        serde_json::json!(["output_b"])
+    );
+    assert!(
+        zones.iter().all(|z| z.outputs.len() == 1),
+        "each zone is single-output again: {zones:?}"
+    );
+
+    let status = adapter.multiroom_status().await.unwrap();
+    assert_eq!(
+        status["groups"].as_array().unwrap().len(),
+        0,
+        "no zone has more than one output after the split"
+    );
+
+    core.stop().await;
+}
+
+#[tokio::test]
+async fn roon_set_group_members_refuses_mixed_protocol_outputs() {
+    let core = FakeRoonCore::start().await;
+    // Neither output lists the other as groupable -- e.g. one is RAAT and the
+    // other AirPlay. Real Roon Cores only group outputs that share a
+    // streaming protocol; `can_group_with_output_ids` is the Core's own
+    // compatibility list for exactly this.
+    core.set_zones(vec![
+        zone_with_grouping("zone_a", "Living Room", "output_a", &[]),
+        zone_with_grouping("zone_b", "Kitchen", "output_b", &[]),
+    ])
+    .await;
+    let adapter = connected(&core).await;
+    wait_for_zone_count(&adapter, 2).await;
+
+    let result = adapter
+        .set_group_members("roon:zone_a", &["roon:zone_b".to_string()], &[])
+        .await;
+
+    let error = result.expect_err("mixed-protocol grouping must be refused, not attempted");
+    let message = error.to_string();
+    assert!(
+        message.contains("protocol"),
+        "refusal should explain why, got: {message}"
+    );
+
+    let group_requests: Vec<_> = core
+        .requests()
+        .await
+        .into_iter()
+        .filter(|r| r.name == "com.roonlabs.transport:2/group_outputs")
+        .collect();
+    assert!(
+        group_requests.is_empty(),
+        "the incompatible request must never reach the Core: {group_requests:?}"
     );
 
     core.stop().await;

--- a/tests/volume_safety.rs
+++ b/tests/volume_safety.rs
@@ -22,6 +22,7 @@ fn db_output() -> Output {
             is_muted: Some(false),
             step: Some(1.0),
         }),
+        can_group_with_output_ids: Vec::new(),
     }
 }
 
@@ -71,6 +72,7 @@ fn pct_output() -> Output {
             is_muted: Some(false),
             step: Some(1.0),
         }),
+        can_group_with_output_ids: Vec::new(),
     }
 }
 
@@ -113,6 +115,7 @@ fn missing_volume_uses_safe_defaults() {
         output_id: "no-vol".to_string(),
         display_name: "No Volume".to_string(),
         volume: None,
+        can_group_with_output_ids: Vec::new(),
     };
     let (min, max) = get_volume_range(Some(&output));
     assert_eq!(min, 0.0);


### PR DESCRIPTION
Closes #530

## Dependency handling

This branch was created from `feat/issue-462-streaming-adapters` (the pinned PR base) and merges, in order, the four dependency branches that were still open at the time this issue was worked:

1. `origin/issue/519` (PR #527 — the HACS integration itself) — fast-forward, no conflicts.
2. `origin/issue/507` (PR #516 — `/api/collections`/`/api/queue`/`/api/play_ref` endpoints) — clean merge, no conflicts.
3. `origin/issue/517` (PR #521 — zone-group routing for musicassistant/lms/roon) — conflicts in `AGENTS.md`'s capability matrix and `tests/mcp_contract.rs`'s cell-count assertions (48, up from 46), resolved by combining both PRs' rows/comments.
4. `origin/issue/531` (PR #533 — LMS+Roon collections slices + per-zone `browse_supported`) — conflicts in `AGENTS.md`, `src/adapters/roon.rs`, `src/adapters/lms.rs`, `src/mcp/capabilities.rs`, `tests/mcp_contract.rs`, and `tests/mock_servers/lms.rs`. The two substantive ones: `RoonAdapter`/`LmsAdapter` each had two independent `impl LibraryAdapter` blocks (one from #521's multiroom grouping, one from #531's collections browsing) that had to be merged into a single `content()` match combining both operation sets; and `mcp/capabilities.rs`'s `routed()`/`GAPS` needed combining so LMS's now-fully-routed `saved_playlists`/`favorites`/`multiroom_sync` cells don't double-count as gaps. The merged `every_supported_capability_reaches_its_named_adapter` cell count is 53.

Since #527/#516/#521/#533 have since merged upstream on `feat/issue-462-streaming-adapters` (or will merge before this lands), a rebase onto the up-to-date base may drop these merge commits' diffs to nothing — that's expected; only this PR's own commit (`feat(hacs): implement browse_media and join/unjoin for HA integration`) carries the new work.

## Approach

**Browse tree.** `async_browse_media` presents three root entries mirroring `hifi_collections`' actions (Browse Library, Playlists, Favorites). Clicking into any of them calls `/api/collections` with that `action` and no `path`; every deeper folder click re-enters with `action=browse` and the previous page's opaque `path` token, since `src/mcp/tools/collections.rs` mints the same ref-target shape regardless of which entry point produced it, and only `action=browse` accepts a `path` at all (`playlists`/`favorites` are entry points, not resumable). Feature gating uses the new per-zone `browse_supported` flag from `/knob/zones` (PR #533) rather than a hardcoded provider set, so it tracks whatever `hifi_collections` implements without a client-side update.

**Play semantics.** `async_play_media` only accepts a `media_id` that `async_browse_media` itself returned (an opaque `ref:<token>` minted by the browse call) and forwards it to `/api/play_ref`. An HA `enqueue` value maps to `hifi_play_ref`'s `play`/`next`/`queue` actions where a distinct verb exists (`next` for `MediaPlayerEnqueue.NEXT`), and falls back to `queue` for `ADD`/`REPLACE` since UHC has no separate "replace the queue" verb.

**Grouping mapping.** `GROUPING_CAPABLE_PROVIDERS` now includes `roon` and `lms` alongside `musicassistant`. `async_join_players` refuses (client-side, before any adapter call) when a member zone id's prefix doesn't match the target zone's own provider — UHC has no protocol that groups zones across providers. `group_members` is populated from a new periodic aggregate `hifi_zone_group` status poll (`UnifiedHifiControlCoordinator._refresh_group_members`), run alongside the existing SSE-safety-net poll; a provider that can't be reached for that poll is skipped rather than failing the whole refresh. Both Roon's `roon:<output_id>` member-id convention and LMS's leaderless groups are tolerated verbatim, per `src/mcp/tools/groups.rs`'s documented conventions.

**Rust changes.** No new HTTP endpoints were needed — `/api/collections`, `/api/play_ref`, and `hifi_zone_group` (over `/mcp`) already existed after the dependency merges. The only Rust changes here are conflict-resolution fixes from combining #521 and #531: `RoonAdapter`/`LmsAdapter`'s `impl LibraryAdapter` blocks are each now a single `content()` dispatching both multiroom and collections operations, and `mcp/capabilities.rs`'s gap table was de-duplicated against the now-fully-routed LMS cells.

## Test results

Rust (from the worktree root, `RUSTC_WRAPPER=""` with rustup's 1.97.1 toolchain ahead of Homebrew's, after `make css`):
- `cargo test --test mcp_contract` — 118 passed, 0 failed
- `cargo test --test roon_protocol` — 69 passed, 0 failed
- `cargo test --test adapter_integration` — 61 passed, 0 failed
- `cargo test` (full suite) — all green except the documented pre-existing `web_fullstack_runner_contract::runner_builds_matching_assets_before_it_starts_the_server` failure (not touched by this change)
- `cargo clippy --lib --tests` — no errors, only pre-existing warnings in unrelated files

Python (venv with `pip install -r custom_components/unified_hifi_control/requirements_test.txt`):
- `pytest custom_components/unified_hifi_control/tests -v` — 55 passed, 0 failed (28 pre-existing + 27 new, covering browse root/walk/refusal, play/enqueue mapping, cross-provider join refusal, group_members population and failure-tolerance, and the new API client methods)
- `ruff check custom_components/unified_hifi_control` — clean

Note: in my environment, the currently-latest `pytest-homeassistant-custom-component` (0.13.357) requires `aiodns`/`pycares` present for its own session-scoped zeroconf-resolver fixture — the opposite of this repo's documented `pip uninstall -y aiodns pycares` workaround, which addresses a different (thread-leak false-positive) issue on other package version combinations. I did not change that documented guidance since it's version-dependent and out of this issue's scope; I just installed `aiodns`/`pycares` to get the suite running.

## Deviations from #530's acceptance criteria

- **Artwork**: `hifi_collections` items carry no per-item artwork field server-side (only now-playing state does, via `/knob/now_playing/image`). Browsed folders/tracks render without `BrowseMedia.thumbnail` rather than a fabricated placeholder. Documented in `docs/home_assistant_integration.md`.
- Everything else in the acceptance criteria is implemented as specified: `BROWSE_MEDIA` gated by provider support, folder navigation, playing a browsed item with enqueue honored, `GROUPING` + join/unjoin for musicassistant/roon/lms with cross-provider refusal, `group_members` populated, providers without either feature simply lack the flags, pytest coverage, ruff-clean, and docs updated.