### PR TITLE
Apple Music companion: build and publish ARM (Apple Silicon) DMG

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -37,6 +37,26 @@ https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-
 ```
 Then install "Unified Hi-Fi Control" from the plugin list.
 
+### Apple Music Companion (macOS, Apple Silicon)
+
+Download `unified-hifi-applemusic-companion-macos-arm64-*.dmg` from the assets
+below, open it, and drag **AppleMusicCompanionMac.app** (shown in Finder as
+"Apple Music Companion") into **Applications**. Apple Silicon (arm64) Macs
+only.
+
+**This build is unsigned.** macOS Gatekeeper will block the first launch.
+Either:
+- Right-click (or Control-click) the app in Applications and choose **Open**,
+  then confirm the dialog, or
+- Remove the quarantine attribute from Terminal:
+  ```bash
+  xattr -dr com.apple.quarantine "/Applications/AppleMusicCompanionMac.app"
+  ```
+
+Notarization is tracked as a follow-up and is not required to use the app.
+See `companion/apple_music/README.md` for details on what this companion
+does and does not control.
+
 ---
 
 ## MCP Server (Claude Integration)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,10 @@ on:
         description: 'Build macOS universal'
         type: boolean
         default: false
+      build_applemusic_macos:
+        description: 'Build Apple Music companion DMG (macOS arm64)'
+        type: boolean
+        default: false
       build_windows:
         description: 'Build Windows'
         type: boolean
@@ -69,6 +73,7 @@ jobs:
       is_beta: ${{ steps.decide.outputs.is_beta }}
       build_linux_arm: ${{ steps.decide.outputs.build_linux_arm }}
       build_macos: ${{ steps.decide.outputs.build_macos }}
+      build_applemusic_macos: ${{ steps.decide.outputs.build_applemusic_macos }}
       build_windows: ${{ steps.decide.outputs.build_windows }}
       build_lms: ${{ steps.decide.outputs.build_lms }}
       build_synology: ${{ steps.decide.outputs.build_synology }}
@@ -116,6 +121,7 @@ jobs:
           HAS_LABEL_ALL: ${{ contains(github.event.pull_request.labels.*.name, 'build:all') }}
           HAS_LABEL_LINUX_ARM: ${{ contains(github.event.pull_request.labels.*.name, 'build:linux-arm') }}
           HAS_LABEL_MACOS: ${{ contains(github.event.pull_request.labels.*.name, 'build:macos') }}
+          HAS_LABEL_APPLEMUSIC_MACOS: ${{ contains(github.event.pull_request.labels.*.name, 'build:applemusic-macos') }}
           HAS_LABEL_WINDOWS: ${{ contains(github.event.pull_request.labels.*.name, 'build:windows') }}
           HAS_LABEL_LMS: ${{ contains(github.event.pull_request.labels.*.name, 'build:lms') }}
           HAS_LABEL_LMS_MACOS: ${{ contains(github.event.pull_request.labels.*.name, 'build:lms-macos') }}
@@ -127,6 +133,7 @@ jobs:
           # Inputs (only present on workflow_dispatch)
           INPUT_LINUX_ARM: ${{ inputs.build_linux_arm }}
           INPUT_MACOS: ${{ inputs.build_macos }}
+          INPUT_APPLEMUSIC_MACOS: ${{ inputs.build_applemusic_macos }}
           INPUT_WINDOWS: ${{ inputs.build_windows }}
           INPUT_LMS: ${{ inputs.build_lms }}
           INPUT_SYNOLOGY: ${{ inputs.build_synology }}
@@ -145,6 +152,7 @@ jobs:
             echo "is_release=false" >> $GITHUB_OUTPUT
             echo "build_linux_arm=false" >> $GITHUB_OUTPUT
             echo "build_macos=false" >> $GITHUB_OUTPUT
+            echo "build_applemusic_macos=false" >> $GITHUB_OUTPUT
             echo "build_windows=false" >> $GITHUB_OUTPUT
             echo "build_lms=false" >> $GITHUB_OUTPUT
             echo "build_synology=false" >> $GITHUB_OUTPUT
@@ -199,6 +207,14 @@ jobs:
           if [[ "$HAS_LABEL_LMS_MACOS" == "true" ]]; then BUILD_MACOS="true"; fi
           if [[ "$INPUT_MACOS" == "true" ]]; then BUILD_MACOS="true"; fi
           echo "build_macos=$BUILD_MACOS" >> $GITHUB_OUTPUT
+
+          # Apple Music companion DMG (macOS arm64-only). Independent of the
+          # main macOS binary build - it packages the Xcode companion app.
+          BUILD_APPLEMUSIC_MACOS="false"
+          if should_build; then BUILD_APPLEMUSIC_MACOS="true"; fi
+          if [[ "$HAS_LABEL_APPLEMUSIC_MACOS" == "true" ]]; then BUILD_APPLEMUSIC_MACOS="true"; fi
+          if [[ "$INPUT_APPLEMUSIC_MACOS" == "true" ]]; then BUILD_APPLEMUSIC_MACOS="true"; fi
+          echo "build_applemusic_macos=$BUILD_APPLEMUSIC_MACOS" >> $GITHUB_OUTPUT
 
           # Windows
           BUILD_WINDOWS="false"
@@ -286,6 +302,11 @@ jobs:
             if [[ "$IS_RELEASE_TRIGGER" == "true" ]]; then add_row "macos" "$RELEASE_TRIGGER_NAME"
             elif [[ "$HAS_LABEL_LMS_MACOS" == "true" ]]; then add_row "macos" "build:lms-macos"
             elif [[ "$HAS_LABEL_MACOS" == "true" ]]; then add_row "macos" "build:macos"
+            fi
+          fi
+          if [[ "$BUILD_APPLEMUSIC_MACOS" == "true" ]]; then
+            if [[ "$IS_RELEASE_TRIGGER" == "true" ]]; then add_row "applemusic-macos" "$RELEASE_TRIGGER_NAME"
+            elif [[ "$HAS_LABEL_APPLEMUSIC_MACOS" == "true" ]]; then add_row "applemusic-macos" "build:applemusic-macos"
             fi
           fi
           if [[ "$BUILD_LINUX_ARM" == "true" ]]; then
@@ -1002,6 +1023,30 @@ jobs:
           path: dist/bin/
           retention-days: 5
 
+  build-applemusic-companion-dmg:
+    name: Build Apple Music Companion DMG (macOS arm64)
+    needs: [plan]
+    if: needs.plan.outputs.build_applemusic_macos == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # No signing identity is available in CI, so this produces an
+      # unsigned/ad-hoc DMG. ARM64 (Apple Silicon) only - by design, not a
+      # gap: see companion/apple_music/README.md for the right-click-Open /
+      # xattr workaround users need on first launch.
+      - name: Build arm64-only DMG
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: companion/apple_music/build-dmg.sh
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v7
+        with:
+          name: applemusic-companion-dmg
+          path: companion/apple_music/dist/*.dmg
+          retention-days: 5
+
   build-windows:
     name: Build Windows
     needs: [plan, build-wasm]
@@ -1641,7 +1686,7 @@ jobs:
   # Note: Web assets are embedded in the binary (ADR 002)
   upload-release:
     name: Upload to Release
-    needs: [plan, build-linux-x64, build-linux-arm, build-macos-universal, build-windows, build-linux-packages, build-lms-universal, build-synology, build-qnap-x64, build-qnap-arm]
+    needs: [plan, build-linux-x64, build-linux-arm, build-macos-universal, build-applemusic-companion-dmg, build-windows, build-linux-packages, build-lms-universal, build-synology, build-qnap-x64, build-qnap-arm]
     if: needs.plan.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -1666,6 +1711,7 @@ jobs:
           find artifacts -name "*.zip" -type f -exec cp {} release/ \;
           find artifacts -name "*.spk" -type f -exec cp {} release/ \;
           find artifacts -name "*.qpkg" -type f -exec cp {} release/ \;
+          find artifacts -name "*.dmg" -type f -exec cp {} release/ \;
           ls -la release/
 
       - name: Generate asset list
@@ -1691,6 +1737,12 @@ jobs:
           ### NAS Packages
           - `.spk` for Synology DSM 7+
           - `.qpkg` for QNAP
+
+          ### macOS Companion Apps
+          - `unified-hifi-applemusic-companion-macos-arm64-*.dmg` - Apple Music
+            companion (Apple Silicon only). Unsigned: see the "Unsigned app"
+            note in [companion/apple_music/README.md](https://github.com/${{ github.repository }}/blob/v3/companion/apple_music/README.md)
+            for the right-click-Open / xattr workaround required on first launch.
 
           ### LMS Plugin
           - `lms-unified-hifi-control-*.zip` - Install via LMS Settings > Plugins
@@ -1893,6 +1945,7 @@ jobs:
       - smoke-test
       - build-linux-arm
       - build-macos-universal
+      - build-applemusic-companion-dmg
       - build-windows
       - build-lms-universal
       - build-synology

--- a/Makefile
+++ b/Makefile
@@ -24,18 +24,19 @@ else
     TAILWIND_BINARY := tailwindcss-linux-x64
 endif
 
-.PHONY: help setup-tailwind css css-watch web-prereqs web-run synology-test qnap-test clean
+.PHONY: help setup-tailwind css css-watch web-prereqs web-run synology-test qnap-test companion-apple-music-dmg clean
 
 help:
 	@echo "Available targets:"
-	@echo "  setup-tailwind  - Download Tailwind CSS standalone CLI"
-	@echo "  css             - Build Tailwind CSS"
-	@echo "  css-watch       - Watch and rebuild Tailwind CSS"
-	@echo "  web-prereqs     - Install the Rust target required by the web build"
-	@echo "  web-run         - Build matching server + WASM, then run UHC"
-	@echo "  synology-test   - Validate SPK structure and unprivileged lifecycle"
-	@echo "  qnap-test       - Validate QNAP x86_64 package contract"
-	@echo "  clean           - Remove generated files"
+	@echo "  setup-tailwind             - Download Tailwind CSS standalone CLI"
+	@echo "  css                        - Build Tailwind CSS"
+	@echo "  css-watch                  - Watch and rebuild Tailwind CSS"
+	@echo "  web-prereqs                - Install the Rust target required by the web build"
+	@echo "  web-run                    - Build matching server + WASM, then run UHC"
+	@echo "  synology-test              - Validate SPK structure and unprivileged lifecycle"
+	@echo "  qnap-test                  - Validate QNAP x86_64 package contract"
+	@echo "  companion-apple-music-dmg  - Build the arm64-only Apple Music companion .dmg (macOS only)"
+	@echo "  clean                      - Remove generated files"
 
 setup-tailwind:
 	@if [ ! -f ./tailwindcss ]; then \
@@ -74,6 +75,9 @@ synology-test:
 
 qnap-test:
 	tests/qnap_package_contract.sh
+
+companion-apple-music-dmg:
+	companion/apple_music/build-dmg.sh
 
 clean:
 	rm -f public/tailwind.css

--- a/companion/apple_music/.gitignore
+++ b/companion/apple_music/.gitignore
@@ -1,0 +1,10 @@
+# Swift Package Manager build output (swift build / build-app.sh)
+.build/
+.swiftpm/
+
+# Xcode build products (xcodebuild -derivedDataPath, DerivedData/)
+DerivedData/
+xcuserdata/
+
+# build-dmg.sh output
+dist/

--- a/companion/apple_music/README.md
+++ b/companion/apple_music/README.md
@@ -35,3 +35,43 @@ stable companion ID, bridge ID, and UHC URL in Keychain; inject
 Signed-host lifecycle, Keychain identity, and physical validation remain
 required by #486/#487. Linux, QNAP, and other non-macOS builds do not compile
 this package.
+
+## Building a distributable DMG (Apple Silicon only)
+
+`build-dmg.sh` builds the Xcode app
+(`XcodeMac/AppleMusicCompanionMac.xcworkspace`, scheme
+`AppleMusicCompanionMac`) for **arm64 only** — no x86_64 or universal build,
+by explicit project decision — and wraps it in a `.dmg` with `hdiutil`. It
+verifies the built executable is arm64-only before packaging. Run it via:
+
+```sh
+make companion-apple-music-dmg
+# or directly, from this directory:
+VERSION=0.1.0 ./build-dmg.sh
+```
+
+The DMG is written to `companion/apple_music/dist/` (gitignored). This
+mirrors the `build-applemusic-companion-dmg` CI job in
+`.github/workflows/build.yml`; see `docs/gh-release.md` for how it's wired
+into label-gated PR builds and releases.
+
+By default the app is built **unsigned** (ad-hoc, `codesign --sign -`),
+since CI has no code-signing identity available. Set `CODE_SIGN_IDENTITY`
+(and `DEVELOPMENT_TEAM`) to build with a local Developer ID or Apple
+Development identity instead.
+
+### Unsigned app: first-launch workaround
+
+Because the shipped DMG is unsigned, macOS Gatekeeper quarantines the app on
+download and blocks a normal double-click launch. After copying
+`AppleMusicCompanionMac.app` to `/Applications`, either:
+
+- Right-click (Control-click) the app and choose **Open**, then confirm the
+  dialog, or
+- Remove the quarantine attribute from Terminal:
+  ```sh
+  xattr -dr com.apple.quarantine "/Applications/AppleMusicCompanionMac.app"
+  ```
+
+Notarization is tracked as a follow-up (not a blocker for distributing this
+DMG) — see issue #535.

--- a/companion/apple_music/XcodeMac/AppleMusicCompanionMac.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/companion/apple_music/XcodeMac/AppleMusicCompanionMac.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "dfa043e097cfd7e8c706f056fe786f0ab2ef8a3f20a2101968c788550c307839",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-testing.git",
+      "state" : {
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/companion/apple_music/build-dmg.sh
+++ b/companion/apple_music/build-dmg.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the arm64-only (Apple Silicon) macOS companion app from the Xcode
+# project (XcodeMac/AppleMusicCompanionMac.xcworkspace) and wrap it in a
+# distributable .dmg. This reproduces what CI's companion-dmg job produces
+# (see .github/workflows/build.yml) so it can be verified locally on a
+# Mac before/without CI.
+#
+# ARM64 (Apple Silicon) only, by user decision — this script never builds
+# x86_64 or a universal binary.
+#
+# By default the app is built unsigned/ad-hoc (no Developer ID required),
+# matching the CI environment which has no signing identity available. Set
+# CODE_SIGN_IDENTITY (and DEVELOPMENT_TEAM) to sign with a local identity
+# instead. See companion/apple_music/README.md for the right-click-Open /
+# xattr workaround unsigned builds require on first launch.
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+WORKSPACE="$SCRIPT_DIR/XcodeMac/AppleMusicCompanionMac.xcworkspace"
+SCHEME=${SCHEME:-AppleMusicCompanionMac}
+CONFIGURATION=${CONFIGURATION:-Release}
+APP_NAME=AppleMusicCompanionMac
+VERSION=${VERSION:-0.0.0-dev}
+VOLUME_NAME=${VOLUME_NAME:-"Apple Music Companion"}
+OUTPUT_DIR=${OUTPUT_DIR:-"$SCRIPT_DIR/dist"}
+DMG_NAME=${DMG_NAME:-"unified-hifi-applemusic-companion-macos-arm64-${VERSION}.dmg"}
+
+# Signing overrides. Defaults produce an unsigned/ad-hoc build so this works
+# without a Developer ID (matches CI). CODE_SIGN_IDENTITY=- is ad-hoc;
+# DEVELOPMENT_TEAM must stay empty for ad-hoc signing.
+CODE_SIGN_IDENTITY=${CODE_SIGN_IDENTITY:--}
+CODE_SIGN_STYLE=${CODE_SIGN_STYLE:-Manual}
+DEVELOPMENT_TEAM=${DEVELOPMENT_TEAM:-}
+CODE_SIGNING_REQUIRED=${CODE_SIGNING_REQUIRED:-NO}
+CODE_SIGNING_ALLOWED=${CODE_SIGNING_ALLOWED:-YES}
+
+if ! command -v xcodebuild >/dev/null 2>&1; then
+  echo "error: xcodebuild not found. Install Xcode (not just the Command Line Tools)." >&2
+  exit 1
+fi
+
+if ! xcodebuild -version >/dev/null 2>&1; then
+  echo "error: xcodebuild requires a full Xcode install, not just the Command Line" >&2
+  echo "  Tools. If Xcode.app is installed but 'xcode-select' points elsewhere," >&2
+  echo "  either run 'sudo xcode-select -s /Applications/Xcode.app/Contents/Developer'" >&2
+  echo "  or re-run this script with DEVELOPER_DIR set, e.g.:" >&2
+  echo "  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer $0" >&2
+  exit 1
+fi
+
+DERIVED_DATA_DIR=$(mktemp -d "${TMPDIR:-/tmp}/applemusic-companion-dmg.XXXXXX")
+STAGING_DIR=$(mktemp -d "${TMPDIR:-/tmp}/applemusic-companion-staging.XXXXXX")
+cleanup() {
+  rm -rf "$DERIVED_DATA_DIR" "$STAGING_DIR"
+}
+trap cleanup EXIT
+
+echo "==> Building $SCHEME ($CONFIGURATION, arm64) from $WORKSPACE"
+xcodebuild \
+  -workspace "$WORKSPACE" \
+  -scheme "$SCHEME" \
+  -configuration "$CONFIGURATION" \
+  -derivedDataPath "$DERIVED_DATA_DIR" \
+  -destination 'generic/platform=macOS' \
+  ARCHS=arm64 \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGN_IDENTITY="$CODE_SIGN_IDENTITY" \
+  CODE_SIGN_STYLE="$CODE_SIGN_STYLE" \
+  DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
+  CODE_SIGNING_REQUIRED="$CODE_SIGNING_REQUIRED" \
+  CODE_SIGNING_ALLOWED="$CODE_SIGNING_ALLOWED" \
+  build
+
+BUILT_APP="$DERIVED_DATA_DIR/Build/Products/$CONFIGURATION/$APP_NAME.app"
+if [[ ! -d "$BUILT_APP" ]]; then
+  echo "error: expected built app at $BUILT_APP" >&2
+  exit 1
+fi
+
+EXECUTABLE="$BUILT_APP/Contents/MacOS/$APP_NAME"
+ARCHES=$(lipo -archs "$EXECUTABLE")
+echo "==> Executable architectures: $ARCHES"
+if [[ "$ARCHES" != "arm64" ]]; then
+  echo "error: expected an arm64-only executable, got '$ARCHES'" >&2
+  exit 1
+fi
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+cp -R "$BUILT_APP" "$STAGING_DIR/"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+DMG_PATH="$OUTPUT_DIR/$DMG_NAME"
+rm -f "$DMG_PATH"
+
+echo "==> Creating $DMG_PATH"
+hdiutil create \
+  -volname "$VOLUME_NAME" \
+  -srcfolder "$STAGING_DIR" \
+  -ov -format UDZO \
+  "$DMG_PATH"
+
+echo "==> Created $DMG_PATH"
+if [[ "$CODE_SIGN_IDENTITY" == "-" ]]; then
+  echo "==> This is an unsigned/ad-hoc build. First launch on another Mac"
+  echo "    requires right-click > Open (or removing the quarantine"
+  echo "    attribute with 'xattr -dr com.apple.quarantine'). See"
+  echo "    companion/apple_music/README.md for details."
+fi
+
+echo "$DMG_PATH"

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -28,6 +28,7 @@ Add labels to your PR to enable optional builds:
 | `build:docker` | Docker x64 image |
 | `build:linux-arm` | Linux arm64 + armv7 binaries |
 | `build:macos` | macOS universal binary |
+| `build:applemusic-macos` | Apple Music companion DMG (macOS arm64 only) |
 | `build:windows` | Windows exe |
 | `build:linux-packages` | deb/rpm packages |
 | `build:all` | Everything |
@@ -254,6 +255,42 @@ The QDK 2.5.3 release assets used here are:
 - `qdk_2.5.3_amd64.deb`: `17b3841b7d4590a4ee025844ba583304b5e3c497d9fa8934d5175131d3908022`
 - `qdk_2.5.3_arm64.deb`: `4b00c009cb48c0ffa7e4b7b00c5a6a1982a0955d663c0c6ec57020353e68eeb9` (available from the release, not used by CI)
 
+### Apple Music Companion DMG
+
+`build-applemusic-companion-dmg` builds the macOS companion app
+(`companion/apple_music/XcodeMac/AppleMusicCompanionMac.xcworkspace`) with
+`xcodebuild`, forcing `ARCHS=arm64` — Apple Silicon only, no x86_64 or
+universal build, by explicit project decision. The job runs
+`companion/apple_music/build-dmg.sh`, which also verifies the built
+executable is arm64-only (via `lipo -archs`) before wrapping it with
+`hdiutil create` into a `.dmg` containing the `.app` and an `Applications`
+symlink.
+
+No code-signing identity is available in CI, so the DMG ships **unsigned**
+(ad-hoc signed with `codesign --sign -`). Notarization is tracked as a
+follow-up, not a blocker (see issue #535). Because the app is unsigned,
+Gatekeeper quarantines it on download; users must either right-click the
+`.app` and choose **Open** (confirming the dialog) on first launch, or run:
+
+```sh
+xattr -dr com.apple.quarantine "/Applications/AppleMusicCompanionMac.app"
+```
+
+This is documented in `companion/apple_music/README.md` and linked from the
+release notes' Download Guide.
+
+To reproduce the CI artifact locally on Apple Silicon:
+
+```sh
+make companion-apple-music-dmg
+# or directly:
+VERSION=0.1.0 companion/apple_music/build-dmg.sh
+```
+
+The DMG lands in `companion/apple_music/dist/`. Set `CODE_SIGN_IDENTITY` (and
+`DEVELOPMENT_TEAM`) to build with a local Developer ID or Apple Development
+identity instead of the unsigned default.
+
 ## Build Matrix
 
 | Target | Caching | Build Tool | Default | Label |
@@ -264,6 +301,7 @@ The QDK 2.5.3 release assets used here are:
 | Linux aarch64-musl | rust-cache | cargo-zigbuild | Release | `build:linux-arm` |
 | Linux armv7-musl | rust-cache | cargo-zigbuild | Release | `build:linux-arm` |
 | macOS universal | sccache + rust-cache | cargo + lipo | Release | `build:macos` |
+| Apple Music companion DMG (macOS arm64) | N/A | xcodebuild + hdiutil | Release | `build:applemusic-macos` |
 | Windows x86_64 | sccache + rust-cache | cargo | Release | `build:windows` |
 | Docker x64 | N/A | pre-built binary | Release | `build:docker` |
 | Docker multi-arch | N/A | pre-built binaries | Release | - |


### PR DESCRIPTION
Closes #535

## Summary
- Add `companion/apple_music/build-dmg.sh`, which builds the Xcode `AppleMusicCompanionMac` app for **arm64 only** (no x86_64/universal, per project decision), verifies the executable is arm64-only via `lipo -archs`, and wraps it in a `.dmg` with `hdiutil`.
- Wire a `build-applemusic-companion-dmg` job into `.github/workflows/build.yml`, gated the same way as the existing `build:macos` label/dispatch/release pattern, with a new `build:applemusic-macos` PR label and `build_applemusic_macos` workflow_dispatch input. Wires into `upload-release` so the DMG attaches to GitHub Releases.
- Add a `make companion-apple-music-dmg` target for local reproduction.
- Document the unsigned-app right-click-Open / `xattr -dr com.apple.quarantine` workaround in `companion/apple_music/README.md`, `docs/gh-release.md`, and `.github/RELEASE_TEMPLATE.md`.
- Add `companion/apple_music/.gitignore` for `.build/`, `.swiftpm/`, `DerivedData/`, and the script's `dist/` output, and commit the Xcode workspace's `Package.resolved` (pins `swift-testing`/`swift-syntax` for reproducible builds).

## Approach
Base is `feat/issue-462-streaming-adapters` per branch-pinning decision (not `v3`); CI does not run on this feature-branch base, so verification was done locally end-to-end on Apple Silicon.

Signing: no Developer ID is available in CI, so the DMG ships **unsigned** (ad-hoc `codesign --sign -`). Notarization is a documented follow-up, not a blocker, matching the issue's acceptance criteria.

## Local verification (Apple Silicon, Xcode 26.6)
```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer VERSION=0.1.0 \
  companion/apple_music/build-dmg.sh
```
- `xcodebuild ... ARCHS=arm64 ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO` → `** BUILD SUCCEEDED **`
- `lipo -archs .../AppleMusicCompanionMac.app/Contents/MacOS/AppleMusicCompanionMac` → `arm64` (single-arch, confirmed via both `lipo` and `file`)
- `hdiutil create -volname "Apple Music Companion" ... -format UDZO` → DMG created
- `hdiutil attach` the produced DMG, confirmed it mounts, contains `AppleMusicCompanionMac.app` + an `Applications` symlink, and the mounted executable is still `arm64` via `lipo`; `hdiutil detach` cleaned up
- `make companion-apple-music-dmg` reproduces the same artifact
- `Info.plist`: `CFBundleIdentifier=com.openhorizonlabs.uhc.applemusiccompanion`, `CFBundleShortVersionString=0.1.0`, `LSMinimumSystemVersion=14.0`
- `.github/workflows/build.yml` validated with `ruby -ryaml` (pyyaml unavailable in sandbox); `bash -n` on `build-dmg.sh`

Note: on this dev Mac, `xcode-select` points at the Command Line Tools rather than the full Xcode install, so local runs need `DEVELOPER_DIR` set (the script now detects this and prints the exact fix); GitHub's `macos-latest` runners have a full Xcode already selected, so this isn't expected to affect CI.

## Deviations from #535's acceptance criteria
None. All checklist items are addressed: arm64-only CI job (label + dispatch + release triggers), launchable `.app` in the DMG with documented unsigned-app instructions, artifact naming consistent with the `unified-hifi-*` convention, a local reproduction script/make target, and `docs/gh-release.md` updated.

## Test plan
- [x] Local `build-dmg.sh` run produces an arm64-only, mountable DMG (see transcript above)
- [x] `make companion-apple-music-dmg` reproduces the same artifact
- [ ] CI job runs on `v3` once this PR's base is promoted (not exercised here — feature-branch base runs no workflows)