### PR TITLE
fix(settings): unconfigured-adapter enable no longer errors or reverts settings

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3267,27 +3267,46 @@ pub async fn api_settings_post_handler(
         // Find the adapter and start/stop it
         if let Some(adapter) = adapters_list.iter().find(|a| a.name() == *name) {
             if now_enabled {
-                tracing::info!("Dynamically enabling adapter: {}", name);
-                if let Err(error) = coord.start_adapter_and_companions(adapter.as_ref()).await {
-                    tracing::warn!("Failed to start adapter {}: {}", name, error);
-                    // Do not persist a feature as enabled when its runtime
-                    // could not be started. The Settings client will restore
-                    // its last confirmed switch position from this response.
-                    coord
-                        .rollback_adapter_transitions(
-                            adapters_list.as_ref(),
-                            old_adapters,
-                            &applied_transitions,
-                        )
-                        .await;
-                    // The new settings were already persisted (inside the write
-                    // lock, for the hidden-zones carry-forward); put the old
-                    // ones back so disk matches the rolled-back runtime.
-                    let _ = mutate_app_settings(|current| *current = old_settings.clone());
-                    return Json(serde_json::json!({
-                        "ok": false,
-                        "error": format!("Could not enable {name}: {error}"),
-                    }));
+                // An adapter that is not yet configured (no host, no
+                // credentials, ...) is not a startup failure -- it is the
+                // ordinary state of "enabled, waiting to be configured".
+                // `start_all_enabled`/`start_enabled` already treat
+                // `can_start() == false` as a skip rather than an error; this
+                // toggle path used to reach `start_adapter_and_companions`
+                // unconditionally, which raised "adapter cannot start" and
+                // rolled the whole settings write back (see issue #544).
+                // Mirror the skip here so enabling an unconfigured adapter
+                // succeeds and leaves it idle, matching v3's behavior, and
+                // only a genuine start failure of a *configured* adapter
+                // triggers rollback.
+                if !adapter.can_start().await {
+                    tracing::info!(
+                        "Adapter {} enabled but not yet configured; leaving idle until configured",
+                        name
+                    );
+                } else {
+                    tracing::info!("Dynamically enabling adapter: {}", name);
+                    if let Err(error) = coord.start_adapter_and_companions(adapter.as_ref()).await {
+                        tracing::warn!("Failed to start adapter {}: {}", name, error);
+                        // Do not persist a feature as enabled when its runtime
+                        // could not be started. The Settings client will restore
+                        // its last confirmed switch position from this response.
+                        coord
+                            .rollback_adapter_transitions(
+                                adapters_list.as_ref(),
+                                old_adapters,
+                                &applied_transitions,
+                            )
+                            .await;
+                        // The new settings were already persisted (inside the write
+                        // lock, for the hidden-zones carry-forward); put the old
+                        // ones back so disk matches the rolled-back runtime.
+                        let _ = mutate_app_settings(|current| *current = old_settings.clone());
+                        return Json(serde_json::json!({
+                            "ok": false,
+                            "error": format!("Could not enable {name}: {error}"),
+                        }));
+                    }
                 }
             } else {
                 tracing::info!("Dynamically disabling adapter: {}", name);
@@ -3571,9 +3590,24 @@ fn adapter_enabled(settings: &AdapterSettings, name: &str) -> Option<bool> {
 mod tests {
     use super::*;
     use crate::bus::{create_bus, BusEvent, PlaybackState, Zone};
+    use axum::response::IntoResponse;
+    use http_body_util::BodyExt;
     use serial_test::serial;
     use std::env;
     use std::time::Duration;
+
+    /// Pulls the JSON body out of a handler's `impl IntoResponse`, for tests
+    /// that need to assert on `{"ok": ..., "error": ...}` rather than only
+    /// on the settings file the handler wrote.
+    async fn response_json(response: impl IntoResponse) -> serde_json::Value {
+        let body = response.into_response().into_body();
+        let bytes = body
+            .collect()
+            .await
+            .expect("response body must be readable")
+            .to_bytes();
+        serde_json::from_slice(&bytes).expect("response body must be valid JSON")
+    }
 
     struct FakeAdapter(&'static str);
 
@@ -3584,6 +3618,41 @@ mod tests {
         }
         async fn start(&self) -> anyhow::Result<()> {
             Ok(())
+        }
+        async fn stop(&self) {}
+    }
+
+    /// Stands in for an adapter that has never been configured -- like a
+    /// fresh HQPlayer instance with no host set. `can_start()` false is the
+    /// normal state of "enabled but not yet set up", not a failure.
+    struct UnconfiguredAdapter(&'static str);
+
+    #[async_trait::async_trait]
+    impl Startable for UnconfiguredAdapter {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+        async fn start(&self) -> anyhow::Result<()> {
+            panic!("start() must not be called when can_start() is false");
+        }
+        async fn stop(&self) {}
+        async fn can_start(&self) -> bool {
+            false
+        }
+    }
+
+    /// Stands in for a *configured* adapter whose runtime genuinely fails to
+    /// start (bad network, crashed process, ...) -- the one case where the
+    /// settings write should still roll back.
+    struct FailingAdapter(&'static str);
+
+    #[async_trait::async_trait]
+    impl Startable for FailingAdapter {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+        async fn start(&self) -> anyhow::Result<()> {
+            Err(anyhow::anyhow!("connection refused"))
         }
         async fn stop(&self) {}
     }
@@ -3913,6 +3982,100 @@ mod tests {
             after.hidden_zone_ids().is_empty(),
             "an explicit empty list must clear the hide list, got {:?}",
             after.hidden_zone_ids()
+        );
+    }
+
+    /// Issue #544: enabling an adapter that has never been configured (e.g. a
+    /// fresh HQPlayer instance with no host set) must succeed and leave the
+    /// adapter idle, exactly like v3's `if adapter.can_start().await { ... }`
+    /// guard did. The integration merge routed this toggle through
+    /// `start_adapter_and_companions`, which raises "adapter cannot start"
+    /// for an unconfigured adapter and used to trip the settings rollback --
+    /// surfacing a generic error to the user and undoing the whole write.
+    #[tokio::test]
+    #[serial]
+    async fn enabling_an_unconfigured_adapter_succeeds_and_stays_idle() {
+        env::set_var(
+            "UHC_CONFIG_DIR",
+            "/tmp/uhc-test-issue-544-unconfigured-enable",
+        );
+
+        let mut seeded = AppSettings::default();
+        seeded.hidden_zones = Some(vec!["roon:phone".to_string()]);
+        seeded.adapters.hqplayer = false;
+        assert!(save_app_settings(&seeded), "failed to seed test settings");
+
+        let state = app_state_with_startable(Arc::new(UnconfiguredAdapter("hqplayer"))).await;
+        state.coordinator.register("hqplayer", false).await;
+
+        let mut enabling = AppSettings::default();
+        enabling.adapters.hqplayer = true;
+        let response = api_settings_post_handler(State(state.clone()), Json(enabling)).await;
+        let body = response_json(response).await;
+
+        assert_eq!(
+            body["ok"], true,
+            "enabling an unconfigured adapter must not be reported as an error, got {body:?}"
+        );
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        assert!(
+            after.adapters.hqplayer,
+            "the toggle itself must still take effect and persist"
+        );
+        assert_eq!(
+            after.hidden_zone_ids(),
+            ["roon:phone".to_string()],
+            "the hide list must survive enabling an unconfigured adapter"
+        );
+        assert!(
+            !state.coordinator.is_running("hqplayer").await,
+            "an unconfigured adapter must stay idle, not be marked running"
+        );
+    }
+
+    /// The other half of issue #544: a *configured* adapter whose runtime
+    /// genuinely fails to start must still roll the settings write back --
+    /// and that rollback must not take the user's hide list down with it.
+    #[tokio::test]
+    #[serial]
+    async fn a_failed_adapter_start_rolls_back_without_erasing_the_hide_list() {
+        env::set_var(
+            "UHC_CONFIG_DIR",
+            "/tmp/uhc-test-issue-544-failed-start-rollback",
+        );
+
+        let mut seeded = AppSettings::default();
+        seeded.hidden_zones = Some(vec!["roon:phone".to_string()]);
+        seeded.adapters.lms = false;
+        assert!(save_app_settings(&seeded), "failed to seed test settings");
+
+        let state = app_state_with_startable(Arc::new(FailingAdapter("lms"))).await;
+        state.coordinator.register("lms", false).await;
+
+        let mut enabling = AppSettings::default();
+        enabling.adapters.lms = true;
+        let response = api_settings_post_handler(State(state.clone()), Json(enabling)).await;
+        let body = response_json(response).await;
+
+        assert_eq!(
+            body["ok"], false,
+            "a genuine start failure of a configured adapter must still be reported"
+        );
+
+        let after = load_app_settings();
+        env::remove_var("UHC_CONFIG_DIR");
+
+        assert!(
+            !after.adapters.lms,
+            "a failed start must roll the toggle back to its previous state"
+        );
+        assert_eq!(
+            after.hidden_zone_ids(),
+            ["roon:phone".to_string()],
+            "rolling back a failed adapter start must not erase the hide list"
         );
     }
 


### PR DESCRIPTION
Closes #544

## Root cause

Two symptoms were reported live on `integration/streaming-ha-alpha`: `hidden_zones` appearing wiped after toggling adapters, and "Could not enable hqplayer: adapter cannot start" when enabling an unconfigured HQPlayer.

Auditing every settings writer (`api_settings_post_handler`'s carry-forward, `zone_name_post`, `zone_order_post`, `zone_visibility_post`, `mutate_app_settings`/`save_app_settings_locked`, and the merge's rollback-restore `*current = old_settings.clone()`) found the hidden-zones/zone-order/zone-names carry-forward and rollback-restore logic already correct on this branch — `old_settings` is captured *before* the new write is applied and fully restored on rollback, so the hide list is never dropped by that path. Regression tests below lock this in so it stays that way.

The real bug is the *trigger* for that rollback path: `api_settings_post_handler`'s adapter-enable branch calls `coordinator::start_adapter_and_companions` → `start_adapter_and_track`, which turns `can_start() == false` into a hard `Err("adapter cannot start")` — unlike `start_all_enabled`/`start_enabled`, which already treat "not configured" as an ordinary skip. v3's original handler (see `git show v3:src/api/mod.rs`) never treated `can_start() == false` as an error at all — it simply didn't call `start()`.

So enabling a never-configured adapter (e.g. HQPlayer with no host) now hits an error path that:
1. surfaces a generic "adapter cannot start" alert to the user, and
2. rolls the entire settings write back — undoing the toggle the user just made (and, transiently, looking like other fields were "wiped" even though the carry-forward/restore itself is sound).

## Fix

`src/api/mod.rs`: check `adapter.can_start().await` before attempting to start it in the settings-toggle loop. If it's `false`, log and leave the adapter enabled-but-idle (matching v3's behavior) instead of calling `start_adapter_and_companions` and treating the resulting error as a failure. A genuine runtime start failure of a *configured* adapter (network error, crashed process, etc.) still triggers the existing rollback-and-restore path unchanged.

## Regression tests added (`src/api/mod.rs`)

- `enabling_an_unconfigured_adapter_succeeds_and_stays_idle` — toggling on an adapter whose `can_start()` is `false` returns `{"ok": true}`, persists the toggle, leaves the adapter not-running, and preserves a pre-existing hide list.
- `a_failed_adapter_start_rolls_back_without_erasing_the_hide_list` — a *configured* adapter whose `start()` genuinely errors still returns `{"ok": false}`, rolls the toggle back, and the hide list survives the rollback.
- Added a `response_json` test helper (`http_body_util::BodyExt`, already a dependency) to assert on the handler's JSON body rather than only on the settings file.

Both new tests pass on the fix and were verified against the pre-fix code path during development (the unconfigured-adapter test reproduces the "adapter cannot start" error and settings churn before the fix).

## Local verification

- `cargo test --lib` — 506 passed, 0 failed
- `cargo clippy --lib -- -D warnings` — clean
- `cargo clippy --all-targets -- -D warnings` — pre-existing failures in `tests/roon_protocol.rs`, `tests/client_harness.rs`, `tests/hqplayer_conformance.rs` confirmed present on `origin/integration/streaming-ha-alpha` before this change (verified via `git stash`); unrelated to this diff.
- `cargo fmt` — clean
- Did not touch client/wasm code, so no wasm check was needed.
- Did not send any request (mutating or read-only) to 192.168.1.2:8088 or 192.168.1.61; verified entirely via unit tests against a temp config dir, per the issue's instruction not to touch the live server.

## Deviations from the oh-task skill flow

- `sg review`/`sg init` are not available in this environment (`sg` here resolves to `ast-grep`, which has no `review` subcommand); skipped that step and relied on `cargo test`/`clippy`/`fmt` plus manual review instead.
- Worked in the harness-provided isolated worktree directly rather than creating an additional nested `.worktrees/issue-544` worktree, since the environment already sandboxes this session to its own worktree.