### PR TITLE
hifi_collections: per-item artwork refs across providers

### DIFF
--- a/custom_components/unified_hifi_control/api.py
+++ b/custom_components/unified_hifi_control/api.py
@@ -93,6 +93,16 @@ class UnifiedHifiControlApiClient:
         """Build the direct URL for a zone's now-playing artwork."""
         return f"{self._base_url}{PATH_NOW_PLAYING_IMAGE}?zone_id={zone_id}"
 
+    def resolve_url(self, path: str) -> str:
+        """Turn a server-relative path (e.g. a hifi_collections item's
+        ``image`` field, ``/api/collections/image?ref=...``) into an
+        absolute URL against this server. Mirrors what :meth:`image_url`
+        already does for now-playing artwork -- the collections image proxy
+        (#549) hands back the same kind of same-origin path, just minted
+        per-item instead of built from a fixed zone_id template.
+        """
+        return f"{self._base_url}{path}"
+
     async def async_zone_group(
         self,
         action: str,

--- a/custom_components/unified_hifi_control/media_player.py
+++ b/custom_components/unified_hifi_control/media_player.py
@@ -376,6 +376,18 @@ class UnifiedHifiControlMediaPlayer(
             item_title = item.get("title") or "Untitled"
             item_path = item.get("path")
             item_ref = item.get("ref")
+            # #549: an item's `image` is a same-origin proxy path
+            # (`/api/collections/image?ref=...`), never a raw provider URL
+            # or id -- resolve it against this server the same way
+            # `UnifiedHifiControlApiClient.image_url` already does for
+            # now-playing artwork. Absent when the provider has no art for
+            # this row (PR #537's "no artwork" deviation, closed by #549).
+            item_image = item.get("image")
+            thumbnail = (
+                self.coordinator.client.resolve_url(item_image)
+                if item_image
+                else None
+            )
             if item_path:
                 children.append(
                     BrowseMedia(
@@ -385,6 +397,7 @@ class UnifiedHifiControlMediaPlayer(
                         title=item_title,
                         can_play=False,
                         can_expand=True,
+                        thumbnail=thumbnail,
                     )
                 )
             elif item_ref:
@@ -396,6 +409,7 @@ class UnifiedHifiControlMediaPlayer(
                         title=item_title,
                         can_play=True,
                         can_expand=False,
+                        thumbnail=thumbnail,
                     )
                 )
             # A row with neither path nor ref (e.g. #396's known LMS

--- a/custom_components/unified_hifi_control/tests/test_media_player.py
+++ b/custom_components/unified_hifi_control/tests/test_media_player.py
@@ -1,7 +1,7 @@
 """Tests for capability mapping in media_player.py."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.components.media_player import (
@@ -157,6 +157,46 @@ async def test_browse_media_top_level_walks_into_collections_browse():
     ]
     assert result.children[0].can_expand and not result.children[0].can_play
     assert result.children[1].can_play and not result.children[1].can_expand
+
+
+@pytest.mark.asyncio
+async def test_browse_media_thumbnail_resolves_an_items_image_field():
+    """#549: an item's `image` (a same-origin `/api/collections/image?ref=...`
+    path) becomes `BrowseMedia.thumbnail`, resolved against this server the
+    same way `UnifiedHifiControlApiClient.image_url` already resolves
+    now-playing artwork -- a row with no `image` field gets no thumbnail,
+    honestly, rather than a guessed-at one.
+    """
+    zone = ZoneState(
+        zone_id="lms:aa", zone_name="Bedroom", source="lms", browse_supported=True
+    )
+    player = _player(zone)
+    player.coordinator.client.async_browse_collections = AsyncMock(
+        return_value=_ok_envelope(
+            {
+                "items": [
+                    {
+                        "title": "Kind of Blue",
+                        "path": "browse-token-albums",
+                        "image": "/api/collections/image?ref=abc123",
+                    },
+                    {"title": "No Art Track", "ref": "play-token-1"},
+                ]
+            }
+        )
+    )
+    player.coordinator.client.resolve_url = MagicMock(
+        side_effect=lambda path: f"http://uhc.test.invalid{path}"
+    )
+    result = await player.async_browse_media(media_content_id="top:browse")
+    player.coordinator.client.resolve_url.assert_called_once_with(
+        "/api/collections/image?ref=abc123"
+    )
+    assert (
+        result.children[0].thumbnail
+        == "http://uhc.test.invalid/api/collections/image?ref=abc123"
+    )
+    assert result.children[1].thumbnail is None
 
 
 @pytest.mark.asyncio

--- a/docs/home_assistant_integration.md
+++ b/docs/home_assistant_integration.md
@@ -116,11 +116,15 @@ subdirectory. Rationale:
     forwards it to `/api/play_ref`; an `enqueue` value HA passes maps to
     `hifi_play_ref`'s `queue`/`next`/`play` actions where a distinct verb
     exists, and to `queue` otherwise (UHC has no separate "replace the
-    queue" verb). **Artwork caveat**: `hifi_collections` items carry no
-    per-item artwork field today (only now-playing state does, via
-    `/knob/now_playing/image`), so browsed folders and tracks render
-    without thumbnails — `BrowseMedia.thumbnail` is left unset rather
-    than guessing at one.
+    queue" verb). **Artwork** (#549): an item that has provider art
+    carries an `image` field, a same-origin
+    `/api/collections/image?ref=...` path over an opaque token UHC mints
+    server-side — never a raw provider image key/URL. `async_browse_media`
+    resolves it against the server (`UnifiedHifiControlApiClient
+    .resolve_url`, the same pattern `image_url` already uses for
+    now-playing artwork) and sets it as `BrowseMedia.thumbnail`; a row
+    with no provider art simply carries no `image` field, and
+    `thumbnail` is left unset rather than guessing at one.
 - **Mute caveat**: UHC's `/knob/now_playing` response does not include
   mute state, and not every provider has confirmed `mute`/`unmute`
   wiring through `/knob/control` end-to-end (only HQPlayer's handler was
@@ -199,10 +203,6 @@ becomes active once this lands on `v3`.
   plain-REST equivalent for grouping (mirroring `src/api/browse.rs`'s
   pattern) would let this integration drop its one remaining MCP
   JSON-RPC call.
-- `hifi_collections` items carry no per-item artwork, so browsed
-  folders/tracks show no thumbnail in the HA browse UI (see the
-  Architecture section's browsing note). Adding artwork to the
-  provider-neutral collections contract is tracked separately.
 - Queue management (`hifi_queue`: read/reorder/remove/transfer) is not
   exposed through this integration yet — only browse-and-play. A future
   version could surface it via `async_get_media_source`/a

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -160,6 +160,29 @@ fn loop_entity_id(row: &Value, entity: &str) -> Option<i64> {
     lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id"))).filter(|id| *id > 0)
 }
 
+/// This row's artwork handle, for `hifi_collections`' image ref (#549), or
+/// `None` when LMS has none for it (an artist row, or a track/album LMS
+/// never assigned art to) -- absent honestly, not a placeholder.
+///
+/// `coverid` first, `artwork_track_id` second: the same preference
+/// `get_player_status` already applies for now-playing art (`artwork_id`,
+/// this file's docs on #407), here read from `tags:cJ` requested on the
+/// `albums`/`titles`/`playlists tracks` queries this helper serves. Both
+/// tags resolve to a plain id `AppState::get_image`'s LMS branch already
+/// knows how to turn into `/music/<id>/cover.jpg` through
+/// `LmsAdapter::get_artwork` -- no different from a coverid read off
+/// `status`.
+fn row_image_key(row: &Value) -> Option<String> {
+    let read = |key: &str| -> Option<String> {
+        row.get(key).and_then(|v| {
+            v.as_str()
+                .map(str::to_string)
+                .or_else(|| v.as_i64().map(|n| n.to_string()))
+        })
+    };
+    read("coverid").or_else(|| read("artwork_track_id"))
+}
+
 /// The next page's offset for a `hifi_collections` page, or `None` at the
 /// end.
 ///
@@ -1634,9 +1657,16 @@ impl LmsAdapter {
         let password = state.password.clone();
         drop(state);
 
-        // If image_key is a URL, fetch directly
+        // If image_key is a URL, fetch directly. #549: a favorite's `icon`
+        // can also be server-relative (a local plugin's own icon path,
+        // unlike the coverid/artwork_track_id ids the collections queries
+        // otherwise hand back) -- same relative-to-absolute rule
+        // docs/lyrion.md already documents for `artwork_url`.
         let url = if image_key.starts_with("http://") || image_key.starts_with("https://") {
             image_key.to_string()
+        } else if let Some(path) = image_key.strip_prefix('/') {
+            let base_url = self.rpc.base_url().await?;
+            format!("{base_url}/{path}")
         } else {
             // Otherwise treat as coverid
             self.get_artwork_url(image_key, width, height).await?
@@ -2136,7 +2166,15 @@ impl LmsAdapter {
         limit: usize,
         artist_id: Option<i64>,
     ) -> Result<Value> {
-        let mut params = vec![json!("albums"), json!(offset), json!(limit)];
+        // #549: `tags:cJ` requests coverid and artwork_track_id (docs/lyrion.md)
+        // so `row_image_key` has something to read; neither tag changes any
+        // field this method already used.
+        let mut params = vec![
+            json!("albums"),
+            json!(offset),
+            json!(limit),
+            json!("tags:cJ"),
+        ];
         if let Some(id) = artist_id {
             params.push(json!(format!("artist_id:{id}")));
         }
@@ -2154,6 +2192,7 @@ impl LmsAdapter {
                     "title": title,
                     "subtitle": artist.map(|a| format!("Album by {a}")),
                     "path": format!("album:{id}"),
+                    "image_key": row_image_key(row),
                 }))
             })
             .collect();
@@ -2200,6 +2239,8 @@ impl LmsAdapter {
                     json!(offset),
                     json!(limit),
                     json!(format!("{filter_key}:{filter_id}")),
+                    // #549: see `row_image_key`'s docs.
+                    json!("tags:cJ"),
                 ],
             )
             .await?;
@@ -2217,6 +2258,7 @@ impl LmsAdapter {
                     "subtitle": artist,
                     "kind": "track",
                     "id": id,
+                    "image_key": row_image_key(row),
                 }))
             })
             .collect();
@@ -2265,6 +2307,8 @@ impl LmsAdapter {
                     json!(offset),
                     json!(limit),
                     json!(format!("playlist_id:{playlist_id}")),
+                    // #549: see `row_image_key`'s docs.
+                    json!("tags:cJ"),
                 ],
             )
             .await?;
@@ -2286,6 +2330,7 @@ impl LmsAdapter {
                     "subtitle": artist,
                     "kind": "track",
                     "id": id,
+                    "image_key": row_image_key(row),
                 }))
             })
             .collect();
@@ -2323,7 +2368,11 @@ impl LmsAdapter {
                     .and_then(Value::as_str)?
                     .to_string();
                 let url = row.get("url").and_then(Value::as_str)?.to_string();
-                Some(json!({"title": title, "url": url}))
+                // #549: `favorites items` hands back `icon` (usually an
+                // absolute URL) on its own, unlike albums/titles/playlists
+                // tracks -- no `tags:` request needed for it.
+                let image_key = row.get("icon").and_then(Value::as_str).map(str::to_string);
+                Some(json!({"title": title, "url": url, "image_key": image_key}))
             })
             .collect();
         let next_offset = next_offset(&raw, offset, limit, items.len());

--- a/src/adapters/musicassistant.rs
+++ b/src/adapters/musicassistant.rs
@@ -1558,6 +1558,15 @@ impl MusicAssistantAdapter {
             if let Some(path) = item.get("path").and_then(Value::as_str) {
                 mapped.insert("path".to_string(), Value::String(path.to_string()));
             }
+            // #549: same field set `parse_now_playing` already reads MA
+            // artwork from (`image_url`/`artwork_url`/`image`) -- MA hands
+            // out an absolute URL directly rather than a separate opaque
+            // provider id, resolved through `AppState::get_image`'s
+            // musicassistant branch once `hifi_collections` mints a ref
+            // over it.
+            if let Some(image_key) = value_string(item, &["image_url", "artwork_url", "image"]) {
+                mapped.insert("image_key".to_string(), Value::String(image_key));
+            }
             items.push(Value::Object(mapped));
         }
         let next_offset = if operation == "collections_browse" {

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -3044,6 +3044,12 @@ impl LibraryAdapter for RoonAdapter {
                         "item_key": item.item_key,
                         "navigable": navigable,
                         "playable": playable,
+                        // #549: Roon's own image_key, resolved through the
+                        // same `RoonAdapter::get_image` now-playing art
+                        // already uses -- `hifi_collections` mints an
+                        // opaque ref over this rather than handing it to a
+                        // client directly.
+                        "image_key": item.image_key,
                     }));
                 }
                 let next_offset = (total > offset + limit).then_some((offset + limit) as u64);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -292,6 +292,12 @@ pub struct AppState {
     /// constructor parameter -- like `sse_connections` above -- so every
     /// existing `AppState::new` call site is untouched by this addition.
     pub mcp_refs: crate::mcp::refs::RefTable,
+    /// Opaque image refs (#549): what a `hifi_collections`/`/api/collections`
+    /// item's `image` field resolves through, so a collection browse row can
+    /// carry a per-item artwork reference without ever handing a client the
+    /// provider-native image handle behind it. Deliberately a separate table
+    /// from `mcp_refs` -- see `crate::mcp::refs::ImageRef`'s docs for why.
+    pub image_refs: crate::mcp::refs::ImageRefTable,
     /// UHC-owned requested listening sequences, separate from provider queue
     /// observations (#483).
     pub listening_plans: crate::mcp::listening_plan::ListeningPlanStore,
@@ -358,6 +364,7 @@ impl AppState {
             shutdown,
             sse_connections: Arc::new(AtomicUsize::new(0)),
             mcp_refs: crate::mcp::refs::RefTable::new(),
+            image_refs: crate::mcp::refs::ImageRefTable::new(),
             listening_plans: crate::mcp::listening_plan::ListeningPlanStore::from_config(),
             apple_feedback: crate::mcp::feedback::FeedbackStore::from_config(),
             reliable_commands: None,
@@ -425,6 +432,8 @@ impl AppState {
             ImageData { content_type, data }
         } else if zone_id.starts_with("applemusic:") {
             fetch_apple_music_artwork(image_key).await?
+        } else if zone_id.starts_with("musicassistant:") {
+            fetch_musicassistant_artwork(image_key).await?
         } else if let Some(instance) = zone_id.strip_prefix("hqplayer:") {
             self.hqp_images.get_current_cover(instance).await?
         } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
@@ -466,6 +475,28 @@ impl AppState {
 async fn fetch_apple_music_artwork(image_key: &str) -> anyhow::Result<crate::bus::ImageData> {
     let url = validate_apple_music_artwork_url(image_key)?;
     fetch_remote_artwork_url(url).await
+}
+
+/// Music Assistant's `image_url` (#549) is already an absolute URL the MA
+/// server hands out for both now-playing and library items -- there is no
+/// separate provider-side id/proxy to resolve the way Roon's `image_key` or
+/// LMS's coverid are. Unlike Apple Music's CDN allowlist (MA art can come
+/// from any of MA's own providers, not one known host), the only guard
+/// worth enforcing here is "this is actually an http(s) URL", so a
+/// malformed or unexpected scheme fails closed rather than being handed to
+/// `reqwest` uninspected.
+async fn fetch_musicassistant_artwork(image_key: &str) -> anyhow::Result<crate::bus::ImageData> {
+    let url = validate_musicassistant_artwork_url(image_key)?;
+    fetch_remote_artwork_url(url).await
+}
+
+fn validate_musicassistant_artwork_url(image_key: &str) -> anyhow::Result<reqwest::Url> {
+    let url = reqwest::Url::parse(image_key)
+        .map_err(|_| anyhow::anyhow!("Music Assistant artwork URL is invalid"))?;
+    if url.scheme() != "http" && url.scheme() != "https" {
+        anyhow::bail!("Music Assistant artwork URL must be http or https");
+    }
+    Ok(url)
 }
 
 fn validate_apple_music_artwork_url(image_key: &str) -> anyhow::Result<reqwest::Url> {
@@ -970,6 +1001,77 @@ pub async fn roon_image_handler(
         }
         Err(e) => {
             tracing::warn!("Image fetch failed: {}", e);
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Query params for the collections image proxy (#549).
+#[derive(Deserialize)]
+pub struct CollectionImageQuery {
+    /// Opaque token minted by `hifi_collections`/`/api/collections` on a
+    /// browse row's `image` field. Never a provider-native image key.
+    pub r#ref: String,
+    #[serde(default)]
+    pub width: Option<u32>,
+    #[serde(default)]
+    pub height: Option<u32>,
+    #[serde(default)]
+    pub format: Option<String>,
+}
+
+/// GET /api/collections/image -- fetch a `hifi_collections` item's artwork.
+///
+/// Resolves the opaque `ref` through `state.image_refs` to a
+/// `(zone_id, image_key)` pair and re-enters `AppState::get_image`'s
+/// existing per-provider dispatch, exactly like `/now_playing/image` and
+/// `/roon/image` already do for now-playing art -- the only difference is
+/// the image handle came from a browse row's ref, not the zone's live state.
+/// An unknown, expired, or evicted ref reads as a plain 404, the same shape
+/// as any other image fetch failure; nothing about a stale-vs-invalid ref is
+/// distinguishable from here, deliberately (see `crate::mcp::refs`' module
+/// docs on why that collapse is the point).
+pub async fn collections_image_handler(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<CollectionImageQuery>,
+) -> impl IntoResponse {
+    let Some(target) = state.image_refs.resolve(&params.r#ref).await else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "image ref is unknown or expired".to_string(),
+            }),
+        )
+            .into_response();
+    };
+    match state
+        .get_image(
+            &target.zone_id,
+            &target.image_key,
+            params.width,
+            params.height,
+            params.format.as_deref(),
+        )
+        .await
+    {
+        Ok(image_data) => {
+            let headers = [(
+                axum::http::header::CONTENT_TYPE,
+                image_data
+                    .content_type
+                    .parse()
+                    .unwrap_or(axum::http::HeaderValue::from_static("image/jpeg")),
+            )];
+            (StatusCode::OK, headers, image_data.data).into_response()
+        }
+        Err(e) => {
+            tracing::warn!("Collection image fetch failed: {}", e);
             (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -818,6 +818,10 @@ mod server {
             // verb vocabulary as the hifi_collections/hifi_queue/hifi_play_ref
             // MCP tools -- see src/api/browse.rs.
             .route("/api/collections", post(api::browse::collections_handler))
+            // Per-item artwork for hifi_collections rows (#549); mirrors
+            // /roon/image and /now_playing/image but resolves an opaque ref
+            // minted by hifi_collections instead of a live zone's own state.
+            .route("/api/collections/image", get(api::collections_image_handler))
             .route("/api/queue", post(api::browse::queue_handler))
             .route("/api/play_ref", post(api::browse::play_ref_handler))
             // Kept on one line each: the API-contract extractor (tests/api_contract.rs) only sees

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -338,6 +338,127 @@ fn generate_token() -> String {
     format!("{TOKEN_PREFIX}{}", URL_SAFE_NO_PAD.encode(bytes))
 }
 
+/// What an image ref resolves to (#549): the zone whose provider serves the
+/// artwork, and the provider-native image handle to fetch through that
+/// provider's `AppState::get_image` dispatch -- the same handle a Roon
+/// `image_key`, an LMS coverid/URL, or a Music Assistant `image_url` already
+/// is, just minted here instead of handed to a client.
+///
+/// A deliberately separate table from [`RefTable`], not a new [`RefTarget`]
+/// variant: an image ref is resolved only by the collections image-proxy
+/// route (`src/api/mod.rs::collections_image_handler`), never by
+/// `hifi_play_ref`. Folding it into `RefTarget` would drag it through every
+/// `(LibraryRoute, RefTarget)` pairing in
+/// `src/mcp/tools/library.rs::handle_play_ref`'s exhaustive dispatch for a
+/// variant that dispatch can never validly reach -- a lot of churn for a
+/// combination that should simply never arise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageRef {
+    pub zone_id: String,
+    pub image_key: String,
+}
+
+struct ImageRecord {
+    target: ImageRef,
+    minted_at: Instant,
+}
+
+struct ImageInner {
+    entries: HashMap<String, ImageRecord>,
+    order: VecDeque<String>,
+    capacity: usize,
+    ttl: Duration,
+}
+
+impl ImageInner {
+    /// Same eviction policy as [`Inner::evict_to_capacity`]: insertion-order,
+    /// draining already-expired fronts opportunistically. See that method's
+    /// docs for why the loop checks both `entries` and `order`.
+    fn evict_to_capacity(&mut self) {
+        while self.entries.len() >= self.capacity || self.order.len() >= self.capacity {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.entries.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+/// The server-side table an `hifi_collections`/`/api/collections` item's
+/// `image` field resolves through. Same opaque-token, bounded-size,
+/// uniform-TTL design as [`RefTable`] -- see its module docs -- kept as its
+/// own type rather than a case of that one (see [`ImageRef`]'s docs).
+#[derive(Clone)]
+pub struct ImageRefTable {
+    inner: Arc<Mutex<ImageInner>>,
+}
+
+impl Default for ImageRefTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageRefTable {
+    /// A table with [`DEFAULT_CAPACITY`] and [`DEFAULT_TTL`].
+    pub fn new() -> Self {
+        Self::with_capacity_and_ttl(DEFAULT_CAPACITY, DEFAULT_TTL)
+    }
+
+    /// A table with an explicit capacity and TTL, for tests that need to
+    /// force eviction or expiry without waiting on the production defaults.
+    pub fn with_capacity_and_ttl(capacity: usize, ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ImageInner {
+                entries: HashMap::new(),
+                order: VecDeque::new(),
+                capacity,
+                ttl,
+            })),
+        }
+    }
+
+    /// Mint an opaque token for `target`, evicting the oldest entry first if
+    /// the table is already at capacity.
+    pub async fn mint(&self, target: ImageRef) -> String {
+        let token = generate_token();
+        let mut inner = self.inner.lock().await;
+        inner.evict_to_capacity();
+        inner.order.push_back(token.clone());
+        inner.entries.insert(
+            token.clone(),
+            ImageRecord {
+                target,
+                minted_at: Instant::now(),
+            },
+        );
+        token
+    }
+
+    /// Resolve a token to its target, or `None` if it is unknown, mangled,
+    /// expired, or evicted -- all four collapse to the same answer, exactly
+    /// as [`RefTable::resolve`] does.
+    pub async fn resolve(&self, token: &str) -> Option<ImageRef> {
+        let mut inner = self.inner.lock().await;
+        let expired = match inner.entries.get(token) {
+            Some(record) => record.minted_at.elapsed() > inner.ttl,
+            None => return None,
+        };
+        if expired {
+            inner.entries.remove(token);
+            return None;
+        }
+        inner.entries.get(token).map(|r| r.target.clone())
+    }
+
+    #[cfg(test)]
+    async fn len(&self) -> usize {
+        self.inner.lock().await.entries.len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -684,5 +805,83 @@ mod tests {
             target,
             RefTarget::AppleMusic { companion_id, .. } if companion_id == "iphone"
         ));
+    }
+
+    // =========================================================================
+    // ImageRefTable (#549): opaque, same as RefTable, but a separate table
+    // so hifi_play_ref's dispatch never has to consider an image ref.
+    // =========================================================================
+
+    #[tokio::test]
+    async fn image_ref_mints_and_resolves_to_its_zone_and_key() {
+        let table = ImageRefTable::new();
+        let token = table
+            .mint(ImageRef {
+                zone_id: "roon:zone1".to_string(),
+                image_key: "abc123".to_string(),
+            })
+            .await;
+        assert!(token.starts_with(TOKEN_PREFIX));
+        let resolved = table.resolve(&token).await.unwrap();
+        assert_eq!(resolved.zone_id, "roon:zone1");
+        assert_eq!(resolved.image_key, "abc123");
+    }
+
+    #[tokio::test]
+    async fn image_ref_token_carries_no_verbatim_image_key() {
+        let table = ImageRefTable::new();
+        let token = table
+            .mint(ImageRef {
+                zone_id: "lms:player1".to_string(),
+                image_key: "a-very-long-and-distinctive-coverid-value-123456".to_string(),
+            })
+            .await;
+        assert!(!token.contains("a-very-long-and-distinctive-coverid-value-123456"));
+    }
+
+    #[tokio::test]
+    async fn unknown_image_token_resolves_to_none() {
+        let table = ImageRefTable::new();
+        assert!(table.resolve("ref_does-not-exist").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn image_ref_expires_after_its_ttl() {
+        let table =
+            ImageRefTable::with_capacity_and_ttl(DEFAULT_CAPACITY, Duration::from_millis(20));
+        let token = table
+            .mint(ImageRef {
+                zone_id: "musicassistant:zone1".to_string(),
+                image_key: "https://example.invalid/art.jpg".to_string(),
+            })
+            .await;
+        assert!(table.resolve(&token).await.is_some());
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(table.resolve(&token).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn image_ref_table_stays_bounded_by_evicting_the_oldest() {
+        let table = ImageRefTable::with_capacity_and_ttl(2, DEFAULT_TTL);
+        let first = table
+            .mint(ImageRef {
+                zone_id: "roon:z".to_string(),
+                image_key: "one".to_string(),
+            })
+            .await;
+        table
+            .mint(ImageRef {
+                zone_id: "roon:z".to_string(),
+                image_key: "two".to_string(),
+            })
+            .await;
+        table
+            .mint(ImageRef {
+                zone_id: "roon:z".to_string(),
+                image_key: "three".to_string(),
+            })
+            .await;
+        assert!(table.resolve(&first).await.is_none(), "oldest is evicted");
+        assert_eq!(table.len().await, 2);
     }
 }

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -84,6 +84,31 @@ struct CollectionItem {
     path: Option<String>,
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     r#ref: Option<String>,
+    /// Artwork URL (#549), present only when the provider has art for this
+    /// row. Always a same-origin `/api/collections/image?ref=...` path over
+    /// an opaque token minted by `state.image_refs` -- never a provider
+    /// image key or a raw remote URL, following the same opaque-ref
+    /// discipline as `path`/`ref` above. Absent (not `null`-valued) when the
+    /// provider has no art for this row, so a client can tell "no artwork"
+    /// from "artwork omitted" the same way `subtitle` already does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<String>,
+}
+
+/// Mint an image ref for a browse row and return the path a client resolves
+/// it through, or `None` if this row's adapter response carried no image
+/// key at all. Shared by all three provider handlers below so the URL shape
+/// (`/api/collections/image?ref=...`) is defined in exactly one place.
+async fn mint_image(state: &AppState, zone_id: &str, image_key: Option<&str>) -> Option<String> {
+    let image_key = image_key?;
+    let token = state
+        .image_refs
+        .mint(crate::mcp::refs::ImageRef {
+            zone_id: zone_id.to_string(),
+            image_key: image_key.to_string(),
+        })
+        .await;
+    Some(format!("/api/collections/image?ref={token}"))
 }
 
 #[derive(Debug, Serialize)]
@@ -285,11 +310,18 @@ async fn handle_music_assistant(
             ),
             None => None,
         };
+        let image = mint_image(
+            state,
+            &args.zone_id,
+            item.get("image_key").and_then(Value::as_str),
+        )
+        .await;
         items.push(CollectionItem {
             title,
             subtitle,
             path,
             r#ref,
+            image,
         });
     }
     Ok(env.json_result(&CollectionPage { items, next_offset }))
@@ -403,11 +435,18 @@ async fn handle_lms(
             ),
             _ => None,
         };
+        let image = mint_image(
+            state,
+            &args.zone_id,
+            item.get("image_key").and_then(Value::as_str),
+        )
+        .await;
         items.push(CollectionItem {
             title,
             subtitle,
             path,
             r#ref,
+            image,
         });
     }
     Ok(env.json_result(&CollectionPage { items, next_offset }))
@@ -547,11 +586,18 @@ async fn handle_roon(
                 (path, r#ref)
             }
         };
+        let image = mint_image(
+            state,
+            &args.zone_id,
+            item.get("image_key").and_then(Value::as_str),
+        )
+        .await;
         items.push(CollectionItem {
             title,
             subtitle,
             path,
             r#ref,
+            image,
         });
     }
     let next_offset = response

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -19,6 +19,7 @@ GET /admin
 GET /api/bridges/applemusic/commands
 GET /api/bridges/applemusic/content
 GET /api/bridges/applemusic/status
+GET /api/collections/image
 GET /api/controller/status
 GET /api/mqtt/status
 GET /api/providers/musicassistant/status

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -1796,14 +1796,16 @@ async fn musicassistant_mcp_handler(
             }]
         }),
         Some("music/browse") => json!([
+            // #549: no image_url -- a folder-shaped row honestly has no art.
             {"name": "Jazz", "path": "library://jazz"},
-            {"name": "So What", "uri": "library://track/42", "artists": [{"name": "Miles Davis"}]}
+            {"name": "So What", "uri": "library://track/42", "artists": [{"name": "Miles Davis"}], "image_url": "https://example.invalid/so-what.jpg"}
         ]),
         Some("music/playlists/library_items") => json!([
+            // #549: no image_url -- exercises the absent-honestly path for playlists too.
             {"name": "Sunday Morning", "uri": "library://playlist/7"}
         ]),
         Some("music/tracks/library_items") => json!([
-            {"name": "My Favorite Track", "uri": "library://track/99", "artists": [{"name": "Nina Simone"}]}
+            {"name": "My Favorite Track", "uri": "library://track/99", "artists": [{"name": "Nina Simone"}], "image_url": "https://example.invalid/favorite-track.jpg"}
         ]),
         Some("music/radio/library_items") => json!([
             {"name": "My Favorite Station", "uri": "library://radio/13"}
@@ -2335,6 +2337,64 @@ async fn roon_zone_group_routes_join_status_and_leave_through_the_registry() {
     core.stop().await;
 }
 
+/// #549: `hifi_collections`' Roon rows carry an `image` field, minted as an
+/// opaque `/api/collections/image?ref=...` path over `RoonAdapter::content`'s
+/// `image_key` (see `RoonAdapter::content`'s `collections_browse` mapping in
+/// `src/adapters/roon.rs`), for a row that has Roon art -- and omit it
+/// entirely, honestly, for one that does not.
+#[tokio::test]
+#[serial_test::serial(uhc_config_dir)]
+async fn roon_collections_browse_mints_an_image_ref_when_roon_has_art() {
+    use mock_servers::roon_core::{album, FakeItem, FakeLibrary, FakeRoonCore};
+
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        album("Kind of Blue", "Miles Davis", &["So What"]).with_image_key("roon-album-art-key"),
+        FakeItem::list("Jazz"),
+    ];
+    let core = FakeRoonCore::start_with(library).await;
+    let app = roon_mcp_app(&core).await;
+
+    let root = app
+        .call_tool(
+            "hifi_collections",
+            json!({"zone_id": "roon:zone_1", "action": "browse"}),
+        )
+        .await;
+    assert_eq!(root["structuredContent"]["outcome"], "ok");
+    let root_page: Value = serde_json::from_str(&result_text(&root)).expect("root page JSON");
+    let with_art = root_page["items"]
+        .as_array()
+        .expect("root items")
+        .iter()
+        .find(|item| item["title"] == "Kind of Blue")
+        .expect("album row must be present");
+    let image = with_art["image"]
+        .as_str()
+        .expect("a row with a Roon image_key must carry an image field");
+    assert!(
+        image.starts_with("/api/collections/image?ref="),
+        "image must be a same-origin proxy path, not a raw Roon image_key: {image}"
+    );
+    assert!(
+        !image.contains("roon-album-art-key"),
+        "the raw Roon image_key must stay server-side: {image}"
+    );
+
+    let without_art = root_page["items"]
+        .as_array()
+        .expect("root items")
+        .iter()
+        .find(|item| item["title"] == "Jazz")
+        .expect("no-art row must be present");
+    assert!(
+        without_art.get("image").is_none(),
+        "a row with no Roon image_key must omit `image`: {without_art}"
+    );
+
+    core.stop().await;
+}
+
 /// Collections must have one provider-neutral wire shape: no MA URI escapes,
 /// pages are explicit, paths continue browse, and playable rows use the same
 /// opaque refs as search.
@@ -2360,6 +2420,12 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
         .expect("browse folder must return an opaque continuation path");
     assert!(path.starts_with("ref_"));
     assert_ne!(path, "library://jazz", "MA path must stay server-side");
+    // #549: the folder-shaped root row has no MA image_url, so it must carry
+    // no image field at all -- absent honestly, not a placeholder.
+    assert!(
+        root_page["items"][0].get("image").is_none(),
+        "a row with no provider artwork must omit `image`: {root_page}"
+    );
 
     let cross_provider = app
         .call_tool(
@@ -2390,6 +2456,20 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
         browse_page["items"][0].get("uri").is_none(),
         "provider URI must stay server-side"
     );
+    // #549: "So What" carries a real MA image_url in the mock fixture --
+    // hifi_collections must mint an opaque, same-origin image ref over it,
+    // never the raw MA URL.
+    let image = browse_page["items"][0]["image"]
+        .as_str()
+        .expect("a row with provider artwork must carry an image field");
+    assert!(
+        image.starts_with("/api/collections/image?ref="),
+        "image must be a same-origin proxy path, not a raw provider URL: {image}"
+    );
+    assert!(
+        !image.contains("example.invalid"),
+        "the raw MA artwork URL must stay server-side: {image}"
+    );
     let next = app
         .call_tool(
             "hifi_play_ref",
@@ -2402,17 +2482,23 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
         .await;
     assert_eq!(next["structuredContent"]["outcome"], "accepted");
 
-    for (action, extra, expected_title) in [
-        ("playlists", json!({}), "Sunday Morning"),
+    for (action, extra, expected_title, expect_image) in [
+        // #549: "Sunday Morning" carries no image_url in the mock fixture --
+        // absent honestly.
+        ("playlists", json!({}), "Sunday Morning", false),
+        // "My Favorite Track" does carry one.
         (
             "favorites",
             json!({"media_type": "tracks"}),
             "My Favorite Track",
+            true,
         ),
+        // "My Favorite Station" does not.
         (
             "favorites",
             json!({"media_type": "radio"}),
             "My Favorite Station",
+            false,
         ),
     ] {
         let mut args = json!({"zone_id": zone_id, "action": action, "limit": 20, "offset": 0});
@@ -2425,6 +2511,11 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
             serde_json::from_str(&result_text(&result)).expect("collection page JSON");
         assert_eq!(page["items"][0]["title"], expected_title);
         assert!(page["items"][0]["ref"].as_str().is_some());
+        assert_eq!(
+            page["items"][0].get("image").is_some(),
+            expect_image,
+            "{expected_title}: image presence must match provider artwork: {page}"
+        );
     }
 
     let requests = mock.requests.lock().expect("requests").clone();
@@ -2471,6 +2562,10 @@ async fn lms_collections_browse_walks_albums_into_tracks() {
     h.mock
         .set_album_tracks(7, vec![(42, "So What", Some("Miles Davis"))])
         .await;
+    // #549: the album has a coverid; the track underneath it deliberately
+    // does not, so this one test exercises both the presence and the
+    // absence path.
+    h.mock.set_artwork(7, "cover-kind-of-blue").await;
 
     let root = h
         .app
@@ -2501,6 +2596,17 @@ async fn lms_collections_browse_walks_albums_into_tracks() {
     let albums_page: Value = serde_json::from_str(&result_text(&albums)).expect("albums page JSON");
     assert_eq!(albums_page["items"][0]["title"], "Kind of Blue");
     assert_eq!(albums_page["items"][0]["subtitle"], "Album by Miles Davis");
+    let album_image = albums_page["items"][0]["image"]
+        .as_str()
+        .expect("an album with a seeded coverid must carry an image field");
+    assert!(
+        album_image.starts_with("/api/collections/image?ref="),
+        "image must be a same-origin proxy path: {album_image}"
+    );
+    assert!(
+        !album_image.contains("cover-kind-of-blue"),
+        "the raw coverid must stay server-side"
+    );
     let album_path = albums_page["items"][0]["path"]
         .as_str()
         .expect("an album is itself browsable, into its tracks");
@@ -2519,6 +2625,11 @@ async fn lms_collections_browse_walks_albums_into_tracks() {
         .as_str()
         .expect("a track is playable, not a browsable path");
     assert!(tracks_page["items"][0].get("path").is_none());
+    // #549: this track's coverid was never seeded -- absent honestly.
+    assert!(
+        tracks_page["items"][0].get("image").is_none(),
+        "a track with no seeded artwork must omit `image`: {tracks_page}"
+    );
 
     // The minted ref plays via hifi_play_ref exactly like a search hit's.
     let play = h
@@ -2547,8 +2658,18 @@ async fn lms_collections_playlists_and_favorites() {
     h.mock
         .set_playlist_tracks(3, vec![(9, "Blue in Green", Some("Miles Davis"))])
         .await;
+    // #549: this playlist track has a seeded coverid.
+    h.mock.set_artwork(9, "cover-blue-in-green").await;
     h.mock
         .set_favorites(vec![("Jazz FM", "http://example.com/jazzfm")])
+        .await;
+    // #549: a second favorite, this one with LMS's own `icon` field.
+    h.mock
+        .set_favorite_with_icon(
+            "Classical FM",
+            "http://example.com/classicalfm",
+            "http://example.com/classicalfm-icon.png",
+        )
         .await;
 
     let playlists = h
@@ -2576,6 +2697,10 @@ async fn lms_collections_playlists_and_favorites() {
     assert_eq!(tracks["structuredContent"]["outcome"], "ok");
     let tracks_page: Value = serde_json::from_str(&result_text(&tracks)).expect("tracks page JSON");
     assert_eq!(tracks_page["items"][0]["title"], "Blue in Green");
+    let track_image = tracks_page["items"][0]["image"]
+        .as_str()
+        .expect("a playlist track with seeded artwork must carry an image field");
+    assert!(track_image.starts_with("/api/collections/image?ref="));
 
     let favorites = h
         .app
@@ -2594,6 +2719,25 @@ async fn lms_collections_playlists_and_favorites() {
     assert!(
         !favorite_ref.contains("jazzfm"),
         "the favorite's url must stay server-side"
+    );
+    // #549: "Jazz FM" was seeded with no icon -- absent honestly.
+    assert!(
+        favorites_page["items"][0].get("image").is_none(),
+        "a favorite with no icon must omit `image`: {favorites_page}"
+    );
+    let with_icon = favorites_page["items"]
+        .as_array()
+        .expect("favorites items")
+        .iter()
+        .find(|item| item["title"] == "Classical FM")
+        .expect("Classical FM favorite must be listed");
+    let favorite_image = with_icon["image"]
+        .as_str()
+        .expect("a favorite with an icon must carry an image field");
+    assert!(favorite_image.starts_with("/api/collections/image?ref="));
+    assert!(
+        !favorite_image.contains("classicalfm-icon"),
+        "the raw icon URL must stay server-side"
     );
 
     h.stop().await;

--- a/tests/mock_servers/lms.rs
+++ b/tests/mock_servers/lms.rs
@@ -101,6 +101,10 @@ pub struct MockTrack {
 pub struct MockFavorite {
     pub name: String,
     pub url: String,
+    /// #549: the `icon` field real LMS hands back for favorites that have
+    /// one, unrelated to the `tags:cJ` coverid/artwork_track_id path
+    /// albums/titles/playlist-tracks use.
+    pub icon: Option<String>,
 }
 
 /// Mock LMS server state
@@ -134,6 +138,12 @@ struct MockLmsState {
     playlist_tracks: HashMap<i64, Vec<MockTrack>>,
     /// The flat favourites list for `favorites items <start> <count>` (#531).
     favorites: Vec<MockFavorite>,
+    /// `entity_id` -> coverid, for #549's `hifi_collections` artwork slice.
+    /// One map shared across albums and tracks: real LMS ids don't collide
+    /// across kinds either, and the fixtures this mock serves keep them
+    /// distinct by construction (see `set_library_albums`/`set_album_tracks`
+    /// call sites).
+    artwork: HashMap<i64, String>,
 }
 
 /// Mock LMS Server
@@ -154,6 +164,7 @@ impl MockLmsServer {
             album_tracks: HashMap::new(),
             playlist_tracks: HashMap::new(),
             favorites: Vec::new(),
+            artwork: HashMap::new(),
         }));
 
         let app = Router::new()
@@ -327,9 +338,35 @@ impl MockLmsServer {
             .map(|(name, url)| MockFavorite {
                 name: name.to_string(),
                 url: url.to_string(),
+                icon: None,
             })
             .collect();
         self.state.write().await.favorites = items;
+    }
+
+    /// Seed a coverid for one album or track id (#549), so
+    /// `hifi_collections`' albums/titles/playlist-tracks rows carry an
+    /// `image_key` the way a real LMS response with `tags:cJ` would. Not
+    /// seeding an id at all is the "no artwork" case -- covered by every
+    /// other `set_library_*`/`set_*_tracks` call in these tests that never
+    /// calls this.
+    pub async fn set_artwork(&self, entity_id: i64, coverid: &str) {
+        self.state
+            .write()
+            .await
+            .artwork
+            .insert(entity_id, coverid.to_string());
+    }
+
+    /// Seed one favourite with an `icon`, real LMS's own artwork field for
+    /// `favorites items` (#549) -- distinct from [`Self::set_favorites`],
+    /// which leaves every favourite's `icon` absent.
+    pub async fn set_favorite_with_icon(&self, name: &str, url: &str, icon: &str) {
+        self.state.write().await.favorites.push(MockFavorite {
+            name: name.to_string(),
+            url: url.to_string(),
+            icon: Some(icon.to_string()),
+        });
     }
 
     /// Commands received for `player_id`, excluding the read-only polling
@@ -776,9 +813,16 @@ async fn handle_jsonrpc(
                 .iter()
                 .skip(offset)
                 .take(count)
-                .map(
-                    |item| json!({"album_id": item.id, "album": item.title, "artist": item.artist}),
-                )
+                .map(|item| {
+                    json!({
+                        "album_id": item.id,
+                        "album": item.title,
+                        "artist": item.artist,
+                        // #549: mirrors real LMS's `tags:cJ` coverid field,
+                        // present only for ids seeded via `set_artwork`.
+                        "coverid": state.artwork.get(&item.id),
+                    })
+                })
                 .collect();
             json!({ "count": all.len(), "albums_loop": page })
         }
@@ -808,7 +852,14 @@ async fn handle_jsonrpc(
                 .iter()
                 .skip(offset)
                 .take(count)
-                .map(|t| json!({"track_id": t.id, "title": t.title, "artist": t.artist}))
+                .map(|t| {
+                    json!({
+                        "track_id": t.id,
+                        "title": t.title,
+                        "artist": t.artist,
+                        "coverid": state.artwork.get(&t.id),
+                    })
+                })
                 .collect();
             json!({ "count": tracks.len(), "titles_loop": page })
         }
@@ -827,7 +878,14 @@ async fn handle_jsonrpc(
                 .iter()
                 .skip(offset)
                 .take(count)
-                .map(|t| json!({"id": t.id, "title": t.title, "artist": t.artist}))
+                .map(|t| {
+                    json!({
+                        "id": t.id,
+                        "title": t.title,
+                        "artist": t.artist,
+                        "coverid": state.artwork.get(&t.id),
+                    })
+                })
                 .collect();
             json!({ "count": tracks.len(), "playlisttracks_loop": page })
         }
@@ -855,7 +913,7 @@ async fn handle_jsonrpc(
                 .iter()
                 .skip(offset)
                 .take(count)
-                .map(|f| json!({"name": f.name, "url": f.url}))
+                .map(|f| json!({"name": f.name, "url": f.url, "icon": f.icon}))
                 .collect();
             json!({ "count": state.favorites.len(), "loop_loop": page })
         }


### PR DESCRIPTION
Closes #549

## Summary

`hifi_collections` (and its HTTP mirror `/api/collections`) rows now carry an optional `image` field for albums, tracks, playlists, and favorites that have provider artwork — a same-origin `/api/collections/image?ref=...` path over an opaque token, never a raw provider image key or URL. A row with no provider art simply omits `image` (absent honestly, never a placeholder).

## Design

- **New opaque-ref table, deliberately separate from the playable-content one.** `hifi_play_ref`'s `(LibraryRoute, RefTarget)` dispatch in `src/mcp/tools/library.rs` is fully exhaustive with no wildcard arm for `RefTarget`. Folding an image ref into `RefTarget` would have forced every one of those pairings to consider a variant it can never validly reach. Instead, `src/mcp/refs.rs` gets a small dedicated `ImageRefTable`/`ImageRef` (same opaque-token/bounded-capacity/uniform-TTL design as `RefTable`, just resolved only by the new image-proxy route). `AppState` gets a new `image_refs` field alongside `mcp_refs`.
- **New route:** `GET /api/collections/image?ref=...` (`src/api/mod.rs::collections_image_handler`) resolves the ref to `(zone_id, image_key)` and re-enters `AppState::get_image`'s existing per-provider dispatch — the same function `/now_playing/image` and `/roon/image` already use for now-playing art.
- **`src/mcp/tools/collections.rs`:** `CollectionItem` gains an `image: Option<String>` field; a shared `mint_image` helper mints the ref and builds the proxy path, called from all three provider handlers (MA/LMS/Roon) after reading an `image_key` field each adapter's response now carries.

## Per-provider artwork source

- **Roon** (`src/adapters/roon.rs`): the browse item's own `image_key` (already present on the `roon-api` crate's `Item` type) is now included in `collections_browse`/`collections_playlists`' mapped JSON, resolved through the same `RoonAdapter::get_image` now-playing art already uses.
- **LMS** (`src/adapters/lms.rs`): albums/titles/playlist-tracks queries now request `tags:cJ` (coverid + artwork_track_id, per `docs/lyrion.md`'s tag table) and a new `row_image_key` helper prefers coverid, falling back to artwork_track_id. Favorites carry LMS's own `icon` field directly. `LmsAdapter::get_artwork` gained a third branch (alongside absolute-URL and coverid) for a server-relative icon path, mirroring the relative-to-absolute rule `docs/lyrion.md` already documents for `artwork_url`.
- **Music Assistant** (`src/adapters/musicassistant.rs`): reuses the same `image_url`/`artwork_url`/`image` field set `parse_now_playing` already reads MA artwork from. `AppState::get_image` gained a `musicassistant:` branch — MA hands out an absolute URL directly (no separate provider-side id to resolve), so it fetches it directly through the same `fetch_remote_artwork_url` helper Apple Music and Spotify use, guarded to http(s) schemes only.

## Web / HACS

- The web UI's `/api/collections` panel gets this for free — the field rides through the existing envelope passthrough, no code change needed there.
- `custom_components/unified_hifi_control`: `UnifiedHifiControlApiClient.resolve_url` (mirrors the existing `image_url` helper) turns a relative `image` path into an absolute URL; `media_player.py`'s `async_browse_media` sets it as `BrowseMedia.thumbnail`. This closes the "no artwork" deviation `docs/home_assistant_integration.md` documented after PR #537.

## Fixture / test changes

- `tests/fixtures/api_routes.txt`: added `GET /api/collections/image` (intentional new route — flagging for the `api-change-approved` label per the contract test's own instructions).
- `tests/mock_servers/lms.rs`: new `set_artwork`/`set_favorite_with_icon` seeding methods and `coverid`/`icon` fields on the relevant mock responses.
- `tests/mcp_contract.rs`: new/extended tests per provider asserting both image presence (opaque proxy path, raw key never leaked) and absence (row with no provider art omits `image` entirely) — Roon (new test), LMS (extended existing album/track/playlist/favorites tests), Music Assistant (extended existing collections test).
- `custom_components/unified_hifi_control/tests/test_media_player.py`: new test asserting `resolve_url` is called with an item's `image` field and the result lands on `BrowseMedia.thumbnail`.

## Test plan

- [x] `cargo test` — full suite green (511 lib tests + all integration test binaries, including the new/extended `mcp_contract.rs` and `mcp_refs.rs` cases)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — same pre-existing failures as `git stash` baseline (911 errors, systemic dead-code across mock-server test binaries plus the three files called out in this issue's brief); no new failures from this change
- [x] `cargo fmt --check` — clean
- [x] HACS: `pytest custom_components/unified_hifi_control/tests -v` — 56 passed (in a scratch venv built from `requirements_test.txt`, matching `.github/workflows/ha-integration.yml`)
- [x] HACS: `ruff check custom_components/unified_hifi_control/` — clean

## Deviations / notes

- LMS's `tags:cJ` choice (coverid + artwork_track_id) is based on `docs/lyrion.md`'s tag table, not verified against a live server — this environment has no network access to the LMS test rig and the task brief prohibits sending requests to it regardless. If a live LMS ever returns something unexpected for these tags on `albums`/`titles`/`playlists tracks`, that's a follow-up, not something this PR could have caught.
- Roon's `image_key` and MA's `image_url` were both already present in adapter-internal types before this change; wiring them into `hifi_collections` required no adapter-level schema change, just mapping.
- Did not touch `src/api/mod.rs`'s settings sections (sibling work on #548).