### PR TITLE
Fix roon_protocol config-dir race: concurrent tests lose pairing-state writes

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -1171,6 +1171,13 @@ pub struct RoonAdapter {
     /// Present only in the composed server.  It routes complete Core callbacks into the
     /// aggregator-owned projection and owns command/callback correlation.
     runtime_bridge: Option<Arc<RoonRuntimeBridge>>,
+    /// Where pairing state (`roon_state.json`) is loaded from and saved to.
+    ///
+    /// Defaults to `get_roon_state_path()`, i.e. the production config directory
+    /// (honouring `UHC_CONFIG_DIR`). Overridable via [`Self::with_state_path_for_tests`]
+    /// so each test instance gets its own file instead of racing every other
+    /// `RoonAdapter` in the test binary over one shared path (issue #554).
+    state_path: PathBuf,
 }
 
 impl RoonAdapter {
@@ -1184,6 +1191,7 @@ impl RoonAdapter {
             started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             knob_store: None,
             runtime_bridge: None,
+            state_path: get_roon_state_path(),
         }
     }
 
@@ -1211,7 +1219,23 @@ impl RoonAdapter {
             started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             knob_store: Some(knob_store),
             runtime_bridge,
+            state_path: get_roon_state_path(),
         }
+    }
+
+    /// Test seam (issue #554): point this adapter's pairing-state persistence at a
+    /// caller-owned path instead of the shared production config directory.
+    ///
+    /// `tests/roon_protocol.rs` spawns many `RoonAdapter`s in one test binary; every
+    /// one of them registers against its own fake Core and read-modify-writes
+    /// `roon_state.json` on pairing. Sharing one file (even a tempdir one) meant two
+    /// adapters could interleave load->save and permanently drop each other's token.
+    /// Each test now gets its own file via this seam, so production behaviour
+    /// (`get_roon_state_path()`, honouring `UHC_CONFIG_DIR`) is unchanged.
+    #[doc(hidden)]
+    pub fn with_state_path_for_tests(mut self, path: PathBuf) -> Self {
+        self.state_path = path;
+        self
     }
 
     /// Create and immediately start Roon adapter (legacy API for compatibility)
@@ -1300,6 +1324,7 @@ impl RoonAdapter {
                 ip,
                 port: port.to_string(),
             },
+            self.state_path.clone(),
         )
         .await
     }
@@ -3108,6 +3133,7 @@ impl AdapterLogic for RoonAdapter {
             self.knob_store.clone(),
             self.runtime_bridge.clone(),
             CoreConnect::Discovery,
+            self.state_path.clone(),
         )
         .await;
         command_shutdown.cancel();
@@ -3500,6 +3526,7 @@ enum CoreConnect {
 }
 
 /// Main Roon event loop
+#[allow(clippy::too_many_arguments)]
 async fn run_roon_loop(
     state: Arc<RwLock<RoonState>>,
     bus: SharedBus,
@@ -3508,6 +3535,7 @@ async fn run_roon_loop(
     knob_store: Option<KnobStore>,
     runtime_bridge: Option<Arc<RoonRuntimeBridge>>,
     connect: CoreConnect,
+    state_path: PathBuf,
 ) -> Result<()> {
     tracing::info!("Starting Roon discovery...");
 
@@ -3516,7 +3544,8 @@ async fn run_roon_loop(
 
     // Ensure config subdirectory exists for state persistence
     // Issue #76: State files now go into unified-hifi/ subdirectory
-    let state_path = get_roon_state_path();
+    // Issue #554: path is caller-supplied (production default: get_roon_state_path()),
+    // so concurrent tests can each own a private file instead of racing over one.
     if let Some(parent) = state_path.parent() {
         if !parent.exists() {
             std::fs::create_dir_all(parent)?;

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -42,38 +42,48 @@ use unified_hifi_control::knobs::KnobStore;
 // Harness
 // =============================================================================
 
-/// Point the adapter's state-file writes at a throwaway directory, and return it.
+/// Give one test's adapter its own throwaway pairing-state file (issue #554).
 ///
-/// `run_roon_loop` persists Roon pairing state via `get_config_file_path`, which
-/// honours `UHC_CONFIG_DIR`. Without this, registering against the fake would write
-/// `roon_state.json` into the operator's real config directory.
+/// `run_roon_loop` persists Roon pairing state by read-modify-writing a JSON file.
+/// Earlier, every `RoonAdapter` in this binary shared one process-global
+/// `UHC_CONFIG_DIR`, so they all read-modify-wrote the *same* `roon_state.json`.
+/// Two adapters registering concurrently could interleave load->save and
+/// permanently drop each other's token — the handshake test polls 2s for its
+/// token and that drop is not a slow update, it is a lost one.
 ///
-/// The `set_var` happens *inside* the `OnceLock` initializer, so it runs exactly
-/// once and every later read of the variable is ordered after it by the `OnceLock`'s
-/// own acquire/release. Calling `set_var` per test would race with concurrent
-/// `getenv` from the other test threads.
-fn isolate_config_dir() -> &'static std::path::Path {
-    use std::sync::OnceLock;
-    static DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
-    DIR.get_or_init(|| {
-        let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("UHC_CONFIG_DIR", dir.path());
-        dir
-    })
-    .path()
+/// `RoonAdapter::with_state_path_for_tests` now lets each adapter own a private
+/// file instead, so this binary's ~70 tests can run fully concurrently without
+/// racing over shared state. The `TempDir` is intentionally leaked (not stored)
+/// so the file outlives the adapter for the rest of the test binary's run; CI
+/// runners and `cargo test`'s tmp dirs are ephemeral regardless.
+fn private_state_path() -> std::path::PathBuf {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("roon_state.json");
+    std::mem::forget(dir);
+    path
 }
 
 /// Start a fake Core and a `RoonAdapter` connected to it, and wait until the
 /// adapter reports Browse as available.
 async fn connected(core: &FakeRoonCore) -> Arc<RoonAdapter> {
-    let _ = isolate_config_dir();
+    connected_at(core, private_state_path()).await.0
+}
 
+/// Like [`connected`], but also returns the pairing-state file path the adapter
+/// was configured with, for tests that need to assert on its contents directly.
+async fn connected_at(
+    core: &FakeRoonCore,
+    state_path: std::path::PathBuf,
+) -> (Arc<RoonAdapter>, std::path::PathBuf) {
     let bus = create_bus();
-    let adapter = Arc::new(RoonAdapter::new_configured(
-        bus,
-        "http://test.invalid:8088".to_string(),
-        KnobStore::new(),
-    ));
+    let adapter = Arc::new(
+        RoonAdapter::new_configured(
+            bus,
+            "http://test.invalid:8088".to_string(),
+            KnobStore::new(),
+        )
+        .with_state_path_for_tests(state_path.clone()),
+    );
 
     let runner = adapter.clone();
     let ip = core.ip();
@@ -87,7 +97,7 @@ async fn connected(core: &FakeRoonCore) -> Arc<RoonAdapter> {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
         if adapter.is_browse_connected().await {
-            return adapter;
+            return (adapter, state_path);
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
@@ -201,7 +211,7 @@ async fn classify_rejection<T: std::fmt::Debug>(
 #[tokio::test]
 async fn roon_core_completes_handshake() {
     let core = FakeRoonCore::start().await;
-    let adapter = connected(&core).await;
+    let (adapter, state_file) = connected_at(&core, private_state_path()).await;
 
     let status = adapter.get_status().await;
     assert!(status.connected);
@@ -221,11 +231,8 @@ async fn roon_core_completes_handshake() {
     assert!(names.contains(&"com.roonlabs.registry:1/register".to_string()));
 
     // Registering makes the adapter persist pairing state. Prove it landed in the
-    // throwaway directory: if this ever fails, the suite is writing into the
-    // operator's real config directory.
-    let state_file = isolate_config_dir()
-        .join("unified-hifi")
-        .join("roon_state.json");
+    // throwaway, adapter-private file: if this ever fails, the suite is writing
+    // into the operator's real config directory.
     let deadline = Instant::now() + Duration::from_secs(2);
     while !state_file.exists() && Instant::now() < deadline {
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -234,9 +241,9 @@ async fn roon_core_completes_handshake() {
         state_file.exists(),
         "expected pairing state at {state_file:?}"
     );
-    // Every test in this binary shares the one config directory, so the file is
-    // rewritten concurrently and a read can catch it mid-truncate. Retry until it
-    // parses and carries this Core's own id.
+    // This adapter owns its state file exclusively (issue #554), so a partial
+    // write can only be this adapter's own in-flight save, not another test's.
+    // Retry briefly until it parses and carries this Core's own id.
     let core_id = core.core_id().await;
     let deadline = Instant::now() + Duration::from_secs(2);
     let saved = loop {


### PR DESCRIPTION
Closes #554

## Summary

`tests/roon_protocol.rs` set one process-global `UHC_CONFIG_DIR` (via a `OnceLock`) for the whole test binary. Nearly every test's `connected()` helper spawns a `RoonAdapter` that registers against a fake Roon Core and read-modify-writes the shared `roon_state.json` on pairing. Two adapters interleaving load->save could lose each other's writes -- the handshake test polls for its token for 2s and could see it permanently dropped by a concurrent test's save (`tests/roon_protocol.rs:252`, "pairing state never carried a token").

Fix direction chosen (the issue's preferred option): make the Roon pairing-state path **injectable per adapter instance** rather than serializing tests.

- `src/adapters/roon.rs`: added a `state_path: PathBuf` field to `RoonAdapter`, defaulting to `get_roon_state_path()` (i.e. today's production behavior, still honouring `UHC_CONFIG_DIR`) in every existing constructor. Added `#[doc(hidden)] pub fn with_state_path_for_tests(mut self, path: PathBuf) -> Self` as a test-only builder seam. Threaded `state_path` through `run_roon_loop` (both call sites: the production `AdapterLogic::run` and the test-only `run_event_loop_against_core_for_tests`), replacing the hardcoded internal `get_roon_state_path()` call inside the loop with the caller-supplied path.
- `tests/roon_protocol.rs`: replaced the shared `isolate_config_dir()` `OnceLock` with `private_state_path()`, which hands each `connected()`/`connected_at()` call its own tempfile via `RoonAdapter::with_state_path_for_tests`. The handshake test (`roon_core_completes_handshake`) now asserts against the exact path its own adapter was given, instead of polling a directory shared with ~70 other tests.

Why this direction over `serial_test`: the issue calls out `serial_test` (already a dependency) as an acceptable but slower fallback. Per-adapter injection keeps the ~70-test binary fully concurrent, is a small, local change (one struct field + one builder method + threading one parameter), and leaves production untouched -- `get_roon_state_path()` remains the sole production code path, so state file location/format in prod is unchanged.

## Stability evidence

```
cargo test --test roon_protocol -- --test-threads=8
```
run 12 times consecutively: **74 passed; 0 failed** every time (previously flaky).

Full suite:
```
cargo test
```
**all binaries green** (512+ tests across the lib, `roon_protocol`, and every other integration test binary; 0 failed).

```
cargo clippy -- -D warnings          # clean (lib + bins)
cargo clippy --test roon_protocol -- -D warnings   # zero issues in tests/roon_protocol.rs or src/adapters/roon.rs
cargo fmt --check                    # clean
```

`cargo clippy --all-targets -- -D warnings` still fails, but confirmed via `git stash` that the failures are pre-existing (shared `tests/mock_servers/*` helpers, `tests/hqplayer_conformance.rs`, etc.) and untouched by this change -- neither `tests/roon_protocol.rs` nor `src/adapters/roon.rs` appear anywhere in that failure list, with or without this diff.

## Test plan
- [x] `cargo test --test roon_protocol` green x12 consecutive runs
- [x] `cargo test` (full suite) green
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] No production behavior change (`get_roon_state_path()` untouched; new field defaults to it everywhere except the test-only builder)