### PR TITLE
fix(library): break the fetch/render loop; correct SSE browse_supported

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2144,6 +2144,43 @@ impl Drop for SseConnectionGuard {
     }
 }
 
+/// Patches a serialized `BusEvent`'s embedded zone with the live
+/// `browse_supported` derivation (#557).
+///
+/// `bus::events::Zone` -- the wire type embedded in `ZoneDiscovered` and
+/// broadcast to every SSE subscriber -- predates #531's per-provider
+/// `browse_supported` flag and has no field for it, unlike the REST
+/// `/zones` and `/knob/zones` projections (`knobs::routes::ZoneInfo`),
+/// which compute it correctly via
+/// [`crate::mcp::tools::collections::zone_supports_hifi_collections`].
+/// Every adapter's zone-discovery path would need a matching edit to add
+/// a field that doesn't exist yet, so instead this patches the
+/// already-serialized JSON at the one point a `ZoneDiscovered` event
+/// leaves the process. The frontend's `crate::app::api::Zone` treats a
+/// missing `browse_supported` as `false` (`#[serde(default)]`), so an
+/// unpatched payload silently told every client -- Roon zones included --
+/// that no zone could browse. A no-op for every other event: none of them
+/// carry a `/payload/zone` pointer.
+fn patch_zone_discovered_browse_supported(value: &mut serde_json::Value) {
+    let Some(zone_id) = value
+        .pointer("/payload/zone/zone_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+    else {
+        return;
+    };
+    let supported = crate::mcp::tools::collections::zone_supports_hifi_collections(&zone_id);
+    if let Some(zone) = value
+        .pointer_mut("/payload/zone")
+        .and_then(|v| v.as_object_mut())
+    {
+        zone.insert(
+            "browse_supported".to_string(),
+            serde_json::Value::Bool(supported),
+        );
+    }
+}
+
 pub async fn events_handler(
     State(state): State<AppState>,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
@@ -2166,9 +2203,17 @@ pub async fn events_handler(
     let stream = with_shutdown
         .filter_map(|result| match result {
             Ok(event) => {
-                // Serialize event to JSON
-                match serde_json::to_string(&event) {
-                    Ok(json) => Some(Ok(Event::default().data(json))),
+                // Serialize event to a Value first so ZoneDiscovered's embedded
+                // zone can be patched with the live browse_supported derivation
+                // (#557) before going out as JSON.
+                match serde_json::to_value(&event) {
+                    Ok(mut value) => {
+                        patch_zone_discovered_browse_supported(&mut value);
+                        match serde_json::to_string(&value) {
+                            Ok(json) => Some(Ok(Event::default().data(json))),
+                            Err(_) => None,
+                        }
+                    }
                     Err(_) => None,
                 }
             }
@@ -3709,6 +3754,69 @@ mod tests {
             .expect("response body must be readable")
             .to_bytes();
         serde_json::from_slice(&bytes).expect("response body must be valid JSON")
+    }
+
+    /// Builds a minimal `bus::events::Zone` for a given zone id, for tests
+    /// that only care about the id -> `browse_supported` derivation.
+    fn test_zone(zone_id: &str) -> Zone {
+        Zone {
+            zone_id: zone_id.to_string(),
+            zone_name: "Test Zone".to_string(),
+            state: PlaybackState::Stopped,
+            volume_control: None,
+            now_playing: None,
+            source: "test".to_string(),
+            is_controllable: true,
+            is_seekable: false,
+            last_updated: 0,
+            is_play_allowed: true,
+            is_pause_allowed: true,
+            is_next_allowed: true,
+            is_previous_allowed: true,
+        }
+    }
+
+    /// #557: a `ZoneDiscovered` event's embedded zone predates #531's
+    /// `browse_supported` flag on the wire, so it must be patched into the
+    /// serialized JSON rather than read off the struct (which has no such
+    /// field). Every provider #531 wired -- Roon included -- must come out
+    /// `true`; a provider it did not wire must come out `false`.
+    #[test]
+    fn zone_discovered_sse_payload_reports_browse_supported() {
+        for (zone_id, expected) in [
+            ("roon:zone-1", true),
+            ("lms:zone-1", true),
+            ("musicassistant:zone-1", true),
+            ("openhome:zone-1", false),
+            ("upnp:zone-1", false),
+            ("hqplayer:zone-1", false),
+        ] {
+            let event = BusEvent::ZoneDiscovered {
+                zone: test_zone(zone_id),
+            };
+            let mut value = serde_json::to_value(&event).expect("event serializes");
+            patch_zone_discovered_browse_supported(&mut value);
+            assert_eq!(
+                value.pointer("/payload/zone/browse_supported"),
+                Some(&serde_json::Value::Bool(expected)),
+                "zone_id={zone_id}"
+            );
+        }
+    }
+
+    /// Non-`ZoneDiscovered` events have no `/payload/zone` pointer, so the
+    /// patch must be a no-op rather than panicking or inserting a stray
+    /// field.
+    #[test]
+    fn patch_is_noop_for_events_without_a_zone() {
+        let event = BusEvent::RoonConnected {
+            core_name: "Test Core".to_string(),
+            version: "1.0".to_string(),
+        };
+        let mut value = serde_json::to_value(&event).expect("event serializes");
+        let before = value.clone();
+        patch_zone_discovered_browse_supported(&mut value);
+        assert_eq!(value, before);
     }
 
     struct FakeAdapter(&'static str);

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -211,6 +211,54 @@ fn resolve_source(
     browsable.first().and_then(|z| z.source.clone())
 }
 
+/// Whether an SSE event should trigger `zones.restart()` -- i.e. a fresh
+/// `/zones` fetch (#557).
+///
+/// Deliberately narrower than [`crate::app::sse::SseContext::should_refresh_zones`]
+/// and than `pages::zones`'s own restart condition: STRUCTURAL changes only
+/// (a zone appearing/disappearing, or a provider connecting/disconnecting).
+/// `ZoneUpdated` is excluded on purpose -- a playing zone's `ZoneUpdated`
+/// stream is effectively continuous, and restarting the zones resource on
+/// every one of them is exactly the fetch loop #557 reports (see this
+/// module's doc comment). This page has no need for the fresh `Zone.state`
+/// a restart would buy: `is_playing` is read from `now_playing`, which is
+/// refreshed on `ZoneUpdated` separately (a single per-zone `GET`, not a
+/// zones-list refetch).
+fn should_restart_zones(event: Option<&SseEvent>) -> bool {
+    matches!(
+        event,
+        Some(
+            SseEvent::ZoneDiscovered { .. }
+                | SseEvent::ZoneRemoved { .. }
+                | SseEvent::RoonConnected
+                | SseEvent::RoonDisconnected
+                | SseEvent::LmsConnected
+                | SseEvent::LmsDisconnected
+        )
+    )
+}
+
+/// Zones present in `list` with no entry yet in `now_playing` -- the ones
+/// worth fetching (#557).
+///
+/// Used instead of unconditionally re-fetching every zone's now-playing
+/// state whenever `zones_list()` changes: `Zone` carries a `state` field
+/// that legitimately changes on every `ZoneUpdated`, so a naive "refetch
+/// everything when the zone list changes" effect reruns on every such
+/// event even though no zone was actually added or removed. Filtering to
+/// zones missing from `now_playing` makes a rerun with no new zones a
+/// true no-op -- no request, no whole-map replace, no downstream
+/// re-render cascade.
+fn missing_now_playing_zones(
+    list: &[Zone],
+    now_playing: &HashMap<String, NowPlaying>,
+) -> Vec<Zone> {
+    list.iter()
+        .filter(|z| !now_playing.contains_key(&z.zone_id))
+        .cloned()
+        .collect()
+}
+
 /// Fetch one page of the current level and apply it.
 #[allow(clippy::too_many_arguments)]
 async fn load_page(
@@ -298,41 +346,48 @@ pub fn Library(
             .collect::<Vec<_>>()
     });
 
+    // Fetch now_playing for any zone we don't have it for yet: the initial
+    // load, or a zone newly added by a structural SSE event. Selective
+    // inserts (`with_mut`) rather than a whole-map `.set()` -- #557: `Zone`
+    // carries a `state` field that legitimately changes on every
+    // `ZoneUpdated`, so `zones_list()` (and this effect, if it depended on
+    // the full zone content) would rerun on every such event even though no
+    // zone was added or removed. Filtering to zones missing from
+    // `now_playing` makes a rerun with no new zones a no-op: no request, no
+    // map replace, no downstream re-render cascade. See this module's doc
+    // comment and #557's issue body for the loop this replaces.
     use_effect(move || {
         let list = zones_list();
-        if !list.is_empty() {
+        let missing = missing_now_playing_zones(&list, &now_playing.peek());
+        if !missing.is_empty() {
             spawn(async move {
-                let mut map = HashMap::new();
-                for zone in list {
+                for zone in missing {
                     let url = format!(
                         "/now_playing?zone_id={}",
                         urlencoding::encode(&zone.zone_id)
                     );
                     if let Ok(np) = api::fetch_json::<NowPlaying>(&url).await {
-                        map.insert(zone.zone_id, np);
+                        now_playing.with_mut(|map| {
+                            map.insert(zone.zone_id, np);
+                        });
                     }
                 }
-                now_playing.set(map);
             });
         }
     });
 
-    // Refresh on SSE events (structural + playback), mirroring pages::zones.
+    // Refresh on SSE events (structural + playback), mirroring pages::zones
+    // -- but stricter (#557): `zones.restart()` only on STRUCTURAL events
+    // (a zone appearing/disappearing, or a provider connecting/
+    // disconnecting), never on `ZoneUpdated`. A playing zone's `ZoneUpdated`
+    // stream is effectively continuous (play/pause, track, position-adjacent
+    // state), and this page has no need for the fresh `Zone.state` a restart
+    // would buy -- is_playing comes from `now_playing`, refreshed below on
+    // exactly this event.
     use_effect(move || {
         let _ = (sse.event_count)();
         let event = (sse.last_event)();
-        if matches!(
-            event.as_ref(),
-            Some(
-                SseEvent::ZoneDiscovered { .. }
-                    | SseEvent::ZoneUpdated { .. }
-                    | SseEvent::ZoneRemoved { .. }
-                    | SseEvent::RoonConnected
-                    | SseEvent::RoonDisconnected
-                    | SseEvent::LmsConnected
-                    | SseEvent::LmsDisconnected
-            )
-        ) {
+        if should_restart_zones(event.as_ref()) {
             zones.restart();
         }
         if let Some(evt) = event {
@@ -1172,5 +1227,140 @@ fn LibraryTile(
                 }
             }
         }
+    }
+}
+
+/// #557 regression guards for the fetch/render loop that pinned the
+/// browser: the render-loop root cause lived in two effects
+/// (`use_effect` bodies that spawn network requests on `zones_list()` and
+/// SSE event changes), which can't be driven directly without a full
+/// Dioxus VDOM test harness. These tests instead exercise the pure
+/// decision functions those effects delegate to -- `should_restart_zones`
+/// gates the `/zones` refetch, `missing_now_playing_zones` gates the
+/// `/now_playing` fan-out -- so the loop-breaking logic itself has direct
+/// coverage even though the effects' wiring does not. A scripted
+/// fullstack run against `tests/mock_servers` (seek events on a playing
+/// zone, counted `/zones` + `/now_playing` hits over time) would cover the
+/// wiring too, but is infeasible in this sandbox (no browser/wasm runtime
+/// to drive the SSE + effect loop end-to-end); see #557's PR description
+/// for this substitution.
+#[cfg(test)]
+mod loop_regression_tests {
+    use super::*;
+    use crate::app::sse::{VolumePayload, ZonePayload};
+
+    fn zone(id: &str) -> Zone {
+        Zone {
+            zone_id: id.to_string(),
+            ..Zone::default()
+        }
+    }
+
+    fn zone_payload(zone_id: &str) -> ZonePayload {
+        ZonePayload {
+            zone_id: zone_id.to_string(),
+        }
+    }
+
+    // ---- should_restart_zones: structural events only ----
+
+    #[test]
+    fn structural_events_restart_zones() {
+        for event in [
+            SseEvent::ZoneRemoved {
+                payload: zone_payload("roon:1"),
+            },
+            SseEvent::RoonConnected,
+            SseEvent::RoonDisconnected,
+            SseEvent::LmsConnected,
+            SseEvent::LmsDisconnected,
+        ] {
+            assert!(
+                should_restart_zones(Some(&event)),
+                "expected {event:?} to restart the zones resource"
+            );
+        }
+    }
+
+    /// The exact regression #557 reports: a playing zone's `ZoneUpdated`
+    /// stream must NOT restart the zones resource, or every one of those
+    /// events re-triggers the `/zones` -> `/now_playing`-fan-out chain --
+    /// the fetch loop that pinned the browser.
+    #[test]
+    fn zone_updated_does_not_restart_zones() {
+        let event = SseEvent::ZoneUpdated {
+            payload: zone_payload("roon:1"),
+        };
+        assert!(!should_restart_zones(Some(&event)));
+    }
+
+    #[test]
+    fn playback_and_volume_events_do_not_restart_zones() {
+        for event in [
+            SseEvent::NowPlayingChanged {
+                payload: zone_payload("roon:1"),
+            },
+            SseEvent::SeekPositionChanged {
+                payload: zone_payload("roon:1"),
+            },
+            SseEvent::VolumeChanged {
+                payload: VolumePayload {
+                    output_id: "roon:1".to_string(),
+                    value: 10.0,
+                    is_muted: false,
+                },
+            },
+        ] {
+            assert!(
+                !should_restart_zones(Some(&event)),
+                "expected {event:?} not to restart the zones resource"
+            );
+        }
+    }
+
+    #[test]
+    fn no_event_does_not_restart_zones() {
+        assert!(!should_restart_zones(None));
+    }
+
+    // ---- missing_now_playing_zones: the loop-breaking no-op guard ----
+
+    #[test]
+    fn all_zones_missing_on_first_load() {
+        let list = vec![zone("roon:1"), zone("roon:2")];
+        let now_playing = HashMap::new();
+        let missing = missing_now_playing_zones(&list, &now_playing);
+        assert_eq!(missing.len(), 2);
+    }
+
+    /// The other half of #557's regression: once every known zone has a
+    /// `now_playing` entry, a `zones_list()` rerun triggered by a restart
+    /// (e.g. a genuine `ZoneDiscovered` for an unrelated zone) must not
+    /// re-fetch zones that were already fetched -- that whole-map refetch
+    /// on every rerun was the other engine of the loop.
+    #[test]
+    fn already_known_zones_are_not_refetched() {
+        let list = vec![zone("roon:1"), zone("roon:2")];
+        let mut now_playing = HashMap::new();
+        now_playing.insert("roon:1".to_string(), NowPlaying::default());
+        now_playing.insert("roon:2".to_string(), NowPlaying::default());
+        let missing = missing_now_playing_zones(&list, &now_playing);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn only_the_newly_discovered_zone_is_fetched() {
+        let list = vec![zone("roon:1"), zone("roon:2")];
+        let mut now_playing = HashMap::new();
+        now_playing.insert("roon:1".to_string(), NowPlaying::default());
+        let missing = missing_now_playing_zones(&list, &now_playing);
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].zone_id, "roon:2");
+    }
+
+    #[test]
+    fn empty_zone_list_fetches_nothing() {
+        let missing = missing_now_playing_zones(&[], &HashMap::new());
+        assert!(missing.is_empty());
     }
 }

--- a/tests/library_sse_single_eventsource.rs
+++ b/tests/library_sse_single_eventsource.rs
@@ -1,0 +1,71 @@
+//! #557 regression guard: exactly one `EventSource` per app session.
+//!
+//! Bug: the live install's console showed repeated "SSE: Creating
+//! EventSource connection to /events" lines alongside the render/fetch
+//! loop, suggesting a per-component (or per-remount) `EventSource` rather
+//! than one shared connection. Investigation confirmed the connection
+//! itself was already centralized correctly (`use_sse_provider()` opens
+//! the browser's `EventSource` once, at the app root, above the router;
+//! every page-level `use_sse()` call only reads the shared context, it
+//! never opens a new connection) -- the actual loop was in `pages::library`'s
+//! effects (see `src/app/pages/library.rs`'s `loop_regression_tests`
+//! module), not in SSE connection management.
+//!
+//! This is a lint test, not a runtime one: driving an actual `EventSource`
+//! open/reconnect count needs a browser (or a wasm test runner with a DOM),
+//! which is not available in this sandbox. It instead scans the source for
+//! the two invariants a second `EventSource` call site would violate, so a
+//! future page that opens its own connection (defeating the single shared
+//! one) fails CI immediately rather than only showing up as console churn
+//! in a live install.
+
+use std::fs;
+
+/// `EventSource::new` must be constructed in exactly one place:
+/// `use_sse_provider()`, called once at the app root (`src/app/mod.rs`).
+/// A second call site -- e.g. a page reaching for its own connection
+/// instead of `use_sse()` -- reproduces the reconnect churn #557 reports.
+#[test]
+fn lint_eventsource_constructed_in_exactly_one_place() {
+    let src = fs::read_to_string("src/app/sse.rs").expect("failed to read src/app/sse.rs");
+    let count = src.matches("EventSource::new(").count();
+    assert_eq!(
+        count, 1,
+        "REGRESSION: EventSource::new(...) must appear exactly once, inside \
+         use_sse_provider(). Found {count} call sites in src/app/sse.rs -- a \
+         second one means some page opens its own SSE connection instead of \
+         sharing the app-root one, which is how #557's reconnect churn happened."
+    );
+}
+
+/// `use_sse_provider()` -- which owns the one `EventSource` -- must be
+/// called exactly once, from the app root, not from any individual page.
+/// Every page instead calls the read-only `use_sse()`.
+#[test]
+fn lint_use_sse_provider_called_once_from_app_root() {
+    let mod_rs = fs::read_to_string("src/app/mod.rs").expect("failed to read src/app/mod.rs");
+    assert!(
+        mod_rs.contains("use_sse_provider();"),
+        "REGRESSION: src/app/mod.rs must call use_sse_provider() at the app root \
+         so every page shares one EventSource."
+    );
+
+    for (path, page_should_not_call_provider) in [
+        ("src/app/pages/library.rs", true),
+        ("src/app/pages/zones.rs", true),
+        ("src/app/pages/knobs.rs", true),
+        ("src/app/pages/settings.rs", true),
+        ("src/app/pages/spotify.rs", true),
+        ("src/app/pages/hqplayer.rs", true),
+        ("src/app/pages/lms.rs", true),
+    ] {
+        let src = fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+        if page_should_not_call_provider {
+            assert!(
+                !src.contains("use_sse_provider("),
+                "REGRESSION: {path} calls use_sse_provider(), which would open a \
+                 second EventSource. Pages must call use_sse() (read-only) instead."
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #557

## Summary

**Bug 1 — infinite fetch/render loop.** The Library page's SSE effect called `zones.restart()` on every `ZoneUpdated` event, and a separate effect whole-map-replaced `now_playing` on every `zones_list()` change. A playing zone's SSE stream is `ZoneUpdated`-heavy (play/pause, position-adjacent state), so this drove an endless `/zones` → `/now_playing` × 9 zones fetch cycle that pinned the wasm main thread and the browser.

Root cause confirmed: `zones.restart()` on `ZoneUpdated` (`src/app/pages/library.rs`'s SSE effect) → new `/zones` GET completes with a changed `Zone.state` → `zones_list()` memo notifies → the fetch-all `now_playing` effect (keyed on `zones_list()`) reruns and re-fetches every zone → `now_playing.set()` (whole-map replace) → downstream effects re-render → next `ZoneUpdated` arrives before this settles. One `EventSource` existed the whole time (`use_sse_provider()` is already called exactly once, at the app root in `src/app/mod.rs`, above the router — every page's `use_sse()` only reads that shared context); the "SSE: Creating EventSource" churn in the console was a symptom of the render storm, not a second connection.

Fix (`src/app/pages/library.rs`):
- `zones.restart()` now fires only on structural SSE events (`ZoneDiscovered`, `ZoneRemoved`, provider connect/disconnect) — never `ZoneUpdated`.
- `now_playing` is fetched only for zones missing an entry (selective `with_mut` inserts), never replaced wholesale — a `zones_list()` rerun with no actual zone added/removed is a true no-op: no request, no map replace, no re-render cascade.
- The two decisions (`should_restart_zones`, `missing_now_playing_zones`) are extracted into pure functions with direct unit coverage, since driving the Dioxus effects themselves needs a browser/VDOM harness this sandbox doesn't have.
- Added a source-scanning guard (`tests/library_sse_single_eventsource.rs`) confirming exactly one `EventSource::new` call site and exactly one `use_sse_provider()` call, so a future page can't reintroduce per-page connections.

**Bug 2 — Roon zones report `browse_supported=false` over SSE.** `bus::events::Zone` (the wire type embedded in `BusEvent::ZoneDiscovered`, broadcast to every `/events` subscriber) predates #531's per-provider `browse_supported` flag and has no field for it. The frontend's `crate::app::api::Zone` treats a missing field as `false` (`#[serde(default)]`), so every `ZoneDiscovered` SSE payload silently reported `browse_supported: false` — Roon included — matching the live diagnostics in the issue exactly.

The REST projections (`/zones`, `/knob/zones` → `knobs::routes::ZoneInfo`) already derive this correctly via `zone_supports_hifi_collections` (a pure `zone_id`-prefix classification, unrelated to adapter registration timing). Rather than thread a new field through every adapter's zone-discovery construction site (~10+ call sites across `src/adapters/*.rs` and their tests), the fix patches the already-serialized SSE JSON at the single point a `ZoneDiscovered` event leaves the process (`src/api/mod.rs`'s `events_handler`), reusing the same canonical derivation.

## Verification

- `cargo test` — 522 lib tests + all integration suites pass (0 failed), including 8 new `library.rs` loop-regression tests and 2 new `api::mod` SSE-patch tests.
- `cargo clippy -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo check --no-default-features --features web --target wasm32-unknown-unknown` — clean.
- `cargo clippy --all-targets -- -D warnings` — diffed against a baseline run on unmodified `integration/streaming-ha-alpha`; the ~124 pre-existing failures (all in `tests/roon_protocol.rs`, `tests/hqplayer_conformance.rs`, `tests/mcp_refs.rs`, `tests/upnp_metadata.rs`, `tests/zones_sha_integration.rs`) are unchanged by this PR — none reference the two files this PR touches.
- **Bounded-request substitution**: a scripted fullstack run against `tests/mock_servers` (a playing zone emitting seek events, counting `/zones` + `/now_playing` hits over time) needs a browser/wasm runtime to drive the SSE + Dioxus-effect loop end-to-end, which isn't available in this sandbox. Substituted with unit-level guards instead: `should_restart_zones` and `missing_now_playing_zones` (the two functions the fix's effects now delegate their loop-breaking decisions to) have direct test coverage proving `ZoneUpdated`/`NowPlayingChanged`/`SeekPositionChanged`/`VolumeChanged` never trigger a `/zones` restart, and that a zone already present in `now_playing` is never re-fetched — the two conditions that, together, made the reported loop possible.

## Deviations

- `sg review` (superego) could not run in this sandbox — its OAuth session isn't available here — so I did a careful manual self-review of the diff instead of the usual automated pass.
- Did not touch `src/input.css`, `src/app/theme.rs`, or nav files (sibling work on #555), per the issue's coordination note.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --no-default-features --features web --target wasm32-unknown-unknown`
- [x] Unit coverage for the loop-breaking decisions and for the `browse_supported` SSE patch