### PR TITLE
feat(release): free-tier release signing (GPG SHA256SUMS, cosign, platform prep)

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -59,6 +59,37 @@ does and does not control.
 
 ---
 
+## Verifying These Artifacts
+
+Every file attached to this release is listed in `SHA256SUMS`. If
+`SHA256SUMS.asc` is also attached, it's a detached GPG signature over
+`SHA256SUMS`, made with the project's release-signing key
+(`docs/release-signing/gpg-public-key.asc` in the repo).
+
+```bash
+# Checksum any downloaded file against SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+
+# Verify SHA256SUMS itself was signed by the project (one-time key import)
+gpg --import gpg-public-key.asc
+gpg --verify SHA256SUMS.asc SHA256SUMS
+```
+
+Docker images (`muness/unified-hifi-control:{{VERSION}}`) are signed
+keylessly with [cosign](https://docs.sigstore.dev/cosign/overview/) via
+GitHub Actions OIDC - no key to import:
+
+```bash
+cosign verify muness/unified-hifi-control:{{VERSION}} \
+  --certificate-identity-regexp 'https://github.com/open-horizon-labs/unified-hifi-control/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Full details, including which platforms are signed today versus pending
+owner credentials: [docs/gh-release.md#release-signing](https://github.com/open-horizon-labs/unified-hifi-control/blob/v3/docs/gh-release.md#release-signing).
+
+---
+
 ## MCP Server (Claude Integration)
 
 The bridge includes a built-in MCP server. Add to your MCP config (Claude Code, Claude Desktop, etc.):

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1043,17 +1043,103 @@ jobs:
     needs: [plan]
     if: needs.plan.outputs.build_applemusic_macos == 'true'
     runs-on: macos-latest
+    # `secrets` isn't allowed directly in step `if:` conditions, so surface
+    # presence checks as job-level env vars instead.
+    env:
+      HAS_APPLE_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12 != '' && secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD != '' }}
+      HAS_APPLE_NOTARY: ${{ secrets.APPLE_NOTARY_KEY_P8 != '' && secrets.APPLE_NOTARY_KEY_ID != '' && secrets.APPLE_NOTARY_KEY_ISSUER_ID != '' }}
     steps:
       - uses: actions/checkout@v6
 
-      # No signing identity is available in CI, so this produces an
-      # unsigned/ad-hoc DMG. ARM64 (Apple Silicon) only - by design, not a
-      # gap: see companion/apple_music/README.md for the right-click-Open /
-      # xattr workaround users need on first launch.
-      - name: Build arm64-only DMG
+      # macOS signing/notarization (issue #561): the owner already has an
+      # Apple Developer Program membership, so this only needs the two
+      # secret groups below - no code changes once they're added.
+      #   APPLE_DEVELOPER_ID_CERT_P12       - base64 of a "Developer ID
+      #                                        Application" .p12 export
+      #   APPLE_DEVELOPER_ID_CERT_PASSWORD  - password for that .p12
+      #   APPLE_DEVELOPMENT_TEAM_ID         - 10-char Apple Team ID
+      #   APPLE_NOTARY_KEY_P8               - base64 App Store Connect API
+      #                                        key (.p8) for notarytool
+      #   APPLE_NOTARY_KEY_ID               - key ID for the API key above
+      #   APPLE_NOTARY_KEY_ISSUER_ID        - issuer ID for the API key
+      # Until they exist, this falls back to the same unsigned/ad-hoc build
+      # CI has always produced - no behavior change.
+      - name: Import Developer ID signing certificate
+        id: import-cert
+        if: ${{ env.HAS_APPLE_CERT == 'true' }}
+        env:
+          CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          echo "$CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN_PATH" -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # shellcheck disable=SC2046  # word splitting is intentional: each existing keychain path becomes its own -s argument
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep 'Developer ID Application' | head -1 | sed -E 's/.*"(.+)"/\1/')
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::No 'Developer ID Application' identity found in the imported certificate."
+            exit 1
+          fi
+          echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
+          echo "has_cert=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed arm64 DMG
+        if: steps.import-cert.outputs.has_cert == 'true'
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+          CODE_SIGN_IDENTITY: ${{ steps.import-cert.outputs.identity }}
+          CODE_SIGN_STYLE: Manual
+          DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM_ID }}
+          CODE_SIGNING_REQUIRED: "YES"
+        run: companion/apple_music/build-dmg.sh
+
+      # No signing identity is available, so this produces an unsigned/ad-hoc
+      # DMG - the same thing CI has always shipped. ARM64 (Apple Silicon)
+      # only - by design, not a gap: see companion/apple_music/README.md for
+      # the right-click-Open / xattr workaround users need on first launch.
+      - name: Build unsigned arm64-only DMG
+        if: steps.import-cert.outputs.has_cert != 'true'
         env:
           VERSION: ${{ needs.plan.outputs.version }}
         run: companion/apple_music/build-dmg.sh
+
+      - name: Notarize and staple DMG
+        if: steps.import-cert.outputs.has_cert == 'true' && env.HAS_APPLE_NOTARY == 'true'
+        env:
+          APPLE_NOTARY_KEY_P8: ${{ secrets.APPLE_NOTARY_KEY_P8 }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_KEY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_KEY_ISSUER_ID }}
+        run: |
+          DMG_PATH=$(ls companion/apple_music/dist/*.dmg)
+          KEY_PATH="$RUNNER_TEMP/notary-key.p8"
+          echo "$APPLE_NOTARY_KEY_P8" | base64 --decode > "$KEY_PATH"
+
+          xcrun notarytool submit "$DMG_PATH" \
+            --key "$KEY_PATH" \
+            --key-id "$APPLE_NOTARY_KEY_ID" \
+            --issuer "$APPLE_NOTARY_KEY_ISSUER_ID" \
+            --wait
+
+          xcrun stapler staple "$DMG_PATH"
+          rm -f "$KEY_PATH"
+
+      - name: Note unsigned/unnotarized DMG
+        if: steps.import-cert.outputs.has_cert != 'true'
+        run: echo "::notice::APPLE_DEVELOPER_ID_CERT_P12/APPLE_DEVELOPER_ID_CERT_PASSWORD not set - DMG ships unsigned/ad-hoc. See docs/gh-release.md#release-signing."
+
+      - name: Note unnotarized DMG
+        if: steps.import-cert.outputs.has_cert == 'true' && env.HAS_APPLE_NOTARY != 'true'
+        run: echo "::notice::APPLE_NOTARY_KEY_P8/APPLE_NOTARY_KEY_ID/APPLE_NOTARY_KEY_ISSUER_ID not set - DMG is signed but not notarized/stapled. See docs/gh-release.md#release-signing."
 
       - name: Upload DMG
         uses: actions/upload-artifact@v7
@@ -1067,6 +1153,10 @@ jobs:
     needs: [plan, build-wasm]
     if: needs.plan.outputs.build_windows == 'true'
     runs-on: windows-latest
+    # `secrets` isn't allowed directly in step `if:` conditions, so surface
+    # the presence check as a job-level env var instead.
+    env:
+      HAS_WINDOWS_CERT: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 != '' && secrets.WINDOWS_SIGNING_CERT_PASSWORD != '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1124,6 +1214,36 @@ jobs:
         run: |
           mkdir -p dist/bin
           cp target/release/unified-hifi-control.exe dist/bin/unified-hifi-win64.exe
+
+      # Windows Authenticode signing (issue #561): deferred until Windows
+      # matters commercially. Prepared but inactive - gated on
+      # WINDOWS_SIGNING_CERT_BASE64/WINDOWS_SIGNING_CERT_PASSWORD, which do
+      # not exist yet, so this step is a no-op today. When the owner is
+      # ready (an Azure Trusted Signing subscription or an OV cert), either
+      # populate those two secrets for a traditional PFX cert, or swap this
+      # step for azure/trusted-signing-action and its AZURE_TRUSTED_SIGNING_*
+      # secrets - both are viable, pick whichever the owner buys.
+      - name: Sign Windows binary (Authenticode)
+        if: ${{ env.HAS_WINDOWS_CERT == 'true' }}
+        shell: bash
+        env:
+          CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
+        run: |
+          echo "$CERT_BASE64" | base64 --decode > cert.pfx
+          SIGNTOOL=$(find "/c/Program Files (x86)/Windows Kits/10/bin" -name signtool.exe -path "*x64*" | sort | tail -1)
+          if [ -z "$SIGNTOOL" ]; then
+            echo "::error::signtool.exe not found on this runner image - verify the Windows SDK path before enabling this step."
+            exit 1
+          fi
+          "$SIGNTOOL" sign /f cert.pfx /p "$CERT_PASSWORD" /tr http://timestamp.digicert.com /td sha256 /fd sha256 dist/bin/unified-hifi-win64.exe
+          "$SIGNTOOL" verify /pa dist/bin/unified-hifi-win64.exe
+          rm -f cert.pfx
+
+      - name: Note unsigned Windows binary
+        if: ${{ env.HAS_WINDOWS_CERT != 'true' }}
+        shell: bash
+        run: echo "::notice::Windows signing deferred (WINDOWS_SIGNING_CERT_BASE64/WINDOWS_SIGNING_CERT_PASSWORD not set) - binary ships unsigned. See docs/gh-release.md#release-signing."
 
       - name: Upload binary
         uses: actions/upload-artifact@v7
@@ -1324,6 +1444,10 @@ jobs:
       needs.plan.outputs.build_qnap == 'true' &&
       needs.qnap-package-test.result == 'success'
     runs-on: ubuntu-latest
+    # `secrets` isn't allowed directly in step `if:` conditions, so surface
+    # the presence check as a job-level env var instead.
+    env:
+      HAS_QNAP_SIGNING: ${{ secrets.QNAP_SIGNING_CERT != '' && secrets.QNAP_SIGNING_KEY != '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1364,6 +1488,27 @@ jobs:
           mkdir -p dist/installers
           mv qnap-build/*.qpkg dist/installers/unified-hifi-control_${{ needs.plan.outputs.version }}_x86_64.qpkg
 
+      # QNAP code-signing (issue #561): waiting on the owner to join the QNAP
+      # developer program and obtain code-signing credentials. Prepared but
+      # inactive - skips cleanly until QNAP_SIGNING_CERT/QNAP_SIGNING_KEY
+      # secrets exist. Without a signature, QNAP App Center shows an
+      # "unverified publisher" warning on install (documented in README).
+      - name: Sign QPKG (QNAP developer program)
+        if: ${{ env.HAS_QNAP_SIGNING == 'true' }}
+        env:
+          QNAP_SIGNING_CERT: ${{ secrets.QNAP_SIGNING_CERT }}
+          QNAP_SIGNING_KEY: ${{ secrets.QNAP_SIGNING_KEY }}
+        run: |
+          echo "::error::QNAP_SIGNING_CERT/QNAP_SIGNING_KEY are set but the signing step is not implemented yet."
+          echo "Once the owner has QNAP developer credentials, wire QDK's qpkg signing tool"
+          echo "(codesign_pkg / QDK sign step) here, using the two secrets above, then remove"
+          echo "this placeholder failure."
+          exit 1
+
+      - name: Note unsigned QPKG
+        if: ${{ env.HAS_QNAP_SIGNING != 'true' }}
+        run: echo "::notice::QNAP_SIGNING_CERT/QNAP_SIGNING_KEY not set - QPKG ships unsigned (App Center will show a signature warning). See docs/gh-release.md#release-signing."
+
       - name: Upload QNAP package
         uses: actions/upload-artifact@v7
         with:
@@ -1380,6 +1525,10 @@ jobs:
       needs.plan.outputs.build_qnap_arm == 'true' &&
       needs.build-linux-arm.result == 'success'
     runs-on: ubuntu-latest
+    # `secrets` isn't allowed directly in step `if:` conditions, so surface
+    # the presence check as a job-level env var instead.
+    env:
+      HAS_QNAP_SIGNING: ${{ secrets.QNAP_SIGNING_CERT != '' && secrets.QNAP_SIGNING_KEY != '' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1419,6 +1568,24 @@ jobs:
         run: |
           mkdir -p dist/installers
           mv qnap-build/*.qpkg dist/installers/unified-hifi-control_${{ needs.plan.outputs.version }}_arm_64.qpkg
+
+      # QNAP code-signing (issue #561): see the matching step in the x64 job
+      # (build-qnap-x64) for context - same secrets, same TODO.
+      - name: Sign QPKG (QNAP developer program)
+        if: ${{ env.HAS_QNAP_SIGNING == 'true' }}
+        env:
+          QNAP_SIGNING_CERT: ${{ secrets.QNAP_SIGNING_CERT }}
+          QNAP_SIGNING_KEY: ${{ secrets.QNAP_SIGNING_KEY }}
+        run: |
+          echo "::error::QNAP_SIGNING_CERT/QNAP_SIGNING_KEY are set but the signing step is not implemented yet."
+          echo "Once the owner has QNAP developer credentials, wire QDK's qpkg signing tool"
+          echo "(codesign_pkg / QDK sign step) here, using the two secrets above, then remove"
+          echo "this placeholder failure."
+          exit 1
+
+      - name: Note unsigned QPKG
+        if: ${{ env.HAS_QNAP_SIGNING != 'true' }}
+        run: echo "::notice::QNAP_SIGNING_CERT/QNAP_SIGNING_KEY not set - QPKG ships unsigned (App Center will show a signature warning). See docs/gh-release.md#release-signing."
 
       - name: Upload QNAP package
         uses: actions/upload-artifact@v7
@@ -1558,6 +1725,12 @@ jobs:
     needs: [plan, build-docker-release]
     if: needs.plan.outputs.is_release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for cosign keyless signing: it exchanges this token for a
+      # short-lived certificate from Sigstore's public-good Fulcio CA, so no
+      # long-lived signing key or secret is needed for the Docker images.
+      id-token: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -1602,6 +1775,23 @@ jobs:
             docker buildx imagetools create $TAGS \
               $(printf 'muness/unified-hifi-control@sha256:%s ' *)
           fi
+
+      # Free-tier release signing (issue #561): cosign keyless (sigstore)
+      # signatures for every tag this release publishes. No secrets or
+      # enrollment needed - cosign uses the job's GitHub OIDC token to get a
+      # short-lived Fulcio certificate and records the signature in the
+      # public Rekor transparency log.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign container images (cosign keyless)
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          for TAG in $(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            echo "Signing $TAG"
+            cosign sign --yes "$TAG"
+          done
 
   # Note: Web assets are embedded in the binary (ADR 002)
   build-linux-packages:
@@ -1706,6 +1896,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # `secrets` isn't allowed directly in step `if:` conditions, so surface
+    # the presence check as a job-level env var instead.
+    env:
+      HAS_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY != '' }}
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -1728,6 +1922,48 @@ jobs:
           find artifacts -name "*.qpkg" -type f -exec cp {} release/ \;
           find artifacts -name "*.dmg" -type f -exec cp {} release/ \;
           ls -la release/
+
+      # Free-tier release signing (issue #561): SHA256SUMS + detached GPG
+      # signature for every release artifact. The signing key itself is
+      # never committed - it's imported from the GPG_PRIVATE_KEY secret at
+      # sign time. Until the owner adds that secret, this step notices and
+      # skips cleanly; the release still ships (just unsigned).
+      - name: Generate SHA256SUMS
+        working-directory: release
+        run: |
+          sha256sum ./* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Import GPG signing key
+        id: gpg-import
+        if: ${{ env.HAS_GPG_KEY == 'true' }}
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          echo "has_key=true" >> "$GITHUB_OUTPUT"
+
+      - name: GPG-sign SHA256SUMS
+        if: steps.gpg-import.outputs.has_key == 'true'
+        working-directory: release
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+            --detach-sign --armor -o SHA256SUMS.asc SHA256SUMS
+          gpg --verify SHA256SUMS.asc SHA256SUMS
+          ls -la
+
+      - name: Print exported public key (for repo)
+        if: steps.gpg-import.outputs.has_key == 'true'
+        run: |
+          echo "::notice::If docs/release-signing/gpg-public-key.asc is still the placeholder, copy the key printed below into that file and commit it so users can verify releases."
+          gpg --armor --export
+
+      - name: Note unsigned checksums
+        if: steps.gpg-import.outputs.has_key != 'true'
+        run: |
+          echo "::warning::GPG_PRIVATE_KEY secret not set - SHA256SUMS ships without a .asc signature. See docs/gh-release.md#release-signing."
 
       - name: Generate asset list
         run: |
@@ -1761,6 +1997,13 @@ jobs:
 
           ### LMS Plugin
           - `lms-unified-hifi-control-*.zip` - Install via LMS Settings > Plugins
+
+          ### Verifying downloads
+          - `SHA256SUMS` - checksums for every file in this release
+          - `SHA256SUMS.asc` - detached GPG signature over `SHA256SUMS` (present once the owner has enrolled the signing key; see below if absent)
+          - Docker images (`muness/unified-hifi-control`) are signed keylessly with [cosign](https://docs.sigstore.dev/cosign/overview/) via GitHub Actions OIDC
+
+          See [Verifying Release Artifacts](https://github.com/${{ github.repository }}/blob/v3/docs/gh-release.md#release-signing) for step-by-step verification commands.
           EOF
 
       - name: Generate beta LMS repository feed

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ Betas are less soaked than releases. Use one channel or the other, not both at o
 
 Pre-built binaries available for Linux (x64, arm64, armv7), macOS (x64, arm64), and Windows from [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases).
 
+### Verifying Release Artifacts
+
+Every release ships a `SHA256SUMS` file covering all attached binaries and
+packages, plus keyless [cosign](https://docs.sigstore.dev/cosign/overview/)
+signatures on the Docker images (no key import needed - verified against
+GitHub's OIDC issuer). Once the project's GPG signing key is enrolled (see
+`docs/release-signing/gpg-public-key.asc`), releases also carry a detached
+`SHA256SUMS.asc` signature.
+
+```bash
+# Checksum a downloaded file
+sha256sum -c SHA256SUMS --ignore-missing
+
+# Verify Docker images
+cosign verify muness/unified-hifi-control:<version> \
+  --certificate-identity-regexp 'https://github.com/open-horizon-labs/unified-hifi-control/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Full verification steps (including GPG) and current per-platform signing
+status: [docs/gh-release.md#release-signing](docs/gh-release.md#release-signing).
+
 ## Quick Start (Docker)
 
 ```yaml

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -331,3 +331,121 @@ This adds ~14s but catches ABI issues, missing linkage, and startup crashes befo
 ## LMS Plugin
 
 See [lms-plugin.md](lms-plugin.md) for LMS plugin distribution modes (bootstrap vs full ZIPs) and testing instructions.
+
+## Release Signing
+
+Tracked as issue #561, worked cheapest-first. Each platform activates
+independently once its GitHub Actions secrets exist - nothing here is
+all-or-nothing.
+
+### Status
+
+| Platform | State | Secrets required |
+|----------|-------|-------------------|
+| SHA256SUMS (all binaries/packages) | **Active** | none - always generated |
+| SHA256SUMS.asc (GPG detached signature) | Gated | `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE` |
+| Docker images (cosign/sigstore keyless) | **Active** | none - uses GitHub OIDC |
+| QNAP QPKG (x64 + arm64) | Prepared, not implemented | `QNAP_SIGNING_CERT`, `QNAP_SIGNING_KEY` (fails loudly if set, since the actual QDK signing call isn't wired up yet) |
+| macOS companion DMG (codesign) | Gated | `APPLE_DEVELOPER_ID_CERT_P12`, `APPLE_DEVELOPER_ID_CERT_PASSWORD`, `APPLE_DEVELOPMENT_TEAM_ID` |
+| macOS companion DMG (notarize + staple) | Gated (requires codesign above) | `APPLE_NOTARY_KEY_P8`, `APPLE_NOTARY_KEY_ID`, `APPLE_NOTARY_KEY_ISSUER_ID` |
+| Windows binary (Authenticode/signtool) | Prepared, disabled | `WINDOWS_SIGNING_CERT_BASE64`, `WINDOWS_SIGNING_CERT_PASSWORD` (deferred until Windows matters commercially) |
+| Synology SPK | Not signable | n/a - Synology does not support self-signed packages; DSM 7 shows an "unrecognized publisher" warning by design (see README) |
+
+Every gated step is written to skip cleanly (or, for QNAP, fail with a clear
+message) when its secrets are absent, so adding platforms later never
+requires touching the workflow's control flow - only adding secrets.
+
+### Free tier (active now)
+
+**SHA256SUMS + GPG signature.** The `upload-release` job in
+`.github/workflows/build.yml` runs `sha256sum *` over every file in the
+release (binaries, packages, DMG, zips) and writes `SHA256SUMS`. If the
+`GPG_PRIVATE_KEY` secret is set, it imports that key and produces a detached,
+armored signature at `SHA256SUMS.asc`; if not, the release still ships,
+just without the `.asc` file. See
+[docs/release-signing/gpg-public-key.asc](release-signing/gpg-public-key.asc)
+for exactly how to generate and install that key - it's currently a
+placeholder because generating a long-lived signing key isn't something CI
+(or an automated change) should do on the owner's behalf.
+
+**cosign (sigstore keyless) for Docker images.** The `docker-manifest` job
+signs every tag it publishes (`muness/unified-hifi-control` and the legacy
+`muness/roon-extension-knob` alias) with `cosign sign --yes <tag>`. This uses
+GitHub Actions' OIDC identity token to get a short-lived certificate from
+Sigstore's public-good Fulcio CA and records the signature in the public
+Rekor transparency log - no secret, no enrollment, no long-lived key. It's
+already active on every tagged release.
+
+### Verifying a release
+
+Given a downloaded release asset (say `unified-hifi-linux-x64`) and the
+`SHA256SUMS`/`SHA256SUMS.asc` files from the same release:
+
+```sh
+# 1. Checksum: does the file match what CI produced?
+sha256sum -c SHA256SUMS --ignore-missing
+
+# 2. Signature: was SHA256SUMS itself signed by the project's key?
+#    (one-time) import the project's public key:
+gpg --import gpg-public-key.asc   # from docs/release-signing/gpg-public-key.asc
+gpg --verify SHA256SUMS.asc SHA256SUMS
+```
+
+For Docker images:
+
+```sh
+cosign verify muness/unified-hifi-control:<version> \
+  --certificate-identity-regexp 'https://github.com/open-horizon-labs/unified-hifi-control/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+If `SHA256SUMS.asc` is missing from a release, GPG signing wasn't active yet
+for that build - the checksum file itself is still valid, just unsigned.
+
+### Gated platforms (prepared, waiting on owner-supplied secrets)
+
+**QNAP QPKG.** `build-qnap-x64` and `build-qnap-arm` each have a signing step
+gated on `QNAP_SIGNING_CERT`/`QNAP_SIGNING_KEY`. Unlike the other gated
+steps, this one is intentionally not a silent no-op if the secrets exist:
+QNAP's actual QDK signing call (`codesign_pkg` or equivalent) isn't
+implemented yet, so the step fails loudly rather than claim a package is
+signed when it isn't. Wire up the real signing call before setting these
+secrets in CI.
+
+**macOS companion DMG.** `build-applemusic-companion-dmg` imports a
+"Developer ID Application" certificate from `APPLE_DEVELOPER_ID_CERT_P12` /
+`APPLE_DEVELOPER_ID_CERT_PASSWORD` into a temporary keychain, builds with
+that identity (`APPLE_DEVELOPMENT_TEAM_ID`), and - if the three
+`APPLE_NOTARY_KEY_*` secrets (an App Store Connect API key) are also set -
+submits the DMG to `notarytool` and staples the ticket. Any subset missing
+falls back to today's unsigned/ad-hoc build; once all six secrets exist, the
+`companion/apple_music/README.md` "unsigned app" workaround and the matching
+note in `.github/RELEASE_TEMPLATE.md`/README should be removed.
+
+**Windows Authenticode.** `build-windows` has a `signtool` step gated on
+`WINDOWS_SIGNING_CERT_BASE64`/`WINDOWS_SIGNING_CERT_PASSWORD` (a base64 PFX +
+password). Deferred by design until Windows matters commercially per issue
+#561. When ready, either populate those two secrets, or replace the step
+with `azure/trusted-signing-action` and its `AZURE_TRUSTED_SIGNING_*` secrets
+if using Azure Trusted Signing instead of a traditional OV certificate -
+both are supported paths, pick whichever the owner buys.
+
+### Secret names, all in one place
+
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `GPG_PRIVATE_KEY` | `upload-release` | ASCII-armored private key, imported at sign time |
+| `GPG_PASSPHRASE` | `upload-release` | Passphrase for the key above (may be empty-string key, see placeholder doc) |
+| `QNAP_SIGNING_CERT` | `build-qnap-x64`, `build-qnap-arm` | QNAP developer program signing certificate |
+| `QNAP_SIGNING_KEY` | `build-qnap-x64`, `build-qnap-arm` | QNAP developer program signing key |
+| `APPLE_DEVELOPER_ID_CERT_P12` | `build-applemusic-companion-dmg` | base64 "Developer ID Application" .p12 export |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD` | `build-applemusic-companion-dmg` | Password for the .p12 above |
+| `APPLE_DEVELOPMENT_TEAM_ID` | `build-applemusic-companion-dmg` | 10-character Apple Developer Team ID |
+| `APPLE_NOTARY_KEY_P8` | `build-applemusic-companion-dmg` | base64 App Store Connect API key (.p8) |
+| `APPLE_NOTARY_KEY_ID` | `build-applemusic-companion-dmg` | Key ID for the API key above |
+| `APPLE_NOTARY_KEY_ISSUER_ID` | `build-applemusic-companion-dmg` | Issuer ID for the API key above |
+| `WINDOWS_SIGNING_CERT_BASE64` | `build-windows` | base64 PFX code-signing certificate (deferred) |
+| `WINDOWS_SIGNING_CERT_PASSWORD` | `build-windows` | Password for the PFX above (deferred) |
+
+None of these are committed anywhere; the workflow only ever imports them
+from GitHub Actions secrets at build time.

--- a/docs/release-signing/gpg-public-key.asc
+++ b/docs/release-signing/gpg-public-key.asc
@@ -1,0 +1,55 @@
+PLACEHOLDER - this is not a real PGP public key yet.
+
+This file exists so verification instructions (docs/gh-release.md,
+.github/RELEASE_TEMPLATE.md, README.md) have a stable path to point at. Until
+the owner completes the steps below, `SHA256SUMS.asc` will not be produced by
+CI (the signing step in .github/workflows/build.yml's `upload-release` job
+skips gracefully whenever the GPG_PRIVATE_KEY secret is unset), so there is
+nothing to verify against yet.
+
+To activate GPG-signed releases:
+
+1. Generate a dedicated release-signing key (do this once, offline, and back
+   up the private key securely - do not use a personal key):
+
+   gpg --batch --full-generate-key <<'EOF'
+   %no-protection
+   Key-Type: EDDSA
+   Key-Curve: ed25519
+   Subkey-Type: ECDH
+   Subkey-Curve: cv25519
+   Name-Real: Unified Hi-Fi Control Release Signing
+   Name-Email: releases@<your-domain-or-noreply>
+   Expire-Date: 2y
+   EOF
+
+   (Or use RSA 4096 if you prefer broader client compatibility. Set a real
+   passphrase and pass it via GPG_PASSPHRASE below instead of %no-protection
+   if you want the key to require one.)
+
+2. Export the private key and add it as a GitHub Actions secret named
+   GPG_PRIVATE_KEY (Settings -> Secrets and variables -> Actions):
+
+   gpg --armor --export-secret-keys releases@<your-domain-or-noreply>
+
+3. If the key has a passphrase, also add a GPG_PASSPHRASE secret with that
+   passphrase. (Recommended: generate one with no passphrase per the
+   %no-protection example above, since it's already access-controlled as a
+   GitHub Actions secret - simplifies CI, one less secret to manage.)
+
+4. Export the public key and replace the entire contents of this file with
+   it:
+
+   gpg --armor --export releases@<your-domain-or-noreply> > docs/release-signing/gpg-public-key.asc
+
+   (The CI workflow also prints the public key in the "Print exported public
+   key (for repo)" step's log on every release run, as a convenience copy of
+   step 4 once the private key secret exists.)
+
+5. Commit the updated docs/release-signing/gpg-public-key.asc. The next
+   tagged release will then produce a SHA256SUMS.asc signature, and the
+   verification instructions in docs/gh-release.md will resolve against a
+   real key.
+
+See docs/gh-release.md#release-signing for the full picture (cosign, QNAP,
+macOS, Windows) and exact GitHub Actions secret names for every platform.


### PR DESCRIPTION
Closes #561 (free tier only - see scope note below)

## Summary

This is the free-tier slice of issue #561 (release signing epic), scoped
per the issue's "Free - start immediately" checklist:

- **SHA256SUMS + GPG signature**: `upload-release` now generates
  `SHA256SUMS` for every release artifact, and signs it (`SHA256SUMS.asc`)
  when the `GPG_PRIVATE_KEY`/`GPG_PASSPHRASE` secrets exist. No key is
  generated or committed by this PR - only a documented placeholder at
  `docs/release-signing/gpg-public-key.asc` with exact steps for the owner
  to generate, install, and commit the real key.
- **cosign (sigstore keyless) Docker image signing**: `docker-manifest` now
  signs every published tag with `cosign sign --yes`, using GitHub's OIDC
  token against Sigstore's public-good Fulcio CA. **Active immediately**,
  no secrets or enrollment needed.
- **Verification docs**: `.github/RELEASE_TEMPLATE.md`, `README.md`, and
  `docs/gh-release.md` (new "Release Signing" section) all document exact
  `sha256sum`/`gpg`/`cosign verify` commands.

It also **prepares but leaves inactive** the remaining platforms from the
issue, each gated on its own GitHub Actions secrets so it activates the
moment the owner adds them - no further workflow changes needed:

- **QNAP QPKG** (`build-qnap-x64`, `build-qnap-arm`): gated on
  `QNAP_SIGNING_CERT`/`QNAP_SIGNING_KEY`. Since the actual QDK signing call
  isn't implemented yet, this step intentionally *fails loudly* if those
  secrets are set, rather than silently claim a package is signed.
- **macOS companion DMG** (`build-applemusic-companion-dmg`): imports a
  Developer ID cert (`APPLE_DEVELOPER_ID_CERT_P12`/
  `APPLE_DEVELOPER_ID_CERT_PASSWORD`/`APPLE_DEVELOPMENT_TEAM_ID`), and if
  present, submits to `notarytool` and staples
  (`APPLE_NOTARY_KEY_P8`/`APPLE_NOTARY_KEY_ID`/`APPLE_NOTARY_KEY_ISSUER_ID`).
  Falls back to today's unsigned/ad-hoc build when secrets are absent.
- **Windows Authenticode** (`build-windows`): `signtool` step gated on
  `WINDOWS_SIGNING_CERT_BASE64`/`WINDOWS_SIGNING_CERT_PASSWORD`, deferred by
  design per the issue.

Full status table and exact secret names:
[docs/gh-release.md#release-signing](docs/gh-release.md#release-signing).

## Verification performed

- `actionlint` (installed via Homebrew) against `.github/workflows/build.yml`:
  zero new findings versus the pre-change baseline (diffed the full output
  before/after). All remaining shellcheck notices are pre-existing
  info/style-level items unrelated to this change.
- Confirmed `secrets.*` is not referenced directly in any step `if:`
  (GitHub disallows this) - every gated step instead reads a job-level
  `env:` var derived from the secret.
- `python3 -c "import yaml; yaml.safe_load(...)"` - workflow parses as
  valid YAML.
- No Rust/CSS/asset files touched, so `cargo check`/`make css` don't apply
  to this change.
- No CI runs on this base branch (stacked PR) - real validation happens
  once this reaches `v3`/an actual release run, as usual for this repo.

## Deviations from the task brief

- Could not run `sg review` (superego) - not installed in this
  environment; only `ast-grep` is present under the `sg` name. Relied on
  actionlint plus manual review instead.
- The QNAP signing step is a placeholder that deliberately fails if its
  secrets are set (rather than a silent no-op), since I have no real QDK
  signing tool to wire up without QNAP developer credentials. This needs a
  follow-up once the owner has those credentials.

## Test plan

- [ ] Confirm `actionlint`/CI is green once this reaches a branch CI runs on
- [ ] Merge and cut a real release (or tag push) to confirm SHA256SUMS and
      cosign signing behave as expected in practice
- [ ] Owner adds `GPG_PRIVATE_KEY`/`GPG_PASSPHRASE` and replaces
      `docs/release-signing/gpg-public-key.asc` with the real public key to
      activate GPG signing end-to-end