### PR TITLE
fix(search): mint browse paths for navigable hifi_search results

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -2153,6 +2153,44 @@ impl RoonAdapter {
         Ok((playable, has_other_content))
     }
 
+    /// Classify one browse-session row's navigable/playable status.
+    ///
+    /// `hint: list` rows are peeked one level (via [`Self::peek_playability`])
+    /// to learn whether Roon also exposes a direct play action there;
+    /// everything else is judged by `item_key` presence alone. This is the
+    /// exact per-item logic `content()`'s `collections_browse`/
+    /// `collections_playlists` mapping used inline before #566 factored it
+    /// out here so `hifi_search` (#566) could apply the identical dual
+    /// navigable+playable treatment PR #547 established for
+    /// `hifi_collections`, rather than maintaining a second copy that could
+    /// silently drift from this one.
+    pub(crate) async fn classify_navigability(
+        &self,
+        zone_id: &str,
+        item: &BrowseItem,
+    ) -> (bool, bool) {
+        let list_hinted = matches!(item.hint, Some(ItemHint::List));
+        let (playable, has_other_content) = if list_hinted {
+            match item.item_key.as_deref() {
+                Some(key) => self
+                    .peek_playability(zone_id, key)
+                    .await
+                    .unwrap_or((false, true)),
+                None => (false, true),
+            }
+        } else {
+            (item.item_key.is_some(), true)
+        };
+        // A pure leaf whose only content one level down is an action list (a
+        // track: "Play Track" and nothing else) has nothing left to navigate
+        // into once that action row is filtered out -- classify it as
+        // playable only, not also navigable, so "Open" doesn't land on an
+        // empty level. A container that offers both real content *and* a
+        // play action (an album, a playlist) stays navigable too.
+        let navigable = list_hinted && (!playable || has_other_content);
+        (navigable, playable)
+    }
+
     /// Enter a named top-level browse node (`"Playlists"`, ...) in a fresh
     /// session and load one page of its contents in a single call --
     /// `hifi_collections playlists`'s whole job, since Roon exposes playlists
@@ -3012,10 +3050,17 @@ impl LibraryAdapter for RoonAdapter {
                     .unwrap_or(20)
                     .clamp(1, 50) as usize;
                 let offset = params.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize;
+                let request_item_key = params.get("item_key").and_then(Value::as_str);
+                // Browsing the true collection root -- `collections_browse`
+                // with no `item_key` to resume into (see
+                // `browse_collection`'s `None => pop_all` branch).
+                // `collections_playlists` always enters the named
+                // "Playlists" node instead, so it is never at this root.
+                let at_collection_root =
+                    operation == "collections_browse" && request_item_key.is_none();
                 let (session_key, items, total) = if operation == "collections_browse" {
-                    let item_key = params.get("item_key").and_then(Value::as_str);
                     let session_key = params.get("session_key").and_then(Value::as_str);
-                    self.browse_collection(zone_id, item_key, session_key, offset, limit)
+                    self.browse_collection(zone_id, request_item_key, session_key, offset, limit)
                         .await?
                 } else {
                     self.browse_named_root_node(zone_id, "Playlists", offset, limit)
@@ -3024,6 +3069,20 @@ impl LibraryAdapter for RoonAdapter {
                 let mut mapped: Vec<Value> = Vec::new();
                 for item in items {
                     if is_ungrounded_grouping(&item) {
+                        continue;
+                    }
+                    // #566 (live install): Roon's browse root also carries
+                    // its own "Settings" node -- extension configuration
+                    // inside Roon's hierarchy, not music content. It has no
+                    // `item_key` (nothing to browse into or play) and was
+                    // leaking through as a permanently inert row. Matched by
+                    // title, documented as such, and scoped to the true
+                    // root only, so a differently-purposed "Settings" row
+                    // nested deeper in the hierarchy (if one ever exists) is
+                    // untouched. Real music nodes (Library, Playlists,
+                    // Radio, TIDAL, Qobuz, ...) are never named "Settings"
+                    // and are unaffected.
+                    if at_collection_root && item.title == "Settings" {
                         continue;
                     }
                     // #545: Header/Action/ActionList rows are the
@@ -3042,27 +3101,7 @@ impl LibraryAdapter for RoonAdapter {
                     ) {
                         continue;
                     }
-                    let list_hinted = matches!(item.hint, Some(ItemHint::List));
-                    let (playable, has_other_content) = if list_hinted {
-                        match item.item_key.as_deref() {
-                            Some(key) => self
-                                .peek_playability(zone_id, key)
-                                .await
-                                .unwrap_or((false, true)),
-                            None => (false, true),
-                        }
-                    } else {
-                        (item.item_key.is_some(), true)
-                    };
-                    // A pure leaf whose only content one level down is an
-                    // action list (a track: "Play Track" and nothing else)
-                    // has nothing left to navigate into once that action row
-                    // is filtered out above -- classify it as playable only,
-                    // not also navigable, so "Open" doesn't land on an empty
-                    // level. A container that offers both real content *and*
-                    // a play action (an album, a playlist) stays navigable
-                    // too.
-                    let navigable = list_hinted && (!playable || has_other_content);
+                    let (navigable, playable) = self.classify_navigability(zone_id, &item).await;
                     mapped.push(serde_json::json!({
                         "title": item.title,
                         "subtitle": item.subtitle,

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -540,6 +540,11 @@ pub struct SearchResult {
     pub subtitle: Option<String>,
     #[serde(rename = "ref", default)]
     pub item_ref: Option<String>,
+    /// Opaque browse-continuation ref (#566), present when this result is
+    /// navigable -- same convention as `CollectionItem::path`, consumed the
+    /// same way (open into browse, push a breadcrumb).
+    #[serde(default)]
+    pub path: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -844,13 +844,40 @@ pub fn Library(
                                             p { class: "text-sm text-muted truncate", "{subtitle}" }
                                         }
                                     }
-                                    if let Some(item_ref) = result.item_ref.clone() {
-                                        button {
-                                            class: "library-play-btn",
-                                            aria_label: "Play {result.title}",
-                                            r#type: "button",
-                                            onclick: move |_| play_item((item_ref.clone(), "play")),
-                                            "▶"
+                                    div { class: "library-row-actions",
+                                        if let Some(item_ref) = result.item_ref.clone() {
+                                            button {
+                                                class: "library-play-btn",
+                                                aria_label: "Play {result.title}",
+                                                r#type: "button",
+                                                onclick: move |_| play_item((item_ref.clone(), "play")),
+                                                "▶"
+                                            }
+                                        }
+                                        // #566: a navigable result (a real
+                                        // hit like an artist, or a grouping
+                                        // row like "Albums · 35 Results")
+                                        // carries a `path` -- open it the
+                                        // same way a browse row does: push a
+                                        // breadcrumb and navigate into it,
+                                        // rather than leaving the row a dead
+                                        // end. Independent of the play
+                                        // button above: a result can have
+                                        // either, both, or neither.
+                                        if let Some(path) = result.path.clone() {
+                                            button {
+                                                class: "library-chevron-btn",
+                                                aria_label: "Open {result.title}",
+                                                r#type: "button",
+                                                onclick: {
+                                                    let title = result.title.clone();
+                                                    let path = path.clone();
+                                                    move |_| open_folder((title.clone(), path.clone()))
+                                                },
+                                                svg { class: "w-5 h-5", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
+                                                    path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M9 5l7 7-7 7" }
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -213,6 +213,12 @@ pub async fn handle_search(
                             subtitle: lms_subtitle(&item),
                             title: item.title,
                             r#ref: ref_token,
+                            // LMS's search drills straight to leaf results
+                            // server-side (see this module's top-level
+                            // docs and #566's audit) -- there is no
+                            // grouping row or browsable container in its
+                            // response shape to mint a path for.
+                            path: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -240,6 +246,10 @@ pub async fn handle_search(
                             title: item.title,
                             subtitle: item.subtitle,
                             r#ref: Some(ref_token),
+                            // Spotify's generic-search response
+                            // (`LibrarySearchResult`) has no grouping or
+                            // browse concept -- see #566's audit.
+                            path: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -267,6 +277,12 @@ pub async fn handle_search(
                             title: item.title,
                             subtitle: item.subtitle,
                             r#ref: Some(ref_token),
+                            // Music Assistant's generic-search response has
+                            // no grouping or browse concept either -- see
+                            // #566's audit. (`hifi_collections` already
+                            // exposes MA's real browse hierarchy
+                            // separately, via `MusicAssistantBrowse`.)
+                            path: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -305,6 +321,10 @@ pub async fn handle_search(
                             title: item.title,
                             subtitle: item.subtitle,
                             r#ref: Some(ref_token),
+                            // The Apple Music companion's search results are
+                            // flat catalog/library hits -- no grouping or
+                            // browse concept -- see #566's audit.
+                            path: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -326,50 +346,89 @@ pub async fn handle_search(
                 Ok((session_key, results)) => {
                     let mut mcp_results = Vec::with_capacity(results.len());
                     for item in results {
+                        let Some(item_key) = item.item_key.clone() else {
+                            // No item_key -- a header or non-navigable row.
+                            // Nothing to mint a ref or path from.
+                            mcp_results.push(McpSearchResult {
+                                title: item.title,
+                                subtitle: item.subtitle,
+                                r#ref: None,
+                                path: None,
+                            });
+                            continue;
+                        };
+                        let target = RoonRefTarget {
+                            item_key,
+                            multi_session_key: session_key.clone(),
+                        };
                         // #396 (found live, ship-gate re-review): a real
                         // Core's search results mix the actual hit with
                         // grouping rows ("Albums", "Tracks", "Artists", ...)
                         // that carry the same `hint: "list"` and a real
                         // `item_key` -- `FakeRoonCore`'s search model never
                         // included these, so nothing caught this minting a
-                        // ref for them indistinguishably from real content.
-                        // `crate::adapters::roon::is_ungrounded_grouping`
-                        // combines the adapter's own pre-existing title-list
-                        // check with a second, source-independent signal
-                        // (subtitle shaped like "<N> Results") verified live
-                        // for Library results but not for TIDAL/Qobuz -- see
-                        // that function's own doc comment for why the second
-                        // check is safe to include even where unverified.
-                        // Resolving a grouping row's ref would land in
-                        // `resolve_item_key`'s "guess the first item"
-                        // fallback and could silently play something the
-                        // client never asked for. Only a real, navigable
-                        // item_key on a non-grouping row gets a ref; a
-                        // grouping row (or one with no item_key at all — a
-                        // header, or non-navigable) mints nothing.
-                        let ref_token = match &item.item_key {
-                            Some(item_key)
-                                if !crate::adapters::roon::is_ungrounded_grouping(&item) =>
-                            {
-                                Some(
-                                    state
-                                        .mcp_refs
-                                        .mint(RefTarget::Roon {
-                                            target: RoonRefTarget {
-                                                item_key: item_key.clone(),
-                                                multi_session_key: session_key.clone(),
-                                            },
-                                            title: item.title.clone(),
-                                        })
-                                        .await,
-                                )
-                            }
-                            _ => None,
+                        // *play* ref for them indistinguishably from real
+                        // content. Resolving a grouping row's play ref would
+                        // land in `resolve_item_key`'s "guess the first
+                        // item" fallback and could silently play something
+                        // the client never asked for.
+                        //
+                        // #566: these rows *do* carry a real, browsable
+                        // item_key into their bucket in this same search
+                        // session (e.g. "Albums" -> that search's 35 album
+                        // hits) -- so rather than the previous "filter it
+                        // out, dead end", they mint a browse *path* only,
+                        // same `RoonBrowse` convention #533/#547 established
+                        // for `hifi_collections`. A real hit gets the dual
+                        // navigable+playable classification #547 also
+                        // established there, shared via
+                        // `RoonAdapter::classify_navigability` so search and
+                        // `hifi_collections` never drift apart on what
+                        // "navigable" means.
+                        let (navigable, playable) =
+                            if crate::adapters::roon::is_ungrounded_grouping(&item) {
+                                (true, false)
+                            } else if let Some(zone_id) = args.zone_id.as_deref() {
+                                state.roon.classify_navigability(zone_id, &item).await
+                            } else {
+                                // No zone to peek playability with (#398: an
+                                // absent zone_id still routes search to Roon) --
+                                // fall back to the pre-#566 behavior: a real
+                                // item_key is playable, and navigability is not
+                                // claimed without a way to verify it.
+                                (false, true)
+                            };
+                        let path = if navigable {
+                            Some(
+                                state
+                                    .mcp_refs
+                                    .mint(RefTarget::RoonBrowse {
+                                        target: target.clone(),
+                                        title: item.title.clone(),
+                                    })
+                                    .await,
+                            )
+                        } else {
+                            None
+                        };
+                        let ref_token = if playable {
+                            Some(
+                                state
+                                    .mcp_refs
+                                    .mint(RefTarget::Roon {
+                                        target,
+                                        title: item.title.clone(),
+                                    })
+                                    .await,
+                            )
+                        } else {
+                            None
                         };
                         mcp_results.push(McpSearchResult {
                             title: item.title,
                             subtitle: item.subtitle,
                             r#ref: ref_token,
+                            path,
                         });
                     }
                     Ok(env.json_result(&mcp_results))

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -67,12 +67,25 @@ pub struct McpNowPlaying {
 /// results genuinely have no safe way to be addressed later, and minting one
 /// anyway would trade "no ref" for "a ref that might play the wrong thing".
 /// `title`/`subtitle` are unchanged from before this issue.
+///
+/// `path` (#566) is the same addition PR #533/#547 made for
+/// `hifi_collections`: a `RefTarget::RoonBrowse` token, present exactly when
+/// the result is navigable (a real hit that can be browsed into, or a
+/// grouping row like "Albums · 35 Results" that names a bucket in the
+/// search session). `path` and `ref` are independent — a result can carry
+/// either, both, or neither, never conflated into one slot. Only Roon mints
+/// it today: LMS's search drills straight to leaf results server-side and
+/// Spotify/Apple Music/Music Assistant's generic search has no grouping or
+/// browse concept, so they always leave this `None` (see
+/// `crate::mcp::tools::library::handle_search`'s per-route docs).
 #[derive(Debug, Serialize)]
 pub struct McpSearchResult {
     pub title: String,
     pub subtitle: Option<String>,
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     pub r#ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 /// `hifi_play`'s structured payload: the adapter's own message about what it

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -3410,6 +3410,17 @@ const FIELD_ROLES: &[(&str, FieldRole)] = &[
          see McpSearchResult's own docs.",
         ),
     ),
+    (
+        "path",
+        Consumed(
+            "hifi_collections.path — the opaque browse-continuation token #533/#547 \
+         added to CollectionItem, and #566 added to McpSearchResult so a navigable \
+         hifi_search result (a real browsable hit, or a grouping row like \
+         \"Albums · 35 Results\") can be opened the same way instead of being a dead \
+         end. `None` (omitted) when a result is not navigable; see both structs' \
+         own docs.",
+        ),
+    ),
     // hifi_status / hifi_hqplayer_status readouts.
     (
         "connected",
@@ -3795,6 +3806,9 @@ async fn no_tool_returns_an_unclassified_field() {
             // #396: `Some` here so the new field is collected and must be
             // classified below, exactly like `title`/`subtitle` above.
             r#ref: Some(String::new()),
+            // #566: same reasoning as `ref` above -- `Some` so `path` is
+            // collected and must be classified below too.
+            path: Some(String::new()),
         })
         .expect("McpSearchResult must serialize"),
         &mut returned,

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -311,6 +311,16 @@ async fn a_category_grouping_row_never_gets_a_ref() {
         "a category grouping row must never get a ref, even though it has a real \
          item_key: {albums_row:?}"
     );
+    // #566: filtered out before, this row is now a dead end no longer --
+    // it mints a browse `path` into its bucket (same `RoonBrowse`
+    // convention #533/#547 established for `hifi_collections`), just never
+    // a play `ref`.
+    let path_token = albums_row
+        .get("path")
+        .and_then(Value::as_str)
+        .expect("a category grouping row must get a browse path: {albums_row:?}")
+        .to_string();
+    assert!(path_token.starts_with("ref_"), "got {path_token:?}");
 
     core.stop().await;
 }
@@ -399,6 +409,17 @@ async fn roon_search_mints_a_ref_and_play_ref_resolves_it() {
         .expect("a Roon hit with an item_key must carry a ref")
         .to_string();
     assert!(ref_token.starts_with("ref_"), "got {ref_token:?}");
+    // #566: with no `zone_id` there is nothing to peek playability with (an
+    // absent `zone_id` still routes search to Roon -- #398), so this falls
+    // back to the pre-#566 behavior: a real item_key still gets a play ref,
+    // but navigability is not claimed without a way to verify it, and no
+    // extra browse traffic is generated peeking for it (see the exact
+    // `browsed_titles` trace below, which a peek would extend).
+    assert_eq!(
+        hit.get("path"),
+        None,
+        "no zone_id means no path can be verified: {hit:?}"
+    );
 
     let played = handle_play_ref(&state, play_ref_args(&ref_token, "roon:zone_fake_1", None)).await;
     assert_eq!(
@@ -421,6 +442,62 @@ async fn roon_search_mints_a_ref_and_play_ref_resolves_it() {
             "Play Album",
             "Play Now"
         ]
+    );
+
+    core.stop().await;
+}
+
+/// **The dual navigable+playable case** (#566): a real hit that is both
+/// browsable (an album's own tracks) and directly playable (its "Play
+/// Album" action) mints both a `ref` *and* a `path`, mirroring PR #547's
+/// dual classification for `hifi_collections` -- exercised through
+/// `RoonAdapter::classify_navigability`, which #566 factored out of
+/// `content()`'s `collections_browse` mapping so both surfaces share one
+/// definition of "navigable".
+///
+/// This needs a `zone_id`: `classify_navigability` peeks one level into the
+/// item to tell "playable only" apart from "playable and navigable", and
+/// has nothing to peek with otherwise -- see
+/// `roon_search_mints_a_ref_and_play_ref_resolves_it`'s zone-less case
+/// immediately above, which stays play-ref-only for exactly that reason.
+#[tokio::test]
+async fn roon_search_result_with_zone_context_mints_both_ref_and_path() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let search = handle_search(
+        &state,
+        HifiSearchTool {
+            query: "kind of blue".to_string(),
+            zone_id: Some("roon:zone_fake_1".to_string()),
+            source: None,
+        },
+    )
+    .await;
+    let results = search_results_of(&search);
+    assert_eq!(results.len(), 1, "got {results:?}");
+    let hit = &results[0];
+    assert_eq!(
+        hit.get("title"),
+        Some(&Value::String("Kind of Blue".to_string()))
+    );
+    let ref_token = hit
+        .get("ref")
+        .and_then(Value::as_str)
+        .expect("a browsable-and-playable album must still get a play ref: {hit:?}")
+        .to_string();
+    assert!(ref_token.starts_with("ref_"), "got {ref_token:?}");
+    let path_token = hit
+        .get("path")
+        .and_then(Value::as_str)
+        .expect("a browsable-and-playable album must also get a browse path: {hit:?}")
+        .to_string();
+    assert!(path_token.starts_with("ref_"), "got {path_token:?}");
+    assert_ne!(
+        ref_token, path_token,
+        "the play ref and the browse path are minted from the same target but are \
+         distinct tokens"
     );
 
     core.stop().await;

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -1758,6 +1758,43 @@ async fn roon_collections_browse_still_excludes_category_grouping_rows() {
     core.stop().await;
 }
 
+/// #566 (live install): Roon's own browse root carries a "Settings" node
+/// (extension configuration inside Roon's hierarchy, not music content) that
+/// was leaking through `hifi_collections browse`'s root listing as a
+/// permanently inert row -- no `item_key`, so it could not be played or
+/// browsed into. `FakeLibrary::standard()`'s root already models this
+/// (`FakeItem::new("Settings").unkeyed()`), matching the live evidence.
+///
+/// The filter is scoped to the true collection root only (`item_key: None`)
+/// -- real music nodes (`Library`, `TIDAL`, `Qobuz`) at that same root stay,
+/// and nothing deeper in the hierarchy is touched.
+#[tokio::test]
+async fn roon_collections_browse_root_excludes_settings() {
+    let core = FakeRoonCore::start().await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let titles: Vec<String> = root["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["title"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        titles,
+        vec!["Library", "TIDAL", "Qobuz"],
+        "the root's own utility node (Settings) must not appear as an inert row"
+    );
+
+    core.stop().await;
+}
+
 // =============================================================================
 // AppState for the HTTP-boundary test
 // =============================================================================


### PR DESCRIPTION
Closes #566

## Summary

- **Backend (Roon), defect 1 — real hits with no browse path**: `handle_search`'s Roon branch now mints a `path` (`RefTarget::RoonBrowse`, same convention `hifi_collections` established in #533/#547) alongside the play `ref` for navigable results. The navigable/playable classification is shared via a new `RoonAdapter::classify_navigability` helper, factored out of `content()`'s `collections_browse`/`collections_playlists` mapping so both surfaces (search and collections) use one definition of "navigable" rather than two that could drift. A result can carry `ref`, `path`, both, or neither, matching #547's dual-classification precedent.
- **Backend (Roon), defect 2 — category rows ("Albums · 35 Results") inert**: these rows are known-never-playable (unchanged reasoning from `is_ungrounded_grouping`'s own docs), but per the issue's guidance they carry a real, browsable `item_key` in the search session — so instead of being filtered out, they now mint a browse `path` into their bucket (no `ref`). Clicking "Albums" opens that search's album results.
- **Zone-less search fallback**: `hifi_search` with no `zone_id` still routes to Roon (#398, unchanged) but has nothing to peek playability with, so real hits fall back to the pre-#566 behavior (play ref only, no path claimed) — pinned by a new test.
- **MCP wire shape**: `McpSearchResult` gained an optional `path` field (mirrors `CollectionItem::path`); `FIELD_ROLES` in `tests/mcp_contract.rs` documents it as `Consumed("hifi_collections.path")`.
- **LMS / Spotify / Apple Music / Music Assistant audit**: none of these have a grouping-row or browse-container concept in their search result shape (LMS drills straight to leaf results server-side; the others use the generic flat `LibrarySearchResult`/catalog search). They're unaffected; each constructor now explicitly sets `path: None` with a comment explaining why, so the gap is documented rather than silent.
- **UI (`src/app/pages/library.rs`)**: the "Everywhere" global-search-results section now renders an open-folder chevron (reusing the existing `open_folder`/breadcrumb-push helper already used by local browse rows) whenever a result carries a `path`, independent of the existing play button.
- **Related live-install defect, same code path**: Roon's own browse-root "Settings" node (extension configuration, not music content) was leaking through `hifi_collections browse`'s root listing as a permanently inert row. Now filtered at the true collection root only (`item_key: None`), by title, with a comment documenting the reasoning; real music nodes (Library/TIDAL/Qobuz/Playlists/Radio) are untouched.

## Backend changes per provider

| Provider | Grouping/browse concept in search? | Change |
|---|---|---|
| Roon | Yes (the bug) | Dual `ref`+`path` minting; grouping rows get `path` only |
| LMS | No (drills to leaf results server-side) | `path: None`, documented |
| Spotify | No (flat catalog search) | `path: None`, documented |
| Music Assistant | No (flat catalog search; browse hierarchy is separately exposed via `hifi_collections`) | `path: None`, documented |
| Apple Music | No (flat companion catalog/library hits) | `path: None`, documented |

## Verification

- `cargo test` — full suite green (525+ tests across all binaries, including `reactive_loop_lint`, `no_tool_returns_an_unclassified_field`, and the fixture-pinned `mcp_contract` tests — no `UPDATE_MCP_FIXTURES` regeneration was needed since no pinned tool-schema/fixture text changed).
- `cargo clippy --lib -- -D warnings` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean specifically in every file this PR touches; the repo-wide `--all-targets` failures are pre-existing on `origin/integration/streaming-ha-alpha` (confirmed via `git stash` before/after comparison), unrelated to this change, and left alone per the task's own note.
- `cargo fmt --check` — clean.
- wasm check (`cargo check --target wasm32-unknown-unknown --features web --no-default-features`, rustup toolchain ahead of Homebrew's on `PATH`) — clean.
- New/updated integration tests against `FakeRoonCore` (`tests/mcp_refs.rs`, `tests/roon_protocol.rs`):
  - `roon_search_result_with_zone_context_mints_both_ref_and_path` — a browsable-and-playable album gets both tokens.
  - `a_category_grouping_row_never_gets_a_ref` (extended) — the grouping row now also asserts it gets a `path`.
  - `roon_search_mints_a_ref_and_play_ref_resolves_it` (extended) — zone-less search asserts `path` stays absent, and the existing exact `browsed_titles` trace assertion is preserved (proving no extra browse traffic is generated without a zone to peek with).
  - `roon_collections_browse_root_excludes_settings` (new) — root listing excludes "Settings", keeps Library/TIDAL/Qobuz.

### Runtime browser probe — attempted, blocked by environment, documented honestly

Per the task's mandatory-verification rule, I built a throwaway harness to drive the **real** production Dioxus UI against a **live** `FakeRoonCore` (not the zero-adapter fallback, which the issue explicitly rules out): a standalone `FakeRoonCore` process seeded with a library shaped exactly like the issue's own evidence (a "Michael Jackson" hit plus "Albums"/"Artists"/... grouping rows, each carrying real content one level in), and a temporary env-var-gated hook in `main.rs` (`UHC_TEST_ROON_FAKE_CORE_ADDR`) that points `RoonAdapter` at it via the same `run_event_loop_against_core_for_tests` connection `tests/mcp_refs.rs` already uses, instead of real SOOD discovery.

The `FakeRoonCore` process started successfully and was reachable. But the `make web-run` release+wasm build (663 crates, `dx build --release --platform web`) exhausted the shared build machine's disk mid-build — `df -h /` dropped to **122Mi free out of 926Gi**, and the Bash tool itself started failing with `ENOSPC` on every command, including `df` and `echo`. This is a shared-environment resource constraint (many other worktrees' `target/` directories on the same volume), not a defect in this change. I killed the build and the fake-core process, reverted the `main.rs` probe hook (git diff on `main.rs` is now clean — nothing in this PR touches it), deleted the throwaway harness test file, and freed ~250MB of my own `target/wasm32-unknown-unknown` cache to help the shared disk recover.

**What this proves and doesn't:** the backend fix (dual ref+path minting, grouping-row path minting, zone-less fallback, the Settings-root filter) is proven correct by the integration tests above, run against the identical `FakeRoonCore` wire protocol the browser probe would have exercised — same adapter code, same mock Core, same session/browse mechanics, just invoked from `handle_search`/`handle_collections` directly rather than through an HTTP+browser round trip. What is **not** independently proven by a real rendered/hydrated browser session is the UI wiring itself (`src/app/pages/library.rs`'s new chevron button and its `onclick`/`open_folder` call) — that's a small, low-risk addition (identical markup/handler pattern to the existing, already-shipped browse-row chevron a few lines above it in the same file) and it does compile cleanly against the `web` feature (wasm check, above) and pass the `reactive_loop_lint` (the exact regression class the issue's history calls out), but it has not been clicked in a live browser. I'm reporting this gap rather than claiming a click-through transcript that didn't happen.

## Deviations from the task brief

- No MCP fixture regeneration was needed (`tools_list_matches_fixture`/`tool_text_matches_the_fixture_except_for_398s_listed_corrections` stayed green) — `hifi_search`'s tool schema/description didn't change, only its response shape, which isn't fixture-pinned.
- The runtime browser probe is incomplete for the reason documented above (shared build-machine disk exhaustion), not skipped by choice.