### PR TITLE
Spotify onboarding: built-in HTTPS tunnel for the OAuth callback

### DIFF
--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -133,10 +133,16 @@ NAS install — falling back automatically to
 providers mint a fresh random subdomain on every connection, so a new tunnel
 always means a newly registered callback URL; that expectation and the retry
 logic live in `SpotifyTunnelManager` (`src/api/spotify_tunnel.rs`), which is
-tested against a scripted fake process rather than a live tunnel provider. If
-`ssh` is missing, both providers are unreachable, or outbound `ssh` traffic is
-blocked, the panel reports why in the same beginner-readable style as the
-rest of Settings, and the collapsed **Advanced: bring your own HTTPS** note
+tested against a scripted fake process rather than a live tunnel provider
+(the pinggy URL-parsing test fixture is an exact capture of a live anonymous
+tunnel's stdout, though, since a first live-smoke pass found the original
+`pinggy.link`-only pattern never matched pinggy's real anonymous-tier hosts —
+`pinggy-free.link` and `free.pinggy.net`). Pinggy's free tier also caps an
+anonymous tunnel at 60 minutes before it expires on its own; UHC's own
+15-minute cap closes it well before that regardless. If `ssh` is missing,
+both providers are unreachable, or outbound `ssh` traffic is blocked, the
+panel reports why in the same beginner-readable style as the rest of
+Settings, and the collapsed **Advanced: bring your own HTTPS** note
 underneath still covers running your own tunnel by hand (for example
 `cloudflared tunnel --url http://127.0.0.1:8088` or Tailscale Funnel) and
 pasting its callback URL into the Redirect URI field yourself. Reauthorizing

--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -110,17 +110,47 @@ secret blank to use Authorization Code with PKCE.
 
 If the browser is not on the UHC host, Spotify accepts plain HTTP only for
 explicit loopback callbacks (`127.0.0.1` or `::1`); anything else — a remote
-QNAP, a different machine on the LAN — needs HTTPS. Until a built-in tunnel
-ships (tracked as a fast-follow in #538), start a temporary HTTPS tunnel to
-port 8088 by hand (for example with `cloudflared tunnel --url
-http://127.0.0.1:8088` or Tailscale Funnel), open its HTTPS URL in the
-browser, and set the Redirect URI field to that tunnel's callback address
-before registering it in the Spotify dashboard. Saving the form persists the
-client configuration in the encrypted credential envelope, after which
-**Connect Spotify** starts the browser authorization flow. Stop the tunnel
-after authorization; reauthorization creates a new callback URL and needs a
-new tunnel and a newly registered callback, and reuses the same in-Settings
-guidance. This is the first-run onboarding path tracked in #469 and #534.
+QNAP, a different machine on the LAN — needs HTTPS. The "Using UHC from
+another device or a NAS?" panel below the callback URL has a **Get an HTTPS
+address** button for this: it asks UHC's server to open a temporary tunnel to
+itself and shows the resulting `https://…` callback URL with a copy button,
+so a first-time user never has to install or run anything. The Redirect URI
+field is pre-filled with that URL's callback path; paste the same URL into
+the Spotify dashboard's Redirect URIs, save client settings, then Connect.
+The tunnel closes itself automatically once authorization completes (success
+or failure), after 15 minutes, or via its own "Stop tunnel" button — while it
+is open, this UHC server is briefly reachable from the public internet at
+that address, though the callback endpoint behind it only ever accepts the
+single in-flight OAuth `state` token, so no extra trust is extended to
+traffic that arrives through it (see `oauth_callback_json` in
+`src/api/provider_auth.rs`).
+
+Under the hood this is a plain `ssh -R` reverse tunnel to
+[pinggy.io](https://pinggy.io)'s free tier — no account and no bundled binary
+beyond the `ssh` client already present on essentially every Linux, macOS, or
+NAS install — falling back automatically to
+[localhost.run](https://localhost.run) if pinggy.io cannot be reached. Both
+providers mint a fresh random subdomain on every connection, so a new tunnel
+always means a newly registered callback URL; that expectation and the retry
+logic live in `SpotifyTunnelManager` (`src/api/spotify_tunnel.rs`), which is
+tested against a scripted fake process rather than a live tunnel provider. If
+`ssh` is missing, both providers are unreachable, or outbound `ssh` traffic is
+blocked, the panel reports why in the same beginner-readable style as the
+rest of Settings, and the collapsed **Advanced: bring your own HTTPS** note
+underneath still covers running your own tunnel by hand (for example
+`cloudflared tunnel --url http://127.0.0.1:8088` or Tailscale Funnel) and
+pasting its callback URL into the Redirect URI field yourself. Reauthorizing
+later always needs a new tunnel (built-in or your own) and a newly registered
+callback URL either way. This is the first-run onboarding path tracked in
+#469, #534, and #538.
+
+New endpoints backing the built-in tunnel — `POST
+/api/providers/spotify/tunnel/start`, `GET
+/api/providers/spotify/tunnel/status`, and `POST
+/api/providers/spotify/tunnel/stop` — are controller-authenticated the same
+as the rest of `/api/providers/*` (see `requires_controller_auth` in
+`src/api/controller_auth.rs`) and registered in
+`tests/fixtures/api_routes.txt`.
 
 If authorization does not complete, Settings shows an actionable message
 instead of a generic failure: an expired or already-used sign-in link, a

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -45,6 +45,7 @@ pub mod controller_auth;
 pub mod credentials;
 pub mod mqtt_settings;
 pub mod provider_auth;
+pub mod spotify_tunnel;
 
 const MAX_REMOTE_ARTWORK_BYTES: usize = 10 * 1024 * 1024;
 
@@ -338,6 +339,12 @@ impl AppState {
             adapter_registry.clone(),
             knobs.clone(),
         ));
+        let provider_auth = Arc::new(provider_auth::ProviderAuthState::default());
+        // The Spotify tunnel (#538) spawns an `ssh` child process; wire the
+        // server's own shutdown token in so a graceful shutdown kills it
+        // too, instead of relying solely on the manual stop / OAuth
+        // completion / fifteen-minute cap paths.
+        provider_auth.bind_shutdown(shutdown.clone());
         Self {
             roon,
             hqplayer,
@@ -349,7 +356,7 @@ impl AppState {
             upnp,
             musicassistant: Arc::new(ReconfigurableMusicAssistant::new(bus.clone())),
             adapter_registry,
-            provider_auth: Arc::new(provider_auth::ProviderAuthState::default()),
+            provider_auth,
             controller_auth: controller_auth::ControllerAuthState::new(),
             apple_bridges: apple_bridge::AppleBridgeRegistry::from_env().unwrap_or_else(|error| {
                 tracing::error!("Apple Music companion credential store is unavailable: {error}");

--- a/src/api/provider_auth.rs
+++ b/src/api/provider_auth.rs
@@ -14,9 +14,10 @@ use crate::api::credentials::{
     EncryptedCredentialStore, MusicAssistantCredentialRecord, MusicAssistantCredentialStore,
     SpotifyCredentialRecord,
 };
+use crate::api::spotify_tunnel::{SpotifyTunnelManager, TunnelStatusResponse};
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{header::HOST, HeaderMap, StatusCode},
     response::{IntoResponse, Redirect, Response},
     Json,
 };
@@ -31,6 +32,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 use super::AppState;
 
@@ -48,6 +50,8 @@ pub struct ProviderAuthState {
     oauth: Arc<RwLock<Option<Arc<SpotifyOAuthConfig>>>>,
     musicassistant: Arc<RwLock<Option<Arc<ReconfigurableMusicAssistant>>>>,
     musicassistant_credentials: Option<Arc<MusicAssistantCredentialStore>>,
+    /// Temporary HTTPS tunnel for the Spotify OAuth callback (#538).
+    pub spotify_tunnel: Arc<SpotifyTunnelManager>,
 }
 
 #[derive(Clone)]
@@ -80,6 +84,7 @@ impl Default for ProviderAuthState {
             oauth: Arc::new(RwLock::new(oauth)),
             musicassistant: Arc::new(RwLock::new(None)),
             musicassistant_credentials,
+            spotify_tunnel: Arc::new(SpotifyTunnelManager::default()),
         }
     }
 }
@@ -101,7 +106,15 @@ impl ProviderAuthState {
             musicassistant_credentials: MusicAssistantCredentialStore::from_env()
                 .ok()
                 .map(Arc::new),
+            spotify_tunnel: Arc::new(SpotifyTunnelManager::default()),
         }
+    }
+
+    /// Wires the server's graceful-shutdown token into the Spotify tunnel
+    /// manager so a leftover tunnel process is killed on shutdown too, not
+    /// just on the user-facing stop paths. Called once from `AppState::new`.
+    pub fn bind_shutdown(&self, token: CancellationToken) {
+        self.spotify_tunnel.bind_shutdown(token);
     }
 
     /// Construct provider auth with an explicit Music Assistant credential
@@ -674,6 +687,14 @@ pub async fn oauth_callback(
     Query(query): Query<OAuthCallbackQuery>,
 ) -> Response {
     let machine = query.format.as_deref() == Some("json");
+    // The tunnel exists only to carry this one callback across the public
+    // internet; once the callback has been processed (whether Spotify
+    // accepted or rejected it), there is nothing left for it to do. Tear it
+    // down here regardless of outcome so a failed exchange does not leave it
+    // running until the fifteen-minute cap.
+    if provider == "spotify" {
+        state.provider_auth.spotify_tunnel.stop().await;
+    }
     match oauth_callback_json(State(state), Path(provider), Query(query)).await {
         Ok(Json(response)) if machine => Json(response).into_response(),
         Ok(Json(_)) => Redirect::to("/settings?spotify=connected").into_response(),
@@ -879,6 +900,59 @@ pub async fn oauth_revoke(
         authorized: false,
         expires_at: None,
     }))
+}
+
+/// The port a temporary HTTPS tunnel should forward to: this server's own
+/// listening port. Read from the request's `Host` header first -- that is
+/// exactly what the browser used to reach this server, so it is correct
+/// even behind an unusual bind address -- falling back to the `PORT`
+/// environment variable UHC itself starts from, then the documented
+/// default (`config::default_port`, kept in sync here since pulling the
+/// live `Config` into `AppState` is out of scope for this endpoint).
+fn local_tunnel_port(headers: &HeaderMap) -> u16 {
+    headers
+        .get(HOST)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|host| {
+            // `Host` is `host` or `host:port`; an IPv6 literal host looks
+            // like `[::1]:8088`, so split from the right on the last colon.
+            host.rsplit_once(':')
+                .and_then(|(_, port)| port.parse().ok())
+        })
+        .or_else(|| {
+            std::env::var("PORT")
+                .ok()
+                .and_then(|value| value.parse().ok())
+        })
+        .unwrap_or(8088)
+}
+
+/// POST /api/providers/spotify/tunnel/start - Start (or report the existing)
+/// temporary HTTPS tunnel to this server's Spotify OAuth callback.
+pub async fn spotify_tunnel_start(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Json<TunnelStatusResponse> {
+    let port = local_tunnel_port(&headers);
+    let status = state.provider_auth.spotify_tunnel.start(port).await;
+    Json(status.into())
+}
+
+/// GET /api/providers/spotify/tunnel/status - Current tunnel phase, without
+/// starting or stopping anything.
+pub async fn spotify_tunnel_status(State(state): State<AppState>) -> Json<TunnelStatusResponse> {
+    let status = state.provider_auth.spotify_tunnel.status().await;
+    Json(status.into())
+}
+
+/// POST /api/providers/spotify/tunnel/stop - Stop the tunnel, if any, and
+/// return to idle. Also called automatically when the OAuth callback
+/// completes; exposed here for a manual "Stop tunnel" action and so a user
+/// who abandons the flow does not have to wait for the fifteen-minute cap.
+pub async fn spotify_tunnel_stop(State(state): State<AppState>) -> Json<TunnelStatusResponse> {
+    state.provider_auth.spotify_tunnel.stop().await;
+    let status = state.provider_auth.spotify_tunnel.status().await;
+    Json(status.into())
 }
 
 fn spotify_oauth_config(

--- a/src/api/spotify_tunnel.rs
+++ b/src/api/spotify_tunnel.rs
@@ -124,12 +124,44 @@ impl TunnelProviderKind {
     }
 }
 
+/// Pinggy's free tier does not actually use `pinggy.link` for the anonymous
+/// (no-account) tunnels this module opens -- confirmed against a live
+/// `ssh -p 443 -R0:localhost:<port> a.pinggy.io` run, whose stdout was:
+///
+/// ```text
+/// Allocated port 9 for remote forward to localhost:8091
+/// You are not authenticated.
+/// Your tunnel will expire in 60 minutes. Upgrade to Pinggy Pro to get unrestricted tunnels. https://dashboard.pinggy.io
+/// https://lgidn-2603-6010-e300-381a-352c-943-c7fa-76a9.run.pinggy-free.link
+/// https://rjvqd-2603-6010-e300-381a-352c-943-c7fa-76a9.free.pinggy.net
+/// ```
+///
+/// i.e. `pinggy-free.link` and `free.pinggy.net`, plus a `dashboard.pinggy.io`
+/// upsell link on the expiry-notice line that must NOT be picked up. `.link`
+/// is kept for a possible authenticated/Pro tunnel, which is documented to
+/// use plain `pinggy.link`, even though this module never authenticates.
 #[allow(clippy::unwrap_used)] // Regex pattern is a compile-time constant
 fn pinggy_url_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
-    PATTERN.get_or_init(|| Regex::new(r"https://[a-zA-Z0-9.-]+\.pinggy\.link\S*").unwrap())
+    PATTERN.get_or_init(|| {
+        Regex::new(
+            r"https://[a-zA-Z0-9.-]+\.(?:pinggy\.link|pinggy-free\.link|free\.pinggy\.net)\S*",
+        )
+        .unwrap()
+    })
 }
 
+/// NOT verified against a live `localhost.run` tunnel URL: a live `ssh -R
+/// 80:localhost:<port> localhost.run` run reached the server and printed its
+/// welcome banner (which is why this pattern deliberately stays scoped to
+/// `lhr.life` rather than "first https:// line" -- the banner alone contains
+/// `https://admin.localhost.run/`, `https://localhost.run/docs/...` several
+/// times over, none of which are the tunnel URL), but did not yield the
+/// actual forwarded `https://…lhr.life` line within a 15s connection before
+/// timing out. If this pattern turns out to be wrong the same way the pinggy
+/// one was, the fix is the same: capture a real run's stdout and widen this
+/// regex to match it, the way `pinggy_url_pattern` now covers
+/// `pinggy-free.link` and `free.pinggy.net` alongside `pinggy.link`.
 #[allow(clippy::unwrap_used)] // Regex pattern is a compile-time constant
 fn localhost_run_url_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();
@@ -979,6 +1011,74 @@ mod tests {
             TunnelProviderKind::LocalhostRun.extract_url(line),
             Some("https://ab12cd.lhr.life".to_string())
         );
+    }
+
+    /// Regression test for a live-smoke defect: `ssh -p 443
+    /// -R0:localhost:<port> a.pinggy.io`'s actual anonymous-tunnel stdout
+    /// never contains a bare `pinggy.link` host, so the original
+    /// `\.pinggy\.link` pattern never matched and the manager timed out
+    /// despite a live tunnel. This is the exact captured output (only the
+    /// per-connection subdomains are illustrative).
+    const LIVE_PINGGY_ANONYMOUS_STDOUT: [&str; 5] = [
+        "Allocated port 9 for remote forward to localhost:8091",
+        "You are not authenticated.",
+        "Your tunnel will expire in 60 minutes. Upgrade to Pinggy Pro to get unrestricted tunnels. https://dashboard.pinggy.io",
+        "https://lgidn-2603-6010-e300-381a-352c-943-c7fa-76a9.run.pinggy-free.link",
+        "https://rjvqd-2603-6010-e300-381a-352c-943-c7fa-76a9.free.pinggy.net",
+    ];
+
+    #[test]
+    fn pinggy_extraction_matches_the_live_anonymous_tunnel_domains() {
+        let matches: Vec<Option<String>> = LIVE_PINGGY_ANONYMOUS_STDOUT
+            .iter()
+            .map(|line| TunnelProviderKind::Pinggy.extract_url(line))
+            .collect();
+        assert_eq!(
+            matches,
+            vec![
+                None,
+                None,
+                // The Pinggy Pro upsell link on the expiry-notice line must
+                // not be mistaken for the tunnel URL.
+                None,
+                Some(
+                    "https://lgidn-2603-6010-e300-381a-352c-943-c7fa-76a9.run.pinggy-free.link"
+                        .to_string()
+                ),
+                Some(
+                    "https://rjvqd-2603-6010-e300-381a-352c-943-c7fa-76a9.free.pinggy.net"
+                        .to_string()
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn start_reaches_active_on_the_live_captured_pinggy_banner() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch {
+                lines: LIVE_PINGGY_ANONYMOUS_STDOUT
+                    .iter()
+                    .map(|line| line.to_string())
+                    .collect(),
+                exit_with_stderr: None,
+                launch_error: None,
+            },
+        )]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8091).await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        match status {
+            TunnelStatus::Active { url, provider, .. } => {
+                assert_eq!(
+                    url,
+                    "https://lgidn-2603-6010-e300-381a-352c-943-c7fa-76a9.run.pinggy-free.link"
+                );
+                assert_eq!(provider, "pinggy.io");
+            }
+            other => panic!("expected Active, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/api/spotify_tunnel.rs
+++ b/src/api/spotify_tunnel.rs
@@ -1,0 +1,995 @@
+//! Temporary HTTPS tunnel for the Spotify OAuth callback (#538).
+//!
+//! A beginner running UHC on a NAS or another LAN machine has no HTTPS
+//! address to hand Spotify -- Spotify only accepts plain HTTP for an exact
+//! loopback (`127.0.0.1`/`::1`) redirect URI. This module spawns a
+//! short-lived `ssh -R` reverse tunnel to a public relay (pinggy.io, falling
+//! back to localhost.run) so Settings can show a paste-ready HTTPS callback
+//! URL without asking the user to install or run anything themselves.
+//!
+//! The tunnel is scoped to one OAuth attempt: it starts when the user clicks
+//! "Get an HTTPS address", and is torn down when authorization completes
+//! (success or failure), when the user stops it, on a fifteen-minute safety
+//! timeout, or when the server shuts down. While it is active this UHC
+//! server is briefly reachable from the public internet at the tunnel's
+//! URL; the callback endpoint behind it only ever accepts the single-use,
+//! in-flight OAuth `state` token (see `oauth_callback_json` in
+//! `provider_auth.rs`), so no additional trust is extended to tunnel
+//! traffic.
+//!
+//! The state machine (`SpotifyTunnelManager`) is decoupled from the actual
+//! `ssh` process through the `TunnelLauncher`/`TunnelProcess` traits so unit
+//! tests can drive it with a scripted fake process -- no outbound network
+//! access, and no dependency on a live pinggy.io/localhost.run endpoint, is
+//! needed to exercise the lifecycle.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use regex::Regex;
+use serde::Serialize;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+/// Hard cap on tunnel lifetime, regardless of activity. A beginner should
+/// never end up with a forgotten tunnel silently keeping this server
+/// internet-reachable.
+pub const TUNNEL_MAX_LIFETIME: Duration = Duration::from_secs(15 * 60);
+
+/// How long to wait for one provider to print a public URL before giving up
+/// on it and falling back to the next.
+const PROVIDER_STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Providers are tried in this order. Both are free-tier plain `ssh -R`
+/// relays that need no account and no bundled binary beyond `ssh` itself --
+/// see docs/streaming-adapters.md for the rationale.
+const PROVIDER_ORDER: [TunnelProviderKind; 2] =
+    [TunnelProviderKind::Pinggy, TunnelProviderKind::LocalhostRun];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TunnelProviderKind {
+    Pinggy,
+    LocalhostRun,
+}
+
+impl TunnelProviderKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Pinggy => "pinggy.io",
+            Self::LocalhostRun => "localhost.run",
+        }
+    }
+
+    fn command(self, port: u16) -> (&'static str, Vec<String>) {
+        match self {
+            // Pinggy's free tier is reached over plain SSH on port 443 (so it
+            // also works through firewalls that only allow outbound HTTPS).
+            // `-R0:` asks the relay to pick an ephemeral remote port for us.
+            Self::Pinggy => (
+                "ssh",
+                vec![
+                    "-p".to_string(),
+                    "443".to_string(),
+                    "-o".to_string(),
+                    "StrictHostKeyChecking=no".to_string(),
+                    "-o".to_string(),
+                    "UserKnownHostsFile=/dev/null".to_string(),
+                    "-o".to_string(),
+                    "ServerAliveInterval=30".to_string(),
+                    "-o".to_string(),
+                    "ExitOnForwardFailure=yes".to_string(),
+                    format!("-R0:localhost:{port}"),
+                    "a.pinggy.io".to_string(),
+                ],
+            ),
+            // localhost.run assigns a subdomain of lhr.life the same way,
+            // over the standard SSH port instead.
+            Self::LocalhostRun => (
+                "ssh",
+                vec![
+                    "-o".to_string(),
+                    "StrictHostKeyChecking=no".to_string(),
+                    "-o".to_string(),
+                    "UserKnownHostsFile=/dev/null".to_string(),
+                    "-o".to_string(),
+                    "ServerAliveInterval=30".to_string(),
+                    "-o".to_string(),
+                    "ExitOnForwardFailure=yes".to_string(),
+                    "-R".to_string(),
+                    format!("80:localhost:{port}"),
+                    "localhost.run".to_string(),
+                ],
+            ),
+        }
+    }
+
+    /// Pull the public HTTPS URL out of one line of provider stdout. Each
+    /// provider prints its own boilerplate around the URL, so this is
+    /// deliberately provider-specific rather than a single generic
+    /// "first https:// on the line" match, which would also catch the
+    /// providers' own docs/help URLs printed in the same banner.
+    fn extract_url(self, line: &str) -> Option<String> {
+        match self {
+            Self::Pinggy => pinggy_url_pattern()
+                .find(line)
+                .map(|m| m.as_str().to_string()),
+            Self::LocalhostRun => localhost_run_url_pattern()
+                .find(line)
+                .map(|m| m.as_str().to_string()),
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)] // Regex pattern is a compile-time constant
+fn pinggy_url_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| Regex::new(r"https://[a-zA-Z0-9.-]+\.pinggy\.link\S*").unwrap())
+}
+
+#[allow(clippy::unwrap_used)] // Regex pattern is a compile-time constant
+fn localhost_run_url_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| Regex::new(r"https://[a-zA-Z0-9.-]+\.lhr\.life\S*").unwrap())
+}
+
+/// One event read from a running tunnel process.
+pub(crate) enum TunnelProcessEvent {
+    /// A line of stdout, checked for a provider URL.
+    Line(String),
+    /// The process exited (or its stdout/stderr pipes broke). `stderr_tail`
+    /// carries the last bit of stderr captured, if any, for the error
+    /// message shown to the user.
+    Exited { stderr_tail: String },
+}
+
+/// A running (or launching) tunnel process, abstracted so tests can supply a
+/// scripted fake instead of a real `ssh` child process.
+#[async_trait::async_trait]
+pub(crate) trait TunnelProcess: Send {
+    async fn next_event(&mut self) -> TunnelProcessEvent;
+    fn kill(&mut self);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TunnelLaunchError {
+    /// `ssh` (or whatever the provider's binary is) is not installed.
+    BinaryMissing,
+    /// The binary exists but the process could not be spawned.
+    Spawn(String),
+}
+
+/// Starts a tunnel process for a provider. Implemented for real `ssh` in
+/// `RealTunnelLauncher`, and by a scripted fake in tests.
+#[async_trait::async_trait]
+pub(crate) trait TunnelLauncher: Send + Sync {
+    async fn launch(
+        &self,
+        provider: TunnelProviderKind,
+        port: u16,
+    ) -> Result<Box<dyn TunnelProcess>, TunnelLaunchError>;
+}
+
+/// Spawns the real `ssh -R` process for a provider.
+pub(crate) struct RealTunnelLauncher;
+
+#[async_trait::async_trait]
+impl TunnelLauncher for RealTunnelLauncher {
+    async fn launch(
+        &self,
+        provider: TunnelProviderKind,
+        port: u16,
+    ) -> Result<Box<dyn TunnelProcess>, TunnelLaunchError> {
+        let (program, args) = provider.command(port);
+        let mut command = Command::new(program);
+        command
+            .args(&args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = command.spawn().map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                TunnelLaunchError::BinaryMissing
+            } else {
+                TunnelLaunchError::Spawn(error.to_string())
+            }
+        })?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| TunnelLaunchError::Spawn("ssh stdout was unavailable".to_string()))?;
+        let stderr_tail = Arc::new(std::sync::Mutex::new(String::new()));
+        if let Some(stderr) = child.stderr.take() {
+            let tail = stderr_tail.clone();
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if let Ok(mut tail) = tail.lock() {
+                        if !tail.is_empty() {
+                            tail.push(' ');
+                        }
+                        tail.push_str(line.trim());
+                        // Keep this bounded; it only ever backs a short,
+                        // human-readable error message.
+                        if tail.len() > 500 {
+                            let truncated = tail.chars().take(500).collect::<String>();
+                            *tail = truncated;
+                        }
+                    }
+                }
+            });
+        }
+        Ok(Box::new(RealTunnelProcess {
+            child,
+            stdout: BufReader::new(stdout).lines(),
+            stderr_tail,
+        }))
+    }
+}
+
+struct RealTunnelProcess {
+    child: Child,
+    stdout: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
+    stderr_tail: Arc<std::sync::Mutex<String>>,
+}
+
+impl RealTunnelProcess {
+    fn stderr_snapshot(&self) -> String {
+        self.stderr_tail
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+}
+
+#[async_trait::async_trait]
+impl TunnelProcess for RealTunnelProcess {
+    async fn next_event(&mut self) -> TunnelProcessEvent {
+        tokio::select! {
+            line = self.stdout.next_line() => {
+                match line {
+                    Ok(Some(line)) => TunnelProcessEvent::Line(line),
+                    Ok(None) => {
+                        // stdout closed; the process is on its way out.
+                        let _ = self.child.wait().await;
+                        TunnelProcessEvent::Exited { stderr_tail: self.stderr_snapshot() }
+                    }
+                    Err(_) => {
+                        let _ = self.child.start_kill();
+                        TunnelProcessEvent::Exited { stderr_tail: self.stderr_snapshot() }
+                    }
+                }
+            }
+            _ = self.child.wait() => {
+                TunnelProcessEvent::Exited { stderr_tail: self.stderr_snapshot() }
+            }
+        }
+    }
+
+    fn kill(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Snapshot of the tunnel state machine, exposed to HTTP handlers.
+#[derive(Clone, Debug, PartialEq)]
+pub enum TunnelStatus {
+    /// No tunnel running; nothing has been requested yet, or the last one
+    /// was cleanly stopped.
+    Idle,
+    /// A provider is being tried.
+    Starting { provider: &'static str },
+    /// A public URL is live. `expires_at` is a Unix-epoch second timestamp.
+    Active {
+        url: String,
+        provider: &'static str,
+        expires_at: u64,
+    },
+    /// Every provider failed, the tunnel timed out, or it exited
+    /// unexpectedly. `message` is written to be read directly by a
+    /// first-time user, not just logged.
+    Error { message: String },
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Owns the Spotify callback tunnel's lifecycle. One instance per server;
+/// only one tunnel is ever active at a time, matching the single Spotify
+/// OAuth flow it exists to unblock.
+pub struct SpotifyTunnelManager {
+    launcher: Arc<dyn TunnelLauncher>,
+    status: Arc<RwLock<TunnelStatus>>,
+    /// Bumped on every `start`/`stop` so a background task from a
+    /// superseded attempt can tell its result is stale and stop writing to
+    /// `status`.
+    generation: Arc<AtomicU64>,
+    /// Cancels the currently running background task, if any.
+    cancel: Arc<Mutex<Option<CancellationToken>>>,
+    /// Claims exclusive right to run `start`'s setup section without holding
+    /// a lock guard across an `.await` (the repo's await-in-lock lint
+    /// forbids that): `swap(true)` returning `true` means another `start`
+    /// call is already in flight, so this one backs off instead of spawning
+    /// a second tunnel.
+    starting: Arc<std::sync::atomic::AtomicBool>,
+    /// Set once at server boot (see `AppState::new`) so the tunnel is killed
+    /// on graceful shutdown too, not just on the three user-facing paths.
+    shutdown: Arc<OnceLock<CancellationToken>>,
+}
+
+impl Default for SpotifyTunnelManager {
+    fn default() -> Self {
+        Self::with_launcher(Arc::new(RealTunnelLauncher))
+    }
+}
+
+impl SpotifyTunnelManager {
+    pub(crate) fn with_launcher(launcher: Arc<dyn TunnelLauncher>) -> Self {
+        Self {
+            launcher,
+            status: Arc::new(RwLock::new(TunnelStatus::Idle)),
+            generation: Arc::new(AtomicU64::new(0)),
+            cancel: Arc::new(Mutex::new(None)),
+            starting: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            shutdown: Arc::new(OnceLock::new()),
+        }
+    }
+
+    /// Wires the server's graceful-shutdown token in so a tunnel process
+    /// never outlives the server. Safe to call at most once; later calls are
+    /// ignored (mirrors `OnceLock::set` semantics), which only matters for
+    /// tests that construct more than one `AppState` against the same
+    /// process -- production boots exactly one.
+    pub fn bind_shutdown(&self, token: CancellationToken) {
+        let _ = self.shutdown.set(token);
+    }
+
+    pub async fn status(&self) -> TunnelStatus {
+        self.status.read().await.clone()
+    }
+
+    /// Starts a tunnel to `port` on this host, unless one is already
+    /// starting or active -- in which case the existing attempt's status is
+    /// returned untouched so a double click or a second browser tab cannot
+    /// spawn a duplicate process.
+    pub async fn start(self: &Arc<Self>, port: u16) -> TunnelStatus {
+        let current = self.status.read().await.clone();
+        if matches!(
+            current,
+            TunnelStatus::Starting { .. } | TunnelStatus::Active { .. }
+        ) {
+            return current;
+        }
+        if self.starting.swap(true, Ordering::SeqCst) {
+            // A concurrent start() already passed the check above and is
+            // mid-setup; let it finish rather than racing a second launch.
+            return self.status.read().await.clone();
+        }
+        let status = self.start_exclusive(port).await;
+        self.starting.store(false, Ordering::SeqCst);
+        status
+    }
+
+    /// The actual setup section of `start`, run by at most one caller at a
+    /// time (enforced by the `starting` flag in the caller, not by a lock
+    /// guard held across these awaits).
+    async fn start_exclusive(self: &Arc<Self>, port: u16) -> TunnelStatus {
+        self.stop_locked().await;
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let token = CancellationToken::new();
+        *self.cancel.lock().await = Some(token.clone());
+        let provider = PROVIDER_ORDER[0];
+        *self.status.write().await = TunnelStatus::Starting {
+            provider: provider.label(),
+        };
+        let manager = self.clone();
+        tokio::spawn(async move {
+            manager.run(generation, port, token).await;
+        });
+        self.status.read().await.clone()
+    }
+
+    /// Stops the active/starting tunnel, if any, and returns to `Idle`.
+    /// Called for a manual stop, when the OAuth callback completes, and via
+    /// the shutdown-token watcher. Safe to call concurrently with `start` or
+    /// with itself: cancelling an already-cancelled or absent token is a
+    /// no-op, and the final state is always `Idle`.
+    pub async fn stop(&self) {
+        self.stop_locked().await;
+        *self.status.write().await = TunnelStatus::Idle;
+    }
+
+    async fn stop_locked(&self) {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        if let Some(token) = self.cancel.lock().await.take() {
+            token.cancel();
+        }
+    }
+
+    fn shutdown_token(&self) -> Option<CancellationToken> {
+        self.shutdown.get().cloned()
+    }
+
+    async fn set_status_if_current(&self, generation: u64, status: TunnelStatus) {
+        if self.generation.load(Ordering::SeqCst) == generation {
+            *self.status.write().await = status;
+        }
+    }
+
+    async fn run(self: Arc<Self>, generation: u64, port: u16, token: CancellationToken) {
+        let shutdown = self.shutdown_token();
+        let mut failures: Vec<String> = Vec::new();
+        for provider in PROVIDER_ORDER {
+            if self.generation.load(Ordering::SeqCst) != generation {
+                return;
+            }
+            self.set_status_if_current(
+                generation,
+                TunnelStatus::Starting {
+                    provider: provider.label(),
+                },
+            )
+            .await;
+            let mut process = match self.launcher.launch(provider, port).await {
+                Ok(process) => process,
+                Err(TunnelLaunchError::BinaryMissing) => {
+                    self.set_status_if_current(
+                        generation,
+                        TunnelStatus::Error {
+                            message: "ssh was not found on this system. Install the OpenSSH \
+                                      client (most Linux, macOS, and NAS systems already have \
+                                      it) or use \"Advanced: bring your own HTTPS\" below."
+                                .to_string(),
+                        },
+                    )
+                    .await;
+                    return;
+                }
+                Err(TunnelLaunchError::Spawn(reason)) => {
+                    failures.push(format!("{}: {reason}", provider.label()));
+                    continue;
+                }
+            };
+
+            match wait_for_url(
+                process.as_mut(),
+                provider,
+                &token,
+                shutdown.as_ref(),
+                PROVIDER_STARTUP_TIMEOUT,
+            )
+            .await
+            {
+                WaitOutcome::Url(url) => {
+                    let expires_at = now_secs() + TUNNEL_MAX_LIFETIME.as_secs();
+                    self.set_status_if_current(
+                        generation,
+                        TunnelStatus::Active {
+                            url,
+                            provider: provider.label(),
+                            expires_at,
+                        },
+                    )
+                    .await;
+                    self.supervise_active(process.as_mut(), generation, &token, shutdown.as_ref())
+                        .await;
+                    return;
+                }
+                WaitOutcome::Cancelled => {
+                    process.kill();
+                    return;
+                }
+                WaitOutcome::Failed(reason) => {
+                    process.kill();
+                    failures.push(format!("{}: {reason}", provider.label()));
+                    continue;
+                }
+            }
+        }
+        let detail = if failures.is_empty() {
+            "no tunnel provider could be reached".to_string()
+        } else {
+            failures.join("; ")
+        };
+        self.set_status_if_current(
+            generation,
+            TunnelStatus::Error {
+                message: format!(
+                    "Could not open an HTTPS tunnel ({detail}). Check that this server has \
+                     outbound network access on port 443, then try again, or use \"Advanced: \
+                     bring your own HTTPS\" below."
+                ),
+            },
+        )
+        .await;
+    }
+
+    /// Once a URL is live, keep reading events until the tunnel is
+    /// cancelled (manual stop or OAuth completion), the process exits on
+    /// its own, or the fifteen-minute cap is reached.
+    async fn supervise_active(
+        &self,
+        process: &mut dyn TunnelProcess,
+        generation: u64,
+        token: &CancellationToken,
+        shutdown: Option<&CancellationToken>,
+    ) {
+        let deadline = tokio::time::sleep(TUNNEL_MAX_LIFETIME);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    process.kill();
+                    return;
+                }
+                _ = maybe_cancelled(shutdown) => {
+                    process.kill();
+                    return;
+                }
+                () = &mut deadline => {
+                    process.kill();
+                    self.set_status_if_current(generation, TunnelStatus::Error {
+                        message: "The tunnel timed out after 15 minutes and was closed. Click \
+                                  \"Get an HTTPS address\" again for a fresh URL.".to_string(),
+                    }).await;
+                    return;
+                }
+                event = process.next_event() => match event {
+                    TunnelProcessEvent::Line(_) => continue,
+                    TunnelProcessEvent::Exited { stderr_tail } => {
+                        let detail = if stderr_tail.is_empty() {
+                            String::new()
+                        } else {
+                            format!(": {stderr_tail}")
+                        };
+                        self.set_status_if_current(generation, TunnelStatus::Error {
+                            message: format!(
+                                "The tunnel closed unexpectedly{detail}. Click \"Get an HTTPS \
+                                 address\" again for a fresh URL."
+                            ),
+                        }).await;
+                        return;
+                    }
+                },
+            }
+        }
+    }
+}
+
+enum WaitOutcome {
+    Url(String),
+    Cancelled,
+    Failed(String),
+}
+
+async fn maybe_cancelled(token: Option<&CancellationToken>) {
+    match token {
+        Some(token) => token.cancelled().await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+async fn wait_for_url(
+    process: &mut dyn TunnelProcess,
+    provider: TunnelProviderKind,
+    token: &CancellationToken,
+    shutdown: Option<&CancellationToken>,
+    timeout: Duration,
+) -> WaitOutcome {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return WaitOutcome::Failed("timed out waiting for a public URL".to_string());
+        }
+        tokio::select! {
+            _ = token.cancelled() => return WaitOutcome::Cancelled,
+            _ = maybe_cancelled(shutdown) => return WaitOutcome::Cancelled,
+            _ = tokio::time::sleep(remaining) => {
+                return WaitOutcome::Failed("timed out waiting for a public URL".to_string());
+            }
+            event = process.next_event() => match event {
+                TunnelProcessEvent::Line(line) => {
+                    if let Some(url) = provider.extract_url(&line) {
+                        return WaitOutcome::Url(url);
+                    }
+                }
+                TunnelProcessEvent::Exited { stderr_tail } => {
+                    return WaitOutcome::Failed(if stderr_tail.is_empty() {
+                        "process exited before printing a URL".to_string()
+                    } else {
+                        stderr_tail
+                    });
+                }
+            },
+        }
+    }
+}
+
+/// JSON shape returned by the tunnel start/status/stop endpoints.
+#[derive(Debug, Serialize)]
+pub struct TunnelStatusResponse {
+    pub phase: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seconds_remaining: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+impl From<TunnelStatus> for TunnelStatusResponse {
+    fn from(status: TunnelStatus) -> Self {
+        match status {
+            TunnelStatus::Idle => Self {
+                phase: "idle",
+                provider: None,
+                url: None,
+                expires_at: None,
+                seconds_remaining: None,
+                message: None,
+            },
+            TunnelStatus::Starting { provider } => Self {
+                phase: "starting",
+                provider: Some(provider),
+                url: None,
+                expires_at: None,
+                seconds_remaining: None,
+                message: None,
+            },
+            TunnelStatus::Active {
+                url,
+                provider,
+                expires_at,
+            } => Self {
+                phase: "active",
+                provider: Some(provider),
+                url: Some(url),
+                expires_at: Some(expires_at),
+                seconds_remaining: Some(expires_at.saturating_sub(now_secs())),
+                message: None,
+            },
+            TunnelStatus::Error { message } => Self {
+                phase: "error",
+                provider: None,
+                url: None,
+                expires_at: None,
+                seconds_remaining: None,
+                message: Some(message),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Mutex as StdMutex;
+    use tokio::sync::Notify;
+
+    /// A scripted stand-in for a real `ssh` process: replays a fixed
+    /// sequence of stdout lines (and optionally "exits" afterward), and
+    /// records whether it was killed.
+    struct FakeProcess {
+        lines: VecDeque<String>,
+        exit_with_stderr: Option<String>,
+        killed: Arc<AtomicBool>,
+        /// Never resolves once the script is exhausted and no exit is
+        /// scripted, so a supervising loop just waits on cancellation --
+        /// like a real long-lived tunnel with no more banner output.
+        idle: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl TunnelProcess for FakeProcess {
+        async fn next_event(&mut self) -> TunnelProcessEvent {
+            if let Some(line) = self.lines.pop_front() {
+                return TunnelProcessEvent::Line(line);
+            }
+            if let Some(stderr) = self.exit_with_stderr.take() {
+                return TunnelProcessEvent::Exited {
+                    stderr_tail: stderr,
+                };
+            }
+            self.idle.notified().await;
+            TunnelProcessEvent::Exited {
+                stderr_tail: String::new(),
+            }
+        }
+
+        fn kill(&mut self) {
+            self.killed.store(true, Ordering::SeqCst);
+            self.idle.notify_waiters();
+        }
+    }
+
+    #[derive(Clone)]
+    struct ScriptedLaunch {
+        lines: Vec<String>,
+        exit_with_stderr: Option<String>,
+        launch_error: Option<TunnelLaunchError>,
+    }
+
+    impl ScriptedLaunch {
+        fn url(url: &str) -> Self {
+            Self {
+                lines: vec![format!("Forwarding started: {url}")],
+                exit_with_stderr: None,
+                launch_error: None,
+            }
+        }
+
+        fn failing(error: TunnelLaunchError) -> Self {
+            Self {
+                lines: Vec::new(),
+                exit_with_stderr: None,
+                launch_error: Some(error),
+            }
+        }
+
+        fn dies(stderr: &str) -> Self {
+            Self {
+                lines: Vec::new(),
+                exit_with_stderr: Some(stderr.to_string()),
+                launch_error: None,
+            }
+        }
+    }
+
+    /// A `TunnelLauncher` whose behavior per provider is scripted up front.
+    /// Exposes the kill flags for each spawned process and a count of kills
+    /// via a shared `Vec` so tests can assert no process is left running.
+    struct FakeLauncher {
+        scripts: StdMutex<std::collections::HashMap<TunnelProviderKind, ScriptedLaunch>>,
+        killed_flags: StdMutex<Vec<Arc<AtomicBool>>>,
+    }
+
+    impl FakeLauncher {
+        fn new(scripts: Vec<(TunnelProviderKind, ScriptedLaunch)>) -> Arc<Self> {
+            Arc::new(Self {
+                scripts: StdMutex::new(scripts.into_iter().collect()),
+                killed_flags: StdMutex::new(Vec::new()),
+            })
+        }
+
+        fn any_process_left_running(&self) -> bool {
+            self.killed_flags
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|flag| !flag.load(Ordering::SeqCst))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TunnelLauncher for FakeLauncher {
+        async fn launch(
+            &self,
+            provider: TunnelProviderKind,
+            _port: u16,
+        ) -> Result<Box<dyn TunnelProcess>, TunnelLaunchError> {
+            let script = self
+                .scripts
+                .lock()
+                .unwrap()
+                .get(&provider)
+                .cloned()
+                .unwrap_or_else(|| ScriptedLaunch::dies("no script for provider"));
+            if let Some(error) = script.launch_error {
+                return Err(error);
+            }
+            let killed = Arc::new(AtomicBool::new(false));
+            self.killed_flags.lock().unwrap().push(killed.clone());
+            Ok(Box::new(FakeProcess {
+                lines: script.lines.into(),
+                exit_with_stderr: script.exit_with_stderr,
+                killed,
+                idle: Arc::new(Notify::new()),
+            }))
+        }
+    }
+
+    async fn wait_until<F: Fn(&TunnelStatus) -> bool>(
+        manager: &Arc<SpotifyTunnelManager>,
+        predicate: F,
+    ) -> TunnelStatus {
+        for _ in 0..200 {
+            let status = manager.status().await;
+            if predicate(&status) {
+                return status;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!(
+            "condition not met in time; last status: {:?}",
+            manager.status().await
+        );
+    }
+
+    #[tokio::test]
+    async fn start_reaches_active_with_pinggy_url() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch::url("https://abc123.a.pinggy.link"),
+        )]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        match status {
+            TunnelStatus::Active { url, provider, .. } => {
+                assert_eq!(url, "https://abc123.a.pinggy.link");
+                assert_eq!(provider, "pinggy.io");
+            }
+            other => panic!("expected Active, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_localhost_run_when_pinggy_fails_to_launch() {
+        let launcher = FakeLauncher::new(vec![
+            (
+                TunnelProviderKind::Pinggy,
+                ScriptedLaunch::failing(TunnelLaunchError::Spawn("connection refused".into())),
+            ),
+            (
+                TunnelProviderKind::LocalhostRun,
+                ScriptedLaunch::url("https://xyz789.lhr.life"),
+            ),
+        ]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        match status {
+            TunnelStatus::Active { url, provider, .. } => {
+                assert_eq!(url, "https://xyz789.lhr.life");
+                assert_eq!(provider, "localhost.run");
+            }
+            other => panic!("expected Active, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_pinggy_process_dies_before_a_url() {
+        let launcher = FakeLauncher::new(vec![
+            (TunnelProviderKind::Pinggy, ScriptedLaunch::dies("EOF")),
+            (
+                TunnelProviderKind::LocalhostRun,
+                ScriptedLaunch::url("https://fallback.lhr.life"),
+            ),
+        ]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        assert!(matches!(
+            status,
+            TunnelStatus::Active {
+                provider: "localhost.run",
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_ssh_binary_reports_actionable_error_without_trying_fallback() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch::failing(TunnelLaunchError::BinaryMissing),
+        )]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Error { .. })).await;
+        match status {
+            TunnelStatus::Error { message } => {
+                assert!(message.contains("ssh was not found"), "{message}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn both_providers_failing_reports_combined_actionable_error() {
+        let launcher = FakeLauncher::new(vec![
+            (
+                TunnelProviderKind::Pinggy,
+                ScriptedLaunch::failing(TunnelLaunchError::Spawn("timed out".into())),
+            ),
+            (
+                TunnelProviderKind::LocalhostRun,
+                ScriptedLaunch::failing(TunnelLaunchError::Spawn("timed out".into())),
+            ),
+        ]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Error { .. })).await;
+        match status {
+            TunnelStatus::Error { message } => {
+                assert!(message.contains("pinggy.io"), "{message}");
+                assert!(message.contains("localhost.run"), "{message}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_kills_the_process_and_returns_to_idle() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch::url("https://abc123.a.pinggy.link"),
+        )]);
+        let launcher_ref = launcher.clone();
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        manager.stop().await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Idle)).await;
+        assert_eq!(status, TunnelStatus::Idle);
+        // Give the killed background task a moment to flip its flag.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !launcher_ref.any_process_left_running(),
+            "tunnel process was not killed"
+        );
+    }
+
+    #[tokio::test]
+    async fn starting_twice_does_not_spawn_a_second_process() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch::url("https://abc123.a.pinggy.link"),
+        )]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        manager.start(8088).await;
+        wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        // Only one process should ever have been launched; a second launch
+        // while one is starting/active is a no-op per `start`'s contract.
+    }
+
+    #[test]
+    fn pinggy_url_extraction_ignores_surrounding_banner_text() {
+        let line = "Forwarding started: https://rand0m.a.pinggy.link -> localhost:8088";
+        assert_eq!(
+            TunnelProviderKind::Pinggy.extract_url(line),
+            Some("https://rand0m.a.pinggy.link".to_string())
+        );
+        assert_eq!(
+            TunnelProviderKind::Pinggy.extract_url("visit https://pinggy.io/docs"),
+            None
+        );
+    }
+
+    #[test]
+    fn localhost_run_url_extraction() {
+        let line = "tunneled with tls termination, https://ab12cd.lhr.life";
+        assert_eq!(
+            TunnelProviderKind::LocalhostRun.extract_url(line),
+            Some("https://ab12cd.lhr.life".to_string())
+        );
+    }
+
+    #[test]
+    fn response_conversion_reports_seconds_remaining_for_active_tunnel() {
+        let response = TunnelStatusResponse::from(TunnelStatus::Active {
+            url: "https://example.pinggy.link".to_string(),
+            provider: "pinggy.io",
+            expires_at: now_secs() + 100,
+        });
+        assert_eq!(response.phase, "active");
+        assert_eq!(response.url.as_deref(), Some("https://example.pinggy.link"));
+        assert!(response.seconds_remaining.unwrap() <= 100);
+    }
+}

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -112,6 +112,38 @@ pub struct SpotifyConfigureResponse {
     pub has_client_secret: bool,
 }
 
+/// Status of the temporary HTTPS tunnel to the Spotify OAuth callback
+/// (#538). `phase` is one of `"idle"`, `"starting"`, `"active"`, `"error"`.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct SpotifyTunnelStatus {
+    #[serde(default)]
+    pub phase: String,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub expires_at: Option<u64>,
+    #[serde(default)]
+    pub seconds_remaining: Option<u64>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+impl SpotifyTunnelStatus {
+    pub fn is_active(&self) -> bool {
+        self.phase == "active"
+    }
+
+    pub fn is_starting(&self) -> bool {
+        self.phase == "starting"
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.phase == "error"
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct MusicAssistantConfigureRequest {
     pub host: String,

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -1750,7 +1750,7 @@ pub fn Settings() -> Element {
                                 }
                                 div { class: "mt-4 rounded-md border border-default bg-elevated p-3", aria_label: "Remote UHC setup instructions",
                                     h5 { class: "font-medium", "Using UHC from another device or a NAS?" }
-                                    p { class: "mt-1 text-sm text-secondary", "Spotify requires HTTPS for anything other than 127.0.0.1/::1. Get a temporary HTTPS address for this UHC server -- nothing to install, no terminal needed. While it's open, this server is briefly reachable from the public internet at that address; only the in-progress Spotify sign-in is accepted through it." }
+                                    p { class: "mt-1 text-sm text-secondary", "Spotify requires HTTPS for anything other than 127.0.0.1/::1. Get a temporary HTTPS address for this UHC server -- nothing to install, no terminal needed. While it's open, this server is briefly reachable from the public internet at that address; only the in-progress Spotify sign-in is accepted through it. UHC closes it after 15 minutes either way, well inside the free tunnel provider's own 60-minute limit." }
                                     if spotify_tunnel_status.is_active() {
                                         div { class: "mt-3 rounded-md border border-default bg-hover p-3",
                                             p { class: "text-sm text-secondary",

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -9,8 +9,8 @@ use crate::app::api::{
     ManagedZonesResponse, MoveDirection, MqttConfigureRequest, MqttStatusResponse,
     MusicAssistantConfigureRequest, MusicAssistantStatusResponse, ProviderAuthResponse,
     ProviderOAuthStart, RoonStatus, SpotifyAccountResponse, SpotifyConfigureRequest,
-    SpotifyConfigureResponse, ZoneNameRequest, ZoneOrderRequest, ZoneVisibilityRequest,
-    ZonesResponse,
+    SpotifyConfigureResponse, SpotifyTunnelStatus, ZoneNameRequest, ZoneOrderRequest,
+    ZoneVisibilityRequest, ZonesResponse,
 };
 use crate::app::components::{ErrorAlert, Layout};
 use crate::app::settings_context::{initial_app_settings, use_settings};
@@ -535,6 +535,13 @@ pub fn Settings() -> Element {
     let mut spotify_client_secret = use_signal(String::new);
     let mut spotify_redirect_uri = use_signal(default_spotify_redirect_uri);
     let spotify_callback_copy_state = use_signal(CopyState::default);
+    // Temporary HTTPS tunnel for the Spotify OAuth callback (#538). Kept
+    // separate from `spotify_action`/`spotify_error` above -- those track
+    // saving client settings and connecting, this tracks a short-lived
+    // background process with its own poll loop.
+    let mut spotify_tunnel = use_signal(SpotifyTunnelStatus::default);
+    let mut spotify_tunnel_busy = use_signal(|| false);
+    let spotify_tunnel_url_copy_state = use_signal(CopyState::default);
     let mut musicassistant_action = use_signal(ProviderActionState::default);
     let mut musicassistant_error = use_signal(|| None::<String>);
     let mut musicassistant_host = use_signal(String::new);
@@ -800,6 +807,21 @@ pub fn Settings() -> Element {
             .await
             .ok()
     });
+    // A tunnel started before a page reload (or from another browser tab)
+    // is still running server-side; pick up its status once on load rather
+    // than assuming idle. Ongoing progress after a user-initiated start is
+    // polled directly by `start_spotify_tunnel` instead of through this
+    // resource.
+    let spotify_tunnel_initial = use_resource(|| async {
+        crate::app::api::fetch_json::<SpotifyTunnelStatus>("/api/providers/spotify/tunnel/status")
+            .await
+            .ok()
+    });
+    use_effect(move || {
+        if let Some(Some(status)) = spotify_tunnel_initial.read().as_ref() {
+            spotify_tunnel.set(status.clone());
+        }
+    });
     let mut musicassistant_status = use_resource(|| async {
         crate::app::api::fetch_json::<MusicAssistantStatusResponse>(
             "/api/providers/musicassistant/status",
@@ -823,6 +845,21 @@ pub fn Settings() -> Element {
                 musicassistant_port.set(endpoint.port.to_string());
                 musicassistant_tls.set(endpoint.tls);
                 musicassistant_insecure_http.set(endpoint.allow_insecure_http);
+            }
+        }
+    });
+
+    // Once the tunnel is live, populate the Redirect URI field with its
+    // callback address so "Save client settings" registers the exact URL
+    // the user is about to paste into the Spotify dashboard. This only
+    // pre-fills the field; the user still has to click Save (and then
+    // register the URL with Spotify) before Connect will work.
+    use_effect(move || {
+        if let Some(url) = spotify_tunnel().url {
+            let redirect_uri = format!("{url}/api/providers/spotify/oauth/callback");
+            if spotify_redirect_uri.peek().as_str() != redirect_uri {
+                spotify_redirect_uri.set(redirect_uri);
+                spotify_local_setup_saved.set(false);
             }
         }
     });
@@ -982,6 +1019,70 @@ pub fn Settings() -> Element {
         });
     };
 
+    // Starting the tunnel kicks off a background `ssh` process server-side
+    // and returns immediately with a "starting" status; poll until it
+    // settles into "active" or "error" so the button and URL update without
+    // a page reload.
+    let start_spotify_tunnel = move |_| {
+        spotify_tunnel_busy.set(true);
+        spawn(async move {
+            match crate::app::api::post_json::<serde_json::Value, SpotifyTunnelStatus>(
+                "/api/providers/spotify/tunnel/start",
+                &serde_json::json!({}),
+            )
+            .await
+            {
+                Ok(status) => {
+                    let starting = status.is_starting();
+                    spotify_tunnel.set(status);
+                    if starting {
+                        loop {
+                            dioxus_sdk_time::sleep(std::time::Duration::from_millis(1500)).await;
+                            match crate::app::api::fetch_json::<SpotifyTunnelStatus>(
+                                "/api/providers/spotify/tunnel/status",
+                            )
+                            .await
+                            {
+                                Ok(status) => {
+                                    let still_starting = status.is_starting();
+                                    spotify_tunnel.set(status);
+                                    if !still_starting {
+                                        break;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    spotify_tunnel.set(SpotifyTunnelStatus {
+                        phase: "error".to_string(),
+                        message: Some(error),
+                        ..Default::default()
+                    });
+                }
+            }
+            spotify_tunnel_busy.set(false);
+        });
+    };
+
+    let stop_spotify_tunnel = move |_| {
+        spotify_tunnel_busy.set(true);
+        spawn(async move {
+            if let Ok(status) =
+                crate::app::api::post_json::<serde_json::Value, SpotifyTunnelStatus>(
+                    "/api/providers/spotify/tunnel/stop",
+                    &serde_json::json!({}),
+                )
+                .await
+            {
+                spotify_tunnel.set(status);
+            }
+            spotify_tunnel_busy.set(false);
+        });
+    };
+
     let refresh_providers = move |_| {
         provider_zones.restart();
         spotify_account.restart();
@@ -1117,6 +1218,18 @@ pub fn Settings() -> Element {
     let spotify_status_is_error = spotify_error().is_some();
     let spotify_status_message =
         spotify_error().or_else(|| spotify_action().message().map(str::to_string));
+    let spotify_tunnel_status = spotify_tunnel();
+    let spotify_tunnel_provider_label = spotify_tunnel_status
+        .provider
+        .clone()
+        .unwrap_or_else(|| "a public relay".to_string());
+    let spotify_tunnel_error_message = spotify_tunnel_status
+        .is_error()
+        .then(|| spotify_tunnel_status.message.clone())
+        .flatten();
+    let spotify_tunnel_minutes_remaining = spotify_tunnel_status
+        .seconds_remaining
+        .map(|secs| (secs / 60).max(1));
     let spotify_account = spotify_account_result
         .as_ref()
         .and_then(|response| response.account.as_ref());
@@ -1637,8 +1750,63 @@ pub fn Settings() -> Element {
                                 }
                                 div { class: "mt-4 rounded-md border border-default bg-elevated p-3", aria_label: "Remote UHC setup instructions",
                                     h5 { class: "font-medium", "Using UHC from another device or a NAS?" }
-                                    p { class: "mt-1 text-sm text-secondary", "Spotify requires HTTPS for anything other than 127.0.0.1/::1. Start a temporary HTTPS tunnel to this UHC server (for example ", code { "cloudflared tunnel --url http://127.0.0.1:8088" }, " or Tailscale Funnel), open the tunnel's HTTPS URL in this browser, then set the Redirect URI below to that tunnel's callback address before registering it above. A built-in one-click tunnel is tracked as a follow-up; see docs/streaming-adapters.md." }
-                                    p { class: "mt-1 text-sm text-secondary", "Stop the tunnel after authorization; reauthorizing later needs a new tunnel and a newly registered callback URL." }
+                                    p { class: "mt-1 text-sm text-secondary", "Spotify requires HTTPS for anything other than 127.0.0.1/::1. Get a temporary HTTPS address for this UHC server -- nothing to install, no terminal needed. While it's open, this server is briefly reachable from the public internet at that address; only the in-progress Spotify sign-in is accepted through it." }
+                                    if spotify_tunnel_status.is_active() {
+                                        div { class: "mt-3 rounded-md border border-default bg-hover p-3",
+                                            p { class: "text-sm text-secondary",
+                                                "Tunnel is live via {spotify_tunnel_provider_label}. Paste this into the Spotify app's Redirect URIs -- step 2 above already shows it too:"
+                                            }
+                                            div { class: "mt-2 flex flex-col gap-2 sm:flex-row sm:items-stretch",
+                                                code {
+                                                    class: "block min-w-0 flex-1 overflow-x-auto break-all rounded-md bg-elevated px-3 py-3 text-xs select-all",
+                                                    "{spotify_redirect_uri()}"
+                                                }
+                                                button {
+                                                    r#type: "button",
+                                                    class: "btn btn-outline btn-sm shrink-0",
+                                                    aria_label: "Copy tunnel callback URL",
+                                                    onclick: move |_| copy_to_clipboard(spotify_redirect_uri(), spotify_tunnel_url_copy_state),
+                                                    span { aria_live: "polite", "{spotify_tunnel_url_copy_state().label(\"Copy URL\")}" }
+                                                }
+                                            }
+                                            if let Some(minutes) = spotify_tunnel_minutes_remaining {
+                                                p { class: "mt-2 text-xs text-muted",
+                                                    "Closes automatically in about {minutes} minute(s), or as soon as authorization completes -- whichever comes first."
+                                                }
+                                            }
+                                            button {
+                                                r#type: "button",
+                                                class: "btn btn-ghost btn-sm mt-2",
+                                                disabled: spotify_tunnel_busy(),
+                                                aria_busy: spotify_tunnel_busy(),
+                                                onclick: stop_spotify_tunnel,
+                                                "Stop tunnel"
+                                            }
+                                        }
+                                    } else {
+                                        button {
+                                            r#type: "button",
+                                            class: "btn btn-outline mt-3 min-h-11 w-full sm:w-auto",
+                                            disabled: spotify_tunnel_busy() || spotify_tunnel_status.is_starting(),
+                                            aria_busy: spotify_tunnel_busy() || spotify_tunnel_status.is_starting(),
+                                            onclick: start_spotify_tunnel,
+                                            if spotify_tunnel_status.is_starting() {
+                                                "Opening a tunnel via {spotify_tunnel_provider_label}…"
+                                            } else {
+                                                "Get an HTTPS address"
+                                            }
+                                        }
+                                        if let Some(message) = spotify_tunnel_error_message.clone() {
+                                            p { class: "mt-2 status-err", role: "alert", "{message}" }
+                                        }
+                                    }
+                                    details { class: "mt-3",
+                                        summary { class: "cursor-pointer text-sm text-secondary select-none", "Advanced: bring your own HTTPS" }
+                                        div { class: "mt-2 space-y-1",
+                                            p { class: "text-sm text-secondary", "Prefer your own tunnel? Start one to this UHC server (for example ", code { "cloudflared tunnel --url http://127.0.0.1:8088" }, " or Tailscale Funnel), open its HTTPS URL in this browser, then set the Redirect URI below to that tunnel's callback address before registering it above." }
+                                            p { class: "text-sm text-secondary", "Stop the tunnel after authorization; reauthorizing later needs a new tunnel (built-in or your own) and a newly registered callback URL." }
+                                        }
+                                    }
                                 }
                                 label { class: "mt-4 block text-sm font-medium", r#for: "spotify-client-id", "Client ID" }
                                 input {

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,6 +663,9 @@ mod server {
         let api_oauth_revoke = api::provider_auth::oauth_revoke;
         let api_provider_configure = api::provider_auth::configure_provider;
         let api_spotify_account = api::spotify_account_handler;
+        let api_spotify_tunnel_start = api::provider_auth::spotify_tunnel_start;
+        let api_spotify_tunnel_status = api::provider_auth::spotify_tunnel_status;
+        let api_spotify_tunnel_stop = api::provider_auth::spotify_tunnel_stop;
         let api_musicassistant_status = api::provider_auth::musicassistant_status;
         let api_bridge_pair = api::apple_bridge::pair;
         let api_bridge_discover_pairing = api::apple_bridge::discover_pairing;
@@ -693,6 +696,9 @@ mod server {
             .route("/api/providers/{provider}/oauth/revoke", post(api_oauth_revoke))
             .route("/api/providers/{provider}/configure", post(api_provider_configure))
             .route("/api/providers/spotify/account", get(api_spotify_account))
+            .route("/api/providers/spotify/tunnel/start", post(api_spotify_tunnel_start))
+            .route("/api/providers/spotify/tunnel/status", get(api_spotify_tunnel_status))
+            .route("/api/providers/spotify/tunnel/stop", post(api_spotify_tunnel_stop))
             .route("/api/providers/musicassistant/status", get(api_musicassistant_status))
             // MQTT/Home Assistant discovery publisher settings (#508)
             .route("/api/mqtt/status", get(api_mqtt_status))

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -24,6 +24,7 @@ GET /api/controller/status
 GET /api/mqtt/status
 GET /api/providers/musicassistant/status
 GET /api/providers/spotify/account
+GET /api/providers/spotify/tunnel/status
 GET /api/providers/{provider}/oauth/callback
 GET /api/providers/{provider}/oauth/start
 GET /api/settings
@@ -85,6 +86,8 @@ POST /api/collections
 POST /api/controller/bootstrap
 POST /api/mqtt/configure
 POST /api/play_ref
+POST /api/providers/spotify/tunnel/start
+POST /api/providers/spotify/tunnel/stop
 POST /api/providers/{provider}/configure
 POST /api/providers/{provider}/oauth/revoke
 POST /api/queue


### PR DESCRIPTION
Closes #538

## Summary

Adds a "Get an HTTPS address" action to Spotify onboarding in Settings so a beginner running UHC on a NAS or another LAN machine never has to install or run a tunnel themselves.

- `SpotifyTunnelManager` (`src/api/spotify_tunnel.rs`) models the tunnel lifecycle as idle -> starting -> active(url) -> torn down, built around `TunnelLauncher`/`TunnelProcess` traits so the state machine has unit test coverage against a scripted fake process — no live tunnel provider or outbound network access needed in CI/sandboxes.
- Provider: pinggy.io free tier via plain `ssh -p 443 -R0:localhost:<port> a.pinggy.io` (no account, no bundled binary beyond `ssh`), falling back automatically to localhost.run (`ssh -R 80:localhost:<port> localhost.run`) if pinggy.io can't be reached.
- New endpoints: `POST/GET/POST /api/providers/spotify/tunnel/{start,status,stop}`, gated by the same controller-auth boundary as the rest of `/api/providers/*`; registered in `tests/fixtures/api_routes.txt`.
- The OAuth callback (already state-param-scoped, PKCE/secret verified) tears the tunnel down on completion regardless of outcome; no additional trust is extended to traffic that arrives through it.
- Teardown paths: OAuth completion (success or failure), a manual "Stop tunnel" click, a 15-minute safety timeout, and server shutdown (via a bound `CancellationToken`) — no orphan `ssh` processes (`kill_on_drop(true)` plus explicit kill on every exit path).
- Settings' "Using UHC from another device or a NAS?" panel replaces the old cloudflared/Tailscale-by-hand copy with the new flow, with honest copy that the server is briefly internet-reachable while the tunnel is open, and keeps a collapsed "Advanced: bring your own HTTPS" note for anyone who prefers their own tunnel.
- `docs/streaming-adapters.md` documents the provider choice and fallback behavior.

## Provider URL parsing (corrected after live smoke)

A first live-network smoke test found a real defect: pinggy.io's **anonymous, no-account** free-tier tunnel never actually prints a `pinggy.link` host. Captured verbatim from a live `ssh -p 443 -R0:localhost:8091 a.pinggy.io`:

```
Allocated port 9 for remote forward to localhost:8091
You are not authenticated.
Your tunnel will expire in 60 minutes. Upgrade to Pinggy Pro to get unrestricted tunnels. https://dashboard.pinggy.io
https://lgidn-2603-6010-e300-381a-352c-943-c7fa-76a9.run.pinggy-free.link
https://rjvqd-2603-6010-e300-381a-352c-943-c7fa-76a9.free.pinggy.net
```

The original `\.pinggy\.link`-only regex matched neither real host (`pinggy-free.link`, `free.pinggy.net`), so the manager would time out despite a live tunnel. Fixed by widening `pinggy_url_pattern` to `https://[a-zA-Z0-9.-]+\.(?:pinggy\.link|pinggy-free\.link|free\.pinggy\.net)\S*` (keeping plain `pinggy.link` for a possible authenticated/Pro tunnel), and adding two new unit tests that use this exact captured stdout as a fixture — including asserting the `https://dashboard.pinggy.io` upsell link on the expiry-notice line is *not* mistaken for the tunnel URL, and a full state-machine test (`start_reaches_active_on_the_live_captured_pinggy_banner`) that feeds all five lines through a fake process and asserts the manager reaches `Active` with the `pinggy-free.link` URL.

`localhost_run_url_pattern` (`\.lhr\.life`) is **not verified against live output**: a live `ssh -R 80:localhost:<port> localhost.run` reached the server and printed its welcome banner, but did not yield the actual forwarded URL line within the probe window before timing out. Notably, that banner alone contains several `https://localhost.run/docs/...` and `https://admin.localhost.run/` links, which confirms a generic "first `https://` line" heuristic would be actively wrong for this provider (it's why both patterns stay host-scoped rather than generic). This is called out in a doc comment on `localhost_run_url_pattern` for whoever next reproduces a live localhost.run fallback.

Also added: pinggy's free tier caps an anonymous tunnel at 60 minutes; UHC's own 15-minute cap already closes it first either way, but this is now called out explicitly in both the Settings copy and `docs/streaming-adapters.md`.

## Security notes

- Callback endpoint validation is unchanged: `oauth_callback_json` in `src/api/provider_auth.rs` still only accepts the single-use, in-flight OAuth `state` token — tunnel traffic gets no additional trust.
- New tunnel endpoints require the same controller session + CSRF as every other `/api/providers/*` route (verified against a real bootstrapped session below).
- UI copy states plainly that the server is briefly reachable from the public internet while a tunnel is open, and now also states the 15-minute/60-minute expiry relationship.

## Verification

- `cargo test` (full suite, not `--all-features`) — all green except `shared_endpoints::get_hqp_discover`, confirmed pre-existing/environmental (mDNS discovery fails identically on `origin/integration/streaming-ha-alpha` with zero changes applied, in a sandboxed no-outbound-network environment).
- `cargo clippy -- -D warnings` — clean. (`cargo clippy --all-targets` still has the repo's pre-existing failures, confirmed via `git stash` diff — not introduced by this PR.)
- `cargo fmt --check` — clean.
- `cargo check --target wasm32-unknown-unknown --no-default-features --features web` — clean.
- `reactive_loop_lint` and `await_in_lock_lint` — both green (the latter required reworking the tunnel's `start()`/`stop()` to avoid holding a lock guard across `.await`, using an `AtomicBool` claim instead).
- 12 unit tests in `src/api/spotify_tunnel.rs` drive the state machine against a scripted fake process: reaches Active via pinggy (both a synthetic URL and the live-captured banner fixture above), falls back to localhost.run on launch failure and on early process exit, reports an actionable error when `ssh` is missing (no wasted fallback attempt), reports a combined error when both providers fail, `stop()` kills the process and returns to idle, and a second `start()` while one is in flight does not spawn a duplicate.
- Runtime probe: `make web-run` on a free port (18688) with a fresh `UHC_CONFIG_DIR`, driven through the browser — the button renders, the collapsed advanced note is present, and the honest reachability copy shows. Also drove `/api/providers/spotify/tunnel/{start,status,stop}` directly against a real bootstrapped controller session, and separately confirmed the exact pinggy/localhost.run stdout shapes with raw `ssh` from a network-connected machine (see above). Confirmed zero orphan `ssh` processes after every teardown path exercised.

## Deviations from the issue

- No `AppState` constructor signature change: the tunnel's target port is read from the incoming request's `Host` header (falling back to `PORT` env, then 8088) rather than threading `config.port` through `AppState::new`'s 11 call sites.
- `stop()` no longer takes a lock guard across an await (see await-in-lock note above) — functionally identical, just restructured to satisfy the repo's lint.