### PR TITLE
fix(web+library): serve the current client build and make Library navigation clicks land (#566)

### DIFF
--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -480,17 +480,28 @@ pub fn Library(
     let current_tab = Tab::parse(&route_tab);
     let breadcrumbs = use_signal(|| decode_path(route_path.as_deref()));
 
-    // Re-sync local breadcrumb signal when navigation (back/forward, or a
-    // deep link) changes the route's `path` out from under us.
+    // Re-sync local breadcrumb signal when navigation (a row click's
+    // `navigator.push`, back/forward, or a deep link) changes the route's
+    // `path` out from under us.
+    //
+    // #566 (live probe): `use_reactive!` is load-bearing. `path` is a plain
+    // route prop, not a signal -- an effect that merely *captures* it has no
+    // tracked dependency and runs exactly once, at mount. In-app navigation
+    // keeps this component mounted, so every breadcrumb-changing click
+    // (browse rows and the new search-result chevrons alike) updated the URL
+    // while the visible level never changed -- the click read as a no-op.
+    // Deep links appeared to work only because a fresh mount seeds the
+    // signal's initial value. `use_reactive!` diffs the prop across renders
+    // and re-runs this effect when it actually changes.
     {
         let mut breadcrumbs = breadcrumbs;
         let route_path_for_effect = path.clone();
-        use_effect(move || {
+        use_effect(use_reactive!(|route_path_for_effect| {
             let decoded = decode_path(route_path_for_effect.as_deref());
             if *breadcrumbs.peek() != decoded {
                 breadcrumbs.set(decoded);
             }
-        });
+        }));
     }
 
     let items = use_signal(Vec::<CollectionItem>::new);
@@ -549,8 +560,26 @@ pub fn Library(
         });
     };
 
+    // The search box's text. Declared before `open_folder` (its consumers --
+    // the input binding and the search effect -- live in the "Unified search"
+    // block below) because opening a folder must clear it.
+    let mut search_query = use_signal(String::new);
+
     let open_folder = {
         move |(title, folder_path): (String, String)| {
+            // #566 (live probe): a non-empty query keeps the search-results
+            // view mounted, so opening a search hit navigated the route (URL
+            // and breadcrumbs updated) while the visible page stayed on the
+            // results list -- the click read as a no-op, the exact dead end
+            // this issue exists to remove. Opening a folder is a statement
+            // that the search is done: clear the query so the browse level
+            // the navigation lands on is actually shown. A no-op for browse
+            // rows opened outside a search (the query is already empty).
+            // (Signals are Copy: the shadow keeps this closure `Fn` -- setting
+            // the captured copy directly would make it `FnMut`, which the row
+            // components' handler props don't accept.)
+            let mut search_query = search_query;
+            search_query.set(String::new());
             let mut stack = breadcrumbs();
             stack.push(BreadcrumbEntry {
                 title,
@@ -657,7 +686,8 @@ pub fn Library(
     });
 
     // ---- Unified search (#550): local filter + debounced global search ----
-    let mut search_query = use_signal(String::new);
+    // (Declared above `open_folder` so opening a folder can clear it -- see
+    // there. Kept in this block so the search wiring reads as one unit.)
     let search_generation = use_signal(|| 0u64);
     let global_results = use_signal(Vec::<SearchResult>::new);
     let global_searching = use_signal(|| false);

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -48,10 +48,52 @@ pub fn has_embedded_assets() -> bool {
     PublicAssets::iter().next().is_some()
 }
 
-/// Get the embedded index.html content.
-/// Returns None if assets weren't embedded.
+/// The fresh dx build output directory next to the running server binary
+/// (`target/dx/<app>/release/web/{server,public}`), when it exists.
+///
+/// #566 postmortem: [`PublicAssets`] is snapshotted when the server crate
+/// *compiles*, but `dx build` writes the current build's hashed
+/// `assets/*.js`/`*.wasm` bundles and `index.html` into `web/public` around /
+/// after that compile — so the embedded snapshot always lags one build
+/// behind. It contains only *previous* builds' clients, and its `index.html`
+/// points at whichever bundle was newest when the compiler ran. Served
+/// as-is, an SSR page could execute a stale client — arbitrarily old,
+/// including pre-#560 clients whose search effect hangs the wasm renderer at
+/// mount — instead of (or in addition to) the client the server was actually
+/// built from. Preferring this on-disk directory whenever it exists makes
+/// the served client the one `dx` just built; the embedded copy stays as the
+/// fallback that keeps true single-binary deployments (no `public/` on disk)
+/// working exactly as before.
+fn disk_public_root() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?.join("public");
+    dir.is_dir().then_some(dir)
+}
+
+/// Read `rel` (a `/`-separated path *inside* public/) disk-first, falling
+/// back to the embedded snapshot. `rel` may come from a URL path, so any
+/// segment that could escape the public root rejects the disk read outright
+/// (the embedded lookup was always a pure map lookup and needs no guard).
+fn read_public(rel: &str) -> Option<Vec<u8>> {
+    let path_is_safe = !rel.is_empty()
+        && rel
+            .split('/')
+            .all(|seg| !seg.is_empty() && seg != "." && seg != ".." && !seg.contains('\\'));
+    if path_is_safe {
+        if let Some(root) = disk_public_root() {
+            if let Ok(bytes) = std::fs::read(root.join(rel)) {
+                return Some(bytes);
+            }
+        }
+    }
+    PublicAssets::get(rel).map(|file| file.data.into_owned())
+}
+
+/// Get the index.html content: the on-disk one next to the binary when
+/// present (always the current build's — see [`disk_public_root`]), else the
+/// embedded snapshot. Returns None only when neither exists.
 pub fn get_index_html() -> Option<String> {
-    PublicAssets::get("index.html").map(|file| String::from_utf8_lossy(&file.data).into_owned())
+    read_public("index.html").map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
 }
 
 /// Axum handler to serve embedded assets at /assets/* paths.
@@ -62,8 +104,8 @@ pub async fn serve_embedded_asset(
     // Files are in assets/ subfolder
     let asset_path = format!("assets/{}", path);
 
-    match PublicAssets::get(&asset_path) {
-        Some(content) => {
+    match read_public(&asset_path) {
+        Some(bytes) => {
             let mime = mime_guess::from_path(&asset_path)
                 .first_or_octet_stream()
                 .to_string();
@@ -73,7 +115,7 @@ pub async fn serve_embedded_asset(
                 .header(header::CONTENT_TYPE, mime)
                 // Immutable cache for hashed assets
                 .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
-                .body(Body::from(content.data.into_owned()))
+                .body(Body::from(bytes))
                 .unwrap_or_else(|_| Response::new(Body::empty()))
         }
         None => Response::builder()
@@ -93,8 +135,8 @@ pub async fn serve_embedded_font(
 ) -> Response<Body> {
     let asset_path = format!("fonts/{}", path);
 
-    match PublicAssets::get(&asset_path) {
-        Some(content) => {
+    match read_public(&asset_path) {
+        Some(bytes) => {
             let mime = mime_guess::from_path(&asset_path)
                 .first_or_octet_stream()
                 .to_string();
@@ -104,7 +146,7 @@ pub async fn serve_embedded_font(
                 .header(header::CONTENT_TYPE, mime)
                 // Immutable cache: font filenames carry their own content hash upstream.
                 .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
-                .body(Body::from(content.data.into_owned()))
+                .body(Body::from(bytes))
                 .unwrap_or_else(|_| Response::new(Body::empty()))
         }
         None => Response::builder()
@@ -134,8 +176,8 @@ pub async fn serve_index_html() -> Response<Body> {
 pub async fn serve_static_file(
     axum::extract::Path(path): axum::extract::Path<String>,
 ) -> Response<Body> {
-    match PublicAssets::get(&path) {
-        Some(content) => {
+    match read_public(&path) {
+        Some(bytes) => {
             let mime = mime_guess::from_path(&path)
                 .first_or_octet_stream()
                 .to_string();
@@ -144,7 +186,7 @@ pub async fn serve_static_file(
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, mime)
                 .header(header::CACHE_CONTROL, "public, max-age=3600")
-                .body(Body::from(content.data.into_owned()))
+                .body(Body::from(bytes))
                 .unwrap_or_else(|_| Response::new(Body::empty()))
         }
         None => Response::builder()
@@ -199,6 +241,26 @@ pub fn extract_bootstrap_snippet() -> Option<String> {
 // =============================================================================
 // This middleware intercepts HTML responses from SSR and injects the WASM
 // bootstrap scripts, enabling the client to hydrate without a public/ directory.
+
+/// Whether the bootstrap snippet must be injected into this HTML response.
+///
+/// Injection exists for one case only: a Dioxus SSR page (it carries the
+/// hydration-data marker) that has **no** WASM loader of its own. A server
+/// built by `dx` renders SSR pages that already carry their own
+/// `<script type="module" ...>` loader for the exact client bundle it was
+/// built with — injecting a second loader on top of that is how #566's
+/// mount hang happened: the snippet comes from the (potentially stale — see
+/// [`disk_public_root`]) `index.html`, so the page ended up executing TWO
+/// different client builds against one DOM, one of which could be old enough
+/// to carry the pre-#560 mount loop. A page that already has any module
+/// script therefore never gets the snippet; the exact-match check stays as a
+/// belt-and-braces guard against double-injection on repeated middleware
+/// passes.
+fn needs_bootstrap(html: &str, bootstrap: &str) -> bool {
+    html.contains("initial_dioxus_hydration_data")
+        && !html.contains("<script type=\"module\"")
+        && !html.contains(bootstrap)
+}
 
 /// Tower layer that injects Dioxus bootstrap scripts into SSR HTML responses.
 #[derive(Clone)]
@@ -273,9 +335,7 @@ where
 
             let mut html = String::from_utf8_lossy(&body_bytes).to_string();
 
-            // Only inject into SSR pages (have hydration data) that don't already have bootstrap
-            // The hydration data marker indicates this is a Dioxus SSR page
-            if html.contains("initial_dioxus_hydration_data") && !html.contains(&bootstrap) {
+            if needs_bootstrap(&html, &bootstrap) {
                 // Inject before </body> if present, otherwise append
                 if let Some(idx) = html.rfind("</body>") {
                     html.insert_str(idx, &format!("\n{}\n", bootstrap));
@@ -306,5 +366,70 @@ mod tests {
     fn test_get_index_html_handles_missing() {
         // This should return None if assets aren't embedded, not panic
         let _index = get_index_html();
+    }
+
+    const BOOTSTRAP: &str =
+        r#"<script type="module" async src="/./assets/unified-hifi-control-dxhOLD.js"></script>"#;
+
+    /// #566 mount-hang regression: an SSR page that already carries its own
+    /// module-script WASM loader (every page rendered by a dx-built server
+    /// does) must NOT get a second loader injected — the snippet comes from
+    /// a potentially stale index.html snapshot, and two different client
+    /// builds hydrating one DOM is exactly how the Library page hung at
+    /// mount (a stale pre-#560 client brought its since-fixed reactive loop
+    /// along with it).
+    #[test]
+    fn ssr_page_with_its_own_module_script_never_gets_a_second_loader() {
+        let html = r#"<body><div id="main"><script>window.initial_dioxus_hydration_data="x";</script></div>
+            <script type="module" async src="/./assets/unified-hifi-control-dxhNEW.js"></script></body>"#;
+        assert!(!needs_bootstrap(html, BOOTSTRAP));
+    }
+
+    /// The one case injection exists for: a Dioxus SSR page with no WASM
+    /// loader at all (a server built by plain `cargo build`, per ADR 002).
+    #[test]
+    fn ssr_page_without_any_loader_gets_the_bootstrap() {
+        let html = r#"<body><script>window.initial_dioxus_hydration_data="x";</script></body>"#;
+        assert!(needs_bootstrap(html, BOOTSTRAP));
+    }
+
+    /// Non-SSR responses (no hydration marker) are never touched.
+    #[test]
+    fn non_ssr_html_is_never_touched() {
+        assert!(!needs_bootstrap("<body>plain page</body>", BOOTSTRAP));
+    }
+
+    /// Idempotence: a page that already contains this exact snippet is not
+    /// injected again.
+    #[test]
+    fn bootstrap_is_not_injected_twice() {
+        let html = format!(
+            r#"<body><script>window.initial_dioxus_hydration_data="x";</script>{BOOTSTRAP}</body>"#
+        );
+        assert!(!needs_bootstrap(&html, BOOTSTRAP));
+    }
+
+    /// `read_public` serves URL-derived paths; anything that could step out
+    /// of public/ must refuse the disk read (the embedded map lookup is
+    /// inherently safe). With no disk root and nothing embedded these all
+    /// come back None either way — the assertion that matters is "no panic,
+    /// no escape", pinned by exercising the guard's rejection branch.
+    #[test]
+    fn read_public_rejects_traversal_shapes() {
+        for rel in [
+            "../Cargo.toml",
+            "assets/../../secret",
+            "assets//x.js",
+            ".",
+            "",
+            "assets\\..\\x",
+        ] {
+            // Must not read anything from outside public/ (and must not panic).
+            let got = read_public(rel);
+            assert!(
+                got.is_none() || PublicAssets::get(rel).is_some(),
+                "traversal-shaped path {rel:?} must never be served from disk"
+            );
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #567 for #566: closes the "Library hangs at mount" regression report against it, and makes the #567 feature actually work when clicked.

## TL;DR

Two commits:

1. **`fix(web)` — the "hang" (`src/embedded.rs`).** PR #567's code never hung the Library page. The hang bisected to a989dc0 is a serving-infrastructure defect that makes `make web-run` execute a **stale client build** — arbitrarily old, including pre-#560 clients whose since-fixed reactive loop pegs the wasm renderer at mount. Rebuilding at a989dc0 merely changed *which* stale client got served; the bisect measured build history, not code.
2. **`fix(library)` — the feature (`src/app/pages/library.rs`).** With the hang out of the way, a live FakeRoonCore probe showed the #567 chevron click was still a perceived no-op, for two client-side reasons: the route→breadcrumb resync effect had no reactive dependency on the route path (it ran once, at mount — so **every** in-app breadcrumb navigation, browse rows included, updated the URL without updating the page), and opening a search hit left the query in the box, keeping the search-results view mounted over the browse level. Both fixed; full click-through now verified in a real browser.

## The hang, proven both directions (live browser, LAN IP, zero zones, Roon disabled)

**Mechanism.** `PublicAssets` (rust-embed of `target/dx/.../web/public/`) is snapshotted when the server crate *compiles*, but `dx` writes the current build's hashed bundles and `index.html` into that folder after that point — so the embedded snapshot always lags: first build in a fresh tree embeds nothing (dev SSR mode, disk serving — works); every later build embeds *previous* clients and flips the server into embedded SSR mode. There, the SSR page already carries its own module-script loader for the current client, but `InjectDioxusBootstrapLayer` appended a second loader from the (stale) embedded `index.html`, and `/assets/*` served only embedded files. The page then executes a stale client (the fresh one 404s), or two different clients against one DOM (when both resolve). Proven from the rlib dep-info (the a989dc0 build's lib tracked/embedded only the base build's bundles) and `strings` on each server binary.

**Repro matrix** (all `dx build --release --platform web --features web`, real Chromium at the machine's LAN IP, fresh `UHC_CONFIG_DIR`, zero zones):

| Build | Client actually executed | Result |
|---|---|---|
| `d97acc0` (base, cleared tree) | its own | renders, responsive |
| `f5bac59` (= d97acc0+8d980db+a989dc0) | its own (after double-build) | renders, hydrates, SSE opens, 10× 5s-heartbeats with max gap 5016 ms, JS eval instant — **a989dc0 is clean** |
| `f5bac59` after seeding the folder with a pre-#560 (`36956c3`) build | fresh + pre-#560 **both** (both 200) | **wasm renderer pegged at mount**: JS eval times out (>30 s), even navigation away can't commit; network stops at the one-shot `/zones` + `/status` + `/events` set — the reported fingerprint, on demand |

**Fix.** `read_public()` makes every public/ lookup (assets, fonts, index.html, static files) disk-first (the `public/` directory next to the running binary — always the current build) with the embedded snapshot as fallback, so single-binary deployments are unchanged; URL-derived paths are traversal-guarded. `needs_bootstrap()` stops the middleware from ever adding a loader to a page that already has one — injection now exists only for the ADR 002 plain-`cargo` server whose SSR pages carry none. Unit tests pin both. Post-fix, the same poisoned tree serves exactly one (current) bundle and stays responsive through the 65 s probe.

## The feature, verified end-to-end (FakeRoonCore + real browser)

Production UI, real `RoonAdapter` event loop connected to a local `FakeRoonCore` (tests/mock_servers) seeded with #566's live shape — a "Michael Jackson · 13 Albums" artist, an "Albums · 35 Results for michael jackson" grouping row, and a directly playable "Thriller" album:

* `POST /api/search {"query":"michael jackson","zone_id":"roon:zone_fake_1"}` returned all three classifications: artist `path` only, grouping row `path` only, Thriller **dual `ref`+`path`**.
* Typing "michael jackson" in the Library search box rendered all three rows; Thriller carried both the play button and the chevron.
* Clicking the artist chevron cleared the search box and landed in the browse tab: breadcrumb `Library / Michael Jackson`, items Thriller + Bad. (`POST /api/collections` with the minted path returned them, each again dual ref+path.)
* Clicking the "Albums" grouping-row chevron opened its bucket: breadcrumb `… / Albums`, items Thriller + Off the Wall.
* Clicking ▶ on the dual Thriller search result resolved the play ref against the fake Core ("Play Album" action invoked) and the UI showed "Playing" — play unaffected.

Without the second commit, none of the clicks visibly navigate: the URL updates and the page doesn't. The resync effect captured the route `path` prop with no reactive dependency (`use_effect` with zero tracked reads runs once), so in-app `navigator.push` — from browse rows and search results alike — never re-synced the level; deep links only appeared to work because a fresh mount seeds the signal. `use_reactive!` fixes that; `open_folder` clearing the query makes the navigation visible when it starts from search results.

The probe used a temporary, env-gated hook (`UHC_TEST_ROON_FAKE_CORE_ADDR` in `main.rs` driving `run_event_loop_against_core_for_tests`, plus a zone-visibility line in `zone_list.rs`, plus a parked `tests/probe_fake_core.rs` harness) so the adapter reached the fake Core **without SOOD multicast** — no real Core contacted, no pairing surfaced. All three were reverted/deleted before commit; this PR's diff carries zero trace, and Roon stayed disabled in the probe config throughout the zero-zone phases.

## Gates (clean committed tree, temp hooks stripped)

* `cargo test` (default features): green across all suites except `client_harness::shared_endpoints::get_hqp_discover`, which fails **identically on unmodified a989dc0** (verified by checking it out and rerunning) — the documented `/hqp/discover` UDP-multicast dev-machine failure this repo's own mock-server docs call out; untouched by this diff. New `embedded::tests` (7) all pass.
* `cargo clippy -- -D warnings`: clean.
* `cargo fmt --check`: clean.
* wasm check (`cargo check --target wasm32-unknown-unknown --features web --no-default-features`): clean.
* `reactive_loop_lint`: green (runs inside `cargo test`); the new signal writes live in an event handler (`open_folder`) and a `use_reactive!` effect that only `peek`s the signal it writes.

## Observed, deliberately left for follow-ups

* `/tailwind.css` + `/dx-components-theme.css` 404 in web/embedded mode (routes registered only for non-`web` builds) — pre-existing on base, cosmetic.
* `UHC_GIT_SHA` is a cargo `env-dep` and goes stale across rebuilds (server built from ab481f2 reported `f815976`) — actively misleading during diagnosis.
* Tab switches with an unchanged breadcrumb stack share the same "plain prop captured by a run-once effect" hazard as the resync bug fixed here (`route_tab` in the reload effect); source switches are safe (memo-tracked).
* `reactive_loop_lint` cannot catch the hang class fixed here — the executed wasm wasn't built from the source being linted. The durable guard is the `needs_bootstrap` unit pin; a CI probe asserting the SSR page references exactly one client bundle would harden it further.
