### PR TITLE
fix(web): serve stylesheet/static routes in embedded SSR mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -878,45 +878,53 @@ mod server {
             // embedded like every other public/ file, but (unlike
             // /assets/*) nothing routed requests there, so the SPA
             // fallback answered instead. Registered unconditionally
-            // (not gated on `feature = "web"` like the block below) because
-            // it serves the same embedded PublicAssets data regardless of
-            // that feature.
+            // because it serves the same embedded PublicAssets data in
+            // every mode.
             .route("/fonts/{*path}", get(embedded::serve_embedded_font));
 
-        // Static file routes: only needed for non-web builds (cargo run).
-        // In web/fullstack mode, Dioxus automatically serves public/ directory.
-        #[cfg(not(feature = "web"))]
-        let router = router
-            .route(
-                "/favicon.ico",
-                get(|| embedded::serve_static_file(axum::extract::Path("favicon.ico".to_string()))),
-            )
-            .route(
-                "/apple-touch-icon.png",
-                get(|| {
-                    embedded::serve_static_file(axum::extract::Path(
-                        "apple-touch-icon.png".to_string(),
-                    ))
-                }),
-            )
-            .route(
-                "/tailwind.css",
-                get(|| {
-                    embedded::serve_static_file(axum::extract::Path("tailwind.css".to_string()))
-                }),
-            )
-            .route(
-                "/dx-components-theme.css",
-                get(|| {
-                    embedded::serve_static_file(axum::extract::Path(
-                        "dx-components-theme.css".to_string(),
-                    ))
-                }),
-            );
-
-        // Keep router in scope for web builds (static files served by Dioxus)
-        #[cfg(feature = "web")]
-        let router = router;
+        // Static file routes (favicon, touch icon, stylesheets). Gated at
+        // runtime on the same condition that picks the serve branch below:
+        // with embedded assets we use serve_api_application(), which serves
+        // NO static files — without these routes the app head's stylesheet
+        // links 404 on every page load of the dx-built fullstack server.
+        // Without embedded assets, serve_dioxus_application() nest_services
+        // every file in exe-adjacent public/ itself, and registering these
+        // same paths there makes axum panic at startup on overlapping routes.
+        let router = if embedded::has_embedded_assets() {
+            router
+                .route(
+                    "/favicon.ico",
+                    get(|| {
+                        embedded::serve_static_file(axum::extract::Path(
+                            "favicon.ico".to_string(),
+                        ))
+                    }),
+                )
+                .route(
+                    "/apple-touch-icon.png",
+                    get(|| {
+                        embedded::serve_static_file(axum::extract::Path(
+                            "apple-touch-icon.png".to_string(),
+                        ))
+                    }),
+                )
+                .route(
+                    "/tailwind.css",
+                    get(|| {
+                        embedded::serve_static_file(axum::extract::Path("tailwind.css".to_string()))
+                    }),
+                )
+                .route(
+                    "/dx-components-theme.css",
+                    get(|| {
+                        embedded::serve_static_file(axum::extract::Path(
+                            "dx-components-theme.css".to_string(),
+                        ))
+                    }),
+                )
+        } else {
+            router
+        };
 
         let router = router
             // MCP routes (same port as main app)


### PR DESCRIPTION
## Problem

`src/main.rs` registered `/tailwind.css`, `/dx-components-theme.css`, `/favicon.ico`, and `/apple-touch-icon.png` only under `#[cfg(not(feature = "web"))]`. On the dx-built fullstack server (`make web-run`, embedded SSR mode) those routes therefore don't exist, and the embedded branch uses `serve_api_application()`, which serves **no** static assets — so the app head's stylesheet links 404 on every page load. Cosmetic (pages still style via inlined CSS) but it pollutes every probe/console.

## Fix

Replace the compile-time feature gate with a runtime gate on `embedded::has_embedded_assets()` — the exact condition that selects the serve branch:

- **Embedded assets present** (→ `serve_api_application`): register the four routes, served via `embedded::serve_static_file` (disk-first with embedded fallback since #569).
- **No embedded assets** (→ `serve_dioxus_application` dev branch): skip them. Dioxus's `serve_static_assets()` `nest_service`s a route for every file in exe-adjacent `public/` — including `/tailwind.css` — so registering the same literal paths there would make axum **panic at startup** on overlapping routes. This is the route-conflict check requested before landing: the conflict is real, and the runtime gate is what avoids it.

## Verification (local — stacked PRs run no CI)

- `make web-run`, server logging `Using embedded SSR mode`: `/tailwind.css` 200 text/css 55978B, `/dx-components-theme.css` 200 text/css 3587B, `/favicon.ico` 200, `/apple-touch-icon.png` 200, `/` 200.
- Dev branch (`Using SSR mode (no embedded assets)`): server boots cleanly with the routes skipped and dioxus serves both CSS paths itself (200).
- `cargo check` (default/non-web features): clean.

Note: the unconditional `/fonts/{*path}` route (#560) has the same latent dev-branch overlap; left out of scope here.