### PR TITLE
Build provenance: truthful git_sha in /status + CI guard for exactly one client bundle

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,17 @@
 //! Environment variables (set by CI or fall back to defaults):
 //! - UHC_VERSION: Version string (defaults to CARGO_PKG_VERSION)
 //! - UHC_GIT_SHA: Git commit SHA (defaults to "unknown" or git rev-parse)
+//!
+//! #572: when neither env var is set (the common local `make web-run` path),
+//! the SHA is computed once by shelling out to `git rev-parse`. Cargo only
+//! reruns a build script when a file/env dependency it declared changes, and
+//! the old version declared none tied to git state — so after the first
+//! build, `UHC_GIT_SHA` was frozen at whatever commit happened to be checked
+//! out the first time, and every later rebuild (new commits, checkouts,
+//! rebases) kept serving that stale SHA from `/status` even though nothing
+//! else about the build was cached. That sent a live diagnosis session
+//! chasing the wrong commit twice. Declaring `cargo:rerun-if-changed` on the
+//! files that move whenever HEAD moves closes the gap.
 
 use std::process::Command;
 
@@ -23,6 +34,35 @@ fn main() {
     println!("cargo:rerun-if-env-changed=UHC_VERSION");
     println!("cargo:rerun-if-env-changed=UHC_GIT_SHA");
     println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+
+    // Rebuild whenever the checked-out commit moves, so a plain rebuild
+    // (with no env vars set) picks up the new SHA instead of the one that
+    // happened to be current the first time this crate compiled. `--git-path`
+    // resolves these correctly for linked worktrees too (where `.git` is a
+    // file, not a directory, and HEAD lives under `.git/worktrees/<name>/`).
+    for rel in ["HEAD", "logs/HEAD"] {
+        if let Some(path) = git_path(rel) {
+            println!("cargo:rerun-if-changed={}", path);
+        }
+    }
+}
+
+/// Resolve a path relative to the repo's (possibly worktree-specific) git
+/// directory via `git rev-parse --git-path`, e.g. `HEAD` or `logs/HEAD`.
+fn git_path(rel: &str) -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "--git-path", rel])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+            } else {
+                None
+            }
+        })
 }
 
 fn get_git_sha() -> String {

--- a/tests/build_provenance_contract.rs
+++ b/tests/build_provenance_contract.rs
@@ -1,0 +1,59 @@
+//! Static regression guard for truthful `/status` git-sha provenance (#572).
+//!
+//! `build.rs` bakes `UHC_GIT_SHA` into the binary via `env!("UHC_GIT_SHA")`
+//! (see `src/api/mod.rs::status_handler`). When neither `UHC_GIT_SHA` nor
+//! `GITHUB_SHA` is set -- the common local `make web-run` path -- the SHA
+//! comes from a `git rev-parse` shelled out inside `build.rs`. Cargo only
+//! reruns a build script when a declared file/env dependency changes; the
+//! original version declared none tied to git state, so after the first
+//! local build `/status` kept reporting whatever commit was checked out at
+//! that first build forever, surviving later commits, checkouts, and
+//! rebases. That sent a live diagnosis chasing the wrong commit twice (see
+//! the #572 issue history).
+//!
+//! Actually proving the fix requires a real double-build (see the PR
+//! description for the empirical transcript: build, note `/status`'s sha,
+//! make an empty commit, rebuild, confirm the new sha) -- that isn't
+//! something a fast unit test can reproduce cheaply. This test instead pins
+//! the regression at the source level, in the style of
+//! `tests/web_fullstack_runner_contract.rs`: `build.rs` must still declare a
+//! `cargo:rerun-if-changed` on the files that move whenever HEAD moves, so a
+//! future edit can't silently drop the fix back to the frozen-SHA bug.
+use std::fs;
+
+#[test]
+fn build_script_reruns_when_head_moves() {
+    let build_rs = fs::read_to_string("build.rs").expect("read build.rs");
+
+    assert!(
+        build_rs.contains("cargo:rerun-if-changed"),
+        "build.rs must declare cargo:rerun-if-changed dependencies so cargo reruns it when the \
+         checked-out commit changes -- without this, UHC_GIT_SHA freezes at whatever commit was \
+         checked out the first time this crate compiled (#572)"
+    );
+    assert!(
+        build_rs.contains("--git-path"),
+        "build.rs must resolve its git-state watch paths via `git rev-parse --git-path` so the \
+         rerun trigger also works correctly from a linked worktree (where .git is a file, not a \
+         directory, and HEAD lives under .git/worktrees/<name>/)"
+    );
+    assert!(
+        build_rs.contains("\"HEAD\""),
+        "build.rs must watch git's HEAD file so a new commit or checkout invalidates the cached SHA"
+    );
+    assert!(
+        build_rs.contains("logs/HEAD"),
+        "build.rs must watch git's HEAD reflog so commits, checkouts, and rebases all invalidate \
+         the cached SHA (a plain HEAD watch alone misses cases where HEAD's target ref file moves \
+         but HEAD's own symbolic-ref contents do not)"
+    );
+
+    // The env-var overrides (CI's explicit UHC_GIT_SHA / GITHUB_SHA) must
+    // still take precedence and still be declared, unchanged from before.
+    for env_var in ["UHC_GIT_SHA", "UHC_VERSION", "GITHUB_SHA"] {
+        assert!(
+            build_rs.contains(&format!("cargo:rerun-if-env-changed={env_var}")),
+            "build.rs dropped its cargo:rerun-if-env-changed declaration for {env_var}"
+        );
+    }
+}

--- a/tests/web_bundle_consistency_contract.rs
+++ b/tests/web_bundle_consistency_contract.rs
@@ -1,0 +1,185 @@
+//! Guard against serving mismatched client bundles (issue #572).
+//!
+//! #566's postmortem (see `src/embedded.rs::disk_public_root`) found that an
+//! SSR page could execute a stale WASM client because more than one build's
+//! worth of `assets/*.js` / `*.wasm` bundles were in play at once, or the
+//! served `index.html` pointed at a bundle that no longer matched what was
+//! on disk. That defect was fixed by preferring the fresh `dx build` output
+//! next to the running binary, but nothing asserted the invariant directly:
+//! the served SSR shell must reference **exactly one** client JS bundle and
+//! **exactly one** wasm bundle, and both files must actually exist in the
+//! served asset set.
+//!
+//! This is an integration test against `dx`'s *built output*
+//! (`target/dx/unified-hifi-control/release/web/public/`), the exact
+//! directory [`crate::embedded::disk_public_root`] serves from at runtime.
+//! That output only exists after `make web-run` (or CI's equivalent `dx
+//! build`) has run, so — in the style of
+//! `tests/web_fullstack_runner_contract.rs`, which pins build-layout
+//! invariants from the repo's static files — the checks that don't need a
+//! build run unconditionally, and the on-disk bundle assertion runs fully
+//! whenever dx output is present and skips loudly (not silently) otherwise.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Where `dx build --platform web` (see `scripts/run-web.sh`) writes the
+/// fullstack client's static assets, next to the server binary it built.
+fn dx_public_dir() -> PathBuf {
+    Path::new("target/dx/unified-hifi-control/release/web/public").to_path_buf()
+}
+
+/// Every `src="..."` attribute value found in `html`, in document order.
+/// Good enough for the small, machine-generated `index.html` dx emits; this
+/// test only needs to find the module-script reference, not parse HTML.
+fn extract_attr_values(html: &str, attr: &str) -> Vec<String> {
+    let needle = format!("{attr}=\"");
+    let mut out = Vec::new();
+    let mut rest = html;
+    while let Some(start) = rest.find(&needle) {
+        rest = &rest[start + needle.len()..];
+        if let Some(end) = rest.find('"') {
+            out.push(rest[..end].to_string());
+            rest = &rest[end + 1..];
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+/// Resolve an `index.html` asset reference (e.g. `/./assets/foo-HASH.js`)
+/// to a path relative to the public dir.
+fn relative_asset_path(reference: &str) -> Option<String> {
+    let trimmed = reference
+        .trim_start_matches('/')
+        .trim_start_matches("./")
+        .trim_start_matches('/');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[test]
+fn dx_public_dir_path_matches_what_the_server_serves_from() {
+    // Keep this test honest against src/embedded.rs: if the disk-serving
+    // path ever moves, this test's target directory must move with it.
+    let embedded_src = fs::read_to_string("src/embedded.rs").expect("read src/embedded.rs");
+    assert!(
+        embedded_src.contains(r#"exe.parent()?.join("public")"#),
+        "src/embedded.rs must still serve the built client from next to the running binary; \
+         update dx_public_dir() in this test if that layout changes"
+    );
+    assert!(
+        embedded_src
+            .contains(r#"#[folder = "target/dx/unified-hifi-control/release/web/public/"]"#),
+        "src/embedded.rs's embedded snapshot folder moved; update dx_public_dir() in this test"
+    );
+}
+
+/// The bundle-consistency assertion this issue asks for. Runs fully when
+/// `make web-run` / CI's `dx build` has already produced output in this
+/// checkout; otherwise skips loudly rather than silently passing or failing
+/// a machine that never ran a web build.
+///
+/// dx's SSR shell (`index.html`) references the client JS entrypoint
+/// directly via `<script type="module" src="...">`; the paired `.wasm`
+/// module is not linked from the HTML at all -- wasm-bindgen's glue code
+/// fetches it by its hashed filename from inside the JS bundle. So "exactly
+/// one JS bundle + one wasm, with matching hashes" is checked in two hops:
+/// (1) the shell must name exactly one JS entrypoint and that file must
+/// exist, and (2) the served asset set must contain exactly one `.wasm`
+/// file, and that JS entrypoint's own source must reference it by its exact
+/// (content-hashed) filename -- i.e. the JS and wasm the server is actually
+/// serving are the ones built together, not a stale pairing.
+#[test]
+fn ssr_shell_references_exactly_one_js_bundle_and_one_wasm_with_matching_files_on_disk() {
+    let public_dir = dx_public_dir();
+    let index_path = public_dir.join("index.html");
+
+    if !index_path.is_file() {
+        eprintln!(
+            "SKIPPING ssr_shell_references_exactly_one_js_bundle_and_one_wasm_with_matching_files_on_disk: \
+             no dx build output at {} (run `make web-run` or CI's dx build first to exercise this guard)",
+            index_path.display()
+        );
+        return;
+    }
+
+    let html = fs::read_to_string(&index_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", index_path.display()));
+
+    // (1) Exactly one client JS bundle referenced by the shell.
+    let js_refs: BTreeSet<String> = extract_attr_values(&html, "src")
+        .into_iter()
+        .filter(|src| src.ends_with(".js"))
+        .collect();
+    assert_eq!(
+        js_refs.len(),
+        1,
+        "the SSR shell at {} must reference exactly one client JS bundle via <script src>, found {:?} \
+         (a second bundle reference is how #566's mount hang happened -- see needs_bootstrap in src/embedded.rs)",
+        index_path.display(),
+        js_refs
+    );
+    let js_ref = js_refs.into_iter().next().unwrap();
+    let js_rel = relative_asset_path(&js_ref)
+        .unwrap_or_else(|| panic!("could not resolve JS reference {js_ref:?} to a relative path"));
+    let js_path = public_dir.join(&js_rel);
+    assert!(
+        js_path.is_file(),
+        "the SSR shell references JS bundle {js_ref:?} but no such file exists at {} -- \
+         the served bundle set is stale relative to what the shell advertises",
+        js_path.display()
+    );
+    let js_bytes = fs::read(&js_path).unwrap_or_else(|e| panic!("read {}: {e}", js_path.display()));
+    assert!(
+        !js_bytes.is_empty(),
+        "referenced JS bundle {} is empty",
+        js_path.display()
+    );
+    let js_text = String::from_utf8_lossy(&js_bytes);
+
+    // (2) Exactly one wasm bundle in the served asset set, and the JS
+    // entrypoint names it exactly (the hash match).
+    let assets_dir = public_dir.join("assets");
+    let wasm_files: Vec<String> = fs::read_dir(&assets_dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", assets_dir.display()))
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            name.ends_with(".wasm").then_some(name)
+        })
+        .collect();
+    assert_eq!(
+        wasm_files.len(),
+        1,
+        "the served asset set at {} must contain exactly one wasm bundle, found {:?}",
+        assets_dir.display(),
+        wasm_files
+    );
+    let wasm_file = &wasm_files[0];
+    let wasm_path = assets_dir.join(wasm_file);
+    let wasm_bytes =
+        fs::read(&wasm_path).unwrap_or_else(|e| panic!("read {}: {e}", wasm_path.display()));
+    assert!(
+        !wasm_bytes.is_empty(),
+        "wasm bundle {} is empty",
+        wasm_path.display()
+    );
+
+    assert!(
+        js_text.contains(wasm_file.as_str()),
+        "client JS bundle {} does not reference the wasm bundle {wasm_file:?} that is actually on disk \
+         (found no occurrence of its exact hashed filename) -- the JS/wasm pair being served is mismatched",
+        js_path.display()
+    );
+
+    eprintln!(
+        "verified dx build output: SSR shell references exactly one JS bundle ({js_rel:?}), \
+         exactly one wasm bundle ({wasm_file:?}) exists on disk, and the JS bundle names it by its exact hash"
+    );
+}


### PR DESCRIPTION
Closes #572

## Summary

- **Truthful `/status` git_sha**: `build.rs`'s fallback SHA (`git rev-parse`, used whenever CI's `UHC_GIT_SHA`/`GITHUB_SHA` aren't set — the common `make web-run` path) declared no `cargo:rerun-if-changed` tied to git state. Cargo therefore never reran the build script after the first build, so `/status` kept reporting whatever commit was checked out the first time the crate compiled, surviving every later commit, checkout, or rebase. Fixed by watching `HEAD` and its reflog via `git rev-parse --git-path` (correct for linked worktrees too, where `.git` is a file). CI's explicit `UHC_GIT_SHA`/`GITHUB_SHA`/`UHC_VERSION` env-var overrides are unchanged.
- **Bundle-consistency guard**: a new integration test asserts dx's built SSR shell (`target/dx/unified-hifi-control/release/web/public/index.html`) references exactly one client JS bundle, that exactly one wasm bundle exists in the served asset set, and that the JS bundle names the wasm by its exact content-hashed filename (catching the #566-style stale/mismatched-bundle class of bug PR #569's forensics called out). It skips loudly (not silently) when no dx build output exists in the test environment, and runs fully wherever `make web-run`/CI's `dx build` has already run.
- A small static regression test (`tests/build_provenance_contract.rs`) pins the `build.rs` rerun-if-changed shape so it can't silently regress back to the frozen-SHA bug.

## Mechanism chosen for a fresh sha

`build.rs` now resolves `git rev-parse --git-path HEAD` and `--git-path logs/HEAD` and declares both as `cargo:rerun-if-changed` inputs. `logs/HEAD` (the reflog) is what actually changes on every commit/checkout/rebase in the common case; `HEAD` itself is watched too for detached-HEAD moves. Resolving via `--git-path` (rather than assuming `.git/HEAD`) keeps this correct in linked worktrees, where `.git` is a file pointing at `.git/worktrees/<name>/`.

## Empirical proof transcript

```
$ git rev-parse --short HEAD
1728edd
$ cargo build --release            # (fix already staged in build.rs)
$ curl -s http://127.0.0.1:65079/status
{"service":"unified-hifi-control","version":"0.0.0","git_sha":"1728edd", ...}

$ git commit --allow-empty -m "test: empirical proof commit"
[issue/572 1cebd0b] test: empirical proof commit ...
$ cargo build --release
   Compiling unified-hifi-control v0.0.0 (...)      # only the crate itself recompiled
    Finished `release` profile [optimized] target(s) in 3m 31s
$ git rev-parse --short HEAD
1cebd0b
$ curl -s http://127.0.0.1:65079/status
{"service":"unified-hifi-control","version":"0.0.0","git_sha":"1cebd0b", ...}
```

git_sha tracked the new commit on a plain rebuild with no env vars set, and only the top-level crate recompiled (build-script rerun triggered correctly, no full dependency rebuild). The proof commit was then `git reset --soft`'d back out before this PR's real commit.

Server was started from a fresh `UHC_CONFIG_DIR` with all adapters (including Roon) disabled via `app-settings.json`, on a free local port (65079), never touching 192.168.1.2:8088.

## Guard test behavior in both environments

- **With dx build output present** (ran `dx build --release --platform web --features web --bin unified-hifi-control` locally): both tests in `tests/web_bundle_consistency_contract.rs` pass, confirming exactly one JS bundle referenced by the SSR shell, exactly one wasm bundle on disk, and the JS bundle names the wasm by its exact hashed filename.
- **Without dx build output** (renamed `target/dx` away and reran): the bundle-consistency test prints a loud `SKIPPING ...: no dx build output at ...` message via `eprintln!` and passes without asserting anything, per the issue's "skip gracefully (with a loud note)" requirement. The static `dx_public_dir_path_matches_what_the_server_serves_from` test still runs unconditionally in both cases.

## Verification

- `make css` (run first, per repo rules)
- `RUSTC_WRAPPER="" cargo build --release` — clean build, then rebuild-after-commit proof above
- `cargo test` — full suite green, including the two new test files and `web_fullstack_runner_contract.rs`
- `cargo clippy -- -D warnings` — clean (matches CI's exact invocation in `.github/workflows/build.yml`/`docker.yml`, not `--tests`, which surfaces unrelated pre-existing lint debt in this checkout)
- `cargo fmt --check` — clean
- rustup's toolchain (1.97.1) kept ahead of Homebrew's on PATH throughout

## Deviations

- The `sg review` step from the standard oh-task flow was unavailable in this environment — `sg` resolves to `ast-grep`, not the expected review tool — so I did a manual self-review of the diff instead.
- Spun off a separate background task suggestion (not part of this PR, out of scope for #572): the Dockerfile appears to never `COPY build.rs` into its builder stage, which would break `env!("UHC_VERSION")`/`env!("UHC_GIT_SHA")` compilation in Docker builds. Flagged for independent investigation rather than folded into this change.
- Per issue scope boundaries, did not touch `src/app/pages/library.rs` or any css route registrations in `main.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rebuild detection when Git metadata changes, including projects using linked worktrees.
  * Enhanced build reliability by preserving version and commit information across rebuilds.
  * Strengthened web asset consistency checks to help ensure generated pages load the correct JavaScript and WebAssembly resources.

* **Tests**
  * Added safeguards covering Git-based rebuild triggers and consistency between rendered pages and bundled assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->