### PR TITLE
fix(controller-auth): route owner-gated 401s into a bootstrap prompt

### DIFF
--- a/docs/controller-auth.md
+++ b/docs/controller-auth.md
@@ -85,3 +85,15 @@ browser session and CSRF checks. The Spotify OAuth callback is authenticated
 by its pending state/PKCE exchange instead of the browser cookie. Read-only
 device/status pages remain available, and native Apple bridge bearer routes
 remain independent.
+
+Independent of that switch, `/api/providers/*` and Apple Music pairing are
+*always* owner-gated (`requires_controller_auth` in
+`src/api/controller_auth.rs`) — a fresh install cannot let any reachable
+client replace OAuth credentials or mint a companion pairing before the owner
+bootstraps. The Settings UI's client-side counterpart to this contract lives
+in `src/app/controller_auth.rs` and `src/app/components/bootstrap_prompt.rs`:
+every fetch helper in `src/app/api.rs` routes a `controller_unauthorized`
+response into an in-page bootstrap prompt (token → `POST
+/api/controller/bootstrap` → CSRF token stored for subsequent requests)
+instead of surfacing the raw `HTTP 401`. See "First save on a NAS: the owner
+bootstrap prompt" in `docs/streaming-adapters.md` for the full walkthrough.

--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -104,9 +104,44 @@ For a local or QNAP install, open Settings in the browser you will use for
 authorization. The Spotify card's "Client settings" pane now walks through the
 whole flow as numbered steps: create/open an app in the Spotify Developer
 Dashboard, copy the exact callback URL shown there (with a one-click copy
-button) into the app's Redirect URIs, paste the Client ID (and Client Secret,
-if not using PKCE) into the fields below, save, then Connect. Leave the client
-secret blank to use Authorization Code with PKCE.
+button) into the app's Redirect URIs, paste the Client ID into the field
+below, save, then Connect. The client secret lives in a collapsed "Advanced"
+section and can almost always stay blank — UHC signs in securely without it;
+only fill it in if your Spotify app was specifically set up to require one.
+
+### First save on a NAS: the owner bootstrap prompt (#570)
+
+On a fresh NAS install, `/api/providers/*` (Spotify client settings, OAuth
+start/revoke, the tunnel endpoints) and Apple Music pairing are always
+owner-gated — see `requires_controller_auth` in
+`src/api/controller_auth.rs`. The first time you save Spotify client settings
+or click **Get an HTTPS address**, UHC does not just fail with a raw
+`HTTP 401`: the Settings UI catches the `controller_unauthorized` response
+(see `crate::app::api::response_error` and
+`crate::app::controller_auth::open_bootstrap_prompt` in
+`src/app/controller_auth.rs`) and opens an in-page **Owner setup required**
+prompt instead. It explains, in beginner language, that this is a one-time
+step and tells you where to find the token:
+
+- **QNAP**: `$QPKG_ROOT/unified-hifi-control.log` (the log file icon in QTS
+  App Center → UHC).
+- **Synology, Docker, or a plain binary install**: the server log or console
+  output where UHC started — look for the line beginning
+  `UHC controller bootstrap token`.
+- If your operator set `UHC_BOOTSTRAP_TOKEN` in the environment, use that
+  value instead; UHC never echoes an operator-supplied token to the log.
+
+Paste the token into the prompt, which posts it to
+`POST /api/controller/bootstrap`. On success UHC mints a browser session
+cookie plus a CSRF token; the prompt closes and the page reports that owner
+access is unlocked. Click the original button (Save, Connect, Get an HTTPS
+address) again and it now succeeds — the CSRF token is attached automatically
+to every state-changing request from then on (see
+`crate::app::controller_auth::current_csrf_token`, mirrored into
+`localStorage` so it survives a page reload without a second bootstrap). The
+bootstrap token itself is single-use: once accepted, the same token cannot be
+replayed, and `GET /api/controller/status` reports `bootstrap_required:
+false` afterward.
 
 If the browser is not on the UHC host, Spotify accepts plain HTTP only for
 explicit loopback callbacks (`127.0.0.1` or `::1`); anything else — a remote

--- a/src/api/controller_auth.rs
+++ b/src/api/controller_auth.rs
@@ -366,7 +366,12 @@ fn unauthorized() -> Response {
     (
         StatusCode::UNAUTHORIZED,
         Json(AuthError {
-            error: "Controller authentication required",
+            // Shared with the client-side detector in
+            // `crate::app::api::CONTROLLER_UNAUTHORIZED_MESSAGE` so the two
+            // sides cannot drift apart (#570): the browser fetch helpers
+            // match this exact text to route into the bootstrap prompt
+            // instead of rendering the raw HTTP error.
+            error: crate::app::api::CONTROLLER_UNAUTHORIZED_MESSAGE,
             code: "controller_unauthorized",
         }),
     )

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -40,6 +40,81 @@ pub struct LmsStatus {
 }
 
 // =============================================================================
+// Controller-auth types (#570)
+//
+// Client-side mirrors of `src/api/controller_auth.rs`'s wire types. That
+// module gates provider/credential routes behind a one-time owner bootstrap
+// token; these types and helpers let the Settings UI (and any other
+// owner-gated call site) drive `GET /api/controller/status` and
+// `POST /api/controller/bootstrap` without duplicating field names that
+// could drift from the server shape.
+// =============================================================================
+
+/// The exact `error` text `src/api/controller_auth.rs::unauthorized()` uses
+/// for a `controller_unauthorized` 401. A shared constant (referenced
+/// directly from that server-side function) rather than two independently
+/// typed literals, so detection here can never silently drift from the
+/// message it is matching against.
+pub const CONTROLLER_UNAUTHORIZED_MESSAGE: &str = "Controller authentication required";
+
+/// True when a fetch helper's formatted `Err(String)` came from the
+/// controller-auth 401 gate. `response_error` below already routes this case
+/// into the bootstrap prompt as a side effect; callers that render their own
+/// error text should pass their `Err` through
+/// [`suppress_controller_unauthorized`] so the raw HTTP text is not also
+/// shown next to the prompt.
+pub fn is_controller_unauthorized_error(message: &str) -> bool {
+    message.ends_with(CONTROLLER_UNAUTHORIZED_MESSAGE)
+}
+
+/// Drop a `controller_unauthorized` error (it already opened the bootstrap
+/// prompt) and pass every other error through unchanged, for call sites that
+/// display fetch errors directly.
+pub fn suppress_controller_unauthorized(message: String) -> Option<String> {
+    if is_controller_unauthorized_error(&message) {
+        None
+    } else {
+        Some(message)
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct ControllerStatus {
+    pub authenticated: bool,
+    pub bootstrap_required: bool,
+    #[serde(default)]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ControllerBootstrapRequest {
+    pub token: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct ControllerBootstrapResponse {
+    pub authenticated: bool,
+    pub csrf_token: String,
+    pub expires_at: u64,
+}
+
+/// `GET /api/controller/status`.
+pub async fn fetch_controller_status() -> Result<ControllerStatus, String> {
+    fetch_json("/api/controller/status").await
+}
+
+/// `POST /api/controller/bootstrap`.
+pub async fn bootstrap_controller(token: &str) -> Result<ControllerBootstrapResponse, String> {
+    post_json(
+        "/api/controller/bootstrap",
+        &ControllerBootstrapRequest {
+            token: token.to_string(),
+        },
+    )
+    .await
+}
+
+// =============================================================================
 // Settings Types
 // =============================================================================
 
@@ -891,6 +966,17 @@ pub async fn post_json<T: Serialize, R: for<'de> Deserialize<'de>>(
     headers
         .set("Content-Type", "application/json")
         .map_err(|e| format!("{:?}", e))?;
+    // Attach the double-submit CSRF token from a completed bootstrap (#570).
+    // The server's controller-auth middleware requires this header on every
+    // non-GET/HEAD request once a session cookie exists -- see
+    // `csrf_matches` in `src/api/controller_auth.rs`. Before bootstrap (or
+    // when controller auth is off entirely) there is no token to attach and
+    // the header is simply omitted.
+    if let Some(token) = crate::app::controller_auth::current_csrf_token() {
+        headers
+            .set("x-uhc-csrf-token", &token)
+            .map_err(|e| format!("{:?}", e))?;
+    }
 
     let body_str = serde_json::to_string(body).map_err(|e| e.to_string())?;
 
@@ -940,6 +1026,12 @@ pub async fn post_json_no_response<T: Serialize>(url: &str, body: &T) -> Result<
     headers
         .set("Content-Type", "application/json")
         .map_err(|e| format!("{:?}", e))?;
+    // See the matching comment in `post_json` above (#570).
+    if let Some(token) = crate::app::controller_auth::current_csrf_token() {
+        headers
+            .set("x-uhc-csrf-token", &token)
+            .map_err(|e| format!("{:?}", e))?;
+    }
 
     let body_str = serde_json::to_string(body).map_err(|e| e.to_string())?;
 
@@ -990,6 +1082,14 @@ async fn response_error(resp: web_sys::Response) -> String {
                 body
             }
         });
+    // Route every fetch helper's controller-auth 401 into the bootstrap
+    // prompt instead of leaving the caller to render this raw string
+    // (#570). This is the single interception point: `fetch_json`,
+    // `post_json`, and `post_json_no_response` all funnel their non-ok
+    // responses through here.
+    if status == 401 && detail == CONTROLLER_UNAUTHORIZED_MESSAGE {
+        crate::app::controller_auth::open_bootstrap_prompt();
+    }
     format!("HTTP {status}: {detail}")
 }
 

--- a/src/app/components/bootstrap_prompt.rs
+++ b/src/app/components/bootstrap_prompt.rs
@@ -84,6 +84,18 @@ pub fn BootstrapPrompt() -> Element {
                                 class: "input w-full mb-3",
                                 r#type: "password",
                                 autocomplete: "off",
+                                // This dialog typically opens while the user's focus is
+                                // elsewhere (they're copying the token from a server log or
+                                // terminal in another window). Without an explicit focus
+                                // target, the first click back into this browser window can
+                                // go toward refocusing the window itself rather than the
+                                // control under the cursor -- an OS/browser-level behavior
+                                // no page script can fully prevent -- which reads as a
+                                // "first click did nothing" bug on whatever happens to be
+                                // clicked first (reported against Unlock). Autofocusing the
+                                // token field means that returning click, wherever it lands,
+                                // has somewhere useful to go from the very first attempt.
+                                autofocus: true,
                                 placeholder: "Paste the token from the server log",
                                 value: "{token}",
                                 oninput: move |e| token.set(e.value()),

--- a/src/app/components/bootstrap_prompt.rs
+++ b/src/app/components/bootstrap_prompt.rs
@@ -1,0 +1,113 @@
+//! Owner bootstrap prompt (#570).
+//!
+//! Renders in place of a raw `HTTP 401: Controller authentication required`
+//! whenever `crate::app::controller_auth::bootstrap_prompt_open()` is true.
+//! Mounted once at the app root (`src/app/mod.rs`) so it covers every page's
+//! owner-gated action without each page duplicating the check.
+
+use dioxus::prelude::*;
+
+use crate::app::controller_auth;
+
+#[component]
+pub fn BootstrapPrompt() -> Element {
+    let mut token = use_signal(String::new);
+    let mut busy = use_signal(|| false);
+    let mut error = use_signal(|| None::<String>);
+    let mut unlocked = use_signal(|| false);
+
+    rsx! {
+        if controller_auth::bootstrap_prompt_open() {
+            div {
+                class: "fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4",
+                div {
+                    class: "card p-6 max-w-lg w-full",
+                    role: "dialog",
+                    aria_modal: "true",
+                    aria_label: "Owner setup required",
+
+                    h2 { class: "text-xl font-semibold mb-2", "Owner setup required" }
+                    p { class: "text-sm text-secondary mb-4",
+                        "This is a one-time step on a fresh install. UHC generated a private owner token so only "
+                        "you can change provider credentials (like Spotify) or pairing settings. Paste it below to unlock this action."
+                    }
+
+                    div { class: "card bg-elevated p-3 mb-4 text-sm",
+                        p { class: "font-medium mb-1", "Where to find the token:" }
+                        ul { class: "list-disc list-inside space-y-1 text-secondary",
+                            li { "QNAP: open " code { "$QPKG_ROOT/unified-hifi-control.log" } " (QTS App Center → UHC → the log file icon)." }
+                            li { "Synology, Docker, or a plain binary install: check the server log or console output where UHC started." }
+                            li { "Look for a line starting with " code { "UHC controller bootstrap token" } "." }
+                            li { "If your operator set " code { "UHC_BOOTSTRAP_TOKEN" } " in the environment, use that value instead." }
+                        }
+                    }
+
+                    if unlocked() {
+                        p { class: "status-ok mb-4", role: "status", "✓ Owner access unlocked. Try that action again." }
+                        button {
+                            r#type: "button",
+                            class: "btn btn-primary w-full",
+                            onclick: move |_| {
+                                unlocked.set(false);
+                                controller_auth::close_bootstrap_prompt();
+                            },
+                            "Done"
+                        }
+                    } else {
+                        if let Some(message) = error() {
+                            div { class: "card bg-error/10 border-error text-error p-3 mb-4 text-sm", role: "alert", "{message}" }
+                        }
+                        form {
+                            onsubmit: move |e| {
+                                e.prevent_default();
+                                let value = token().trim().to_string();
+                                if value.is_empty() {
+                                    error.set(Some("Enter the owner token first.".to_string()));
+                                    return;
+                                }
+                                busy.set(true);
+                                error.set(None);
+                                spawn(async move {
+                                    match controller_auth::submit_bootstrap_token(&value).await {
+                                        Ok(()) => {
+                                            unlocked.set(true);
+                                            token.set(String::new());
+                                        }
+                                        Err(message) => error.set(Some(message)),
+                                    }
+                                    busy.set(false);
+                                });
+                            },
+                            label { class: "block text-sm font-medium mb-1", r#for: "uhc-bootstrap-token", "Owner token" }
+                            input {
+                                id: "uhc-bootstrap-token",
+                                class: "input w-full mb-3",
+                                r#type: "password",
+                                autocomplete: "off",
+                                placeholder: "Paste the token from the server log",
+                                value: "{token}",
+                                oninput: move |e| token.set(e.value()),
+                            }
+                            div { class: "flex gap-2 justify-end",
+                                button {
+                                    r#type: "button",
+                                    class: "btn btn-outline",
+                                    disabled: busy(),
+                                    onclick: move |_| controller_auth::close_bootstrap_prompt(),
+                                    "Cancel"
+                                }
+                                button {
+                                    r#type: "submit",
+                                    class: "btn btn-primary",
+                                    disabled: busy(),
+                                    aria_busy: busy(),
+                                    if busy() { "Unlocking…" } else { "Unlock" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/components/mod.rs
+++ b/src/app/components/mod.rs
@@ -1,5 +1,6 @@
 //! Shared UI components for the Dioxus fullstack web UI.
 
+pub mod bootstrap_prompt;
 pub mod error_alert;
 pub mod form_inputs;
 pub mod hqp_controls;
@@ -8,6 +9,7 @@ pub mod nav;
 pub mod volume;
 pub mod zones_strip;
 
+pub use bootstrap_prompt::BootstrapPrompt;
 pub use error_alert::ErrorAlert;
 pub use form_inputs::{PowerModeInput, ToggleInput};
 pub use hqp_controls::{HqpControlsCompact, HqpMatrixSelect, HqpProfileSelect};

--- a/src/app/controller_auth.rs
+++ b/src/app/controller_auth.rs
@@ -1,0 +1,117 @@
+//! Client-side controller-auth state (#570).
+//!
+//! `src/api/controller_auth.rs` gates provider/credential routes (Spotify
+//! client settings, OAuth, the tunnel endpoints, Apple Music pairing) behind
+//! a one-time owner bootstrap token. Before this module existed, a client
+//! that hit that gate saw the raw `HTTP 401: Controller authentication
+//! required` string -- the gating itself was correct by design, but nothing
+//! told the user a bootstrap flow exists or where the token lives.
+//!
+//! This module is the single place that tracks "should the bootstrap prompt
+//! be showing" and "what CSRF token do state-changing requests need to
+//! attach", as `GlobalSignal`s rather than a `use_context` provider: the
+//! fetch helpers in `crate::app::api` are plain async functions called from
+//! many unrelated pages, not hooks, so they cannot consume a context that
+//! only exists inside a component subtree. A `GlobalSignal` is reachable
+//! from anywhere once the app has mounted once, which is what lets
+//! `crate::app::api::response_error` open the prompt as a side effect of any
+//! fetch helper's error path (`fetch_json`, `post_json`,
+//! `post_json_no_response`) without every call site duplicating the check.
+
+use dioxus::prelude::*;
+
+use crate::app::api::ControllerBootstrapResponse;
+
+#[cfg(target_arch = "wasm32")]
+const CSRF_STORAGE_KEY: &str = "uhc_controller_csrf";
+
+/// CSRF token from the last successful bootstrap. The controller session
+/// cookie is `HttpOnly` (deliberately unreadable by JS -- see
+/// `src/api/controller_auth.rs`), so this double-submit token is the only
+/// piece of bootstrap state the client can see, and the server hands it out
+/// exactly once, in the `POST /api/controller/bootstrap` response body.
+/// Nothing re-issues it, so it is mirrored into `localStorage` and reloaded
+/// on startup -- otherwise every page refresh after a successful bootstrap
+/// would 403 on the first state-changing request even though the session
+/// cookie (good for 30 days) is still valid.
+static CONTROLLER_CSRF_TOKEN: GlobalSignal<Option<String>> = Signal::global(load_stored_csrf_token);
+
+/// Whether the bootstrap prompt overlay should currently be rendered.
+static CONTROLLER_BOOTSTRAP_PROMPT_OPEN: GlobalSignal<bool> = Signal::global(|| false);
+
+fn load_stored_csrf_token() -> Option<String> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        web_sys::window()?
+            .local_storage()
+            .ok()??
+            .get_item(CSRF_STORAGE_KEY)
+            .ok()?
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        None
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn persist_csrf_token(token: &str) {
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item(CSRF_STORAGE_KEY, token);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn persist_csrf_token(_token: &str) {}
+
+/// The CSRF token to attach as `x-uhc-csrf-token` on state-changing
+/// requests, once bootstrap has completed (this session or a prior one that
+/// persisted the token to `localStorage`).
+pub fn current_csrf_token() -> Option<String> {
+    CONTROLLER_CSRF_TOKEN()
+}
+
+/// Whether the bootstrap prompt should currently be shown.
+pub fn bootstrap_prompt_open() -> bool {
+    CONTROLLER_BOOTSTRAP_PROMPT_OPEN()
+}
+
+/// Open the bootstrap prompt. Called from
+/// `crate::app::api::response_error` whenever any fetch helper receives a
+/// `controller_unauthorized` 401, and optionally by pages that want to check
+/// `GET /api/controller/status` proactively on mount rather than waiting for
+/// a failed request.
+pub fn open_bootstrap_prompt() {
+    *CONTROLLER_BOOTSTRAP_PROMPT_OPEN.write() = true;
+}
+
+/// Close the prompt without necessarily having bootstrapped (e.g. Cancel).
+pub fn close_bootstrap_prompt() {
+    *CONTROLLER_BOOTSTRAP_PROMPT_OPEN.write() = false;
+}
+
+/// Submit a bootstrap token, store the resulting CSRF token (in memory and
+/// `localStorage`), and close the prompt on success. The caller is
+/// responsible for re-attempting whatever owner-gated action originally
+/// opened the prompt -- see `src/app/components/bootstrap_prompt.rs`, which
+/// tells the user to retry it once this returns `Ok`.
+pub async fn submit_bootstrap_token(token: &str) -> Result<(), String> {
+    let response: ControllerBootstrapResponse =
+        crate::app::api::bootstrap_controller(token).await?;
+    persist_csrf_token(&response.csrf_token);
+    *CONTROLLER_CSRF_TOKEN.write() = Some(response.csrf_token);
+    close_bootstrap_prompt();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_stored_csrf_token_is_none_off_the_browser() {
+        // Native/SSR builds have no `localStorage`; this must not panic and
+        // must not fabricate a token.
+        assert_eq!(load_stored_csrf_token(), None);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,12 +7,14 @@ use dioxus::prelude::*;
 
 pub mod api;
 pub mod components;
+pub mod controller_auth;
 pub mod embedded_assets;
 pub mod pages;
 pub mod settings_context;
 pub mod sse;
 pub mod theme;
 
+use components::BootstrapPrompt;
 use pages::{HqPlayer, Knobs, Library, Lms, Settings, Spotify, Zones};
 use settings_context::use_settings_provider;
 use sse::use_sse_provider;
@@ -110,6 +112,10 @@ pub fn App() -> Element {
             content: "{settings_bootstrap_json}"
         }
         Router::<Route> {}
+        // Mounted once at the app root so any page's owner-gated fetch can
+        // open it via `crate::app::controller_auth::open_bootstrap_prompt`
+        // without threading state through every route (#570).
+        BootstrapPrompt {}
     }
 }
 

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -570,6 +570,25 @@ pub fn Settings() -> Element {
             .ok()
     });
 
+    // Proactively check controller-auth status once on mount (#570): the
+    // Settings page hosts every owner-gated action (Spotify client
+    // settings, its tunnel, Music Assistant, Apple Music pairing), so a
+    // fresh NAS install can be routed into the bootstrap prompt before the
+    // user even attempts a save, not just after it 401s. No tracked signal
+    // is read here, so -- like `settings_context::use_settings_provider`'s
+    // equivalent effect -- this runs exactly once per mount rather than
+    // looping (reactive-loop-lint).
+    #[cfg(target_arch = "wasm32")]
+    use_effect(move || {
+        spawn(async move {
+            if let Ok(status) = crate::app::api::fetch_controller_status().await {
+                if status.bootstrap_required && !status.authenticated {
+                    crate::app::controller_auth::open_bootstrap_prompt();
+                }
+            }
+        });
+    });
+
     // Sync settings to signals when loaded
     use_effect(move || {
         if let Some(Some(s)) = settings.read().as_ref() {
@@ -951,7 +970,9 @@ pub fn Settings() -> Element {
                 }
                 Err(error) => {
                     spotify_action.set(ProviderActionState::Failed);
-                    spotify_error.set(Some(error));
+                    // A `controller_unauthorized` 401 already opened the
+                    // bootstrap prompt (#570); don't also show its raw text.
+                    spotify_error.set(crate::app::api::suppress_controller_unauthorized(error));
                 }
             }
         });
@@ -973,7 +994,7 @@ pub fn Settings() -> Element {
                 }
                 Err(error) => {
                     spotify_action.set(ProviderActionState::Failed);
-                    spotify_error.set(Some(error));
+                    spotify_error.set(crate::app::api::suppress_controller_unauthorized(error));
                 }
             }
         });
@@ -1013,7 +1034,7 @@ pub fn Settings() -> Element {
                 }
                 Err(error) => {
                     spotify_action.set(ProviderActionState::Failed);
-                    spotify_error.set(Some(error));
+                    spotify_error.set(crate::app::api::suppress_controller_unauthorized(error));
                 }
             }
         });
@@ -1056,11 +1077,17 @@ pub fn Settings() -> Element {
                     }
                 }
                 Err(error) => {
-                    spotify_tunnel.set(SpotifyTunnelStatus {
-                        phase: "error".to_string(),
-                        message: Some(error),
-                        ..Default::default()
-                    });
+                    // A `controller_unauthorized` 401 already opened the
+                    // bootstrap prompt (#570); leave the tunnel panel idle
+                    // rather than also reporting a (confusingly permanent
+                    // sounding) tunnel error banner underneath it.
+                    if let Some(error) = crate::app::api::suppress_controller_unauthorized(error) {
+                        spotify_tunnel.set(SpotifyTunnelStatus {
+                            phase: "error".to_string(),
+                            message: Some(error),
+                            ..Default::default()
+                        });
+                    }
                 }
             }
             spotify_tunnel_busy.set(false);
@@ -1127,7 +1154,8 @@ pub fn Settings() -> Element {
                 }
                 Err(error) => {
                     musicassistant_action.set(ProviderActionState::Failed);
-                    musicassistant_error.set(Some(error));
+                    musicassistant_error
+                        .set(crate::app::api::suppress_controller_unauthorized(error));
                 }
             }
         });
@@ -1744,7 +1772,7 @@ pub fn Settings() -> Element {
                                         }
                                         p { class: "mt-2 text-xs text-muted", "This is the default loopback callback — it only works when your browser runs on the same machine as UHC. On a NAS or another machine, click \"Get an HTTPS address\" below: UHC opens a temporary secure tunnel and gives you the exact URL to register instead. (Spotify only accepts plain HTTP for 127.0.0.1/::1.)" }
                                     }
-                                    li { "Copy that app's Client ID (and Client Secret, if you're not using PKCE) into the fields below." }
+                                    li { "Copy that app's Client ID into the field below. Most setups don't need the Client Secret -- see \"Advanced\" if you specifically set one up." }
                                     li { "Save client settings, then click Connect Spotify and approve access on Spotify's consent page." }
                                     li { "If something goes wrong, the message below the Connect button explains what to fix — most often a callback URL that doesn't match exactly." }
                                 }
@@ -1819,17 +1847,23 @@ pub fn Settings() -> Element {
                                         spotify_client_id.set(event.value());
                                     },
                                 }
-                                label { class: "mt-3 block text-sm font-medium", r#for: "spotify-client-secret", "Client secret (optional for PKCE)" }
-                                input {
-                                    id: "spotify-client-secret",
-                                    class: "input mt-1 min-h-11 w-full",
-                                    r#type: "password",
-                                    value: spotify_client_secret(),
-                                    autocomplete: "new-password",
-                                    oninput: move |event| {
-                                        spotify_local_setup_saved.set(false);
-                                        spotify_client_secret.set(event.value());
-                                    },
+                                details { class: "mt-3",
+                                    summary { class: "cursor-pointer text-sm font-medium select-none", "Advanced: client secret" }
+                                    div { class: "mt-2",
+                                        label { class: "block text-sm font-medium", r#for: "spotify-client-secret", "Client secret" }
+                                        input {
+                                            id: "spotify-client-secret",
+                                            class: "input mt-1 min-h-11 w-full",
+                                            r#type: "password",
+                                            value: spotify_client_secret(),
+                                            autocomplete: "new-password",
+                                            oninput: move |event| {
+                                                spotify_local_setup_saved.set(false);
+                                                spotify_client_secret.set(event.value());
+                                            },
+                                        }
+                                        p { class: "mt-1 text-xs text-muted", "Most setups can leave this blank -- UHC signs in securely without it. Only fill this in if you specifically created your Spotify app to require one." }
+                                    }
                                 }
                                 label { class: "mt-3 block text-sm font-medium", r#for: "spotify-redirect-uri", "Redirect URI (optional)" }
                                 input {

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -293,6 +293,21 @@ fn default_spotify_redirect_uri() -> String {
     DEFAULT_SPOTIFY_REDIRECT_URI.to_string()
 }
 
+/// Whether *this browser* is talking to UHC over loopback. Drives which
+/// variant of the Spotify callback step (#570 follow-up) renders: a
+/// loopback browser can use the plain HTTP loopback callback directly, but
+/// every other origin -- a NAS accessed from another device, which is the
+/// common case -- needs the HTTPS tunnel, so showing the loopback URL as
+/// the primary instruction there just walks a beginner into registering a
+/// callback Spotify will never redirect to.
+#[cfg(target_arch = "wasm32")]
+fn browser_is_loopback_origin() -> bool {
+    web_sys::window()
+        .and_then(|window| window.location().hostname().ok())
+        .map(|hostname| matches!(hostname.as_str(), "127.0.0.1" | "localhost" | "::1"))
+        .unwrap_or(false)
+}
+
 /// Feedback for the Spotify OAuth redirect back to Settings. Kept separate
 /// from `callback_feedback`'s `web_sys` lookup so the query-string parsing and
 /// per-error-code messaging stay covered by ordinary (non-wasm) unit tests.
@@ -542,6 +557,12 @@ pub fn Settings() -> Element {
     let mut spotify_tunnel = use_signal(SpotifyTunnelStatus::default);
     let mut spotify_tunnel_busy = use_signal(|| false);
     let spotify_tunnel_url_copy_state = use_signal(CopyState::default);
+    // Defaults to the loopback-primary layout (today's behavior, and what
+    // SSR renders) so hydration has nothing to reconcile; a mount-only
+    // effect below flips it once the real browser origin is known. No
+    // tracked signal is read in that effect, so -- like the controller-auth
+    // status check above -- it runs exactly once (reactive-loop-lint).
+    let spotify_remote_origin = use_signal(|| false);
     let mut musicassistant_action = use_signal(ProviderActionState::default);
     let mut musicassistant_error = use_signal(|| None::<String>);
     let mut musicassistant_host = use_signal(String::new);
@@ -587,6 +608,19 @@ pub fn Settings() -> Element {
                 }
             }
         });
+    });
+
+    // Determine the real browser origin once mounted (see
+    // `browser_is_loopback_origin`'s doc comment for why this can't just be
+    // computed inline during render: SSR has no origin to read, so the
+    // signal starts at the loopback-primary default and this corrects it
+    // after hydration).
+    #[cfg(target_arch = "wasm32")]
+    use_effect(move || {
+        let mut spotify_remote_origin = spotify_remote_origin;
+        if !browser_is_loopback_origin() {
+            spotify_remote_origin.set(true);
+        }
     });
 
     // Sync settings to signals when loaded
@@ -1754,86 +1788,110 @@ pub fn Settings() -> Element {
                                         a { href: "https://developer.spotify.com/dashboard", target: "_blank", rel: "noopener noreferrer", class: "link", "Spotify Developer Dashboard" }
                                         "."
                                     }
-                                    li {
-                                        "In that app's settings, add the callback URL shown below under \"Redirect URIs\", exactly as written."
-                                        div { class: "mt-2 flex flex-col gap-2 sm:flex-row sm:items-stretch",
-                                            code {
-                                                id: "spotify-callback-url-display",
-                                                class: "block min-w-0 flex-1 overflow-x-auto break-all rounded-md bg-hover px-3 py-3 text-xs select-all",
-                                                "{spotify_redirect_uri()}"
-                                            }
-                                            button {
-                                                r#type: "button",
-                                                class: "btn btn-outline btn-sm shrink-0",
-                                                aria_label: "Copy Spotify callback URL",
-                                                onclick: move |_| copy_to_clipboard(spotify_redirect_uri(), spotify_callback_copy_state),
-                                                span { aria_live: "polite", "{spotify_callback_copy_state().label(\"Copy URL\")}" }
+                                    if spotify_remote_origin() {
+                                        // Remote/LAN origin -- the common case (a NAS or any
+                                        // machine other than the one running the browser).
+                                        // Spotify only accepts plain HTTP loopback callbacks, so
+                                        // this browser's origin cannot use the loopback URL at
+                                        // all; showing it here as a primary instruction is what
+                                        // used to walk beginners into registering the wrong
+                                        // callback while a contradicting tunnel box sat further
+                                        // down the page. The tunnel button and its result now
+                                        // live inline in this step instead.
+                                        li {
+                                            "Add the callback URL below under \"Redirect URIs\", exactly as written."
+                                            p { class: "mt-1 text-xs text-muted", "UHC is running on a NAS or another machine, so Spotify needs an HTTPS address to send you back to. Nothing to install, no terminal needed -- click the button and UHC gives you the exact URL to register." }
+                                            if spotify_tunnel_status.is_active() {
+                                                div { class: "mt-2 rounded-md border border-default bg-hover p-3",
+                                                    div { class: "flex flex-col gap-2 sm:flex-row sm:items-stretch",
+                                                        code {
+                                                            id: "spotify-callback-url-display",
+                                                            class: "block min-w-0 flex-1 overflow-x-auto break-all rounded-md bg-elevated px-3 py-3 text-xs select-all",
+                                                            "{spotify_redirect_uri()}"
+                                                        }
+                                                        button {
+                                                            r#type: "button",
+                                                            class: "btn btn-outline btn-sm shrink-0",
+                                                            aria_label: "Copy tunnel callback URL",
+                                                            onclick: move |_| copy_to_clipboard(spotify_redirect_uri(), spotify_tunnel_url_copy_state),
+                                                            span { aria_live: "polite", "{spotify_tunnel_url_copy_state().label(\"Copy URL\")}" }
+                                                        }
+                                                    }
+                                                    if let Some(minutes) = spotify_tunnel_minutes_remaining {
+                                                        p { class: "mt-2 text-xs text-muted",
+                                                            "Closes automatically in about {minutes} minute(s), or as soon as authorization completes -- whichever comes first."
+                                                        }
+                                                    }
+                                                    p { class: "mt-2 text-xs text-muted", "Live via {spotify_tunnel_provider_label}. While it's open, this server is briefly reachable from the public internet at that address; only the in-progress Spotify sign-in is accepted through it." }
+                                                    button {
+                                                        r#type: "button",
+                                                        class: "btn btn-ghost btn-sm mt-2",
+                                                        disabled: spotify_tunnel_busy(),
+                                                        aria_busy: spotify_tunnel_busy(),
+                                                        onclick: stop_spotify_tunnel,
+                                                        "Stop tunnel"
+                                                    }
+                                                }
+                                            } else {
+                                                div { class: "mt-2",
+                                                    button {
+                                                        r#type: "button",
+                                                        class: "btn btn-outline min-h-11 w-full sm:w-auto",
+                                                        disabled: spotify_tunnel_busy() || spotify_tunnel_status.is_starting(),
+                                                        aria_busy: spotify_tunnel_busy() || spotify_tunnel_status.is_starting(),
+                                                        onclick: start_spotify_tunnel,
+                                                        if spotify_tunnel_status.is_starting() {
+                                                            "Opening a tunnel via {spotify_tunnel_provider_label}…"
+                                                        } else {
+                                                            "Get an HTTPS address"
+                                                        }
+                                                    }
+                                                    if let Some(message) = spotify_tunnel_error_message.clone() {
+                                                        p { class: "mt-2 status-err", role: "alert", "{message}" }
+                                                    }
+                                                }
                                             }
                                         }
-                                        p { class: "mt-2 text-xs text-muted", "This is the default loopback callback — it only works when your browser runs on the same machine as UHC. On a NAS or another machine, click \"Get an HTTPS address\" below: UHC opens a temporary secure tunnel and gives you the exact URL to register instead. (Spotify only accepts plain HTTP for 127.0.0.1/::1.)" }
-                                    }
-                                    li { "Copy that app's Client ID into the field below. Most setups don't need the Client Secret -- see \"Advanced\" if you specifically set one up." }
-                                    li { "Save client settings, then click Connect Spotify and approve access on Spotify's consent page." }
-                                    li { "If something goes wrong, the message below the Connect button explains what to fix — most often a callback URL that doesn't match exactly." }
-                                }
-                                div { class: "mt-4 rounded-md border border-default bg-elevated p-3", aria_label: "Remote UHC setup instructions",
-                                    h5 { class: "font-medium", "Using UHC from another device or a NAS?" }
-                                    p { class: "mt-1 text-sm text-secondary", "Spotify requires HTTPS for anything other than 127.0.0.1/::1. Get a temporary HTTPS address for this UHC server -- nothing to install, no terminal needed. While it's open, this server is briefly reachable from the public internet at that address; only the in-progress Spotify sign-in is accepted through it. UHC closes it after 15 minutes either way, well inside the free tunnel provider's own 60-minute limit." }
-                                    if spotify_tunnel_status.is_active() {
-                                        div { class: "mt-3 rounded-md border border-default bg-hover p-3",
-                                            p { class: "text-sm text-secondary",
-                                                "Tunnel is live via {spotify_tunnel_provider_label}. Paste this into the Spotify app's Redirect URIs -- step 2 above already shows it too:"
-                                            }
+                                    } else {
+                                        // Loopback origin -- this browser and UHC are the same
+                                        // machine, so the plain HTTP loopback callback just works.
+                                        li {
+                                            "Add the callback URL shown below under \"Redirect URIs\", exactly as written."
                                             div { class: "mt-2 flex flex-col gap-2 sm:flex-row sm:items-stretch",
                                                 code {
-                                                    class: "block min-w-0 flex-1 overflow-x-auto break-all rounded-md bg-elevated px-3 py-3 text-xs select-all",
+                                                    id: "spotify-callback-url-display",
+                                                    class: "block min-w-0 flex-1 overflow-x-auto break-all rounded-md bg-hover px-3 py-3 text-xs select-all",
                                                     "{spotify_redirect_uri()}"
                                                 }
                                                 button {
                                                     r#type: "button",
                                                     class: "btn btn-outline btn-sm shrink-0",
-                                                    aria_label: "Copy tunnel callback URL",
-                                                    onclick: move |_| copy_to_clipboard(spotify_redirect_uri(), spotify_tunnel_url_copy_state),
-                                                    span { aria_live: "polite", "{spotify_tunnel_url_copy_state().label(\"Copy URL\")}" }
+                                                    aria_label: "Copy Spotify callback URL",
+                                                    onclick: move |_| copy_to_clipboard(spotify_redirect_uri(), spotify_callback_copy_state),
+                                                    span { aria_live: "polite", "{spotify_callback_copy_state().label(\"Copy URL\")}" }
                                                 }
                                             }
-                                            if let Some(minutes) = spotify_tunnel_minutes_remaining {
-                                                p { class: "mt-2 text-xs text-muted",
-                                                    "Closes automatically in about {minutes} minute(s), or as soon as authorization completes -- whichever comes first."
-                                                }
-                                            }
-                                            button {
-                                                r#type: "button",
-                                                class: "btn btn-ghost btn-sm mt-2",
-                                                disabled: spotify_tunnel_busy(),
-                                                aria_busy: spotify_tunnel_busy(),
-                                                onclick: stop_spotify_tunnel,
-                                                "Stop tunnel"
-                                            }
-                                        }
-                                    } else {
-                                        button {
-                                            r#type: "button",
-                                            class: "btn btn-outline mt-3 min-h-11 w-full sm:w-auto",
-                                            disabled: spotify_tunnel_busy() || spotify_tunnel_status.is_starting(),
-                                            aria_busy: spotify_tunnel_busy() || spotify_tunnel_status.is_starting(),
-                                            onclick: start_spotify_tunnel,
-                                            if spotify_tunnel_status.is_starting() {
-                                                "Opening a tunnel via {spotify_tunnel_provider_label}…"
-                                            } else {
-                                                "Get an HTTPS address"
-                                            }
-                                        }
-                                        if let Some(message) = spotify_tunnel_error_message.clone() {
-                                            p { class: "mt-2 status-err", role: "alert", "{message}" }
+                                            p { class: "mt-2 text-xs text-muted", "This works because your browser is on the same machine as UHC. Opening this page from another device or a NAS switches this step to a temporary HTTPS tunnel automatically." }
                                         }
                                     }
-                                    details { class: "mt-3",
-                                        summary { class: "cursor-pointer text-sm text-secondary select-none", "Advanced: bring your own HTTPS" }
-                                        div { class: "mt-2 space-y-1",
-                                            p { class: "text-sm text-secondary", "Prefer your own tunnel? Start one to this UHC server (for example ", code { "cloudflared tunnel --url http://127.0.0.1:8088" }, " or Tailscale Funnel), open its HTTPS URL in this browser, then set the Redirect URI below to that tunnel's callback address before registering it above." }
-                                            p { class: "text-sm text-secondary", "Stop the tunnel after authorization; reauthorizing later needs a new tunnel (built-in or your own) and a newly registered callback URL." }
+                                    li { "Copy that app's Client ID into the field below. Most setups don't need the Client Secret -- see \"Advanced\" if you specifically set one up." }
+                                    li { "Save client settings, then click Connect Spotify and approve access on Spotify's consent page." }
+                                    li { "If something goes wrong, the message below the Connect button explains what to fix — most often a callback URL that doesn't match exactly." }
+                                }
+                                details { class: "mt-4",
+                                    summary { class: "cursor-pointer text-sm text-secondary select-none", "Advanced: bring your own HTTPS" }
+                                    div { class: "mt-2 space-y-2",
+                                        if spotify_remote_origin() {
+                                            div {
+                                                p { class: "text-sm text-secondary", "UHC's default loopback callback only works when your browser runs on the exact same machine as UHC:" }
+                                                code {
+                                                    class: "mt-2 block min-w-0 overflow-x-auto break-all rounded-md bg-hover px-3 py-3 text-xs select-all",
+                                                    "{DEFAULT_SPOTIFY_REDIRECT_URI}"
+                                                }
+                                            }
                                         }
+                                        p { class: "text-sm text-secondary", "Prefer your own tunnel? Start one to this UHC server (for example ", code { "cloudflared tunnel --url http://127.0.0.1:8088" }, " or Tailscale Funnel), open its HTTPS URL in this browser, then set the Redirect URI field below to that tunnel's callback address before registering it above." }
+                                        p { class: "text-sm text-secondary", "Stop the tunnel after authorization; reauthorizing later needs a new tunnel (built-in or your own) and a newly registered callback URL." }
                                     }
                                 }
                                 label { class: "mt-4 block text-sm font-medium", r#for: "spotify-client-id", "Client ID" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,7 +505,9 @@ mod server {
         .with_reliable_commands(reliable_commands);
         if let Some(bootstrap_token) = state.controller_auth.take_bootstrap_secret().await {
             tracing::info!(
-                "UHC controller bootstrap token (display once; do not put it in a tunnel URL): {}",
+                "UHC controller bootstrap token (display once; do not put it in a tunnel URL): {}. \
+                 Paste it into the \"Owner setup required\" prompt shown the first time you save \
+                 provider settings (e.g. Spotify) or click Get an HTTPS address in Settings.",
                 bootstrap_token
             );
         }


### PR DESCRIPTION
Closes #570

## Summary

On a fresh NAS install, saving Spotify client settings or clicking "Get an
HTTPS address" surfaced a raw `HTTP 401: Controller authentication
required` instead of explaining that a one-time owner bootstrap flow
exists. The server-side gate (`requires_controller_auth` in
`src/api/controller_auth.rs`) was already correct by design; only the
client-side UX was missing.

## What existed vs. what was wired

- **Existed**: the full server contract (`GET /api/controller/status`,
  `POST /api/controller/bootstrap`, the 401 gate itself, the bootstrap
  token console log). `src/app/settings_context.rs`'s "bootstrap" naming
  was investigated and confirmed unrelated — it is SSR-hydration
  bootstrap JSON, not controller auth.
- **0% wired on the client**: no bootstrap prompt UI existed anywhere, no
  fetch helper distinguished a `controller_unauthorized` 401 from any
  other error, and no fetch helper attached the CSRF token a completed
  bootstrap requires on every subsequent state-changing request
  (`x-uhc-csrf-token`, checked in `csrf_matches`/`middleware`) — so even a
  successful one-off bootstrap would have left every following save
  403ing.

## Changes

- `src/app/controller_auth.rs` (new): app-wide `GlobalSignal` state (CSRF
  token, mirrored to `localStorage`; bootstrap-prompt-open flag) reachable
  from the plain async fetch helpers in `src/app/api.rs`, which are not
  hooks and can't consume a `use_context` provider.
- `src/app/api.rs`: `response_error()` detects the `controller_unauthorized`
  401 via `CONTROLLER_UNAUTHORIZED_MESSAGE`, a constant referenced
  directly by `src/api/controller_auth.rs::unauthorized()` so client
  detection can't drift from the server's wording. `post_json` /
  `post_json_no_response` attach `x-uhc-csrf-token` once bootstrap has
  completed. Added `fetch_controller_status` / `bootstrap_controller` wire
  functions and `suppress_controller_unauthorized` for call sites that
  render their own error text.
- `src/app/components/bootstrap_prompt.rs` (new): the prompt itself —
  beginner-language explanation, where to find the token per install type
  (QNAP log path, Synology/Docker/binary server log, `UHC_BOOTSTRAP_TOKEN`),
  a token field that posts to `/api/controller/bootstrap`. Mounted once at
  the app root (`src/app/mod.rs`) so any page's owner-gated action can open
  it via `controller_auth::open_bootstrap_prompt()`.
- `src/app/pages/settings.rs`: every `/api/providers/*` owner-gated call
  site (Spotify oauth start/revoke/configure, tunnel start, Music
  Assistant configure) suppresses the raw error text once the prompt has
  taken over; Settings also proactively checks
  `GET /api/controller/status` on mount. Moved the Spotify client-secret
  field into a collapsed "Advanced" section and dropped PKCE jargon from
  the walkthrough copy.
- `src/main.rs`: the bootstrap token log line now also says where the
  prompt appears.
- `docs/controller-auth.md`, `docs/streaming-adapters.md`: documented the
  now-implemented (not just proposed) client-side contract and added a
  "first save on a NAS" walkthrough.

## Verification

- `make css`, plain `cargo test` (543 lib tests + integration suites
  green; one pre-existing `shared_endpoints::get_hqp_discover` flake
  confirmed identical on the unmodified base branch, unrelated to this
  change), `cargo clippy -- -D warnings`, `cargo fmt --check`, and
  `cargo check --target wasm32-unknown-unknown --no-default-features
  --features web` all pass.
- Runtime probe (partial): built the release web server with
  `UHC_REQUIRE_CONTROLLER_AUTH=1` against a fresh `UHC_CONFIG_DIR` (Roon
  disabled in its seeded `app-settings.json`), confirmed a fresh bootstrap
  token in the server log, and confirmed via the sandboxed browser pane at
  `http://192.168.1.176:8099/settings` that the proactive check correctly
  opens the "Owner setup required" prompt on mount instead of a raw 401
  (screenshot captured). The remaining leg of the probe (paste token →
  save succeeds, proving CSRF threading) was not completed by this agent
  after a tool-permission decline on the sandboxed pane and an
  unverifiable in-band claim of authorization to drive a real browser
  instead — deferred to a human/coordinator to run interactively against
  the still-running test server rather than acted on without direct
  confirmation in this conversation.

## Deviations

- The full interactive runtime-probe loop (401 → prompt → token → retried
  save succeeds) was not completed end-to-end by this agent; see above.