### PR TITLE
fix(library): Library defect audit fixes (defects 1-8, 10, 11 + visual pass V1-V4) — progresses #573

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -237,6 +237,127 @@ pub(crate) fn is_ungrounded_grouping(item: &BrowseItem) -> bool {
     is_category(item) || looks_like_a_result_count_grouping(item)
 }
 
+/// Whether an action-hinted browse row is a *verb* ("Play Playlist",
+/// "Shuffle", ...) rather than playable leaf content (a track).
+///
+/// #573 defect 1: #545 dropped every `hint: action`/`action_list` row from
+/// `hifi_collections browse` listings -- but a live Core marks a playlist's
+/// and an album's **track rows** `action_list` too (entering a track opens
+/// its Play Now/Queue/Start Radio menu), so every album and playlist level
+/// came back `items: []`. The two kinds must be told apart:
+///
+/// - `hint: action` rows fire immediately when browsed (the #545 live repro's
+///   "Play Playlist") -- always an action row, never content.
+/// - `hint: action_list` rows are only action rows when they read as a play
+///   verb *and* carry none of the content signals every live track row
+///   carried (an artist subtitle, artwork). A track named "Play That Funky
+///   Music" keeps its subtitle/artwork and stays content; a bare
+///   "Play Album"/"Play Playlist"/"Shuffle" wrapper row has neither.
+pub(crate) fn is_immediate_action_row(item: &BrowseItem) -> bool {
+    match item.hint {
+        Some(ItemHint::Action) => true,
+        Some(ItemHint::ActionList) => {
+            item.subtitle.as_deref().map_or(true, str::is_empty)
+                && item.image_key.is_none()
+                && is_play_verb_title(&item.title)
+        }
+        _ => false,
+    }
+}
+
+/// Whether a row title reads as one of Roon's play verbs.
+///
+/// The vocabulary is every context verb observed live (#545's repro and the
+/// #573 crawl) plus the canonical three-item menu -- deliberately a closed
+/// list, not a "starts with play" prefix match, so a track that merely starts
+/// with the word "play" cannot be mistaken for a verb (see
+/// [`is_immediate_action_row`]'s second signal for the belt-and-braces
+/// subtitle/artwork requirement on top of this).
+fn is_play_verb_title(title: &str) -> bool {
+    let lower = title.trim().to_lowercase();
+    matches!(
+        lower.as_str(),
+        "play now" | "shuffle" | "queue" | "add next" | "add to queue" | "start radio"
+    ) || lower.strip_prefix("play ").is_some_and(|noun| {
+        matches!(
+            noun,
+            "now"
+                | "album"
+                | "playlist"
+                | "playlists"
+                | "artist"
+                | "track"
+                | "tracks"
+                | "all"
+                | "genre"
+                | "composer"
+                | "work"
+                | "station"
+                | "radio station"
+        )
+    })
+}
+
+/// Whether a row is Roon's "No Results" placeholder rather than content.
+///
+/// #573 defect 7: an empty node (the live crawl's "My Live Radio") comes back
+/// as a single row titled "No Results" that still carries an `item_key`, so
+/// `classify_navigability`'s "non-list row with a key is playable" rule
+/// minted a play ref for it and the UI offered Play on a non-item. Matched by
+/// title plus the absence of every content signal (subtitle, artwork), same
+/// belt-and-braces shape as [`is_immediate_action_row`], so a real track that
+/// happens to be titled "No Results" keeps its subtitle/art and stays.
+pub(crate) fn is_no_results_placeholder(item: &BrowseItem) -> bool {
+    item.title.eq_ignore_ascii_case("no results")
+        && item.subtitle.as_deref().map_or(true, str::is_empty)
+        && item.image_key.is_none()
+        && !matches!(item.hint, Some(ItemHint::List))
+}
+
+/// Strip Roon's `[[id|Name]]` link markup down to `Name`, leaving all other
+/// text untouched.
+///
+/// #573 defect 5: browse `subtitle` fields embed Roon's internal link markup
+/// verbatim -- `[[55418|Michael Jackson]]`, including compound credits like
+/// `[[8827258|Willie Colón]] & [[1981050|Rubén Blades]]`. Clients (the web
+/// UI, `hifi_collections`, `hifi_search`) have no use for the ids, so the
+/// adapter mapping strips them to plain names in one place. Malformed markup
+/// (an unterminated `[[`, no `|`) is passed through literally rather than
+/// guessed at.
+pub(crate) fn strip_roon_link_markup(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find("[[") {
+        let (before, after_open) = rest.split_at(start);
+        out.push_str(before);
+        let body = &after_open[2..];
+        match body.find("]]") {
+            Some(end) => {
+                let inner = &body[..end];
+                match inner.split_once('|') {
+                    // `[[id|Name]]` -> `Name`
+                    Some((_, name)) => out.push_str(name),
+                    // `[[something]]` without a `|`: not Roon's link shape;
+                    // keep it verbatim.
+                    None => {
+                        out.push_str("[[");
+                        out.push_str(inner);
+                        out.push_str("]]");
+                    }
+                }
+                rest = &body[end + 2..];
+            }
+            None => {
+                // Unterminated `[[`: keep the rest verbatim.
+                out.push_str(after_open);
+                return out;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 /// Strip "roon:" prefix from zone/output IDs.
 /// MCP and aggregator use prefixed IDs (e.g., "roon:zone_123"), but Roon API expects bare IDs.
 fn strip_roon_prefix(id: &str) -> &str {
@@ -2061,7 +2182,7 @@ impl RoonAdapter {
         }
         self.browse(opts).await?;
 
-        let load = self
+        let mut load = self
             .load(LoadOpts {
                 multi_session_key: Some(session_key.clone()),
                 offset,
@@ -2069,6 +2190,54 @@ impl RoonAdapter {
                 ..Default::default()
             })
             .await?;
+
+        // #573 defect 11: entering an album from a search hit lands on an
+        // intermediate level whose sole row is the album itself again (same
+        // title as the level, `hint: list`), forcing a second click that adds
+        // nothing. When a non-root level's entire content is that one
+        // self-referential list row, descend through it so the caller gets
+        // the real level (the tracks) in one step. The title-equality guard
+        // keeps a legitimate single-child folder (an artist with one album)
+        // untouched. One descent only -- Roon does not nest this shape.
+        if item_key.is_some() && load.list.count == 1 {
+            let only_row = match load.items.first() {
+                Some(row) => Some(row.clone()),
+                // A paged request (offset past the single row) still needs
+                // the row to decide; fetch it without disturbing `offset`.
+                None => self
+                    .load(LoadOpts {
+                        multi_session_key: Some(session_key.clone()),
+                        offset: 0,
+                        count: Some(1),
+                        ..Default::default()
+                    })
+                    .await?
+                    .items
+                    .into_iter()
+                    .next(),
+            };
+            if let Some(row) = only_row {
+                if matches!(row.hint, Some(ItemHint::List)) && row.title == load.list.title {
+                    if let Some(self_key) = row.item_key.as_deref() {
+                        self.browse(BrowseOpts {
+                            multi_session_key: Some(session_key.clone()),
+                            item_key: Some(self_key.to_string()),
+                            zone_or_output_id: Some(bare_zone_id.to_string()),
+                            ..Default::default()
+                        })
+                        .await?;
+                        load = self
+                            .load(LoadOpts {
+                                multi_session_key: Some(session_key.clone()),
+                                offset,
+                                count: Some(limit),
+                                ..Default::default()
+                            })
+                            .await?;
+                    }
+                }
+            }
+        }
 
         // #545: a level must never hand back the very item it was just
         // entered through as one of its own children -- browsing that child
@@ -2148,8 +2317,21 @@ impl RoonAdapter {
                 )
             })
             .count();
+        // #573 defect 1: `action_list`-hinted track rows are content, not
+        // action rows (see `is_immediate_action_row`) -- only the verb rows
+        // that get filtered out of listings count against "other content"
+        // here, or an album whose whole peek window is [Play Album,
+        // track, track, ...] would read as a pure action leaf and lose its
+        // navigability. `playable` stays judged on the broad action count:
+        // any action-ish row one level down means Roon can play this
+        // directly.
+        let immediate_action_rows = loaded
+            .items
+            .iter()
+            .filter(|item| is_immediate_action_row(item))
+            .count();
         let playable = action_rows_seen > 0;
-        let has_other_content = loaded.list.count > action_rows_seen;
+        let has_other_content = loaded.list.count > immediate_action_rows;
         Ok((playable, has_other_content))
     }
 
@@ -2189,6 +2371,90 @@ impl RoonAdapter {
         // play action (an album, a playlist) stays navigable too.
         let navigable = list_hinted && (!playable || has_other_content);
         (navigable, playable)
+    }
+
+    /// Filter and map one raw browse page into `hifi_collections`' item
+    /// shape, appending to `mapped`. Shared by `content()`'s first-page
+    /// mapping and its #573 fetch-ahead loop so the two can never disagree
+    /// about what a listing row is.
+    async fn map_collection_page(
+        &self,
+        zone_id: &str,
+        items: Vec<BrowseItem>,
+        at_collection_root: bool,
+        mapped: &mut Vec<Value>,
+    ) {
+        for item in items {
+            // #573 defect 3: the exact-title category filter
+            // (`is_category`) was verified for *search result* levels only,
+            // but the Library node's real children are titled exactly
+            // "Artists"/"Albums"/"Tracks"/... too -- so it swallowed the
+            // whole Library level down to "Search". Browse levels rely on
+            // the source-independent `"<N> Results"` subtitle signal alone;
+            // search paths (`hifi_search`) keep the stricter dual check.
+            if looks_like_a_result_count_grouping(&item) {
+                continue;
+            }
+            if at_collection_root {
+                // #566 (live install): Roon's browse root also carries its
+                // own "Settings" node -- extension configuration inside
+                // Roon's hierarchy, not music content. It has no `item_key`
+                // (nothing to browse into or play) and was leaking through
+                // as a permanently inert row. Matched by title, documented
+                // as such, and scoped to the true root only, so a
+                // differently-purposed "Settings" row nested deeper in the
+                // hierarchy (if one ever exists) is untouched.
+                if item.title == "Settings" {
+                    continue;
+                }
+                // #573 defect 4: the root's "Playlists" node duplicates the
+                // dedicated Playlists tab (`collections_playlists` enters
+                // the same node by name), so the Browse tab hides it rather
+                // than offering the same list twice.
+                if item.title == "Playlists" {
+                    continue;
+                }
+            }
+            // #545 / #573 defect 1: verb rows ("Play Playlist", "Play
+            // Album", "Shuffle", ...) are the implementation detail
+            // `resolve_item_key` walks to invoke a play action, not
+            // addressable content. But a live Core also marks playlist and
+            // album *track rows* `action_list` -- dropping every
+            // action-hinted row (as #545 first did) emptied every album and
+            // playlist level. `is_immediate_action_row` keeps the verb rows
+            // out while the action_list-hinted playable leaf rows stay.
+            if matches!(item.hint, Some(ItemHint::Header)) || is_immediate_action_row(&item) {
+                continue;
+            }
+            // #573 defect 7: Roon renders an empty node as a "No Results"
+            // placeholder row that still carries an `item_key`; minting a
+            // play ref for it offers Play on a non-item.
+            if is_no_results_placeholder(&item) {
+                continue;
+            }
+            let (navigable, playable) = self.classify_navigability(zone_id, &item).await;
+            // #573 defect 4: at the collection root, "Library" repeats the
+            // page's own name (the UI breadcrumb read "Library / Library").
+            // "Local Library" names the same node distinguishably.
+            let title = if at_collection_root && item.title == "Library" {
+                "Local Library".to_string()
+            } else {
+                // #573 defect 5: strip `[[id|Name]]` link markup.
+                strip_roon_link_markup(&item.title)
+            };
+            mapped.push(serde_json::json!({
+                "title": title,
+                "subtitle": item.subtitle.as_deref().map(strip_roon_link_markup),
+                "item_key": item.item_key,
+                "navigable": navigable,
+                "playable": playable,
+                // #549: Roon's own image_key, resolved through the same
+                // `RoonAdapter::get_image` now-playing art already uses --
+                // `hifi_collections` mints an opaque ref over this rather
+                // than handing it to a client directly.
+                "image_key": item.image_key,
+            }));
+        }
     }
 
     /// Enter a named top-level browse node (`"Playlists"`, ...) in a fresh
@@ -3067,56 +3333,38 @@ impl LibraryAdapter for RoonAdapter {
                         .await?
                 };
                 let mut mapped: Vec<Value> = Vec::new();
-                for item in items {
-                    if is_ungrounded_grouping(&item) {
-                        continue;
+                self.map_collection_page(zone_id, items, at_collection_root, &mut mapped)
+                    .await;
+                // #573 defect 8: `next_offset` used to be computed against
+                // Roon's raw `list.count`, *before* the grouping/action-row
+                // filters above dropped items -- so a fully-filtered page
+                // advertised "Load more" over nothing, potentially forever.
+                // Fetch ahead instead: while the filtered page is still
+                // short and raw rows remain, load and filter further chunks
+                // (bounded), and advertise a next page only when raw rows
+                // genuinely remain past what was consumed.
+                let mut consumed = (offset + limit).min(total);
+                const FETCH_AHEAD_ROUNDS: usize = 4;
+                let mut rounds = 0;
+                while mapped.len() < limit && consumed < total && rounds < FETCH_AHEAD_ROUNDS {
+                    let chunk = self
+                        .load(LoadOpts {
+                            multi_session_key: Some(session_key.clone()),
+                            offset: consumed,
+                            count: Some(limit),
+                            ..Default::default()
+                        })
+                        .await?;
+                    if chunk.items.is_empty() {
+                        consumed = total;
+                        break;
                     }
-                    // #566 (live install): Roon's browse root also carries
-                    // its own "Settings" node -- extension configuration
-                    // inside Roon's hierarchy, not music content. It has no
-                    // `item_key` (nothing to browse into or play) and was
-                    // leaking through as a permanently inert row. Matched by
-                    // title, documented as such, and scoped to the true
-                    // root only, so a differently-purposed "Settings" row
-                    // nested deeper in the hierarchy (if one ever exists) is
-                    // untouched. Real music nodes (Library, Playlists,
-                    // Radio, TIDAL, Qobuz, ...) are never named "Settings"
-                    // and are unaffected.
-                    if at_collection_root && item.title == "Settings" {
-                        continue;
-                    }
-                    // #545: Header/Action/ActionList rows are the
-                    // implementation detail `resolve_item_key` walks to
-                    // invoke a play action, not addressable content -- a
-                    // real Core mixes them into an otherwise-ordinary level
-                    // (e.g. a playlist's own browse: `["Play Playlist",
-                    // <track>, <track>, ...]`), and rendering them as plain
-                    // browse rows is what put a stray "Play Album"/"Play
-                    // Playlist" entry in the list next to real content.
-                    if matches!(
-                        item.hint,
-                        Some(ItemHint::Header)
-                            | Some(ItemHint::Action)
-                            | Some(ItemHint::ActionList)
-                    ) {
-                        continue;
-                    }
-                    let (navigable, playable) = self.classify_navigability(zone_id, &item).await;
-                    mapped.push(serde_json::json!({
-                        "title": item.title,
-                        "subtitle": item.subtitle,
-                        "item_key": item.item_key,
-                        "navigable": navigable,
-                        "playable": playable,
-                        // #549: Roon's own image_key, resolved through the
-                        // same `RoonAdapter::get_image` now-playing art
-                        // already uses -- `hifi_collections` mints an
-                        // opaque ref over this rather than handing it to a
-                        // client directly.
-                        "image_key": item.image_key,
-                    }));
+                    consumed = (consumed + chunk.items.len()).min(total);
+                    self.map_collection_page(zone_id, chunk.items, at_collection_root, &mut mapped)
+                        .await;
+                    rounds += 1;
                 }
-                let next_offset = (total > offset + limit).then_some((offset + limit) as u64);
+                let next_offset = (consumed < total).then_some(consumed as u64);
                 Ok(serde_json::json!({
                     "session_key": session_key,
                     "items": mapped,

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -257,7 +257,7 @@ pub(crate) fn is_immediate_action_row(item: &BrowseItem) -> bool {
     match item.hint {
         Some(ItemHint::Action) => true,
         Some(ItemHint::ActionList) => {
-            item.subtitle.as_deref().map_or(true, str::is_empty)
+            item.subtitle.as_deref().is_none_or(str::is_empty)
                 && item.image_key.is_none()
                 && is_play_verb_title(&item.title)
         }
@@ -309,7 +309,7 @@ fn is_play_verb_title(title: &str) -> bool {
 /// happens to be titled "No Results" keeps its subtitle/art and stays.
 pub(crate) fn is_no_results_placeholder(item: &BrowseItem) -> bool {
     item.title.eq_ignore_ascii_case("no results")
-        && item.subtitle.as_deref().map_or(true, str::is_empty)
+        && item.subtitle.as_deref().is_none_or(str::is_empty)
         && item.image_key.is_none()
         && !matches!(item.hint, Some(ItemHint::List))
 }
@@ -4467,6 +4467,116 @@ async fn run_roon_loop(
 
 // Startable trait implementation via macro
 crate::impl_startable!(RoonAdapter, "roon", is_configured);
+
+#[cfg(test)]
+mod defect_573_row_classification {
+    use super::*;
+
+    fn item(title: &str, hint: Option<ItemHint>) -> BrowseItem {
+        BrowseItem {
+            title: title.to_string(),
+            subtitle: None,
+            image_key: None,
+            item_key: Some("k".to_string()),
+            hint,
+            input_prompt: None,
+        }
+    }
+
+    /// Every play-verb shape observed live is an action row.
+    #[test]
+    fn verb_rows_are_immediate_action_rows() {
+        for title in [
+            "Play Now",
+            "Play Album",
+            "Play Playlist",
+            "Play Artist",
+            "Shuffle",
+            "Queue",
+            "Start Radio",
+        ] {
+            assert!(
+                is_immediate_action_row(&item(title, Some(ItemHint::ActionList))),
+                "{title} (action_list) must classify as an action row"
+            );
+        }
+        // A plain `action` hint always fires immediately, whatever its title.
+        assert!(is_immediate_action_row(&item(
+            "Anything",
+            Some(ItemHint::Action)
+        )));
+    }
+
+    /// #573 defect 1: an `action_list` track row (artist subtitle, artwork)
+    /// is content, never an action row -- including tracks whose titles
+    /// start with "Play".
+    #[test]
+    fn action_list_track_rows_are_content() {
+        let mut track = item("So What", Some(ItemHint::ActionList));
+        track.subtitle = Some("Miles Davis".to_string());
+        assert!(!is_immediate_action_row(&track));
+
+        let mut tricky = item("Play That Funky Music", Some(ItemHint::ActionList));
+        tricky.subtitle = Some("Wild Cherry".to_string());
+        assert!(
+            !is_immediate_action_row(&tricky),
+            "a track titled with the word Play keeps its subtitle and stays content"
+        );
+
+        // Even a bare action_list row is content unless its title reads as
+        // a known verb.
+        assert!(!is_immediate_action_row(&item(
+            "Blue in Green",
+            Some(ItemHint::ActionList)
+        )));
+
+        // List rows are never action rows.
+        assert!(!is_immediate_action_row(&item(
+            "Play Album",
+            Some(ItemHint::List)
+        )));
+    }
+
+    /// #573 defect 7: the placeholder is matched by title plus the absence
+    /// of every content signal.
+    #[test]
+    fn no_results_placeholder_is_detected() {
+        assert!(is_no_results_placeholder(&item("No Results", None)));
+        assert!(is_no_results_placeholder(&item("no results", None)));
+
+        let mut real_track = item("No Results", None);
+        real_track.subtitle = Some("Some Band".to_string());
+        assert!(
+            !is_no_results_placeholder(&real_track),
+            "a real track titled No Results keeps its subtitle and stays"
+        );
+        assert!(!is_no_results_placeholder(&item(
+            "No Results",
+            Some(ItemHint::List)
+        )));
+    }
+
+    /// #573 defect 5: markup stripping, including the compound live shapes.
+    #[test]
+    fn link_markup_is_stripped_to_plain_names() {
+        assert_eq!(
+            strip_roon_link_markup("[[55418|Michael Jackson]]"),
+            "Michael Jackson"
+        );
+        assert_eq!(
+            strip_roon_link_markup("[[8827258|Willie Colón]] & [[1981050|Rubén Blades]]"),
+            "Willie Colón & Rubén Blades"
+        );
+        assert_eq!(strip_roon_link_markup("plain text"), "plain text");
+        // Malformed shapes pass through verbatim rather than being guessed at.
+        assert_eq!(strip_roon_link_markup("[[no pipe]]"), "[[no pipe]]");
+        assert_eq!(strip_roon_link_markup("[[unterminated"), "[[unterminated");
+        assert_eq!(
+            strip_roon_link_markup("prefix [[1|Name]] suffix"),
+            "prefix Name suffix"
+        );
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -279,6 +279,14 @@ pub struct Zone {
     /// will refuse every call.
     #[serde(default)]
     pub browse_supported: bool,
+    /// Which Library-page tabs this zone's provider serves (#573 defect 6):
+    /// a subset of `["browse", "playlists", "favorites", "radio"]`, derived
+    /// server-side from the capability matrix. `default`s to empty, which
+    /// the Library page treats as "no information -- show every tab" so a
+    /// response from a build predating this field degrades to the old
+    /// behavior rather than hiding everything.
+    #[serde(default)]
+    pub library_tabs: Vec<String>,
 }
 
 // =============================================================================
@@ -458,7 +466,11 @@ pub struct CollectionItem {
     pub path: Option<String>,
     #[serde(rename = "ref", default)]
     pub item_ref: Option<String>,
-    /// Opaque artwork ref, resolved via `GET /api/collections/image?ref=...`.
+    /// Artwork URL, used verbatim as an `<img src>`. The server sends the
+    /// complete same-origin path (`/api/collections/image?ref=...`) --
+    /// #573 defect 2: the UI must never prepend anything to it (an earlier
+    /// draft documented this as a bare ref and the UI double-prefixed it,
+    /// 404ing every image).
     #[serde(default)]
     pub image: Option<String>,
 }
@@ -577,6 +589,11 @@ pub struct SearchResult {
     /// same way (open into browse, push a breadcrumb).
     #[serde(default)]
     pub path: Option<String>,
+    /// Artwork URL (#573 defect 10) -- same contract as
+    /// `CollectionItem::image`: a complete same-origin path, used verbatim
+    /// as an `<img src>`.
+    #[serde(default)]
+    pub image: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src/app/components/zones_strip.rs
+++ b/src/app/components/zones_strip.rs
@@ -145,6 +145,14 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
 
     rsx! {
         div { class: "zones-strip",
+            // #573 (visual pass V4): Escape closes the zone picker. Key
+            // events bubble from whichever picker control has focus, so the
+            // strip container is the one place that hears them all.
+            onkeydown: move |evt| {
+                if evt.key() == Key::Escape {
+                    picker_open.set(false);
+                }
+            },
             div { class: "zones-strip-inner",
                 // Art + now playing, doubles as the picker trigger on small screens
                 button {

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -590,9 +590,22 @@ pub fn Library(
         let Some(zone_id) = browse_zone_id() else {
             return;
         };
-        let action = current_tab.action().to_string();
-        let media_type = current_tab.media_type().map(ToOwned::to_owned);
         let path = breadcrumbs.read().last().and_then(|e| e.path.clone());
+        // #573 (visual pass V2b root cause): a tab's action ("playlists",
+        // "favorites") lists that tab's ROOT and ignores `path` -- so once
+        // the user opened a playlist, every reload re-listed the parent
+        // under an advanced breadcrumb (an empty playlist looked like the
+        // playlists list itself). Any level below a tab's root is reached
+        // by its opaque `path`, and the documented way to continue into a
+        // path is the `browse` action, whatever tab it started from.
+        let (action, media_type) = if path.is_some() {
+            ("browse".to_string(), None)
+        } else {
+            (
+                current_tab.action().to_string(),
+                current_tab.media_type().map(ToOwned::to_owned),
+            )
+        };
         let request_offset = if append { offset() } else { 0 };
         spawn(load_page(
             zone_id,

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -100,6 +100,46 @@ impl Tab {
 
 const TABS: &[Tab] = &[Tab::Browse, Tab::Playlists, Tab::Favorites, Tab::Radio];
 
+/// Which tabs to render for the current browse zone (#573 defect 6).
+///
+/// `library_tabs` is the server's per-provider list (`Zone::library_tabs`),
+/// derived from the same capability facts the matrix reports -- a Roon zone
+/// sends `["browse", "playlists"]`, so Favorites and Radio (which Roon's
+/// collections surface refuses on every call) are never rendered. An empty
+/// list means "no information" (a response from a build predating the
+/// field): degrade to showing every tab rather than none.
+fn visible_tabs_for(library_tabs: &[String]) -> Vec<Tab> {
+    if library_tabs.is_empty() {
+        return TABS.to_vec();
+    }
+    TABS.iter()
+        .copied()
+        .filter(|tab| library_tabs.iter().any(|name| name == tab.as_str()))
+        .collect()
+}
+
+/// The tab actually shown: the route's tab when this provider serves it,
+/// otherwise Browse -- so a deep link to `?tab=favorites` on a Roon zone
+/// lands on a working tab instead of a permanent refusal page.
+fn effective_tab(requested: Tab, visible: &[Tab]) -> Tab {
+    if visible.contains(&requested) {
+        requested
+    } else {
+        Tab::Browse
+    }
+}
+
+/// #573 defect 2 pin: the API's `image` fields (`CollectionItem::image`,
+/// `SearchResult::image`) are complete same-origin URLs
+/// (`/api/collections/image?ref=...`) and are used **verbatim** as
+/// `<img src>`. This helper is the single place a row image becomes a `src`;
+/// the double-prefix regression ("/api/collections/image?ref={image}" around
+/// an already-full path, 404ing every image) cannot re-enter through rsx
+/// string interpolation as long as rendering goes through here.
+fn image_src(image: &str) -> &str {
+    image
+}
+
 /// One breadcrumb: what the user picked, and the opaque path it opened.
 /// The root ("Library") is implicit and never stored -- an empty stack
 /// means "at the root of this tab".
@@ -477,7 +517,18 @@ pub fn Library(
             .map(|z| z.zone_id.clone())
     });
 
-    let current_tab = Tab::parse(&route_tab);
+    // Tabs the current browse zone's provider serves (#573 defect 6), and
+    // the tab actually rendered (the route's tab, downgraded to Browse when
+    // this provider does not serve it).
+    let visible_tabs = use_memo(move || {
+        let list = zones_list();
+        let tabs = browse_zone_id()
+            .and_then(|id| list.iter().find(|z| z.zone_id == id))
+            .map(|z| z.library_tabs.clone())
+            .unwrap_or_default();
+        visible_tabs_for(&tabs)
+    });
+    let current_tab = effective_tab(Tab::parse(&route_tab), &visible_tabs());
     let breadcrumbs = use_signal(|| decode_path(route_path.as_deref()));
 
     // Re-sync local breadcrumb signal when navigation (a row click's
@@ -541,6 +592,9 @@ pub fn Library(
         let _ = browse_zone_id();
         let _ = route_tab.clone();
         let _ = breadcrumbs.read().clone();
+        // Tracked so the level refetches when the served-tab set arrives and
+        // downgrades a deep-linked unsupported tab to Browse (#573 defect 6).
+        let _ = visible_tabs();
         if browse_zone_id().is_some() {
             refresh(false);
         }
@@ -868,10 +922,24 @@ pub fn Library(
                                 li {
                                     key: "{result.title}-{result.subtitle.clone().unwrap_or_default()}",
                                     class: "library-row",
-                                    div { class: "min-w-0",
-                                        p { class: "font-medium truncate", "{result.title}" }
-                                        if let Some(subtitle) = result.subtitle.clone() {
-                                            p { class: "text-sm text-muted truncate", "{subtitle}" }
+                                    div { class: "min-w-0 flex items-center gap-2",
+                                        // #573 defect 10: search hits carry
+                                        // artwork where the provider supplies
+                                        // it -- same verbatim-URL contract as
+                                        // browse rows (see `image_src`).
+                                        if let Some(image) = result.image.clone() {
+                                            img {
+                                                class: "library-row-thumb",
+                                                src: "{image_src(&image)}",
+                                                alt: "",
+                                                loading: "lazy",
+                                            }
+                                        }
+                                        div { class: "min-w-0",
+                                            p { class: "font-medium truncate", "{result.title}" }
+                                            if let Some(subtitle) = result.subtitle.clone() {
+                                                p { class: "text-sm text-muted truncate", "{subtitle}" }
+                                            }
                                         }
                                     }
                                     div { class: "library-row-actions",
@@ -980,9 +1048,9 @@ pub fn Library(
                     }
 
                     div { class: "library-tabs",
-                        for candidate in TABS {
+                        for candidate in visible_tabs() {
                             {
-                                let candidate = *candidate;
+                                let candidate = candidate;
                                 let active = candidate == current_tab;
                                 rsx! {
                                     button {
@@ -1131,7 +1199,9 @@ fn LibraryRow(
                 if let Some(image) = item.image.clone() {
                     img {
                         class: "library-row-thumb",
-                        src: "/api/collections/image?ref={image}",
+                        // #573 defect 2: `image` is already the complete URL;
+                        // it must be used verbatim (see `image_src`).
+                        src: "{image_src(&image)}",
                         alt: "",
                         loading: "lazy",
                     }
@@ -1250,7 +1320,9 @@ fn LibraryTile(
                 if let Some(image) = item.image.clone() {
                     img {
                         class: "library-tile-art-img",
-                        src: "/api/collections/image?ref={image}",
+                        // #573 defect 2: `image` is already the complete URL;
+                        // it must be used verbatim (see `image_src`).
+                        src: "{image_src(&image)}",
                         alt: "",
                         loading: "lazy",
                     }

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -299,6 +299,19 @@ fn missing_now_playing_zones(
         .collect()
 }
 
+/// A failed level load, split by what went wrong (#573 visual pass V3).
+///
+/// `unreachable` is true only when the HTTP request itself failed -- the one
+/// case "«source» isn't reachable right now." is true of. A well-formed
+/// refusal envelope (a capability gap, an expired path, ...) reaches the
+/// server fine; rendering it under unreachability copy told users the
+/// provider was down when it wasn't.
+#[derive(Clone, Debug, PartialEq)]
+struct LevelError {
+    message: String,
+    unreachable: bool,
+}
+
 /// Fetch one page of the current level and apply it.
 #[allow(clippy::too_many_arguments)]
 async fn load_page(
@@ -312,7 +325,7 @@ async fn load_page(
     mut next_offset: Signal<Option<u32>>,
     mut offset: Signal<u32>,
     mut loading: Signal<bool>,
-    mut error: Signal<Option<String>>,
+    mut error: Signal<Option<LevelError>>,
 ) {
     loading.set(true);
     error.set(None);
@@ -336,15 +349,26 @@ async fn load_page(
             offset.set(request_offset);
         }
         Ok(env) => {
-            error.set(Some(env.error_detail()));
+            error.set(Some(LevelError {
+                message: env.error_detail(),
+                unreachable: false,
+            }));
             if !append {
+                // #573 visual pass V2: clear the whole level, not just the
+                // items -- a stale `next_offset` would render "Load more"
+                // under the error panel.
                 items.set(Vec::new());
+                next_offset.set(None);
             }
         }
         Err(message) => {
-            error.set(Some(message));
+            error.set(Some(LevelError {
+                message,
+                unreachable: true,
+            }));
             if !append {
                 items.set(Vec::new());
+                next_offset.set(None);
             }
         }
     }
@@ -559,7 +583,7 @@ pub fn Library(
     let offset = use_signal(|| 0u32);
     let next_offset = use_signal(|| None::<u32>);
     let loading = use_signal(|| false);
-    let error = use_signal(|| None::<String>);
+    let error = use_signal(|| None::<LevelError>);
     let mut status = use_signal(|| None::<String>);
 
     let refresh = use_callback(move |append: bool| {
@@ -863,12 +887,24 @@ pub fn Library(
                 Link { class: "btn btn-primary", to: Route::Settings {}, "Go to Settings" }
             }
         }
-    } else if let Some(message) = current_error.clone() {
+    } else if let Some(level_error) = current_error.clone() {
         let retry_source = current_source.clone();
+        // #573 visual pass V3: unreachability copy is reserved for actual
+        // network failures; a genuine refusal (a capability gap, an expired
+        // path) renders its own reason instead of claiming the provider is
+        // down.
+        let heading = if level_error.unreachable {
+            format!(
+                "{} isn't reachable right now.",
+                source_label(current_source.as_deref().unwrap_or("this source"))
+            )
+        } else {
+            "This view isn't available.".to_string()
+        };
         rsx! {
             div { class: "library-provider-down",
-                p { "{source_label(current_source.as_deref().unwrap_or(\"this source\"))} isn't reachable right now." }
-                p { class: "text-sm text-muted", "{message}" }
+                p { "{heading}" }
+                p { class: "text-sm text-muted", "{level_error.message}" }
                 button {
                     class: "btn btn-outline",
                     r#type: "button",
@@ -922,6 +958,18 @@ pub fn Library(
                                 li {
                                     key: "{result.title}-{result.subtitle.clone().unwrap_or_default()}",
                                     class: "library-row",
+                                    // #573 visual pass V1: the whole result
+                                    // row opens a navigable hit, same as
+                                    // browse rows.
+                                    onclick: {
+                                        let path = result.path.clone();
+                                        let title = result.title.clone();
+                                        move |_| {
+                                            if let Some(path) = path.clone() {
+                                                open_folder((title.clone(), path.clone()));
+                                            }
+                                        }
+                                    },
                                     div { class: "min-w-0 flex items-center gap-2",
                                         // #573 defect 10: search hits carry
                                         // artwork where the provider supplies
@@ -948,7 +996,10 @@ pub fn Library(
                                                 class: "library-play-btn",
                                                 aria_label: "Play {result.title}",
                                                 r#type: "button",
-                                                onclick: move |_| play_item((item_ref.clone(), "play")),
+                                                onclick: move |evt: Event<MouseData>| {
+                                                    evt.stop_propagation();
+                                                    play_item((item_ref.clone(), "play"));
+                                                },
                                                 "▶"
                                             }
                                         }
@@ -970,7 +1021,13 @@ pub fn Library(
                                                 onclick: {
                                                     let title = result.title.clone();
                                                     let path = path.clone();
-                                                    move |_| open_folder((title.clone(), path.clone()))
+                                                    // stop_propagation: the row's
+                                                    // own click does the same
+                                                    // navigation.
+                                                    move |evt: Event<MouseData>| {
+                                                        evt.stop_propagation();
+                                                        open_folder((title.clone(), path.clone()));
+                                                    }
                                                 },
                                                 svg { class: "w-5 h-5", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
                                                     path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M9 5l7 7-7 7" }
@@ -1050,7 +1107,6 @@ pub fn Library(
                     div { class: "library-tabs",
                         for candidate in visible_tabs() {
                             {
-                                let candidate = candidate;
                                 let active = candidate == current_tab;
                                 rsx! {
                                     button {
@@ -1195,6 +1251,20 @@ fn LibraryRow(
         li {
             class: "library-row library-row--reveal",
             style: "{stagger_style}",
+            // #573 visual pass V1: the whole row is the navigation target
+            // for a navigable item, matching the row-wide hover affordance
+            // -- not just the right-edge chevron. The play/overflow/chevron
+            // buttons stop propagation so their own actions stay separate
+            // hit areas.
+            onclick: {
+                let path = item.path.clone();
+                let title = item.title.clone();
+                move |_| {
+                    if let Some(path) = path.clone() {
+                        on_open((title.clone(), path.clone()));
+                    }
+                }
+            },
             div { class: "min-w-0 flex items-center gap-2",
                 if let Some(image) = item.image.clone() {
                     img {
@@ -1229,7 +1299,10 @@ fn LibraryRow(
                         r#type: "button",
                         onclick: {
                             let item_ref = item_ref.clone();
-                            move |_| on_play((item_ref.clone(), "play"))
+                            move |evt: Event<MouseData>| {
+                                evt.stop_propagation();
+                                on_play((item_ref.clone(), "play"));
+                            }
                         },
                         "▶"
                     }
@@ -1238,7 +1311,10 @@ fn LibraryRow(
                             class: "library-overflow-trigger",
                             aria_label: "More actions for {item.title}",
                             r#type: "button",
-                            onclick: move |_| menu_open.toggle(),
+                            onclick: move |evt: Event<MouseData>| {
+                                evt.stop_propagation();
+                                menu_open.toggle();
+                            },
                             "⋯"
                         }
                         if menu_open() {
@@ -1247,7 +1323,8 @@ fn LibraryRow(
                                     r#type: "button",
                                     onclick: {
                                         let item_ref = item_ref.clone();
-                                        move |_| {
+                                        move |evt: Event<MouseData>| {
+                                            evt.stop_propagation();
                                             menu_open.set(false);
                                             on_play((item_ref.clone(), "next"));
                                         }
@@ -1258,7 +1335,8 @@ fn LibraryRow(
                                     r#type: "button",
                                     onclick: {
                                         let item_ref = item_ref.clone();
-                                        move |_| {
+                                        move |evt: Event<MouseData>| {
+                                            evt.stop_propagation();
                                             menu_open.set(false);
                                             on_play((item_ref.clone(), "queue"));
                                         }
@@ -1277,7 +1355,12 @@ fn LibraryRow(
                         onclick: {
                             let title = item.title.clone();
                             let path = path.clone();
-                            move |_| on_open((title.clone(), path.clone()))
+                            // stop_propagation so the row's own click
+                            // handler (same navigation) doesn't fire twice.
+                            move |evt: Event<MouseData>| {
+                                evt.stop_propagation();
+                                on_open((title.clone(), path.clone()));
+                            }
                         },
                         svg { class: "w-5 h-5", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
                             path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M9 5l7 7-7 7" }
@@ -1306,17 +1389,20 @@ fn LibraryTile(
         li {
             class: "library-tile library-tile--reveal",
             style: "{stagger_style}",
+            // #573 visual pass V1: the whole tile navigates (art, title,
+            // subtitle alike), not just the art block -- the play button
+            // below stops propagation to stay its own hit area.
+            onclick: {
+                let path = item.path.clone();
+                let title = item.title.clone();
+                move |_| {
+                    if let Some(path) = path.clone() {
+                        on_open((title.clone(), path.clone()));
+                    }
+                }
+            },
             div {
                 class: "library-tile-art",
-                onclick: {
-                    let path = item.path.clone();
-                    let title = item.title.clone();
-                    move |_| {
-                        if let Some(path) = path.clone() {
-                            on_open((title.clone(), path.clone()));
-                        }
-                    }
-                },
                 if let Some(image) = item.image.clone() {
                     img {
                         class: "library-tile-art-img",
@@ -1502,5 +1588,51 @@ mod loop_regression_tests {
     fn empty_zone_list_fetches_nothing() {
         let missing = missing_now_playing_zones(&[], &HashMap::new());
         assert!(missing.is_empty());
+    }
+}
+
+/// #573 pins for the Library page's pure helpers.
+#[cfg(test)]
+mod library_defect_pins {
+    use super::*;
+
+    /// Defect 2 pin: the API's `image` field is the complete `<img src>`
+    /// value. It must be used verbatim -- prefixing it again
+    /// (`/api/collections/image?ref={image}` around an already-full path)
+    /// is the double-prefix regression that 404ed every image.
+    #[test]
+    fn api_image_url_is_used_verbatim_as_img_src() {
+        let api_value = "/api/collections/image?ref=ref_abc123";
+        let src = image_src(api_value);
+        assert_eq!(src, api_value, "the API value must pass through verbatim");
+        assert!(
+            !src.contains("?ref=/api/"),
+            "src must never be double-prefixed"
+        );
+    }
+
+    /// Defect 6 pin: a Roon zone's served-tab list hides Favorites and
+    /// Radio; the rendered set is exactly what the server reports.
+    #[test]
+    fn roon_tab_list_hides_favorites_and_radio() {
+        let served = vec!["browse".to_string(), "playlists".to_string()];
+        assert_eq!(visible_tabs_for(&served), vec![Tab::Browse, Tab::Playlists]);
+    }
+
+    /// Defect 6 pin: no tab information (a `/zones` response from a build
+    /// predating `library_tabs`) degrades to showing every tab, never none.
+    #[test]
+    fn missing_tab_information_shows_every_tab() {
+        assert_eq!(visible_tabs_for(&[]), TABS.to_vec());
+    }
+
+    /// Defect 6 pin: a deep link to a tab this provider does not serve
+    /// lands on Browse instead of a permanent refusal page.
+    #[test]
+    fn unsupported_deep_linked_tab_falls_back_to_browse() {
+        let visible = vec![Tab::Browse, Tab::Playlists];
+        assert_eq!(effective_tab(Tab::Favorites, &visible), Tab::Browse);
+        assert_eq!(effective_tab(Tab::Radio, &visible), Tab::Browse);
+        assert_eq!(effective_tab(Tab::Playlists, &visible), Tab::Playlists);
     }
 }

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -114,6 +114,13 @@ pub struct ZoneInfo {
     /// on this instead of a hardcoded `musicassistant:` prefix check, so LMS
     /// and Roon zones light up as their slices land, without a web change.
     pub browse_supported: bool,
+    /// Which Library-page tabs this zone's provider serves (#573 defect 6):
+    /// a subset of `["browse", "playlists", "favorites", "radio"]`, derived
+    /// from the same capability facts `hifi_capabilities` reports (see
+    /// `crate::mcp::tools::collections::collections_tabs_for_zone`). The web
+    /// Library page hides tabs missing from this list instead of rendering
+    /// ones whose every call would be refused.
+    pub library_tabs: Vec<&'static str>,
 }
 
 /// GET /knob/zones response
@@ -179,6 +186,7 @@ pub async fn get_all_zones_internal(state: &AppState) -> Vec<ZoneInfo> {
             browse_supported: crate::mcp::tools::collections::zone_supports_hifi_collections(
                 &z.zone_id,
             ),
+            library_tabs: crate::mcp::tools::collections::collections_tabs_for_zone(&z.zone_id),
             zone_id: z.zone_id,
             zone_name: z.zone_name,
             source: z.source,
@@ -1686,6 +1694,7 @@ mod tests {
             volume_control: None,
             dsp: None,
             browse_supported: false,
+            library_tabs: Vec::new(),
         }
     }
 

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -51,6 +51,36 @@ pub fn zone_supports_hifi_collections(zone_id: &str) -> bool {
     )
 }
 
+/// Which Library-page tabs this zone's provider can actually serve, in the
+/// page's own tab vocabulary (`browse`, `playlists`, `favorites`, `radio`).
+///
+/// #573 defect 6: the web Library page rendered a static four-tab strip for
+/// every provider, so Roon zones showed Favorites and Radio tabs whose every
+/// call was refused. This derives the visible set from the same capability
+/// facts the matrix reports (`crate::mcp::capabilities::support`), through
+/// the same [`zone_supports_hifi_collections`] gate this tool routes on --
+/// the tabs and the refusals can never disagree. `favorites` and `radio` are
+/// one capability cell: both map to the `favorites` action (`media_type` is
+/// what tells them apart).
+pub fn collections_tabs_for_zone(zone_id: &str) -> Vec<&'static str> {
+    if !zone_supports_hifi_collections(zone_id) {
+        return Vec::new();
+    }
+    let target = ZoneTarget::classify(zone_id);
+    let mut tabs = Vec::new();
+    if matches!(support(target, Capability::Browse), Support::Supported) {
+        tabs.push("browse");
+    }
+    if matches!(support(target, Capability::SavedPlaylists), Support::Supported) {
+        tabs.push("playlists");
+    }
+    if matches!(support(target, Capability::Favorites), Support::Supported) {
+        tabs.push("favorites");
+        tabs.push("radio");
+    }
+    tabs
+}
+
 #[mcp_tool(
     name = "hifi_collections",
     description = "Alpha capability: expect refinement across releases. Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection. Implemented for lms and roon zones; Music Assistant zones (see hifi_queue's provider notes); Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one."
@@ -99,7 +129,13 @@ struct CollectionItem {
 /// it through, or `None` if this row's adapter response carried no image
 /// key at all. Shared by all three provider handlers below so the URL shape
 /// (`/api/collections/image?ref=...`) is defined in exactly one place.
-async fn mint_image(state: &AppState, zone_id: &str, image_key: Option<&str>) -> Option<String> {
+/// Also used by `hifi_search`'s Roon mapping (#573 defect 10), so search
+/// results and browse rows resolve artwork through one identical URL shape.
+pub(crate) async fn mint_image(
+    state: &AppState,
+    zone_id: &str,
+    image_key: Option<&str>,
+) -> Option<String> {
     let image_key = image_key?;
     let token = state
         .image_refs
@@ -195,12 +231,46 @@ pub async fn handle_collections(
         );
     }
 
-    if !matches!(support(target, capability), Support::Supported) {
-        return env.failed(format!(
-            "{} is not available for {} zones",
-            capability.name(),
-            target.label()
-        ));
+    // #573 defect 6 (sub-issue): a capability gap is not a backend failure.
+    // This used to be `env.failed(...)`, which serializes as
+    // `reason: backend_error` -- telling a client "retrying may work" about
+    // Roon's unwired favorites. Report the capability table's own state
+    // (`not_implemented`/`provider_limitation`) so the refusal and
+    // `hifi_capabilities` cannot disagree.
+    match support(target, capability) {
+        Support::Supported => {}
+        Support::NotImplemented {
+            tracked_by,
+            evidence,
+        } => {
+            return env.refused(
+                format!(
+                    "{} is not available for {} zones yet.",
+                    capability.name(),
+                    target.label()
+                ),
+                Refusal::NotImplemented {
+                    operation: capability.name().to_string(),
+                    tracked_by,
+                    alternatives: Vec::new(),
+                    detail: evidence.to_string(),
+                },
+            );
+        }
+        Support::Unsupported { evidence } => {
+            return env.refused(
+                format!(
+                    "{} is not available for {} zones.",
+                    capability.name(),
+                    target.label()
+                ),
+                Refusal::ProviderLimitation {
+                    operation: capability.name().to_string(),
+                    alternatives: Vec::new(),
+                    detail: evidence.to_string(),
+                },
+            );
+        }
     }
 
     let limit = args.limit.unwrap_or(20).clamp(1, 50);

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -71,7 +71,10 @@ pub fn collections_tabs_for_zone(zone_id: &str) -> Vec<&'static str> {
     if matches!(support(target, Capability::Browse), Support::Supported) {
         tabs.push("browse");
     }
-    if matches!(support(target, Capability::SavedPlaylists), Support::Supported) {
+    if matches!(
+        support(target, Capability::SavedPlaylists),
+        Support::Supported
+    ) {
         tabs.push("playlists");
     }
     if matches!(support(target, Capability::Favorites), Support::Supported) {
@@ -690,6 +693,40 @@ fn refuse_foreign_path(env: Envelope) -> Result<CallToolResult, CallToolError> {
             "Browse again from this zone and use that result's path.",
         ),
     )
+}
+
+#[cfg(test)]
+mod tab_gating_tests {
+    use super::*;
+
+    /// #573 defect 6: Roon serves Browse and Playlists only -- Favorites
+    /// and Radio (both the `favorites` capability) are not wired, so the
+    /// Library page must not render those tabs for Roon zones.
+    #[test]
+    fn roon_zones_serve_browse_and_playlists_only() {
+        assert_eq!(
+            collections_tabs_for_zone("roon:zone_1"),
+            vec!["browse", "playlists"]
+        );
+    }
+
+    /// The tab list is exactly the capability table's view: a provider this
+    /// tool does not reach at all serves no tabs.
+    #[test]
+    fn unreached_providers_serve_no_tabs() {
+        assert!(collections_tabs_for_zone("spotify:acct").is_empty());
+        assert!(collections_tabs_for_zone("hqplayer:main").is_empty());
+    }
+
+    /// Music Assistant keeps all four tabs (favorites supported implies the
+    /// Radio tab, which is the same capability under `media_type: radio`).
+    #[test]
+    fn music_assistant_serves_all_tabs() {
+        assert_eq!(
+            collections_tabs_for_zone("musicassistant:player_1"),
+            vec!["browse", "playlists", "favorites", "radio"]
+        );
+    }
 }
 
 fn refuse_unknown_path(env: Envelope) -> Result<CallToolResult, CallToolError> {

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -219,6 +219,7 @@ pub async fn handle_search(
                             // grouping row or browsable container in its
                             // response shape to mint a path for.
                             path: None,
+                            image: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -250,6 +251,7 @@ pub async fn handle_search(
                             // (`LibrarySearchResult`) has no grouping or
                             // browse concept -- see #566's audit.
                             path: None,
+                            image: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -283,6 +285,7 @@ pub async fn handle_search(
                             // exposes MA's real browse hierarchy
                             // separately, via `MusicAssistantBrowse`.)
                             path: None,
+                            image: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -325,6 +328,7 @@ pub async fn handle_search(
                             // flat catalog/library hits -- no grouping or
                             // browse concept -- see #566's audit.
                             path: None,
+                            image: None,
                         });
                     }
                     Ok(env.json_result(&mcp_results))
@@ -346,14 +350,31 @@ pub async fn handle_search(
                 Ok((session_key, results)) => {
                     let mut mcp_results = Vec::with_capacity(results.len());
                     for item in results {
+                        // #573 defect 10: search hits carry artwork where
+                        // Roon supplies it, resolved through the identical
+                        // opaque-ref URL browse rows use.
+                        let image = crate::mcp::tools::collections::mint_image(
+                            state,
+                            args.zone_id.as_deref().unwrap_or_default(),
+                            item.image_key.as_deref(),
+                        )
+                        .await;
+                        // #573 defect 5: strip `[[id|Name]]` link markup at
+                        // the mapping, same as `hifi_collections`.
+                        let title = crate::adapters::roon::strip_roon_link_markup(&item.title);
+                        let subtitle = item
+                            .subtitle
+                            .as_deref()
+                            .map(crate::adapters::roon::strip_roon_link_markup);
                         let Some(item_key) = item.item_key.clone() else {
                             // No item_key -- a header or non-navigable row.
                             // Nothing to mint a ref or path from.
                             mcp_results.push(McpSearchResult {
-                                title: item.title,
-                                subtitle: item.subtitle,
+                                title,
+                                subtitle,
                                 r#ref: None,
                                 path: None,
+                                image,
                             });
                             continue;
                         };
@@ -425,10 +446,11 @@ pub async fn handle_search(
                             None
                         };
                         mcp_results.push(McpSearchResult {
-                            title: item.title,
-                            subtitle: item.subtitle,
+                            title,
+                            subtitle,
                             r#ref: ref_token,
                             path,
+                            image,
                         });
                     }
                     Ok(env.json_result(&mcp_results))

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -78,6 +78,11 @@ pub struct McpNowPlaying {
 /// Spotify/Apple Music/Music Assistant's generic search has no grouping or
 /// browse concept, so they always leave this `None` (see
 /// `crate::mcp::tools::library::handle_search`'s per-route docs).
+/// `image` (#573 defect 10) follows `hifi_collections`' artwork convention
+/// exactly: a same-origin `/api/collections/image?ref=...` path over an
+/// opaque minted token, present only when the provider supplied art for the
+/// hit. Only Roon sets it today -- the other providers' generic search
+/// results carry no image key (see `handle_search`'s per-route mappings).
 #[derive(Debug, Serialize)]
 pub struct McpSearchResult {
     pub title: String,
@@ -86,6 +91,8 @@ pub struct McpSearchResult {
     pub r#ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
 }
 
 /// `hifi_play`'s structured payload: the adapter's own message about what it

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -3421,6 +3421,14 @@ const FIELD_ROLES: &[(&str, FieldRole)] = &[
          own docs.",
         ),
     ),
+    (
+        "image",
+        DisplayOnly(
+            "artwork URL (#549 for hifi_collections rows, #573 for hifi_search hits): a \
+         same-origin `/api/collections/image?ref=...` path over an opaque minted token, \
+         fetched by a web client as an <img src>; no MCP tool takes an image as input.",
+        ),
+    ),
     // hifi_status / hifi_hqplayer_status readouts.
     (
         "connected",
@@ -3809,6 +3817,9 @@ async fn no_tool_returns_an_unclassified_field() {
             // #566: same reasoning as `ref` above -- `Some` so `path` is
             // collected and must be classified below too.
             path: Some(String::new()),
+            // #573 defect 10: same again -- `Some` so `image` is collected
+            // and must be classified below.
+            image: Some(String::new()),
         })
         .expect("McpSearchResult must serialize"),
         &mut returned,

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -1327,6 +1327,31 @@ async fn handle_request(
         }
         RequestKind::Browse => handle_browse(req_id, &body, &core, &writer, &root_title).await,
         RequestKind::Load => handle_load(req_id, &body, &core, &writer).await,
+        RequestKind::ImageGet => {
+            // A minimal but real 1x1 PNG, framed the way `moo.rs::parse`
+            // reads binary bodies (`Content-Type: image/png` -> the fork's
+            // `ContentType::Png(body)`), so `RoonAdapter::get_image` -- and
+            // through it `/api/collections/image` (#549/#573) -- can be
+            // exercised end to end against this fake.
+            const PNG_1X1: &[u8] = &[
+                0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+                0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+                0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78,
+                0x9C, 0x63, 0xFC, 0xCF, 0xC0, 0x50, 0x0F, 0x00, 0x04, 0x85, 0x01, 0x80, 0x84, 0xA9,
+                0x8C, 0x21, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+            ];
+            core.write()
+                .await
+                .sent
+                .push((req_id, "Success".to_string()));
+            let mut frame = format!(
+                "MOO/1 COMPLETE Success\nRequest-Id: {req_id}\nContent-Length: {}\nContent-Type: image/png\n\n",
+                PNG_1X1.len()
+            )
+            .into_bytes();
+            frame.extend_from_slice(PNG_1X1);
+            let _ = writer.lock().await.send(Message::Binary(frame)).await;
+        }
         RequestKind::GroupOutputs => handle_group_outputs(req_id, &body, &core, &writer).await,
         RequestKind::UngroupOutputs => handle_ungroup_outputs(req_id, &body, &core, &writer).await,
         RequestKind::Unknown => {
@@ -1360,6 +1385,7 @@ enum RequestKind {
     Ping,
     GroupOutputs,
     UngroupOutputs,
+    ImageGet,
     Unknown,
 }
 
@@ -1376,6 +1402,8 @@ impl RequestKind {
             // FROM FORK: transport.rs:334,343 -- both send only `output_ids`.
             "com.roonlabs.transport:2/group_outputs" => Self::GroupOutputs,
             "com.roonlabs.transport:2/ungroup_outputs" => Self::UngroupOutputs,
+            // FROM FORK: image.rs SVCNAME + get_image.
+            "com.roonlabs.image:1/get_image" => Self::ImageGet,
             _ => Self::Unknown,
         }
     }

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -276,6 +276,46 @@ pub fn playlist(title: &str, tracks: &[&str]) -> FakeItem {
     FakeItem::list(title).with_children(children)
 }
 
+/// An album level shaped like the #573 live crawl captured it: the "Play
+/// Album" verb is an `action_list` wrapper, and -- crucially -- **the track
+/// rows themselves are `action_list` hinted too** (entering a track opens
+/// its Play Now/Queue/Start Radio menu), each carrying an artist subtitle
+/// and artwork. The pre-#573 fixtures modeled tracks as `hint: list`, which
+/// is why #545's "drop every action-hinted row" filter passed every test
+/// while emptying every real album ("`{\"items\":[]}` for a 95-track
+/// playlist").
+pub fn album_live(title: &str, artist: &str, tracks: &[&str]) -> FakeItem {
+    let mut children = vec![FakeItem::action_list("Play Album").with_children(play_actions())];
+    for track in tracks {
+        children.push(
+            FakeItem::action_list(track)
+                .with_subtitle(artist)
+                .with_image_key(&format!("img_{}", track.to_lowercase().replace(' ', "_")))
+                .with_children(play_actions()),
+        );
+    }
+    FakeItem::list(title)
+        .with_subtitle(artist)
+        .with_image_key(&format!("img_{}", title.to_lowercase().replace(' ', "_")))
+        .with_children(children)
+}
+
+/// A playlist level shaped like the #573 live crawl: an immediately-invokable
+/// `"Play Playlist"` action alongside `action_list`-hinted track rows with
+/// artist subtitles (the same live shape #545's repro captured, now with the
+/// track hint modeled correctly -- see [`album_live`]).
+pub fn playlist_live(title: &str, tracks: &[(&str, &str)]) -> FakeItem {
+    let mut children = vec![FakeItem::action("Play Playlist")];
+    for (track, artist) in tracks {
+        children.push(
+            FakeItem::action_list(track)
+                .with_subtitle(artist)
+                .with_children(play_actions()),
+        );
+    }
+    FakeItem::list(title).with_children(children)
+}
+
 /// The fake Core's library: a browse root plus a flat set of searchable items.
 #[derive(Debug, Clone)]
 pub struct FakeLibrary {

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -31,7 +31,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use mock_servers::roon_core::{
-    album, playlist, zone_with_grouping, FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
+    album, album_live, playlist, playlist_live, zone_with_grouping, FakeItem, FakeLibrary,
+    FakeRoonCore, Hint, ItemKeyScope,
 };
 use roon_api::browse::{BrowseOpts, LoadOpts};
 use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
@@ -1532,30 +1533,17 @@ async fn roon_collections_content_classifies_playlist_and_tracks_correctly() {
     let core = FakeRoonCore::start_with(library).await;
     let adapter = connected(&core).await;
 
-    // Browse to "Playlists", then into the playlist itself.
-    let root = adapter
+    // List playlists (the root's "Playlists" node is hidden from
+    // `collections_browse` since #573 defect 4 -- the dedicated
+    // `collections_playlists` operation is the way in), then browse into
+    // the playlist itself.
+    let playlists_level = adapter
         .content(
-            "collections_browse",
+            "collections_playlists",
             &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
         )
         .await
-        .expect("root browse");
-    let session_key = root["session_key"].as_str().unwrap().to_string();
-    let playlists_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
-
-    let playlists_level = adapter
-        .content(
-            "collections_browse",
-            &json!({
-                "zone_id": "roon:zone_1",
-                "item_key": playlists_key,
-                "session_key": session_key,
-                "limit": 20,
-                "offset": 0,
-            }),
-        )
-        .await
-        .expect("Playlists node browse");
+        .expect("Playlists listing");
     let playlist_item = &playlists_level["items"][0];
     assert_eq!(playlist_item["title"], "An Introduction to Qobuz");
     // Missing-Play-button bug (#545): a playlist is both a container (has
@@ -1788,9 +1776,486 @@ async fn roon_collections_browse_root_excludes_settings() {
         .collect();
     assert_eq!(
         titles,
-        vec!["Library", "TIDAL", "Qobuz"],
-        "the root's own utility node (Settings) must not appear as an inert row"
+        vec!["Local Library", "TIDAL", "Qobuz"],
+        "the root's own utility node (Settings) must not appear as an inert row, and \
+         (#573 defect 4) the Library node is renamed so the page's breadcrumb doesn't \
+         read Library / Library"
     );
+
+    core.stop().await;
+}
+
+// =============================================================================
+// #573: Library UI defect audit -- adapter-level fixes, pinned against the
+// live-shaped fixtures (`album_live`/`playlist_live`: track rows are
+// `hint: action_list`, exactly what the live crawl captured).
+// =============================================================================
+
+/// #573 defect 1 (blocker): an album level lists its tracks -- playable,
+/// with no leaked action rows. The #545 filter dropped every
+/// Action/ActionList row, and since a live Core marks *track rows*
+/// `action_list` too, every album and playlist came back `items: []`.
+#[tokio::test]
+async fn roon_collections_live_album_level_lists_tracks_with_play_refs() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Qobuz").with_children(vec![album_live(
+        "Kind of Blue",
+        "Miles Davis",
+        &["So What", "Blue in Green", "Flamenco Sketches"],
+    )])];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .expect("root browse");
+    let session_key = root["session_key"].as_str().unwrap().to_string();
+    let qobuz_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
+
+    // Folder level: the Qobuz node lists its child (the album), navigable.
+    let qobuz_level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": qobuz_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .expect("Qobuz node browse");
+    let album_item = &qobuz_level["items"][0];
+    assert_eq!(album_item["title"], "Kind of Blue");
+    assert_eq!(
+        album_item["navigable"], true,
+        "an album is navigable: {album_item:?}"
+    );
+    assert_eq!(
+        album_item["playable"], true,
+        "an album is also directly playable: {album_item:?}"
+    );
+
+    // Leaf level: the album's tracks, playable, no action rows leaked.
+    let session_key = qobuz_level["session_key"].as_str().unwrap().to_string();
+    let album_key = album_item["item_key"].as_str().unwrap().to_string();
+    let tracks_level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": album_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .expect("album browse");
+    let items = tracks_level["items"].as_array().unwrap();
+    let titles: Vec<&str> = items.iter().map(|i| i["title"].as_str().unwrap()).collect();
+    assert_eq!(
+        titles,
+        vec!["So What", "Blue in Green", "Flamenco Sketches"],
+        "the album level must list its tracks (the #573 blocker was items: [])"
+    );
+    for track in items {
+        assert_eq!(
+            track["playable"], true,
+            "every action_list-hinted track row is a playable leaf: {track:?}"
+        );
+        assert_eq!(
+            track["navigable"], false,
+            "a track leaf must not claim navigability: {track:?}"
+        );
+        assert!(
+            track["item_key"].as_str().is_some(),
+            "a playable track needs an item_key for its play ref: {track:?}"
+        );
+    }
+    assert!(
+        !titles.contains(&"Play Album"),
+        "the Play Album verb row must not leak into the listing"
+    );
+    assert!(
+        tracks_level["next_offset"].is_null(),
+        "3 tracks in a 20-row page: no further page exists (#573 defect 8)"
+    );
+
+    core.stop().await;
+}
+
+/// #573 defect 1 (blocker), playlist half: `collections_playlists` +
+/// browse into a playlist lists its tracks, with the immediately-invokable
+/// "Play Playlist" verb filtered out.
+#[tokio::test]
+async fn roon_collections_live_playlist_level_lists_tracks() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        FakeItem::list("Library"),
+        FakeItem::list("Playlists").with_children(vec![playlist_live(
+            "An Introduction to Qobuz",
+            &[
+                ("Laundromat (Remastered 2017)", "Queen"),
+                ("So What", "Miles Davis"),
+            ],
+        )]),
+    ];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let playlists = adapter
+        .content(
+            "collections_playlists",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .expect("playlists listing");
+    let playlist_item = &playlists["items"][0];
+    assert_eq!(playlist_item["title"], "An Introduction to Qobuz");
+    assert_eq!(playlist_item["navigable"], true);
+    assert_eq!(playlist_item["playable"], true);
+
+    let session_key = playlists["session_key"].as_str().unwrap().to_string();
+    let playlist_key = playlist_item["item_key"].as_str().unwrap().to_string();
+    let tracks_level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": playlist_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .expect("playlist browse");
+    let items = tracks_level["items"].as_array().unwrap();
+    let titles: Vec<&str> = items.iter().map(|i| i["title"].as_str().unwrap()).collect();
+    assert_eq!(
+        titles,
+        vec!["Laundromat (Remastered 2017)", "So What"],
+        "the playlist level must list its tracks"
+    );
+    assert!(
+        items.iter().all(|i| i["playable"] == true),
+        "playlist tracks are playable leaves: {items:?}"
+    );
+
+    core.stop().await;
+}
+
+/// #573 defect 3: the Library node's real children (Artists, Albums,
+/// Tracks, Genres, ...) share their exact titles with `CATEGORY_NAMES`, so
+/// the search-result grouping filter swallowed the whole level down to
+/// "Search". Browse levels now rely on the "<N> Results" subtitle signal
+/// alone (which those real children never carry).
+#[tokio::test]
+async fn roon_collections_library_node_lists_its_real_children() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Library").with_children(vec![
+        FakeItem::list("Search").searchable("Search"),
+        FakeItem::list("Artists").with_children(vec![FakeItem::list("Miles Davis")]),
+        FakeItem::list("Albums").with_children(vec![FakeItem::list("Kind of Blue")]),
+        FakeItem::list("Tracks").with_children(vec![FakeItem::list("So What")]),
+        FakeItem::list("Genres").with_children(vec![FakeItem::list("Jazz")]),
+    ])];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let session_key = root["session_key"].as_str().unwrap().to_string();
+    let library_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
+
+    let level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": library_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let titles: Vec<&str> = level["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["title"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        titles,
+        vec!["Search", "Artists", "Albums", "Tracks", "Genres"],
+        "the Library node's real children must not be swallowed by the category filter"
+    );
+
+    core.stop().await;
+}
+
+/// #573 defect 4: the collection root hides the "Playlists" node (the
+/// dedicated tab lists the same node) -- `collections_playlists` still
+/// reaches it by name.
+#[tokio::test]
+async fn roon_collections_root_hides_the_playlists_node_but_the_tab_still_works() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        FakeItem::list("Library"),
+        FakeItem::list("Playlists")
+            .with_children(vec![playlist_live("Focus", &[("Deep Work", "Eno")])]),
+        FakeItem::list("My Live Radio"),
+    ];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let titles: Vec<&str> = root["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["title"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        titles,
+        vec!["Local Library", "My Live Radio"],
+        "the root must hide Playlists (dedicated tab) and rename Library"
+    );
+
+    let playlists = adapter
+        .content(
+            "collections_playlists",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .expect("the Playlists tab still reaches the node by name");
+    assert_eq!(playlists["items"][0]["title"], "Focus");
+
+    core.stop().await;
+}
+
+/// #573 defect 7: Roon's "No Results" placeholder row (an empty node's only
+/// child, which still carries an item_key) must not be minted as playable
+/// content.
+#[tokio::test]
+async fn roon_collections_no_results_placeholder_is_not_listed() {
+    let mut library = FakeLibrary::standard();
+    library.root_items =
+        vec![FakeItem::list("My Live Radio").with_children(vec![FakeItem::new("No Results")])];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let session_key = root["session_key"].as_str().unwrap().to_string();
+    let radio_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
+
+    let level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": radio_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        level["items"].as_array().unwrap().is_empty(),
+        "the placeholder must not become a playable row: {level:?}"
+    );
+    assert!(
+        level["next_offset"].is_null(),
+        "an empty level must not advertise Load more (#573 defect 8): {level:?}"
+    );
+
+    core.stop().await;
+}
+
+/// #573 defect 8: paging is computed against post-filter reality. A raw
+/// page that filters to nothing (limit 1, first raw row is the "Play
+/// Playlist" verb) fetches ahead and still delivers content, and
+/// `next_offset` advertises a further page only when raw rows genuinely
+/// remain.
+#[tokio::test]
+async fn roon_collections_paging_fetches_ahead_past_filtered_rows() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        FakeItem::list("Playlists").with_children(vec![playlist_live(
+            "Mix",
+            &[("Track One", "A"), ("Track Two", "B"), ("Track Three", "C")],
+        )]),
+    ];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let level = adapter
+        .content(
+            "collections_playlists",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let session_key = level["session_key"].as_str().unwrap().to_string();
+    let playlist_key = level["items"][0]["item_key"].as_str().unwrap().to_string();
+
+    // limit 1: the first raw row is the "Play Playlist" verb, which filters
+    // to nothing. Pre-#573 this returned items: [] with next_offset: 1
+    // forever ("Load more" over nothing).
+    let page = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": playlist_key,
+                "session_key": session_key,
+                "limit": 1,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let items = page["items"].as_array().unwrap();
+    assert!(
+        !items.is_empty(),
+        "a page whose raw rows filter away must fetch ahead, not return empty: {page:?}"
+    );
+    assert_eq!(items[0]["title"], "Track One");
+    let next = page["next_offset"].as_u64().expect("more raw rows remain");
+    assert!(next >= 2, "next_offset must sit past the consumed raw rows");
+
+    core.stop().await;
+}
+
+/// #573 defect 11: a search-derived album continuation whose level is a
+/// single self-referential row (the album again, same title as the level)
+/// auto-descends to the real level -- one click opens the tracks, not a
+/// pointless second copy of the album.
+#[tokio::test]
+async fn roon_collections_single_self_row_level_descends_to_tracks() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        FakeItem::list("Kind of Blue").with_children(vec![album_live(
+            "Kind of Blue",
+            "Miles Davis",
+            &["So What", "Blue in Green"],
+        )]),
+    ];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let session_key = root["session_key"].as_str().unwrap().to_string();
+    let outer_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
+
+    let level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": outer_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let titles: Vec<&str> = level["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["title"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        titles,
+        vec!["So What", "Blue in Green"],
+        "the self-referential single-row level must descend to the tracks"
+    );
+
+    core.stop().await;
+}
+
+/// #573 defect 5: `[[id|Name]]` link markup is stripped to plain names at
+/// the adapter mapping, including compound credits.
+#[tokio::test]
+async fn roon_collections_subtitles_are_stripped_of_link_markup() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Ideal Discography").with_children(vec![
+        FakeItem::list("Thriller").with_subtitle("[[55418|Michael Jackson]]"),
+        FakeItem::list("Siembra")
+            .with_subtitle("[[8827258|Willie Colón]] & [[1981050|Rubén Blades]]"),
+    ])];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let session_key = root["session_key"].as_str().unwrap().to_string();
+    let node_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
+
+    let level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": node_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let items = level["items"].as_array().unwrap();
+    assert_eq!(items[0]["subtitle"], "Michael Jackson");
+    assert_eq!(items[1]["subtitle"], "Willie Colón & Rubén Blades");
 
     core.stop().await;
 }


### PR DESCRIPTION
Progresses #573 (fixes defects 1–8, 10, 11 plus visual-pass V1–V4; defect 9 deliberately excluded — see the issue comment asking for its own issue).

## Per-defect fixes

| # | Fix |
|---|---|
| 1 (blocker) | `src/adapters/roon.rs`: the #545 filter dropped every `hint: action/action_list` row, but a live Core marks album/playlist **track rows** `action_list` too — every leaf level returned `items: []`. New `is_immediate_action_row` distinguishes verb rows ("Play Playlist", "Play Album", "Shuffle", …: `hint: action`, or `action_list` with a closed-list play-verb title AND no subtitle/artwork) from `action_list` playable leaf rows, which now map as playable-only leaves with play refs. `peek_playability` counts only immediate-action rows against "other content" so albums keep navigability. |
| 2 (blocker, UI) | `src/app/pages/library.rs` used `src: "/api/collections/image?ref={image}"` around an already-complete URL (double prefix → 404). The API's `image` field is the documented complete same-origin URL; the UI now renders it verbatim through one helper (`image_src`), pinned by a unit test. `CollectionItem::image` doc in `src/app/api.rs` corrected. |
| 3 | The `CATEGORY_NAMES` exact-title filter (verified only for search-result grouping rows) also swallowed the Library node's real children (Artists/Albums/Tracks/Genres…). Browse levels now drop only rows with the `"<N> Results"` subtitle signal; `hifi_search` keeps the stricter dual check. |
| 4 | Collection root renames "Library" → "Local Library" (breadcrumb no longer reads Library / Library) and hides the root "Playlists" node (duplicated the dedicated tab; `collections_playlists` still reaches it by name). |
| 5 | `strip_roon_link_markup` strips `[[id|Name]]` (incl. compound `[[a|A]] & [[b|B]]`) to plain names at the adapter mapping (browse + playlists + search); malformed markup passes through verbatim. |
| 6 | Tabs are capability-gated per provider: `/zones` now carries `library_tabs` per zone, derived from the same capability facts the matrix uses (`collections_tabs_for_zone` in `src/mcp/tools/collections.rs`); Roon zones send `["browse","playlists"]` so Favorites/Radio tabs never render; unsupported deep-linked tabs fall back to Browse. Sub-issue: capability gaps now refuse as `not_implemented`/`provider_limitation` instead of `backend_error`. |
| 7 | Roon's "No Results" placeholder row (carries an `item_key`) is filtered before minting — no phantom play ref. |
| 8 | `next_offset` is computed against post-filter reality with bounded fetch-ahead: a raw page that filters to nothing keeps loading until the page fills or raw rows run out; `next_offset` only when raw rows genuinely remain. |
| 10 | `hifi_search` Roon hits mint image refs through the same `mint_image` as browse rows; markup stripped there too; the web "Everywhere" list renders the thumbnails. Grouping rows stay out of browse continuations via the subtitle signal. |
| 11 | A non-root level whose entire content is one self-referential `hint: list` row (same title as the level) auto-descends, so a search-derived album opens its tracks in one click. |

## Visual-pass items (issue comment)

- **V1 (blocker)**: whole row/tile is now the navigation target for navigable items (browse rows, tiles, search rows); play/overflow/chevron controls stop propagation and stay separate hit areas. Probe-verified: body clicks navigate.
- **V2**: root cause found and fixed for (b): the playlists/favorites tab actions list the tab ROOT and ignore `path`, so reloading any opened level re-listed the parent under an advanced breadcrumb. Levels with a path now reload via `browse`. (a)'s error-latch is addressed by clearing `items`/`next_offset` on failed loads; the remaining "run-once effect" tab-switch hazard is PR #574's fix (this PR is built compatibly with it, no duplication).
- **V3**: refusals render their own reason under "This view isn't available."; "«source» isn't reachable right now." is reserved for actual network errors (`LevelError { unreachable }`).
- **V4**: Escape closes the zone picker (`zones_strip.rs`).
- **V5/V6 (noted only, per instruction)**: no console diagnostics exist anywhere in the Library page (nothing logs on errors), and #550's skeleton/loading states don't visually appear in practice (the skeleton branch requires an empty item list mid-load). Left for follow-ups.

## Runtime verification (mandatory probe)

Production build (`make web-run`), real `RoonAdapter` event loop connected to a seeded local `FakeRoonCore` (no SOOD, no real Core contacted, Roon adapter disabled in a fresh `UHC_CONFIG_DIR`), real Chrome at the machine's LAN IP (`http://192.168.1.176:8091`). The temporary hook (`UHC_TEST_ROON_FAKE_CORE_ADDR` in `main.rs`, a zone-visibility line in `zone_list.rs`, a parked `tests/probe_fake_core.rs`) was removed before the final commits — this diff carries zero trace (verified below).

API transcript (fake zone `roon:zone_fake_1`):

- `/zones` → `"browse_supported": true, "library_tabs": ["browse","playlists"]` (defect 6).
- Root browse → `Local Library`, `My Live Radio`, `Qobuz` — no `Playlists` row, no `Settings` (defect 4).
- Local Library → `Search, Artists, Albums, Tracks, Genres` (defect 3 — previously only "Search").
- Ideal Discography → albums with `image: "/api/collections/image?ref=…"`, `subtitle: "Michael Jackson"` and `"Willie Colón & Rubén Blades"` (markup stripped, defect 5), dual `path`+`ref`.
- Thriller album → **3 tracks, each with play `ref` and `image`; no "Play Album" row; no `next_offset`** (defect 1 + 8).
- `GET /api/collections/image?ref=…` → `200 image/png` (defect 2 server side; FakeRoonCore now models `com.roonlabs.image:1/get_image`).
- My Live Radio → `items: [], next_offset: None` (defects 7 + 8 — placeholder filtered, no phantom Load more).
- `favorites` → `outcome: unsupported`, `refusal.reason: not_implemented`, `tracked_by: #531` (defect 6 sub-issue — was `backend_error`).
- `/api/search "kind of blue"` → hit with `path` **and** `image` (defect 10); opening the path returns the **tracks** directly (defect 11 auto-descend past the self-row level).

Browser transcript (owner's Chrome via extension, one tab, closed after):

1. Library page renders only **Browse / Playlists** tabs for the Roon zone.
2. Root shows Local Library / My Live Radio / Qobuz.
3. Clicked row **bodies** (not chevrons) through Qobuz → Taste of Qobuz → Ideal Discography (V1): each click navigated; breadcrumb advanced.
4. Ideal Discography renders an art grid — artwork displays (no broken images), subtitles plain ("Willie Colón & Rubén Blades").
5. Clicked the **Thriller tile body** → track grid: Wanna Be Startin' Somethin' / Thriller / Beat It, artwork on every tile, ▶ on hover, no action rows, no Load more.
6. Deep-link refresh at that level restored the same track grid (within ref TTL).
7. Clicked ▶ on a track → status "Playing" (play ref resolved against the FAKE core; the fake logged the browse+action invocation — no real device touched).
8. Typed "kind of blue" → Everywhere hit with thumbnail; clicked the **row body** → search cleared, landed directly on the album's tracks (defect 11 in UI, one click).
9. Playlists tab → playlist tile → opened to its tracks after the V2b fix (re-verified post-rebuild).

## Gates

- `cargo test` (full suite): green.
- `cargo clippy -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- wasm check (`cargo check --target wasm32-unknown-unknown --no-default-features --features web`): clean.
- `reactive_loop_lint`: green (new hook reads are memo/signal-tracked; no prop captures added — compatible with PR #574's stricter pattern-3 lint).

## Deviations

- Defect 9 excluded per scope; commented on #573.
- Defect 4 resolved by rename+hide (the issue's lighter option) rather than root splicing, keeping paging semantics intact.
- Search grouping rows ("Albums · 35 Results") remain navigable in search results — that is #566's deliberate feature; they stay out of browse-continuation levels via the subtitle signal.
