### PR TITLE
docs: add Home Assistant add-on install path (issue #580)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-
 ```
 Betas are less soaked than releases. Use one channel or the other, not both at once — LMS would see two entries for the same plugin.
 
+### Home Assistant Add-on
+
+Runs the bridge as a Supervisor-managed container on your Home Assistant box —
+no separate server, no Docker Compose, no terminal. In Home Assistant, go to
+**Settings → Add-ons → Add-on Store → ⋮ → Repositories** and add:
+
+```text
+https://github.com/open-horizon-labs/uhc-home-assistant-addon
+```
+
+Then install **Unified Hi-Fi Control** from the store. This is the Tier 1
+add-on: the UI opens in its own browser tab at `http://<your-ha-host>:8088`,
+not embedded in the HA dashboard (that's a separate, later "ingress" add-on).
+It runs with host networking, same as the Docker install above, for Roon/mDNS
+discovery. Full walkthrough, including where to find the one-time controller
+bootstrap token on first start, is in the
+[add-on repo's DOCS.md](https://github.com/open-horizon-labs/uhc-home-assistant-addon/blob/main/unified-hifi-control/DOCS.md).
+
 ### Binary Downloads
 
 Pre-built binaries available for Linux (x64, arm64, armv7), macOS (x64, arm64), and Windows from [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases).

--- a/docs/gh-release.md
+++ b/docs/gh-release.md
@@ -449,3 +449,32 @@ both are supported paths, pick whichever the owner buys.
 
 None of these are committed anywhere; the workflow only ever imports them
 from GitHub Actions secrets at build time.
+
+## Home Assistant Add-on Version Bumps
+
+The [Home Assistant add-on](https://github.com/open-horizon-labs/uhc-home-assistant-addon)
+lives in its own repository — it isn't built by this repo's CI. It's a thin
+wrapper: `unified-hifi-control/build.yaml` pins a specific `muness/unified-hifi-control`
+Docker Hub tag as `build_from`, and the Home Assistant Supervisor builds the
+add-on image locally on the user's box from that base at install/update time.
+
+After cutting a release here that you want the add-on to track:
+
+1. In the `uhc-home-assistant-addon` repo, edit `unified-hifi-control/build.yaml`:
+   bump both `build_from.amd64` and `build_from.aarch64` to the new version tag
+   (e.g. `docker.io/muness/unified-hifi-control:3.7.0`). Both arches use the
+   same tag — the published image is already a multi-arch manifest, so Docker
+   resolves the right platform layer.
+2. Bump `version` in `unified-hifi-control/config.yaml` to match (Home
+   Assistant's add-on store uses this field to show/offer the update — it
+   must change or users won't see an update available).
+3. Commit and push directly to `main` (that repo has no release process of
+   its own; the add-on version *is* the tracked UHC version).
+4. The repo's `Lint` GitHub Actions workflow (`frenck/action-addon-linter`)
+   validates the config schema on push — confirm it's green before telling
+   anyone to update.
+
+There's no automation wiring this to this repo's own release workflow yet;
+it's a manual two-field bump after you're satisfied a release is stable
+enough to push to Home Assistant users (skip beta/rc tags — point the add-on
+at stable releases only).


### PR DESCRIPTION
## Summary
- Adds a "Home Assistant Add-on" section to README.md's Installation list, pointing at the new [uhc-home-assistant-addon](https://github.com/open-horizon-labs/uhc-home-assistant-addon) repo (Tier 1: installable, no ingress — see #580).
- Adds a "Home Assistant Add-on Version Bumps" section to docs/gh-release.md documenting the manual `build.yaml`/`config.yaml` bump procedure, since the add-on repo has its own lightweight lint-only CI and isn't built by this repo's release workflow.

Docs-only change; no code, no rust touched.

Relates to open-horizon-labs/unified-hifi-control#580 (Tier 1 add-on packaging tracked in that issue and the linked add-on repo).

## Test plan
- [x] Rendered README.md and docs/gh-release.md locally to confirm formatting/links
- [x] `uhc-home-assistant-addon` repo's own Lint workflow (frenck/action-addon-linter) verified green: https://github.com/open-horizon-labs/uhc-home-assistant-addon/actions
- [ ] Reviewer: confirm the linked add-on repo URL and DOCS.md anchor render correctly on GitHub