### PR TITLE
HA Add-on Tier 2: Ingress support (UHC UI embedded in the HA dashboard)

### DIFF
--- a/public/webmcp-bridge.js
+++ b/public/webmcp-bridge.js
@@ -65,6 +65,11 @@
   "use strict";
 
   var MCP_ENDPOINT = "/mcp";
+  // #581: mirrors BASE_PATH_META in src/app/base_path.rs. Behind an ingress
+  // /subpath proxy the server injects this meta tag; the bridge must issue
+  // its /mcp POSTs under the same prefix or they escape the proxy. Absent
+  // tag (direct mode) resolves to "" and the endpoint stays "/mcp".
+  var BASE_PATH_META = "uhc-base-path";
   var MCP_SESSION_HEADER = "mcp-session-id";
   var CSRF_HEADER = "x-uhc-csrf-token";
   // Mirrors `CSRF_STORAGE_KEY` in src/app/controller_auth.rs exactly -- this
@@ -158,9 +163,22 @@
     return { content: [{ type: "text", text: String(message) }], isError: true };
   }
 
-  function Bridge(fetchImpl, storage) {
+  /// The runtime base path the server advertised (see BASE_PATH_META), or
+  /// "" when there is none. Exported for unit testing.
+  function docBasePath(doc) {
+    if (!doc || typeof doc.querySelector !== "function") return "";
+    var meta = doc.querySelector('meta[name="' + BASE_PATH_META + '"]');
+    var value = (meta && meta.getAttribute("content")) || "";
+    value = value.replace(/\/+$/, "");
+    // Same shape rule as base_path::normalize: a rooted, non-degenerate path.
+    if (value.charAt(0) !== "/" || value.length < 2) return "";
+    return value;
+  }
+
+  function Bridge(fetchImpl, storage, endpoint) {
     this._fetch = fetchImpl;
     this._storage = storage;
+    this._endpoint = endpoint || MCP_ENDPOINT;
     this._sessionId = null;
     this._nextId = 1;
   }
@@ -197,7 +215,7 @@
     if (!isNotification) body.id = self._nextId++;
 
     return self
-      ._fetch(MCP_ENDPOINT, {
+      ._fetch(self._endpoint, {
         method: "POST",
         headers: headers,
         credentials: "same-origin",
@@ -303,7 +321,11 @@
     if (!doc || !doc.modelContext || typeof doc.modelContext.registerTool !== "function") {
       return;
     }
-    var bridge = new Bridge(root.fetch.bind(root), safeLocalStorage(root));
+    var bridge = new Bridge(
+      root.fetch.bind(root),
+      safeLocalStorage(root),
+      docBasePath(doc) + MCP_ENDPOINT
+    );
     bridge.registerAll(doc.modelContext).catch(function (e) {
       if (root.console && root.console.error) {
         root.console.error("WebMCP bridge: failed to register UHC tools", e);
@@ -322,6 +344,7 @@
   return {
     install: install,
     Bridge: Bridge,
+    docBasePath: docBasePath,
     isToolAllowed: isToolAllowed,
     parseSseJson: parseSseJson,
     envelopeToCallToolResult: envelopeToCallToolResult,

--- a/src/api/controller_auth.rs
+++ b/src/api/controller_auth.rs
@@ -227,6 +227,20 @@ pub async fn middleware(
     // has even completed bootstrap.  The switch remains for the broader
     // playback/MCP surface while existing clients adopt the session cookie.
     let owner_operation = requires_controller_auth(path);
+    // HA Ingress (#581): a request proxied by the Supervisor is already
+    // authenticated by the user's Home Assistant session -- a strictly
+    // stronger boundary than the bootstrap cookie. Trust is triple-gated
+    // (UHC_INGRESS=1 set only by the add-on's run.sh, the peer must be the
+    // Supervisor's proxy network, and X-Ingress-Path must be present and
+    // well-formed -- see crate::api::ingress). Same-origin/CSRF cannot apply
+    // through the proxy: the browser Origin is the HA frontend's origin and
+    // Host is the internal proxy address, so they never match; the proxy
+    // itself is what guarantees the request came from an authenticated HA
+    // session. Direct-port requests never satisfy the peer gate and keep the
+    // full posture below, even on an ingress-enabled install.
+    if super::ingress::trusted_ingress_request(&request) {
+        return next.run(request).await;
+    }
     if !controller_auth_required() && !owner_operation {
         return next.run(request).await;
     }

--- a/src/api/ingress.rs
+++ b/src/api/ingress.rs
@@ -1,0 +1,326 @@
+//! Home Assistant Ingress support (#581).
+//!
+//! HA Ingress proxies the UI under `/api/hassio_ingress/<token>/...` and
+//! strips that prefix before forwarding, adding an `X-Ingress-Path` header
+//! carrying it. Server-side routing is therefore untouched; what breaks are
+//! the origin-absolute URLs in the HTML we emit and the URLs the client
+//! constructs. This module owns the server half of the fix:
+//!
+//! - [`IngressRewriteLayer`]: for trusted ingress requests, rewrites HTML
+//!   responses so `href="/..."`/`src="/..."` attributes carry the prefix and
+//!   injects a `<meta name="uhc-base-path">` tag -- the single value
+//!   `crate::app::base_path` reads to prefix every client-issued URL.
+//! - [`trusted_ingress_request`]: the trust rule controller-auth consults.
+//!
+//! # Trust rule (deliberately triple-gated)
+//!
+//! A request is "ingress" only when ALL of:
+//! 1. `UHC_INGRESS=1` -- set exclusively by the HA add-on's run.sh. Any
+//!    other deployment never enters these code paths, so the non-ingress
+//!    posture is byte-identical.
+//! 2. The TCP peer is the Supervisor's ingress proxy network
+//!    (`172.30.32.0/23` by default; `UHC_INGRESS_TRUSTED_PROXIES` overrides
+//!    for testing). `X-Ingress-Path` is just a header -- a LAN client hitting
+//!    the fallback direct port can type it, so the peer check is what makes
+//!    it evidence of Supervisor proxying rather than a client claim.
+//! 3. The `X-Ingress-Path` header is present and shaped like a safe path
+//!    (charset-restricted, so it can be interpolated into HTML without any
+//!    injection surface).
+//!
+//! Controller-auth treats a trusted ingress request as authenticated: Home
+//! Assistant has already authenticated the user session before the
+//! Supervisor proxies anything, which is a strictly stronger boundary than
+//! the one-time bootstrap cookie. Same-origin/CSRF checks are skipped for
+//! those requests too -- the browser Origin is the HA frontend's, never
+//! UHC's own host, and cross-site requests cannot reach the proxy without an
+//! authenticated HA session. Direct-port requests (even on an
+//! ingress-enabled install) never satisfy gate 2 and keep the full posture.
+
+use axum::{
+    body::Body,
+    extract::ConnectInfo,
+    http::{header, Request},
+    response::Response,
+};
+use futures::future::BoxFuture;
+use http_body_util::BodyExt;
+use std::net::{IpAddr, SocketAddr};
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+/// Header the Supervisor's ingress proxy adds with the browser-visible
+/// prefix (e.g. `/api/hassio_ingress/<token>`).
+pub const INGRESS_PATH_HEADER: &str = "x-ingress-path";
+
+/// Meta tag name the rewrite layer injects; mirrored by
+/// `crate::app::base_path::BASE_PATH_META`.
+const BASE_PATH_META: &str = "uhc-base-path";
+
+/// Gate 1: ingress handling is opt-in via the add-on's run.sh.
+pub fn ingress_enabled() -> bool {
+    matches!(
+        std::env::var("UHC_INGRESS").ok().as_deref(),
+        Some("1" | "true" | "TRUE" | "yes" | "on")
+    )
+}
+
+/// Gate 3: the header value must be a plain absolute path over a charset
+/// that cannot break out of an HTML attribute or smuggle traversal.
+fn valid_ingress_path(value: &str) -> bool {
+    value.starts_with('/')
+        && value.len() > 1
+        && value.len() <= 256
+        && !value.contains("..")
+        && !value.ends_with('/')
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '-' | '.'))
+}
+
+/// Gate 2: the TCP peer must be the Supervisor's proxy network.
+/// `UHC_INGRESS_TRUSTED_PROXIES` (comma-separated `ip` or `ip/prefix_len`
+/// IPv4 entries) overrides the default for local verification rigs.
+fn trusted_peer(ip: &IpAddr) -> bool {
+    match std::env::var("UHC_INGRESS_TRUSTED_PROXIES") {
+        Ok(raw) => raw
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .any(|entry| ip_matches(ip, entry)),
+        // Default: the HA Supervisor internal network the ingress proxy
+        // lives on (hassio's docker network, 172.30.32.0/23).
+        Err(_) => ip_matches(ip, "172.30.32.0/23"),
+    }
+}
+
+/// Match `ip` against `entry`: an exact IP (v4 or v6) or an IPv4 CIDR.
+fn ip_matches(ip: &IpAddr, entry: &str) -> bool {
+    if let Some((net, len)) = entry.split_once('/') {
+        let (Ok(net), Ok(len)) = (net.parse::<std::net::Ipv4Addr>(), len.parse::<u32>()) else {
+            return false;
+        };
+        let IpAddr::V4(ip) = ip else { return false };
+        if len > 32 {
+            return false;
+        }
+        let mask = if len == 0 { 0 } else { u32::MAX << (32 - len) };
+        (u32::from(*ip) & mask) == (u32::from(net) & mask)
+    } else {
+        entry.parse::<IpAddr>().map(|e| e == *ip).unwrap_or(false)
+    }
+}
+
+/// The validated ingress base path for this request, when it satisfies all
+/// three trust gates; `None` otherwise (including every direct-mode request).
+pub fn request_ingress_base<B>(request: &Request<B>) -> Option<String> {
+    if !ingress_enabled() {
+        return None;
+    }
+    let peer = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| addr.ip())?;
+    if !trusted_peer(&peer) {
+        return None;
+    }
+    let value = request
+        .headers()
+        .get(INGRESS_PATH_HEADER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .trim_end_matches('/')
+        .to_string();
+    valid_ingress_path(&value).then_some(value)
+}
+
+/// Whether this request arrived through the authenticated Supervisor proxy.
+/// Consulted by `crate::api::controller_auth::middleware`.
+pub fn trusted_ingress_request<B>(request: &Request<B>) -> bool {
+    request_ingress_base(request).is_some()
+}
+
+/// Prefix `attr="/..."` occurrences with `base`, leaving protocol-relative
+/// (`attr="//..."`) and non-rooted values alone.
+fn prefix_attr(html: &str, attr: &str, base: &str) -> String {
+    let needle = format!("{attr}=\"/");
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+    while let Some(idx) = rest.find(&needle) {
+        let after = idx + needle.len();
+        out.push_str(&rest[..after]);
+        // Protocol-relative URL: `attr="//host/..."` -- not a rooted path.
+        if !rest[after..].starts_with('/') {
+            // Rewrite `attr="/x` to `attr="{base}/x`: back up over the `/`
+            // we already copied and splice the base in front of it.
+            out.truncate(out.len() - 1);
+            out.push_str(base);
+            out.push('/');
+        }
+        rest = &rest[after..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Rewrite one HTML document for serving under `base`: prefix rooted
+/// `href`/`src` attributes and inject the base-path meta tag.
+fn rewrite_html(html: &str, base: &str) -> String {
+    let mut out = prefix_attr(html, "href", base);
+    out = prefix_attr(&out, "src", base);
+    let meta = format!("<meta name=\"{BASE_PATH_META}\" content=\"{base}\">");
+    if out.contains(&meta) {
+        return out; // idempotent across repeated middleware passes
+    }
+    if let Some(idx) = out.find("<head>") {
+        out.insert_str(idx + "<head>".len(), &meta);
+    } else {
+        out.insert_str(0, &meta);
+    }
+    out
+}
+
+/// Outermost tower layer: rewrites HTML responses for trusted ingress
+/// requests. Inert (a pure passthrough) for every other request, so direct
+/// mode never observes it.
+#[derive(Clone, Default)]
+pub struct IngressRewriteLayer;
+
+impl<S> Layer<S> for IngressRewriteLayer {
+    type Service = IngressRewriteService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IngressRewriteService { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct IngressRewriteService<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for IngressRewriteService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Response<Body>, S::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let mut inner = self.inner.clone();
+        let base = request_ingress_base(&req);
+
+        Box::pin(async move {
+            let res = inner.call(req).await?;
+            let Some(base) = base else { return Ok(res) };
+
+            let is_html = res
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .map(|ct| ct.starts_with("text/html"))
+                .unwrap_or(false);
+            if !is_html {
+                return Ok(res);
+            }
+
+            let (parts, body) = res.into_parts();
+            let body_bytes = match body.collect().await {
+                Ok(collected) => collected.to_bytes(),
+                Err(_) => return Ok(Response::from_parts(parts, Body::empty())),
+            };
+            let html = String::from_utf8_lossy(&body_bytes).to_string();
+            let rewritten = rewrite_html(&html, &base);
+
+            let mut new_res = Response::from_parts(parts, Body::from(rewritten));
+            new_res.headers_mut().remove(header::CONTENT_LENGTH);
+            Ok(new_res)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "/api/hassio_ingress/tok3n";
+
+    #[test]
+    fn rooted_href_and_src_attributes_are_prefixed() {
+        let html = r#"<head></head><body><a href="/ui/zones">z</a><script src="/./assets/app-dxh123.js"></script><img src="/api/collections/image?ref=r1"></body>"#;
+        let out = rewrite_html(html, BASE);
+        assert!(out.contains(r#"href="/api/hassio_ingress/tok3n/ui/zones""#));
+        assert!(out.contains(r#"src="/api/hassio_ingress/tok3n/./assets/app-dxh123.js""#));
+        assert!(out.contains(r#"src="/api/hassio_ingress/tok3n/api/collections/image?ref=r1""#));
+    }
+
+    #[test]
+    fn absolute_data_and_protocol_relative_urls_are_untouched() {
+        let html = r#"<a href="https://example.com/x">a</a><img src="data:image/png;base64,x"><script src="//cdn.example/x.js"></script>"#;
+        let out = rewrite_html(html, BASE);
+        assert!(out.contains(r#"href="https://example.com/x""#));
+        assert!(out.contains(r#"src="data:image/png;base64,x""#));
+        assert!(out.contains(r#"src="//cdn.example/x.js""#));
+    }
+
+    #[test]
+    fn base_path_meta_is_injected_into_head_exactly_once() {
+        let html = "<html><head><title>t</title></head><body></body></html>";
+        let once = rewrite_html(html, BASE);
+        assert!(once
+            .contains(r#"<head><meta name="uhc-base-path" content="/api/hassio_ingress/tok3n">"#));
+        let twice = rewrite_html(&once, BASE);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn ingress_path_validation_refuses_injection_and_traversal() {
+        assert!(valid_ingress_path("/api/hassio_ingress/AbC-12_3"));
+        assert!(!valid_ingress_path("/"));
+        assert!(!valid_ingress_path(""));
+        assert!(!valid_ingress_path("no-slash"));
+        assert!(!valid_ingress_path("/a/../b"));
+        assert!(!valid_ingress_path("/a\"><script>"));
+        assert!(!valid_ingress_path("/a b"));
+        assert!(!valid_ingress_path(&format!("/{}", "a".repeat(300))));
+    }
+
+    #[test]
+    fn supervisor_network_is_trusted_and_lan_is_not() {
+        // Default rule (no override env var set in the test process; if a
+        // developer machine sets it, these become the override's semantics,
+        // so pin via ip_matches directly).
+        assert!(ip_matches(&"172.30.32.2".parse().unwrap(), "172.30.32.0/23"));
+        assert!(ip_matches(&"172.30.33.7".parse().unwrap(), "172.30.32.0/23"));
+        assert!(!ip_matches(&"172.30.34.1".parse().unwrap(), "172.30.32.0/23"));
+        assert!(!ip_matches(&"192.168.1.50".parse().unwrap(), "172.30.32.0/23"));
+        assert!(ip_matches(&"127.0.0.1".parse().unwrap(), "127.0.0.0/8"));
+        assert!(ip_matches(&"127.0.0.1".parse().unwrap(), "127.0.0.1"));
+        assert!(!ip_matches(&"::1".parse().unwrap(), "172.30.32.0/23"));
+        assert!(ip_matches(&"::1".parse().unwrap(), "::1"));
+        assert!(!ip_matches(&"10.0.0.1".parse().unwrap(), "not-an-ip"));
+        assert!(!ip_matches(&"10.0.0.1".parse().unwrap(), "10.0.0.0/33"));
+    }
+
+    #[test]
+    fn request_gating_requires_env_peer_and_header() {
+        // Without UHC_INGRESS the whole feature is inert regardless of
+        // headers -- the direct-mode guarantee. (Env is process-global, so
+        // this test only asserts the disabled path; the enabled path is
+        // covered by the pure functions above and the live probe.)
+        if !ingress_enabled() {
+            let req = Request::builder()
+                .header(INGRESS_PATH_HEADER, "/api/hassio_ingress/tok")
+                .body(())
+                .unwrap();
+            assert!(request_ingress_base(&req).is_none());
+        }
+    }
+}

--- a/src/api/ingress.rs
+++ b/src/api/ingress.rs
@@ -297,10 +297,22 @@ mod tests {
         // Default rule (no override env var set in the test process; if a
         // developer machine sets it, these become the override's semantics,
         // so pin via ip_matches directly).
-        assert!(ip_matches(&"172.30.32.2".parse().unwrap(), "172.30.32.0/23"));
-        assert!(ip_matches(&"172.30.33.7".parse().unwrap(), "172.30.32.0/23"));
-        assert!(!ip_matches(&"172.30.34.1".parse().unwrap(), "172.30.32.0/23"));
-        assert!(!ip_matches(&"192.168.1.50".parse().unwrap(), "172.30.32.0/23"));
+        assert!(ip_matches(
+            &"172.30.32.2".parse().unwrap(),
+            "172.30.32.0/23"
+        ));
+        assert!(ip_matches(
+            &"172.30.33.7".parse().unwrap(),
+            "172.30.32.0/23"
+        ));
+        assert!(!ip_matches(
+            &"172.30.34.1".parse().unwrap(),
+            "172.30.32.0/23"
+        ));
+        assert!(!ip_matches(
+            &"192.168.1.50".parse().unwrap(),
+            "172.30.32.0/23"
+        ));
         assert!(ip_matches(&"127.0.0.1".parse().unwrap(), "127.0.0.0/8"));
         assert!(ip_matches(&"127.0.0.1".parse().unwrap(), "127.0.0.1"));
         assert!(!ip_matches(&"::1".parse().unwrap(), "172.30.32.0/23"));

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,6 +43,7 @@ pub mod apple_bridge;
 pub mod browse;
 pub mod controller_auth;
 pub mod credentials;
+pub mod ingress;
 pub mod mqtt_settings;
 pub mod provider_auth;
 pub mod spotify_tunnel;

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -942,7 +942,11 @@ pub async fn fetch_json<T: for<'de> Deserialize<'de>>(url: &str) -> Result<T, St
     let opts = RequestInit::new();
     opts.set_method("GET");
 
-    let request = Request::new_with_str_and_init(url, &opts).map_err(|e| format!("{:?}", e))?;
+    // Ingress/subpath deployments (#581): every fetch flows through this
+    // helper and its POST siblings below, so this is the one place request
+    // URLs pick up the runtime base path. Identity in direct mode.
+    let url = crate::app::base_path::href(url);
+    let request = Request::new_with_str_and_init(&url, &opts).map_err(|e| format!("{:?}", e))?;
 
     let resp_value = JsFuture::from(window.fetch_with_request(&request))
         .await
@@ -1002,7 +1006,9 @@ pub async fn post_json<T: Serialize, R: for<'de> Deserialize<'de>>(
     opts.set_headers(&headers);
     opts.set_body(&wasm_bindgen::JsValue::from_str(&body_str));
 
-    let request = Request::new_with_str_and_init(url, &opts).map_err(|e| format!("{:?}", e))?;
+    // See the base-path comment in `fetch_json` (#581).
+    let url = crate::app::base_path::href(url);
+    let request = Request::new_with_str_and_init(&url, &opts).map_err(|e| format!("{:?}", e))?;
 
     let resp_value = JsFuture::from(window.fetch_with_request(&request))
         .await
@@ -1057,7 +1063,9 @@ pub async fn post_json_no_response<T: Serialize>(url: &str, body: &T) -> Result<
     opts.set_headers(&headers);
     opts.set_body(&wasm_bindgen::JsValue::from_str(&body_str));
 
-    let request = Request::new_with_str_and_init(url, &opts).map_err(|e| format!("{:?}", e))?;
+    // See the base-path comment in `fetch_json` (#581).
+    let url = crate::app::base_path::href(url);
+    let request = Request::new_with_str_and_init(&url, &opts).map_err(|e| format!("{:?}", e))?;
 
     let resp_value = JsFuture::from(window.fetch_with_request(&request))
         .await

--- a/src/app/base_path.rs
+++ b/src/app/base_path.rs
@@ -112,8 +112,14 @@ mod tests {
             href_with_base(base, "https://ma.example/image.jpg"),
             "https://ma.example/image.jpg"
         );
-        assert_eq!(href_with_base(base, "data:image/png;base64,xyz"), "data:image/png;base64,xyz");
-        assert_eq!(href_with_base(base, "//cdn.example/x.js"), "//cdn.example/x.js");
+        assert_eq!(
+            href_with_base(base, "data:image/png;base64,xyz"),
+            "data:image/png;base64,xyz"
+        );
+        assert_eq!(
+            href_with_base(base, "//cdn.example/x.js"),
+            "//cdn.example/x.js"
+        );
         assert_eq!(href_with_base(base, "relative/path"), "relative/path");
     }
 

--- a/src/app/base_path.rs
+++ b/src/app/base_path.rs
@@ -1,0 +1,130 @@
+//! Runtime base-path resolution for reverse-proxy subpath deployments (#581).
+//!
+//! Home Assistant Ingress serves the UI under a per-session token path
+//! (`/api/hassio_ingress/<token>/...`). The Supervisor proxy strips that
+//! prefix before forwarding, so the *server* keeps its absolute routes --
+//! but every URL the *browser* issues (fetches, the SSE EventSource,
+//! artwork `<img src>`, router history pushes) must carry the prefix or it
+//! escapes the proxy and dies on Home Assistant's own 401.
+//!
+//! The server advertises the prefix in ONE place: a
+//! `<meta name="uhc-base-path" content="/api/hassio_ingress/<token>">` tag
+//! injected into SSR HTML by `crate::api::ingress::IngressRewriteLayer`
+//! (from the request's `X-Ingress-Path` header). This module is the ONE
+//! client-side consumer: everything that needs an origin-absolute path
+//! turned into a browser-issuable URL calls [`href`]. Outside a proxied
+//! deployment the meta tag is absent, the base is empty, and [`href`] is the
+//! identity function -- direct-mode behavior is unchanged.
+//!
+//! Why the client prefixes API-returned artwork paths (rather than the
+//! server emitting base-relative ones): the `image` fields of
+//! `/api/collections` and `/api/search` are forwarded verbatim from the
+//! `hifi_collections`/`hifi_search` MCP tool envelopes (see
+//! `src/api/browse.rs`), whose consumers include MCP clients that connect to
+//! the origin directly and need origin-absolute paths. The wire shape
+//! therefore stays origin-absolute, and this module maps it for the one
+//! consumer that sits behind a prefix -- through the same resolver the fetch
+//! helpers already use, so there is still exactly one prepend point.
+
+/// The meta tag name `crate::api::ingress` injects and this module reads.
+pub const BASE_PATH_META: &str = "uhc-base-path";
+
+/// The active base path: `""` in a direct deployment, or a normalized
+/// prefix like `/api/hassio_ingress/<token>` (leading `/`, no trailing `/`)
+/// behind an ingress proxy. Cached after the first read -- the tag is part
+/// of the served document and cannot change within a page's lifetime.
+#[cfg(target_arch = "wasm32")]
+pub fn base_path() -> String {
+    thread_local! {
+        static CACHE: std::cell::OnceCell<String> = const { std::cell::OnceCell::new() };
+    }
+    CACHE.with(|cell| cell.get_or_init(|| read_meta().unwrap_or_default()).clone())
+}
+
+/// SSR renders origin-absolute URLs; the ingress layer rewrites the emitted
+/// HTML, so the server-side base is always empty.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn base_path() -> String {
+    String::new()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_meta() -> Option<String> {
+    let document = web_sys::window()?.document()?;
+    let element = document
+        .query_selector(&format!("meta[name=\"{BASE_PATH_META}\"]"))
+        .ok()??;
+    let content = element.get_attribute("content")?;
+    normalize(&content)
+}
+
+/// Normalize a raw meta value into a usable prefix: must start with `/`,
+/// trailing slashes dropped, and a bare `/` (or anything else degenerate)
+/// means "no prefix".
+#[allow(dead_code)] // wasm-only caller; kept target-neutral so tests cover it
+fn normalize(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    (trimmed.starts_with('/') && trimmed.len() > 1).then(|| trimmed.to_string())
+}
+
+/// Turn an origin-absolute path (`/api/...`, `/events`, artwork URLs) into
+/// the URL the browser must actually issue. Identity when there is no base
+/// path, for non-path inputs (full `scheme://` URLs, `data:` URLs), and for
+/// protocol-relative `//host` URLs.
+pub fn href(path: &str) -> String {
+    href_with_base(&base_path(), path)
+}
+
+fn href_with_base(base: &str, path: &str) -> String {
+    if base.is_empty() || !path.starts_with('/') || path.starts_with("//") {
+        return path.to_string();
+    }
+    format!("{base}{path}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_mode_is_the_identity() {
+        assert_eq!(href_with_base("", "/api/settings"), "/api/settings");
+        assert_eq!(href_with_base("", "/events"), "/events");
+    }
+
+    #[test]
+    fn ingress_base_prefixes_origin_absolute_paths() {
+        let base = "/api/hassio_ingress/abc123";
+        assert_eq!(
+            href_with_base(base, "/api/collections/image?ref=r1"),
+            "/api/hassio_ingress/abc123/api/collections/image?ref=r1"
+        );
+        assert_eq!(
+            href_with_base(base, "/events"),
+            "/api/hassio_ingress/abc123/events"
+        );
+    }
+
+    #[test]
+    fn non_path_urls_are_never_touched() {
+        let base = "/api/hassio_ingress/abc123";
+        assert_eq!(
+            href_with_base(base, "https://ma.example/image.jpg"),
+            "https://ma.example/image.jpg"
+        );
+        assert_eq!(href_with_base(base, "data:image/png;base64,xyz"), "data:image/png;base64,xyz");
+        assert_eq!(href_with_base(base, "//cdn.example/x.js"), "//cdn.example/x.js");
+        assert_eq!(href_with_base(base, "relative/path"), "relative/path");
+    }
+
+    #[test]
+    fn normalize_rejects_degenerate_values_and_trims_trailing_slash() {
+        assert_eq!(
+            normalize("/api/hassio_ingress/abc/"),
+            Some("/api/hassio_ingress/abc".to_string())
+        );
+        assert_eq!(normalize("/"), None);
+        assert_eq!(normalize(""), None);
+        assert_eq!(normalize("no-leading-slash"), None);
+    }
+}

--- a/src/app/components/layout.rs
+++ b/src/app/components/layout.rs
@@ -78,8 +78,11 @@ pub fn Layout(props: LayoutProps) -> Element {
         // `asset!()` -- that would pull it into the wasm bundle. It
         // feature-detects `document.modelContext` itself and is a no-op on
         // every browser that doesn't have it yet.
+        // #581: resolved through the runtime base path so the hydrated
+        // client renders the same (possibly ingress-prefixed) src the
+        // server's HTML rewrite emitted. Identity in direct mode.
         document::Script {
-            src: "/webmcp-bridge.js",
+            src: crate::app::base_path::href("/webmcp-bridge.js"),
             defer: true
         }
 

--- a/src/app/components/zones_strip.rs
+++ b/src/app/components/zones_strip.rs
@@ -80,6 +80,8 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
     } else {
         base_image_url
     };
+    // #581: resolve through the runtime base path (identity in direct mode).
+    let image_url = crate::app::base_path::href(&image_url);
     let has_image = !image_url.is_empty();
 
     let volume = np.and_then(|n| n.volume);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,6 +6,7 @@
 use dioxus::prelude::*;
 
 pub mod api;
+pub mod base_path;
 pub mod components;
 pub mod controller_auth;
 pub mod embedded_assets;
@@ -83,6 +84,22 @@ pub fn App() -> Element {
     #[cfg(not(target_arch = "wasm32"))]
     let mcp_endpoint = try_consume_context::<McpEndpoint>().unwrap_or_default();
     use_context_provider(|| mcp_endpoint.clone());
+
+    // HA Ingress (#581): when the document was served behind a subpath
+    // proxy (the server injected a uhc-base-path meta tag), the router must
+    // treat that prefix as its base path -- Link hrefs, pushes, and route
+    // parsing all include it. Provided before Router mounts so it shadows
+    // the default (prefixless) WebHistory the web launch installs at the
+    // root. Direct mode has no meta tag and keeps the default history.
+    #[cfg(all(target_arch = "wasm32", feature = "web"))]
+    use_hook(|| {
+        let base = base_path::base_path();
+        if !base.is_empty() {
+            provide_context::<std::rc::Rc<dyn dioxus::history::History>>(std::rc::Rc::new(
+                dioxus::web::WebHistory::new(Some(base), true),
+            ));
+        }
+    });
 
     // Initialize SSE context at app root (single EventSource for all pages)
     use_sse_provider();

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -130,14 +130,19 @@ fn effective_tab(requested: Tab, visible: &[Tab]) -> Tab {
 }
 
 /// #573 defect 2 pin: the API's `image` fields (`CollectionItem::image`,
-/// `SearchResult::image`) are complete same-origin URLs
+/// `SearchResult::image`) are complete origin-absolute URLs
 /// (`/api/collections/image?ref=...`) and are used **verbatim** as
 /// `<img src>`. This helper is the single place a row image becomes a `src`;
 /// the double-prefix regression ("/api/collections/image?ref={image}" around
 /// an already-full path, 404ing every image) cannot re-enter through rsx
 /// string interpolation as long as rendering goes through here.
-fn image_src(image: &str) -> &str {
-    image
+///
+/// #581: under an ingress/subpath proxy the browser must issue the URL with
+/// the runtime base path prepended -- `base_path::href` is the same single
+/// resolver every fetch helper uses, and it is the identity in direct mode,
+/// so the verbatim pin above still holds where it was minted.
+fn image_src(image: &str) -> String {
+    crate::app::base_path::href(image)
 }
 
 /// One breadcrumb: what the user picked, and the opaque path it opened.

--- a/src/app/sse.rs
+++ b/src/app/sse.rs
@@ -268,8 +268,10 @@ pub fn use_sse_provider() {
                 return;
             }
 
-            // Create EventSource connection to /events
-            let es = match EventSource::new("/events") {
+            // Create EventSource connection to /events (base-path aware for
+            // ingress/subpath deployments, #581 -- identity in direct mode)
+            let events_url = crate::app::base_path::href("/events");
+            let es = match EventSource::new(&events_url) {
                 Ok(es) => es,
                 Err(e) => {
                     web_sys::console::error_1(

--- a/src/main.rs
+++ b/src/main.rs
@@ -986,6 +986,16 @@ mod server {
             router.serve_dioxus_application(serve_config(), app::App)
         };
 
+        // HA Ingress (#581): outermost layer so it sees the final HTML
+        // (including the injected bootstrap snippet above). A pure
+        // passthrough unless UHC_INGRESS=1 AND the request came from the
+        // Supervisor's proxy with a valid X-Ingress-Path -- direct mode
+        // never observes it. See src/api/ingress.rs.
+        let router = router.layer(api::ingress::IngressRewriteLayer);
+        if api::ingress::ingress_enabled() {
+            tracing::info!("HA Ingress mode enabled (UHC_INGRESS=1)");
+        }
+
         // Start server with graceful shutdown
         tracing::info!("Listening on http://{}", addr);
 

--- a/tests/webmcp_bridge.test.js
+++ b/tests/webmcp_bridge.test.js
@@ -258,3 +258,61 @@ test("Bridge.callTool recovers from a transport failure as an isError result and
   await b.callTool("hifi_status", {});
   assert.ok(fetchStub2Calls.includes("initialize"), "a dropped session must be re-initialized");
 });
+
+// ---------------------------------------------------------------------------
+// Base-path awareness (#581): behind HA Ingress the server injects a
+// uhc-base-path meta tag; the bridge must issue /mcp under that prefix.
+// ---------------------------------------------------------------------------
+
+function docWithMeta(content) {
+  return {
+    querySelector: (sel) =>
+      sel === 'meta[name="uhc-base-path"]' && content !== null
+        ? { getAttribute: (n) => (n === "content" ? content : null) }
+        : null,
+  };
+}
+
+test("docBasePath reads the injected meta tag and trims trailing slashes", () => {
+  assert.equal(bridge.docBasePath(docWithMeta("/api/hassio_ingress/tok")), "/api/hassio_ingress/tok");
+  assert.equal(bridge.docBasePath(docWithMeta("/api/hassio_ingress/tok/")), "/api/hassio_ingress/tok");
+});
+
+test("docBasePath is empty in direct mode and for degenerate values", () => {
+  assert.equal(bridge.docBasePath(docWithMeta(null)), "");
+  assert.equal(bridge.docBasePath(docWithMeta("")), "");
+  assert.equal(bridge.docBasePath(docWithMeta("/")), "");
+  assert.equal(bridge.docBasePath(docWithMeta("not-rooted")), "");
+  assert.equal(bridge.docBasePath(undefined), "");
+});
+
+test("Bridge posts to the prefixed MCP endpoint when constructed with one", async () => {
+  const urls = [];
+  const fetchStub = async (url, init) => {
+    urls.push(url);
+    const req = JSON.parse(init.body);
+    if (req.method === "initialize") {
+      return sseResponse({ jsonrpc: "2.0", id: req.id, result: {} }, { "mcp-session-id": "sess-1" });
+    }
+    return sseResponse({ jsonrpc: "2.0", id: req.id, result: { content: [], isError: false } }, {});
+  };
+  const b = new bridge.Bridge(fetchStub, null, "/api/hassio_ingress/tok/mcp");
+  await b.callTool("hifi_status", {});
+  assert.ok(urls.length > 0);
+  assert.ok(urls.every((u) => u === "/api/hassio_ingress/tok/mcp"));
+});
+
+test("Bridge defaults to /mcp when no endpoint is given (direct mode)", async () => {
+  const urls = [];
+  const fetchStub = async (url, init) => {
+    urls.push(url);
+    const req = JSON.parse(init.body);
+    if (req.method === "initialize") {
+      return sseResponse({ jsonrpc: "2.0", id: req.id, result: {} }, { "mcp-session-id": "sess-1" });
+    }
+    return sseResponse({ jsonrpc: "2.0", id: req.id, result: { content: [], isError: false } }, {});
+  };
+  const b = new bridge.Bridge(fetchStub, null);
+  await b.callTool("hifi_status", {});
+  assert.ok(urls.every((u) => u === "/mcp"));
+});


### PR DESCRIPTION
Closes #581

## Summary

Makes the Dioxus SPA and its server survive being proxied under Home Assistant Ingress's per-session token path (`/api/hassio_ingress/<token>/...`), while keeping direct-port behavior byte-identical. Also benefits any reverse-proxy subpath deployment (nginx/caddy subpath users).

## Design

**Base-path mechanism — one server emitter, one client resolver.** HA's proxy strips the token prefix before forwarding (server routing is untouched) and sends `X-Ingress-Path`. A new outermost tower layer (`src/api/ingress.rs::IngressRewriteLayer`) rewrites HTML responses for trusted ingress requests only: prefixes rooted `href="/..."`/`src="/..."` attributes (SSR asset/bootstrap links) and injects `<meta name="uhc-base-path" content="<prefix>">`. The client's single resolver (`src/app/base_path.rs::href`) reads that meta once and is consumed by:
- all three fetch helpers in `src/app/api.rs` (the existing choke point),
- the SSE `EventSource` URL (`src/app/sse.rs`),
- artwork `<img src>` (`library.rs::image_src`, `zones_strip.rs` — one mechanical line each),
- the webmcp bridge's `/mcp` endpoint (`public/webmcp-bridge.js` reads the same meta),
- the Dioxus router: dioxus-web 0.7's `WebHistory` supports a runtime prefix; `App()` provides a prefixed history context before `Router` mounts, so Link hrefs, pushes, and Library query deep links all carry/strip the prefix. Direct mode has no meta tag; everything is the identity.

A `<meta>` was chosen over `<base href>` because the SSR head's asset URLs are origin-absolute (`<base>` wouldn't fix them) — the HTML rewrite is needed regardless, and the meta keeps the client contract explicit.

**Why the client prefixes API-returned artwork paths** (rather than the server returning base-relative ones): `/api/collections`' `image` fields are forwarded verbatim from the `hifi_collections`/`hifi_search` MCP envelopes, whose consumers include MCP clients hitting the origin directly. The wire shape stays origin-absolute; the web client maps it in the one resolver it already uses for every fetch. The #573 "verbatim" defect pin is preserved and re-documented at `image_src`.

**Controller-auth rule — triple-gated Supervisor trust.** A request is treated as an authenticated controller session only when ALL of: (1) `UHC_INGRESS=1` (set solely by the add-on's run.sh), (2) TCP peer inside the Supervisor proxy network `172.30.32.0/23` (`UHC_INGRESS_TRUSTED_PROXIES` override exists for test rigs), (3) well-formed, charset-restricted `X-Ingress-Path`. HA authenticates the user before the Supervisor proxies anything, which is a strictly stronger boundary than the bootstrap cookie; same-origin/CSRF can't apply through the proxy (Origin is the HA frontend's, Host is the proxy's). A LAN client spoofing the header on the direct port fails gate 2 and keeps the full posture — non-ingress installs never even enter these code paths (gate 1).

## Verification

Local rig: caddy on :9099 mapping `/api/hassio_ingress/t3stt0ken/*` → :8099 with `X-Ingress-Path` injected; freshly built `dx` fullstack server, fresh `UHC_CONFIG_DIR`, all adapters off, `UHC_INGRESS=1 UHC_INGRESS_TRUSTED_PROXIES=127.0.0.1`.

All pass (scripted sweep, transcript in the issue thread of record):
- SSR pages under the prefix (/, Library deep links with `?source&tab`, /ui/zones, /settings): 200, meta injected, **every** rooted href/src prefixed, every prefixed subresource (wasm JS bundle, stylesheets, webmcp-bridge.js, nav links) 200 through the proxy
- API GETs and mutations through the proxy (mutation 200 with no cookie/CSRF — Supervisor trust); owner-op POST direct without session: 401 (posture intact)
- SSE `/events` streams through the proxy (200 `text/event-stream`, keepalive `: ping` delivered)
- MCP `initialize` through the prefix returns a session id
- Direct mode: no meta, zero prefixed URLs, byte-identical HTML shape

Honest caveat: the claude-in-chrome extension was unreachable from the sandbox, so in-browser wasm hydration under the prefix was not visually verified; the scripted sweep covers every rewritten URL + SSE, and the client-side resolution/router prefix are unit-tested. Real-HA validation is an owner step (see add-on repo branch).

Gates: `make css`, `cargo test` (all lints incl. reactive_loop/hydration green), `cargo clippy` clean, `cargo fmt --check` clean, wasm `cargo check --features web` clean, `node --test tests/webmcp_bridge.test.js` 18/18.

## Add-on repo

`uhc-home-assistant-addon` branch `tier2-ingress`: `ingress: true`, `ingress_port: 8088`, panel icon/title, run.sh exports `UHC_INGRESS=1`, DOCS.md documents both modes. **Not merged to main**: build_from pins image tag 3.7.0 which must be a UHC release containing this PR — merge after release.