### PR TITLE
fix(roon): My Live Radio stations were filtered out as play-verb rows

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -247,16 +247,32 @@ pub(crate) fn is_ungrounded_grouping(item: &BrowseItem) -> bool {
 /// came back `items: []`. The two kinds must be told apart:
 ///
 /// - `hint: action` rows fire immediately when browsed (the #545 live repro's
-///   "Play Playlist") -- always an action row, never content.
-/// - `hint: action_list` rows are only action rows when they read as a play
-///   verb *and* carry none of the content signals every live track row
-///   carried (an artist subtitle, artwork). A track named "Play That Funky
-///   Music" keeps its subtitle/artwork and stays content; a bare
-///   "Play Album"/"Play Playlist"/"Shuffle" wrapper row has neither.
+///   "Play Playlist").
+/// - `hint: action_list` rows open a menu when browsed.
+///
+/// #587: *neither* hint alone decides. #578's lineage treated every
+/// `hint: action` row as a verb, but a live Core marks **radio station rows**
+/// under My Live Radio `hint: action` too -- browsing a station plays it
+/// immediately, so the hint is honest, yet the row is addressable content.
+/// Captured off the operator's Core (Roon 2.x, 2026-08, issue #587):
+///
+/// ```json
+/// {"title":"WOSU-HD2 WOSU Public Media: Classical 101",
+///  "subtitle":"Columbus, Ohio, USA FM 89.7 HD2 English",
+///  "item_key":"1646:0","hint":"action","image_key":"afd6..."}
+/// ```
+///
+/// Dropping every `action` row emptied My Live Radio exactly the way #545's
+/// "drop every action-hinted row" emptied albums. So both action-ish hints
+/// now share the same belt-and-braces test: a row is a *verb* only when it
+/// reads as one of Roon's play verbs *and* carries none of the content
+/// signals every live content row carried (a subtitle, artwork). A track
+/// named "Play That Funky Music" and a station named "WOSU-HD2" both keep
+/// their subtitle/artwork (and neither title is a verb) and stay content; a
+/// bare "Play Album"/"Play Playlist"/"Shuffle" wrapper row has neither.
 pub(crate) fn is_immediate_action_row(item: &BrowseItem) -> bool {
     match item.hint {
-        Some(ItemHint::Action) => true,
-        Some(ItemHint::ActionList) => {
+        Some(ItemHint::Action) | Some(ItemHint::ActionList) => {
             item.subtitle.as_deref().is_none_or(str::is_empty)
                 && item.image_key.is_none()
                 && is_play_verb_title(&item.title)
@@ -2307,30 +2323,28 @@ impl RoonAdapter {
                 ..Default::default()
             })
             .await?;
-        let action_rows_seen = loaded
-            .items
-            .iter()
-            .filter(|item| {
-                matches!(
-                    item.hint,
-                    Some(ItemHint::Action) | Some(ItemHint::ActionList)
-                )
-            })
-            .count();
         // #573 defect 1: `action_list`-hinted track rows are content, not
         // action rows (see `is_immediate_action_row`) -- only the verb rows
         // that get filtered out of listings count against "other content"
         // here, or an album whose whole peek window is [Play Album,
         // track, track, ...] would read as a pure action leaf and lose its
-        // navigability. `playable` stays judged on the broad action count:
-        // any action-ish row one level down means Roon can play this
-        // directly.
+        // navigability.
+        //
+        // #587: `playable` is judged on the same verb-row count, no longer on
+        // "any action-ish hint one level down". A live Core marks radio
+        // station rows `hint: action` (see `is_immediate_action_row`'s
+        // captured shape), so the broad count read a folder of stations
+        // (My Live Radio) as directly playable -- but invoking it has no
+        // verb row to walk, so the minted Play ref could only ever error
+        // ("Action 'Play Now' not available"). Every genuinely playable
+        // container observed live leads with a verb row ("Play Album",
+        // "Play Playlist", ...), which is exactly what this counts.
         let immediate_action_rows = loaded
             .items
             .iter()
             .filter(|item| is_immediate_action_row(item))
             .count();
-        let playable = action_rows_seen > 0;
+        let playable = immediate_action_rows > 0;
         let has_other_content = loaded.list.count > immediate_action_rows;
         Ok((playable, has_other_content))
     }
@@ -4495,14 +4509,36 @@ mod defect_573_row_classification {
             "Queue",
             "Start Radio",
         ] {
-            assert!(
-                is_immediate_action_row(&item(title, Some(ItemHint::ActionList))),
-                "{title} (action_list) must classify as an action row"
-            );
+            for hint in [ItemHint::ActionList, ItemHint::Action] {
+                assert!(
+                    is_immediate_action_row(&item(title, Some(hint.clone()))),
+                    "{title} ({hint:?}) must classify as an action row"
+                );
+            }
         }
-        // A plain `action` hint always fires immediately, whatever its title.
-        assert!(is_immediate_action_row(&item(
-            "Anything",
+    }
+
+    /// #587: a live Core marks radio station rows under My Live Radio
+    /// `hint: action` (browsing one plays it immediately) -- they are
+    /// content, not verb rows. Shape captured off the operator's Core; see
+    /// `is_immediate_action_row`'s docs.
+    #[test]
+    fn action_hinted_radio_station_rows_are_content() {
+        let mut station = item(
+            "WOSU-HD2 WOSU Public Media: Classical 101",
+            Some(ItemHint::Action),
+        );
+        station.subtitle = Some("Columbus, Ohio, USA FM 89.7 HD2 English".to_string());
+        station.image_key = Some("afd611dd".to_string());
+        assert!(
+            !is_immediate_action_row(&station),
+            "a station row with subtitle and artwork is content"
+        );
+
+        // Even a bare station (no subtitle, no artwork) survives: its title
+        // is not one of Roon's play verbs.
+        assert!(!is_immediate_action_row(&item(
+            "WOSU-HD2",
             Some(ItemHint::Action)
         )));
     }

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -316,6 +316,26 @@ pub fn playlist_live(title: &str, tracks: &[(&str, &str)]) -> FakeItem {
     FakeItem::list(title).with_children(children)
 }
 
+/// A live-radio station row, shaped exactly as the operator's real Core
+/// served one under "My Live Radio" (issue #587, recorded 2026-08 via the
+/// raw `/roon/browse` endpoint against the production install):
+///
+/// ```json
+/// {"title":"WOSU-HD2 WOSU Public Media: Classical 101",
+///  "subtitle":"Columbus, Ohio, USA FM 89.7 HD2 English",
+///  "item_key":"1646:0","hint":"action","image_key":"afd6..."}
+/// ```
+///
+/// The load-bearing part is `hint: action` -- browsing a station **plays it
+/// immediately** (no Play Now menu below it), which is why it has no
+/// children here. #587 was exactly this row being mistaken for a play-verb
+/// row and filtered out of `hifi_collections` listings.
+pub fn radio_station(title: &str, subtitle: &str) -> FakeItem {
+    FakeItem::action(title)
+        .with_subtitle(subtitle)
+        .with_image_key(&format!("img_{}", title.to_lowercase().replace(' ', "_")))
+}
+
 /// The fake Core's library: a browse root plus a flat set of searchable items.
 #[derive(Debug, Clone)]
 pub struct FakeLibrary {
@@ -805,6 +825,31 @@ impl FakeRoonCore {
 
     pub async fn set_item_key_scope(&self, scope: ItemKeyScope) {
         self.state.write().await.item_key_scope = scope;
+    }
+
+    /// Replace the children of the node titled `parent_title`, mid-run.
+    ///
+    /// This is how a test models the library changing under a live Core --
+    /// e.g. the operator adding a radio station in Roon's own app while UHC
+    /// is connected (#587). A real Core serves whatever the level contains
+    /// *at browse time* (this fake likewise snapshots a level's children
+    /// when the level is entered, in `handle_browse`), so the change is
+    /// visible to any browse that happens after the mutation and invisible
+    /// to loads of a level that was entered before it.
+    ///
+    /// Panics when no node carries that title, so a typo fails the test
+    /// loudly instead of mutating nothing.
+    pub async fn set_children_by_title(&self, parent_title: &str, children: Vec<FakeItem>) {
+        let mut state = self.state.write().await;
+        let parent = state
+            .arena
+            .find_by_title(parent_title)
+            .unwrap_or_else(|| panic!("no node titled {parent_title:?} in the fake library"));
+        let indices: Vec<usize> = children
+            .iter()
+            .map(|child| arena_insert(&mut state.arena.nodes, child))
+            .collect();
+        state.arena.nodes[parent].children = indices;
     }
 
     pub async fn set_zones(&self, zones: Vec<Value>) {

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -31,8 +31,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use mock_servers::roon_core::{
-    album, album_live, playlist, playlist_live, zone_with_grouping, FakeItem, FakeLibrary,
-    FakeRoonCore, Hint, ItemKeyScope,
+    album, album_live, playlist, playlist_live, radio_station, zone_with_grouping, FakeItem,
+    FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
 };
 use roon_api::browse::{BrowseOpts, LoadOpts};
 use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
@@ -2100,6 +2100,187 @@ async fn roon_collections_no_results_placeholder_is_not_listed() {
         level["next_offset"].is_null(),
         "an empty level must not advertise Load more (#573 defect 8): {level:?}"
     );
+
+    core.stop().await;
+}
+
+/// #587: a live Core marks radio station rows under "My Live Radio"
+/// `hint: action` (browsing a station plays it immediately) -- see
+/// `radio_station`'s docs for the captured wire shape. #578's classification
+/// treated every `action` row as a play verb and filtered stations out, so
+/// the node listed as empty despite stations existing. Stations must list as
+/// playable leaves; the My Live Radio folder itself must be navigable but
+/// not offer a Play that could only error.
+#[tokio::test]
+async fn roon_collections_my_live_radio_lists_stations_as_playable_leaves() {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![
+        FakeItem::list("My Live Radio").with_children(vec![radio_station(
+            "WOSU-HD2 WOSU Public Media: Classical 101",
+            "Columbus, Ohio, USA FM 89.7 HD2 English",
+        )]),
+    ];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let radio_row = &root["items"][0];
+    assert_eq!(radio_row["title"], "My Live Radio");
+    assert_eq!(
+        radio_row["navigable"], true,
+        "the radio folder must stay browsable: {root:?}"
+    );
+    assert_eq!(
+        radio_row["playable"], false,
+        "a folder of stations offers no play verb to invoke -- a Play ref \
+         here could only error (#587): {root:?}"
+    );
+    let session_key = root["session_key"].as_str().unwrap().to_string();
+    let radio_key = radio_row["item_key"].as_str().unwrap().to_string();
+
+    let level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": radio_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let items = level["items"].as_array().unwrap();
+    assert_eq!(
+        items.len(),
+        1,
+        "the station row must not be filtered as a play verb (#587): {level:?}"
+    );
+    assert_eq!(
+        items[0]["title"],
+        "WOSU-HD2 WOSU Public Media: Classical 101"
+    );
+    assert_eq!(
+        items[0]["subtitle"], "Columbus, Ohio, USA FM 89.7 HD2 English",
+        "the station's location/language subtitle survives the mapping"
+    );
+    assert_eq!(
+        items[0]["playable"], true,
+        "browsing a station plays it -- it must mint a play ref: {level:?}"
+    );
+    assert_eq!(
+        items[0]["navigable"], false,
+        "a station is a leaf: entering it would invoke playback, so it must \
+         not be offered as a folder: {level:?}"
+    );
+    assert!(
+        items[0]["image_key"].is_string(),
+        "station artwork must survive the mapping: {level:?}"
+    );
+
+    core.stop().await;
+}
+
+/// #587 acceptance: a station added in Roon's own app while UHC is running
+/// (modeled as a mid-session library mutation) appears on the next browse of
+/// My Live Radio -- same adapter connection, no restart. Also pins the empty
+/// state on the way: before the station exists, the node lists cleanly empty
+/// (the "No Results" placeholder stays filtered).
+#[tokio::test]
+async fn roon_collections_station_added_mid_session_appears_without_restart() {
+    let mut library = FakeLibrary::standard();
+    library.root_items =
+        vec![FakeItem::list("My Live Radio").with_children(vec![FakeItem::new("No Results")])];
+
+    let core = FakeRoonCore::start_with(library).await;
+    let adapter = connected(&core).await;
+
+    // Walk 1: the node is empty (placeholder filtered, no phantom rows).
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let session_key = root["session_key"].as_str().unwrap().to_string();
+    let radio_key = root["items"][0]["item_key"].as_str().unwrap().to_string();
+    let empty = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": radio_key,
+                "session_key": session_key,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        empty["items"].as_array().unwrap().is_empty(),
+        "before the station exists the node lists cleanly empty: {empty:?}"
+    );
+
+    // The operator adds a station in Roon's own app.
+    core.set_children_by_title(
+        "My Live Radio",
+        vec![radio_station(
+            "WOSU-HD2 WOSU Public Media: Classical 101",
+            "Columbus, Ohio, USA FM 89.7 HD2 English",
+        )],
+    )
+    .await;
+
+    // Walk 2: a fresh root walk (what the UI does on every Browse-tab entry)
+    // sees the station -- no adapter restart, same connection.
+    let root2 = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let session2 = root2["session_key"].as_str().unwrap().to_string();
+    assert_ne!(
+        session2, session_key,
+        "every root walk mints a fresh browse session -- staleness cannot \
+         come from session reuse"
+    );
+    let radio_key2 = root2["items"][0]["item_key"].as_str().unwrap().to_string();
+    let level = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": radio_key2,
+                "session_key": session2,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let items = level["items"].as_array().unwrap();
+    assert_eq!(
+        items.len(),
+        1,
+        "the added station appears without restart: {level:?}"
+    );
+    assert_eq!(
+        items[0]["title"],
+        "WOSU-HD2 WOSU Public Media: Classical 101"
+    );
+    assert_eq!(items[0]["playable"], true);
 
     core.stop().await;
 }


### PR DESCRIPTION
Closes #587

## Root cause (evidence, not hypothesis)

Probed the production install **read-only** through the raw `/roon/browse` endpoint (fresh session, `pop_all`, then one `item_key` browse into the node — never into an action row, so nothing was invoked):

```json
{"action":"list","list":{"title":"My Live Radio","count":1,"level":1},
 "items":[{"title":"WOSU-HD2 WOSU Public Media: Classical 101",
           "subtitle":"Columbus, Ohio, USA FM 89.7 HD2 English",
           "item_key":"1646:0","hint":"action","image_key":"afd6..."}]}
```

- **Not a stale session** (hypothesis 1): a freshly minted session returned the current station immediately (`count: 1`) — consistent with the owner's datum that a full UHC restart didn't help. Every `hifi_collections` root walk already mints a fresh `collections_<nanos>` session.
- **Over-filtering** (hypothesis 2, confirmed): live station rows are `hint: "action"` — browsing a station plays it immediately, so the hint is honest — but `is_immediate_action_row` treated *every* `action` row as a play verb ("Play Playlist"-style) and dropped it from listings. My Live Radio therefore always mapped to `items: []`, the same failure #545 had with albums one hint over.

## Fix (`src/adapters/roon.rs`)

- `is_immediate_action_row`: `action` and `action_list` now share the belt-and-braces test — a row is a verb only when its title is one of Roon's play verbs **and** it carries no content signal (subtitle, artwork). The captured station shape is quoted in the doc comment.
- `peek_playability`: `playable` is judged on verb rows rather than "any action-ish hint one level down", so the My Live Radio *folder* no longer mints a Play ref whose invocation could only error ("Action 'Play Now' not available") — it stays navigable, stations inside are the playable leaves.

## Fixtures + tests

- `tests/mock_servers/roon_core.rs`: `radio_station()` fixture pinned to the live capture, and `set_children_by_title()` to mutate the fake's library mid-run (models the owner adding a station in Roon while UHC is connected; levels stay snapshotted at browse time like a real Core).
- `tests/roon_protocol.rs`:
  - `roon_collections_my_live_radio_lists_stations_as_playable_leaves` — station listed with play ref, subtitle, artwork; folder navigable but not playable.
  - `roon_collections_station_added_mid_session_appears_without_restart` — empty node lists cleanly (No Results still filtered), station added mid-session appears on the next walk, and each root walk provably mints a fresh session.
- Unit tests: live station shape (with and without subtitle/artwork) is content; every observed verb row still filters under both hints.

## Runtime verification (mandatory probe)

Production build (`make web-run`), real `RoonAdapter` event loop connected directly to a seeded local `FakeRoonCore` (no SOOD left the machine — the Roon startable was excluded while the temp hook was active; fresh `UHC_CONFIG_DIR`). Temporary rig (`UHC_TEST_ROON_FAKE_CORE_ADDR` hook in `main.rs`, parked `tests/probe_fake_core.rs`) was removed before push — this diff carries zero trace.

Browser transcript (real Chromium via the Claude Code browser pane; the claude-in-chrome extension was unreachable from this sandbox — honest note per issue instructions):

1. Library → My Live Radio (empty fixture) → clean "Nothing here yet / This folder is empty." — no phantom rows.
2. Mutated the fake core's radio list mid-run (station added, UHC **not** restarted).
3. Library → My Live Radio → station tile renders: artwork, "WOSU-HD2 WOSU Public Media: C…", subtitle "Columbus, Ohio, USA FM 89.7 HD2 English", Play button on hover.
4. API cross-check: `POST /api/collections` on the node → one item with `ref` (playable), `image`, subtitle; folder row itself carries `path` only.

## Gates

- `make css` + full plain `cargo test` — green (556 lib + all integration suites; 85/85 roon_protocol)
- `cargo clippy -- -D warnings` (CI's invocation) — green
- `cargo fmt --check` — green
- `cargo check --target wasm32-unknown-unknown --no-default-features --features web` — green

## Deviations

- `sg review` was skipped: `sg` on this machine is ast-grep 0.45 (no `review` subcommand); no superego binary is installed.
- Read-only probes were made against the production install's `/roon/browse` (browse/list only, never entering an action-hinted row); no mutations were sent to 192.168.1.2:8088.