### PR TITLE
fix(roon): albums at the Artists level carry no play ref (#593)

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -2284,45 +2284,80 @@ impl RoonAdapter {
     /// #545: Roon puts play actions one level *below* the browsable item
     /// itself (see `resolve_item_key`'s docs on `enter_item`) -- there is no
     /// hint on the item's own row that says "you can also play this without
-    /// navigating in". The only way to know is to look: browse `item_key` in
-    /// a disposable session (so this never disturbs the caller's own browse
-    /// position -- `browse_collection`'s session may still be paging through
-    /// the level this item came from) and check the first few rows of what
-    /// comes back.
+    /// navigating in". The only way to know is to look: browse `item_key`,
+    /// check the first few rows of what comes back, and step back out.
+    ///
+    /// # The peek MUST happen inside the caller's own session (#593)
+    ///
+    /// This method's first version peeked in a disposable `peek_<nanos>`
+    /// session instead, assuming `item_key`s resolve across sessions. A real
+    /// Core scopes them per session, and its failure mode is *silent*:
+    /// browsing a foreign key inside a fresh session answers `action: list`
+    /// with the **root** ("Explore", level 0) list -- no error at all.
+    /// Probed read-only against the operator's production Core (Roon 2.x,
+    /// 2026-08, issue #593): a key minted in one `/roon/browse` session,
+    /// browsed inside a fresh one, returned the root every time. So every
+    /// peek judged the root's rows (never a play verb among them), no
+    /// list-hinted container ever classified as playable, and albums under
+    /// Artists rendered with no Play at all -- while the whole suite stayed
+    /// green, because `FakeRoonCore`'s default `ItemKeyScope::Global` modeled
+    /// exactly the assumption that was wrong (`PerSessionSilentRootReset` now
+    /// models the observed behavior).
+    ///
+    /// Peeking in the caller's session pushes the peeked level onto that
+    /// session's stack, so this browses `pop_levels: 1` afterwards to
+    /// restore the caller's position -- `content()`'s fetch-ahead loop pages
+    /// the *current* level by bare `load`s and would otherwise page the
+    /// peeked child instead (same probe: keys of a level still on the stack
+    /// stay valid after descending elsewhere and popping back).
     ///
     /// Bounded to a small peek (`PEEK_COUNT`) rather than the whole level:
     /// every fixture and the live #545 repro both put the action row(s)
     /// first, so a short prefix answers both questions at a fraction of the
     /// cost of loading the full page, and `list.count` (not the prefix
     /// length) is what `has_other_content` is actually judged against.
-    async fn peek_playability(&self, zone_id: &str, item_key: &str) -> Result<(bool, bool)> {
+    async fn peek_playability(
+        &self,
+        zone_id: &str,
+        session_key: &str,
+        item_key: &str,
+    ) -> Result<(bool, bool)> {
         const PEEK_COUNT: usize = 5;
-        let peek_session = format!(
-            "peek_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        );
         let browse_result = self
             .browse(BrowseOpts {
-                multi_session_key: Some(peek_session.clone()),
+                multi_session_key: Some(session_key.to_string()),
                 item_key: Some(item_key.to_string()),
                 zone_or_output_id: Some(zone_id.to_string()),
                 ..Default::default()
             })
             .await?;
         if !matches!(browse_result.action, BrowseAction::List) {
-            // Not expected for a `hint: list` item -- nothing to peek into.
+            // Not expected for a `hint: list` item -- nothing was pushed
+            // onto the session's stack (an invoked action produces no list),
+            // so there is nothing to pop either.
             return Ok((false, false));
         }
         let loaded = self
             .load(LoadOpts {
-                multi_session_key: Some(peek_session),
+                multi_session_key: Some(session_key.to_string()),
                 count: Some(PEEK_COUNT),
                 ..Default::default()
             })
-            .await?;
+            .await;
+        // The browse above pushed the peeked level -- restore the caller's
+        // position before propagating any load failure, or the session would
+        // be left one level deep and every subsequent `load` of the caller's
+        // page would silently read the wrong level.
+        let popped = self
+            .browse(BrowseOpts {
+                multi_session_key: Some(session_key.to_string()),
+                pop_levels: Some(1),
+                zone_or_output_id: Some(zone_id.to_string()),
+                ..Default::default()
+            })
+            .await;
+        let loaded = loaded?;
+        popped?;
         // #573 defect 1: `action_list`-hinted track rows are content, not
         // action rows (see `is_immediate_action_row`) -- only the verb rows
         // that get filtered out of listings count against "other content"
@@ -2360,16 +2395,21 @@ impl RoonAdapter {
     /// navigable+playable treatment PR #547 established for
     /// `hifi_collections`, rather than maintaining a second copy that could
     /// silently drift from this one.
+    ///
+    /// `session_key` must be the session `item` was listed in: a real Core
+    /// scopes `item_key`s per session, and peeking anywhere else silently
+    /// judges the wrong level (#593 -- see [`Self::peek_playability`]).
     pub(crate) async fn classify_navigability(
         &self,
         zone_id: &str,
+        session_key: &str,
         item: &BrowseItem,
     ) -> (bool, bool) {
         let list_hinted = matches!(item.hint, Some(ItemHint::List));
         let (playable, has_other_content) = if list_hinted {
             match item.item_key.as_deref() {
                 Some(key) => self
-                    .peek_playability(zone_id, key)
+                    .peek_playability(zone_id, session_key, key)
                     .await
                     .unwrap_or((false, true)),
                 None => (false, true),
@@ -2394,6 +2434,7 @@ impl RoonAdapter {
     async fn map_collection_page(
         &self,
         zone_id: &str,
+        session_key: &str,
         items: Vec<BrowseItem>,
         at_collection_root: bool,
         mapped: &mut Vec<Value>,
@@ -2446,7 +2487,9 @@ impl RoonAdapter {
             if is_no_results_placeholder(&item) {
                 continue;
             }
-            let (navigable, playable) = self.classify_navigability(zone_id, &item).await;
+            let (navigable, playable) = self
+                .classify_navigability(zone_id, session_key, &item)
+                .await;
             // #573 defect 4: at the collection root, "Library" repeats the
             // page's own name (the UI breadcrumb read "Library / Library").
             // "Local Library" names the same node distinguishably.
@@ -3347,8 +3390,14 @@ impl LibraryAdapter for RoonAdapter {
                         .await?
                 };
                 let mut mapped: Vec<Value> = Vec::new();
-                self.map_collection_page(zone_id, items, at_collection_root, &mut mapped)
-                    .await;
+                self.map_collection_page(
+                    zone_id,
+                    &session_key,
+                    items,
+                    at_collection_root,
+                    &mut mapped,
+                )
+                .await;
                 // #573 defect 8: `next_offset` used to be computed against
                 // Roon's raw `list.count`, *before* the grouping/action-row
                 // filters above dropped items -- so a fully-filtered page
@@ -3374,8 +3423,14 @@ impl LibraryAdapter for RoonAdapter {
                         break;
                     }
                     consumed = (consumed + chunk.items.len()).min(total);
-                    self.map_collection_page(zone_id, chunk.items, at_collection_root, &mut mapped)
-                        .await;
+                    self.map_collection_page(
+                        zone_id,
+                        &session_key,
+                        chunk.items,
+                        at_collection_root,
+                        &mut mapped,
+                    )
+                    .await;
                     rounds += 1;
                 }
                 let next_offset = (consumed < total).then_some(consumed as u64);

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -314,6 +314,29 @@ fn is_play_verb_title(title: &str) -> bool {
     })
 }
 
+/// Error marker: a playability peek descended into an item but the
+/// `pop_levels: 1` browse restoring the caller's position failed, so the
+/// session now sits at an unknown level (#593 review follow-up).
+///
+/// This is categorically different from an ordinary peek failure: a refused
+/// peek leaves the caller's position intact and classification can degrade
+/// gracefully, but after a failed restoration every further `load` in that
+/// session would silently map the wrong list (an album's tracks as its
+/// parent's rows). Carried in an [`anyhow::Error`]'s context chain; callers
+/// test for it with `error.is::<BrowsePositionLost>()` and stop paging.
+#[derive(Debug)]
+pub(crate) struct BrowsePositionLost;
+
+impl std::fmt::Display for BrowsePositionLost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "browse position lost: could not step back out of a playability \
+             peek; abandoning this listing rather than paging an unknown level"
+        )
+    }
+}
+
 /// Whether a row is Roon's "No Results" placeholder rather than content.
 ///
 /// #573 defect 7: an empty node (the live crawl's "My Live Radio") comes back
@@ -2316,6 +2339,14 @@ impl RoonAdapter {
     /// first, so a short prefix answers both questions at a fraction of the
     /// cost of loading the full page, and `list.count` (not the prefix
     /// length) is what `has_other_content` is actually judged against.
+    ///
+    /// # Errors
+    ///
+    /// An ordinary failure (the peek's own browse or load refused) is safe
+    /// to degrade from -- the caller's position is intact. A failure of the
+    /// restoring `pop_levels` browse is not: the error then carries
+    /// [`BrowsePositionLost`] in its chain, and the caller must stop paging
+    /// this session (see [`Self::classify_navigability`]).
     async fn peek_playability(
         &self,
         zone_id: &str,
@@ -2356,8 +2387,17 @@ impl RoonAdapter {
                 ..Default::default()
             })
             .await;
+        // A failed restoration outranks a failed load: the session now sits
+        // at an unknown level, and any further `load` against it (the
+        // fetch-ahead loop, the caller's next page) would silently map the
+        // wrong list -- an album's tracks as the parent's rows. Surface it
+        // as the typed [`BrowsePositionLost`] so classification stops the
+        // page instead of degrading to "not playable" the way an ordinary
+        // peek failure does.
+        if let Err(error) = popped {
+            return Err(error.context(BrowsePositionLost));
+        }
         let loaded = loaded?;
-        popped?;
         // #573 defect 1: `action_list`-hinted track rows are content, not
         // action rows (see `is_immediate_action_row`) -- only the verb rows
         // that get filtered out of listings count against "other content"
@@ -2399,19 +2439,28 @@ impl RoonAdapter {
     /// `session_key` must be the session `item` was listed in: a real Core
     /// scopes `item_key`s per session, and peeking anywhere else silently
     /// judges the wrong level (#593 -- see [`Self::peek_playability`]).
+    ///
+    /// # Errors
+    ///
+    /// `Err` only when the peek lost the session's browse position
+    /// ([`BrowsePositionLost`]): the caller must stop paging this session,
+    /// because every further `load` against it would map an unknown level's
+    /// rows. Any *other* peek failure leaves the position intact and
+    /// degrades gracefully to "navigable, not playable", exactly as before.
     pub(crate) async fn classify_navigability(
         &self,
         zone_id: &str,
         session_key: &str,
         item: &BrowseItem,
-    ) -> (bool, bool) {
+    ) -> Result<(bool, bool)> {
         let list_hinted = matches!(item.hint, Some(ItemHint::List));
         let (playable, has_other_content) = if list_hinted {
             match item.item_key.as_deref() {
-                Some(key) => self
-                    .peek_playability(zone_id, session_key, key)
-                    .await
-                    .unwrap_or((false, true)),
+                Some(key) => match self.peek_playability(zone_id, session_key, key).await {
+                    Ok(peeked) => peeked,
+                    Err(error) if error.is::<BrowsePositionLost>() => return Err(error),
+                    Err(_) => (false, true),
+                },
                 None => (false, true),
             }
         } else {
@@ -2424,13 +2473,16 @@ impl RoonAdapter {
         // empty level. A container that offers both real content *and* a
         // play action (an album, a playlist) stays navigable too.
         let navigable = list_hinted && (!playable || has_other_content);
-        (navigable, playable)
+        Ok((navigable, playable))
     }
 
     /// Filter and map one raw browse page into `hifi_collections`' item
     /// shape, appending to `mapped`. Shared by `content()`'s first-page
     /// mapping and its #573 fetch-ahead loop so the two can never disagree
     /// about what a listing row is.
+    /// `Err` only on [`BrowsePositionLost`] (see
+    /// [`Self::classify_navigability`]) -- the page must not be served, and
+    /// the caller must not keep loading this session.
     async fn map_collection_page(
         &self,
         zone_id: &str,
@@ -2438,7 +2490,7 @@ impl RoonAdapter {
         items: Vec<BrowseItem>,
         at_collection_root: bool,
         mapped: &mut Vec<Value>,
-    ) {
+    ) -> Result<()> {
         for item in items {
             // #573 defect 3: the exact-title category filter
             // (`is_category`) was verified for *search result* levels only,
@@ -2489,7 +2541,7 @@ impl RoonAdapter {
             }
             let (navigable, playable) = self
                 .classify_navigability(zone_id, session_key, &item)
-                .await;
+                .await?;
             // #573 defect 4: at the collection root, "Library" repeats the
             // page's own name (the UI breadcrumb read "Library / Library").
             // "Local Library" names the same node distinguishably.
@@ -2512,6 +2564,7 @@ impl RoonAdapter {
                 "image_key": item.image_key,
             }));
         }
+        Ok(())
     }
 
     /// Enter a named top-level browse node (`"Playlists"`, ...) in a fresh
@@ -3397,7 +3450,7 @@ impl LibraryAdapter for RoonAdapter {
                     at_collection_root,
                     &mut mapped,
                 )
-                .await;
+                .await?;
                 // #573 defect 8: `next_offset` used to be computed against
                 // Roon's raw `list.count`, *before* the grouping/action-row
                 // filters above dropped items -- so a fully-filtered page
@@ -3430,7 +3483,7 @@ impl LibraryAdapter for RoonAdapter {
                         at_collection_root,
                         &mut mapped,
                     )
-                    .await;
+                    .await?;
                     rounds += 1;
                 }
                 let next_offset = (consumed < total).then_some(consumed as u64);

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -410,10 +410,21 @@ pub async fn handle_search(
                             if crate::adapters::roon::is_ungrounded_grouping(&item) {
                                 (true, false)
                             } else if let Some(zone_id) = args.zone_id.as_deref() {
-                                state
+                                match state
                                     .roon
                                     .classify_navigability(zone_id, &session_key, &item)
                                     .await
+                                {
+                                    Ok(classified) => classified,
+                                    // BrowsePositionLost: the search session's
+                                    // browse position is gone, so every further
+                                    // classification in this loop would judge
+                                    // an unknown level. Refuse the search
+                                    // honestly instead of mislabeling hits.
+                                    Err(error) => {
+                                        return env.failed(format!("Search error: {error:#}"));
+                                    }
+                                }
                             } else {
                                 // No zone to peek playability with (#398: an
                                 // absent zone_id still routes search to Roon) --

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -410,7 +410,10 @@ pub async fn handle_search(
                             if crate::adapters::roon::is_ungrounded_grouping(&item) {
                                 (true, false)
                             } else if let Some(zone_id) = args.zone_id.as_deref() {
-                                state.roon.classify_navigability(zone_id, &item).await
+                                state
+                                    .roon
+                                    .classify_navigability(zone_id, &session_key, &item)
+                                    .await
                             } else {
                                 // No zone to peek playability with (#398: an
                                 // absent zone_id still routes search to Roon) --

--- a/tests/mock_servers/README.md
+++ b/tests/mock_servers/README.md
@@ -210,18 +210,27 @@ Home Assistant is not UHC, so this is evidence rather than proof — but it is e
 that #396 should not design on the assumption keys are portable, and enough that
 `/roon/play_item` should be assumed broken until the rig says otherwise.
 
-The default stays `Global` because that is what the adapter's code assumes and these
-tests describe the adapter. **Do not read the default as a claim about Roon.**
-`a_foreign_item_key_is_rejected_when_keys_are_session_scoped` exercises the other
-setting; flip the default once the rig settles it.
+**The rig has now settled it** (issue #593, 2026-08, read-only probe of the
+operator's production Core through UHC's own `/roon/browse`): keys do **not**
+cross sessions, and the observed failure mode is a third one neither citation
+predicted — a foreign key in a fresh session answers *successfully* with the
+root list, no error at all. `ItemKeyScope::PerSessionSilentRootReset` models
+that transcript, and
+`a_foreign_item_key_silently_answers_the_root_when_session_scoping_resets`
+proves the knob fires. The silence is what made #593: `peek_playability`'s
+disposable-session peek judged the root instead of the album and nothing
+errored anywhere.
 
-That last row is the one that matters. `RoonAdapter::play_item` mints a fresh,
-unrelated session key and browses the caller's key inside it, so the repo already
-assumes keys are global. The fake refuses to decide: `ItemKeyScope::Global` is the
-default (matching the repo's assumption) and `ItemKeyScope::PerSession` makes the
-Core reject a foreign key, so a test can pin either answer. #405 must settle it
-against the operator's rig — see
-`a_foreign_item_key_is_rejected_when_keys_are_session_scoped`.
+The default stays `Global` because most existing tests describe the adapter's
+session-internal behavior, where scope never comes into play — but any test
+guarding a code path that browses a held key should set
+`PerSessionSilentRootReset` explicitly, the way #593's collection pins do.
+
+`RoonAdapter::play_item` mints a fresh, unrelated session key and browses the
+caller's key inside it, so it is broken against the observed behavior (it
+would silently land at the root). It has no in-repo callers; see
+`a_foreign_item_key_is_rejected_when_keys_are_session_scoped` for the
+loud-refusal variant a test can still pin.
 
 ### Rejection tests work on both sides of #405, by design
 

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -316,6 +316,38 @@ pub fn playlist_live(title: &str, tracks: &[(&str, &str)]) -> FakeItem {
     FakeItem::list(title).with_children(children)
 }
 
+/// An artist level shaped exactly as the operator's real Core served one
+/// under Library / Artists (issue #593, recorded 2026-08 via the raw
+/// `/roon/browse` endpoint against the production install):
+///
+/// ```json
+/// {"list":{"title":"/Passenger.","count":3,"level":3,"subtitle":"2 Albums"},
+///  "items":[
+///   {"title":"Play Artist","item_key":"2383:0","hint":"action_list"},
+///   {"title":"Flight of the Crow","subtitle":"Passenger","item_key":"2383:1",
+///    "hint":"list","image_key":"e2ce..."},
+///   {"title":"Runaway","subtitle":"Passenger","item_key":"2383:2",
+///    "hint":"list","image_key":"5b18..."}]}
+/// ```
+///
+/// The artist's own row (one level up, at the Artists list) is `hint: list`
+/// with an "N Albums" subtitle and artwork. The album rows *here* are
+/// `hint: list` too -- they are the rows #593 reported rendering with no
+/// Play -- and each album's own level leads with a "Play Album"
+/// `action_list` wrapper (pass [`album_live`] results in for that shape).
+pub fn artist_live(name: &str, albums: Vec<FakeItem>) -> FakeItem {
+    let mut children = vec![FakeItem::action_list("Play Artist").with_children(play_actions())];
+    let album_count = albums.len();
+    children.extend(albums);
+    FakeItem::list(name)
+        .with_subtitle(&format!(
+            "{album_count} Album{}",
+            if album_count == 1 { "" } else { "s" }
+        ))
+        .with_image_key(&format!("img_{}", name.to_lowercase().replace(' ', "_")))
+        .with_children(children)
+}
+
 /// A live-radio station row, shaped exactly as the operator's real Core
 /// served one under "My Live Radio" (issue #587, recorded 2026-08 via the
 /// raw `/roon/browse` endpoint against the production install):
@@ -437,14 +469,27 @@ impl FakeLibrary {
 /// That is [`ItemKeyScope::PerSession`] behaviour, and if it is right then
 /// `/roon/play_item` is broken as #405 feared and #396's ref design changes.
 ///
-/// The default here stays `Global` because that is what the adapter's code assumes,
-/// and these tests describe the adapter. **Do not read the default as a claim about
-/// Roon.** `a_foreign_item_key_is_rejected_when_keys_are_session_scoped` exercises
-/// the other setting; flip the default once the operator's rig settles it.
+/// # The operator's rig has now settled it (issue #593, 2026-08)
 ///
-/// Two caveats against over-reading the citations: Home Assistant's integration is
-/// not UHC and may reuse keys differently, and neither source states the *rule* —
-/// only that reuse fails in practice.
+/// Probed read-only against the production Core through UHC's own
+/// `/roon/browse`: keys do **not** cross sessions -- and the failure mode is
+/// neither of the two the citations suggested. A foreign key in a fresh
+/// session answers *successfully* with the root list
+/// ([`ItemKeyScope::PerSessionSilentRootReset`] has the transcript). This is
+/// exactly what broke #593: `peek_playability` peeked in a disposable
+/// session, silently judged the root instead of the album, and no error ever
+/// surfaced.
+///
+/// The default here stays `Global` because most existing tests describe the
+/// adapter's session-internal behavior, where scope never comes into play.
+/// Tests guarding against cross-session assumptions (#593's pins) must set
+/// `set_item_key_scope(PerSessionSilentRootReset)` explicitly -- and any new
+/// adapter code path that browses a key must be exercised under it.
+///
+/// Two caveats against over-reading the third-party citations: Home Assistant's
+/// integration is not UHC and may reuse keys differently, and neither source
+/// states the *rule* — only that reuse fails in practice. The #593 probe
+/// outranks both for the cross-session question.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ItemKeyScope {
     /// Any session may use any key. Matches what this repo assumes today. Default —
@@ -453,6 +498,23 @@ pub enum ItemKeyScope {
     /// A key only resolves in the session that minted it; elsewhere the Core
     /// answers `InvalidItemKey`.
     PerSession,
+    /// A key only resolves in the session that minted it; elsewhere the Core
+    /// answers **successfully with the root list** -- no error at all.
+    ///
+    /// This is the empirical answer to the type-level docs' open question,
+    /// recorded off the operator's production Core (Roon 2.x, 2026-08,
+    /// issue #593's read-only probe through UHC's own `/roon/browse`):
+    /// a key minted in one `multi_session_key`, browsed inside a fresh one,
+    /// returned `action: "list"` with the root ("Explore", `level: 0`) list
+    /// every time -- freshly minted keys included. The same probe showed
+    /// keys of a level still on a session's stack keep resolving *within*
+    /// that session after descending elsewhere (browsing a sibling key
+    /// jumps back to its level). The silence is the dangerous part: #593's
+    /// missing-Play bug was `peek_playability` reading the root's rows as
+    /// the peeked album's and never finding a play verb, with no error
+    /// anywhere -- [`ItemKeyScope::PerSession`]'s loud refusal could not
+    /// have modeled that.
+    PerSessionSilentRootReset,
 }
 
 /// One MOO request as it arrived, for assertions about what the adapter sent.
@@ -1507,6 +1569,36 @@ async fn handle_browse(
         drop(state);
         refuse(core, writer, "InvalidItemKey", req_id, &session_key).await;
         return;
+    }
+
+    // --- per-session scoping, silent flavor ---------------------------------
+    // Observed live (issue #593, see `ItemKeyScope::PerSessionSilentRootReset`):
+    // a key this session was never served answers with the ROOT list, exactly
+    // as if the request had been `pop_all` -- successfully, with no error.
+    if state.item_key_scope == ItemKeyScope::PerSessionSilentRootReset {
+        if let Some(key) = item_key {
+            let foreign = !state
+                .minted
+                .get(key)
+                .is_some_and(|sessions| sessions.contains(&session_key));
+            if foreign && !state.reject_next_browse {
+                let root_level = Level {
+                    title: root_title.to_string(),
+                    items: state.arena.root_children.clone(),
+                };
+                let session = state.sessions.entry(session_key.clone()).or_default();
+                session.levels = vec![root_level];
+                // Same epoch semantics as `pop_all`: the reset re-mints the
+                // root level's keys freshly (matching the live probe, where
+                // the reset handed out new `<int>:<int>` keys each time).
+                session.epoch += 1;
+                let list = current_list(&state, &session_key);
+                drop(state);
+                let body = json!({ "action": "list", "list": list });
+                respond(core, writer, "COMPLETE", "Success", req_id, Some(&body)).await;
+                return;
+            }
+        }
     }
 
     // --- error injection ---------------------------------------------------

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -685,6 +685,9 @@ struct CoreState {
     rejection_names: HashMap<String, String>,
     /// One-shot: the next browse, whatever it is, is rejected.
     reject_next_browse: bool,
+    /// One-shot: the next browse carrying `pop_levels` is rejected with
+    /// `InvalidLevels` (see [`FakeRoonCore::reject_next_pop_levels`]).
+    reject_next_pop_levels: bool,
     /// Applied before every response.
     delay: Duration,
     /// Per-item_key delay override, so a test can force responses to arrive out
@@ -753,6 +756,7 @@ impl FakeRoonCore {
             rejected_keys: HashSet::new(),
             rejection_names: HashMap::new(),
             reject_next_browse: false,
+            reject_next_pop_levels: false,
             delay: Duration::ZERO,
             key_delays: HashMap::new(),
             level_delays: HashMap::new(),
@@ -887,6 +891,14 @@ impl FakeRoonCore {
 
     pub async fn set_item_key_scope(&self, scope: ItemKeyScope) {
         self.state.write().await.item_key_scope = scope;
+    }
+
+    /// One-shot: refuse the next browse that carries `pop_levels` (with
+    /// `InvalidLevels`). Targets the position-restoring pop of a playability
+    /// peek specifically -- `reject_next_browse` cannot, because the peek's
+    /// own descending browse comes first (#593 review follow-up).
+    pub async fn reject_next_pop_levels(&self) {
+        self.state.write().await.reject_next_pop_levels = true;
     }
 
     /// Replace the children of the node titled `parent_title`, mid-run.
@@ -1568,6 +1580,14 @@ async fn handle_browse(
         state.reject_next_browse = false;
         drop(state);
         refuse(core, writer, "InvalidItemKey", req_id, &session_key).await;
+        return;
+    }
+
+    // --- targeted pop_levels rejection (#593 review follow-up) --------------
+    if pop_levels.is_some() && state.reject_next_pop_levels {
+        state.reject_next_pop_levels = false;
+        drop(state);
+        refuse(core, writer, "InvalidLevels", req_id, &session_key).await;
         return;
     }
 

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -31,8 +31,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use mock_servers::roon_core::{
-    album, album_live, playlist, playlist_live, radio_station, zone_with_grouping, FakeItem,
-    FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
+    album, album_live, artist_live, playlist, playlist_live, radio_station, zone_with_grouping,
+    FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
 };
 use roon_api::browse::{BrowseOpts, LoadOpts};
 use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
@@ -906,6 +906,67 @@ async fn a_foreign_item_key_is_rejected_when_keys_are_session_scoped() {
     assert!(
         errors[0].2.starts_with("play_item_"),
         "the refusal should name play_item's own session: {errors:?}"
+    );
+
+    core.stop().await;
+}
+
+/// The live-observed flavor of session scoping (#593): a foreign key is not
+/// rejected at all -- the Core answers *successfully* with the root list.
+/// This proves the `PerSessionSilentRootReset` knob actually fires, so the
+/// #593 collection pins that run under it are not vacuously green: the fixed
+/// adapter never trips it precisely because it stays in-session.
+#[tokio::test]
+async fn a_foreign_item_key_silently_answers_the_root_when_session_scoping_resets() {
+    let core = FakeRoonCore::start().await;
+    core.set_item_key_scope(ItemKeyScope::PerSessionSilentRootReset)
+        .await;
+    let adapter = connected(&core).await;
+
+    // Session A: browse the root and mint a key.
+    adapter
+        .browse(BrowseOpts {
+            multi_session_key: Some("session_a".into()),
+            pop_all: true,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let root = adapter
+        .load(LoadOpts {
+            multi_session_key: Some("session_a".into()),
+            count: Some(10),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let library_key = root
+        .items
+        .iter()
+        .find(|i| i.title == "Library")
+        .and_then(|i| i.item_key.clone())
+        .unwrap();
+
+    // Session B browses session A's key: no error, but the answer is the
+    // ROOT list -- the exact silent misdirection the operator's Core showed
+    // (#593's read-only probe).
+    let result = adapter
+        .browse(BrowseOpts {
+            multi_session_key: Some("session_b".into()),
+            item_key: Some(library_key),
+            ..Default::default()
+        })
+        .await
+        .expect("the reset is silent: no error surfaces anywhere");
+    let list = result.list.expect("the reset answers with a list");
+    assert_eq!(
+        list.title, "Explore",
+        "a foreign key lands the session back at the root, not in Library"
+    );
+    assert_eq!(list.level, 0, "root level, not one level down");
+    assert!(
+        core.errors_sent().await.is_empty(),
+        "no refusal is ever sent -- that silence is the hazard"
     );
 
     core.stop().await;
@@ -2281,6 +2342,271 @@ async fn roon_collections_station_added_mid_session_appears_without_restart() {
         "WOSU-HD2 WOSU Public Media: Classical 101"
     );
     assert_eq!(items[0]["playable"], true);
+
+    core.stop().await;
+}
+
+/// The #593 library shape: Library -> Artists -> one artist (live capture --
+/// see `artist_live`) -> albums, under the live-observed key scoping
+/// (`PerSessionSilentRootReset`: a key browsed outside its own session
+/// silently answers the root).
+fn artists_library() -> FakeLibrary {
+    let mut library = FakeLibrary::standard();
+    library.root_items = vec![FakeItem::list("Library").with_children(vec![
+        FakeItem::list("Artists").with_children(vec![artist_live(
+            "/Passenger.",
+            vec![
+                album_live(
+                    "Flight of the Crow",
+                    "Passenger",
+                    &["Month of Sundays", "What You're Thinking"],
+                ),
+                album_live("Runaway", "Passenger", &["Hell or High Water"]),
+            ],
+        )]),
+        FakeItem::list("Albums").with_children(vec![album_live(
+            "Runaway",
+            "Passenger",
+            &["Hell or High Water"],
+        )]),
+    ])];
+    library
+}
+
+/// Walk root -> Local Library -> Artists -> artist, returning the final
+/// level's `(session_key, value)` -- the album listing #593 is about.
+async fn walk_to_artist(adapter: &Arc<RoonAdapter>, node: &str) -> (String, serde_json::Value) {
+    let mut level = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let mut session = level["session_key"].as_str().unwrap().to_string();
+    for title in ["Local Library", node] {
+        let key = level["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|i| i["title"] == title)
+            .unwrap_or_else(|| panic!("row {title} missing: {level:?}"))["item_key"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        level = adapter
+            .content(
+                "collections_browse",
+                &json!({
+                    "zone_id": "roon:zone_1",
+                    "item_key": key,
+                    "session_key": session,
+                    "limit": 20,
+                    "offset": 0,
+                }),
+            )
+            .await
+            .unwrap();
+        session = level["session_key"].as_str().unwrap().to_string();
+    }
+    (session, level)
+}
+
+/// #593: albums listed at the Artists level must be dual navigable+playable.
+///
+/// The root cause this pins against: `peek_playability` used to browse the
+/// album's `item_key` inside a disposable `peek_<nanos>` session, assuming
+/// keys resolve across sessions. The operator's production Core scopes them
+/// per session and *silently answers the root list* for a foreign key
+/// (probed read-only, 2026-08 -- see `ItemKeyScope::PerSessionSilentRootReset`),
+/// so the peek judged the root's rows, found no play verb, and every album
+/// under Artists rendered navigable-only (chevron, no Play). Under
+/// `ItemKeyScope::Global` -- the fake's default and the old assumption --
+/// this test would pass even with the disposable-session peek, which is
+/// exactly how the bug shipped; the scoped knob is the load-bearing part.
+#[tokio::test]
+async fn roon_collections_artist_level_albums_are_dual_under_session_scoped_keys() {
+    let core = FakeRoonCore::start_with(artists_library()).await;
+    core.set_item_key_scope(ItemKeyScope::PerSessionSilentRootReset)
+        .await;
+    let adapter = connected(&core).await;
+
+    let (_, artists) = walk_to_artist(&adapter, "Artists").await;
+    let artist_row = &artists["items"][0];
+    assert_eq!(artist_row["title"], "/Passenger.");
+    assert_eq!(
+        artist_row["navigable"], true,
+        "an artist opens to its albums: {artists:?}"
+    );
+    assert_eq!(
+        artist_row["playable"], true,
+        "the artist level leads with a Play Artist verb, so the artist row \
+         itself is also directly playable: {artists:?}"
+    );
+    assert_eq!(
+        artist_row["subtitle"], "2 Albums",
+        "the album-count subtitle survives the mapping: {artists:?}"
+    );
+
+    let (session, artist_level) = walk_to_artist(&adapter, "Artists").await;
+    let artist_key = artist_level["items"][0]["item_key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let albums = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": artist_key,
+                "session_key": session,
+                "limit": 20,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let rows = albums["items"].as_array().unwrap();
+    let titles: Vec<&str> = rows.iter().map(|i| i["title"].as_str().unwrap()).collect();
+    assert_eq!(
+        titles,
+        vec!["Flight of the Crow", "Runaway"],
+        "the Play Artist verb row stays filtered; the albums stay: {albums:?}"
+    );
+    for album in rows {
+        assert_eq!(
+            album["playable"], true,
+            "#593: an album at the artist level must carry a play ref: {album:?}"
+        );
+        assert_eq!(
+            album["navigable"], true,
+            "an album must also still open to its tracks: {album:?}"
+        );
+        assert!(
+            album["image_key"].is_string(),
+            "album artwork must survive the mapping: {album:?}"
+        );
+    }
+
+    // The play ref an artist-level album mints must actually resolve -- in
+    // the same session it was listed in (the whole point of #593's fix).
+    let album_key = rows[0]["item_key"].as_str().unwrap();
+    let session_key = albums["session_key"].as_str().unwrap();
+    let message = adapter
+        .play_ref(
+            album_key,
+            session_key,
+            "roon:zone_fake_1",
+            PlayAction::Play,
+            "Flight of the Crow",
+        )
+        .await
+        .expect("playing an artist-level album ref must succeed");
+    assert!(
+        message.contains("Play Now") || message.contains("Play Album"),
+        "the album's Play Album menu resolves to a real invocation: {message}"
+    );
+
+    core.stop().await;
+}
+
+/// #593 (companion report): the Library / Albums node must list its albums
+/// dual navigable+playable under the same live-observed key scoping. The
+/// row shape is identical to the artist level's (list-hinted, artist
+/// subtitle, artwork, "Play Album" wrapper one level down), so this pins
+/// the top-level node the operator's screenshot showed empty.
+///
+/// (The operator's Core *itself* currently answers the real Albums node
+/// with `count: 0` -- verified read-only through the raw `/roon/browse`
+/// passthrough, so no UHC-side change can affect that; this test pins that
+/// whenever the Core does serve album rows, UHC lists them correctly.)
+#[tokio::test]
+async fn roon_collections_albums_node_lists_albums_dual_under_session_scoped_keys() {
+    let core = FakeRoonCore::start_with(artists_library()).await;
+    core.set_item_key_scope(ItemKeyScope::PerSessionSilentRootReset)
+        .await;
+    let adapter = connected(&core).await;
+
+    let (_, albums) = walk_to_artist(&adapter, "Albums").await;
+    let rows = albums["items"].as_array().unwrap();
+    assert_eq!(rows.len(), 1, "the album row must be listed: {albums:?}");
+    assert_eq!(rows[0]["title"], "Runaway");
+    assert_eq!(
+        rows[0]["playable"], true,
+        "#593: an album under the Albums node must carry a play ref: {albums:?}"
+    );
+    assert_eq!(rows[0]["navigable"], true, "{albums:?}");
+
+    core.stop().await;
+}
+
+/// #593's fix peeks inside the caller's own session, which pushes the peeked
+/// level onto that session's stack -- so the peek must pop back out, or
+/// `content()`'s fetch-ahead loop (whose bare `load`s page the *current*
+/// level) would page the last peeked album's tracks instead of the artist's
+/// remaining albums. Forced here: limit 2 over [verb row, 4 albums] maps
+/// one album short, so fetch-ahead loads offset 2 *after* two peeks ran.
+#[tokio::test]
+async fn roon_collections_peeks_do_not_derail_fetch_ahead_paging() {
+    let mut library = FakeLibrary::standard();
+    library.root_items =
+        vec![
+            FakeItem::list("Library").with_children(vec![FakeItem::list("Artists").with_children(
+                vec![artist_live(
+                    "Prolific",
+                    vec![
+                        album_live("Album One", "Prolific", &["T1"]),
+                        album_live("Album Two", "Prolific", &["T2"]),
+                        album_live("Album Three", "Prolific", &["T3"]),
+                        album_live("Album Four", "Prolific", &["T4"]),
+                    ],
+                )],
+            )]),
+        ];
+    let core = FakeRoonCore::start_with(library).await;
+    core.set_item_key_scope(ItemKeyScope::PerSessionSilentRootReset)
+        .await;
+    let adapter = connected(&core).await;
+
+    let (session, artists) = walk_to_artist(&adapter, "Artists").await;
+    let artist_key = artists["items"][0]["item_key"].as_str().unwrap();
+    let page = adapter
+        .content(
+            "collections_browse",
+            &json!({
+                "zone_id": "roon:zone_1",
+                "item_key": artist_key,
+                "session_key": session,
+                "limit": 2,
+                "offset": 0,
+            }),
+        )
+        .await
+        .unwrap();
+    let titles: Vec<&str> = page["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["title"].as_str().unwrap())
+        .collect();
+    assert!(
+        titles.iter().all(|t| t.starts_with("Album")),
+        "fetch-ahead must keep paging the artist's albums, not a peeked \
+         album's tracks: {titles:?}"
+    );
+    assert!(
+        titles.contains(&"Album Two"),
+        "the fetch-ahead round after the filtered verb row delivers the \
+         next album: {titles:?}"
+    );
+    // Raw rows: [Play Artist, four albums] = 5 total. limit 2 consumes 2
+    // raw rows (1 album), fetch-ahead consumes 2 more (2 albums) and stops
+    // with the page filled; one raw row genuinely remains.
+    assert_eq!(
+        page["next_offset"].as_u64(),
+        Some(4),
+        "further raw rows remain past what was consumed: {page:?}"
+    );
 
     core.stop().await;
 }

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -2611,6 +2611,44 @@ async fn roon_collections_peeks_do_not_derail_fetch_ahead_paging() {
     core.stop().await;
 }
 
+/// #593 review follow-up: when a peek's position-restoring `pop_levels`
+/// browse fails, the session sits at an unknown level -- the listing must
+/// refuse loudly instead of quietly continuing (an ordinary peek failure
+/// degrades to "navigable, not playable"; a lost position must not, because
+/// the fetch-ahead loop's bare `load`s would map the peeked child's rows as
+/// the parent's).
+#[tokio::test]
+async fn roon_collections_lost_peek_position_refuses_instead_of_paging_blind() {
+    let core = FakeRoonCore::start_with(artists_library()).await;
+    let adapter = connected(&core).await;
+
+    core.reject_next_pop_levels().await;
+    let error = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .expect_err("a lost browse position must fail the listing");
+    assert!(
+        format!("{error:#}").contains("browse position lost"),
+        "the refusal must name the position loss: {error:#}"
+    );
+
+    // One-shot knob: the next walk restores normal service, and the level
+    // maps correctly again -- the failure poisoned nothing durable.
+    let root = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .expect("a fresh walk after the transient failure succeeds");
+    assert_eq!(root["items"][0]["title"], "Local Library");
+
+    core.stop().await;
+}
+
 /// #573 defect 8: paging is computed against post-filter reality. A raw
 /// page that filters to nothing (limit 1, first raw row is the "Play
 /// Playlist" verb) fetches ahead and still delivers content, and


### PR DESCRIPTION
Closes #593

## Root cause (evidence, not hypothesis)

Probed the production install **read-only** through the raw `/roon/browse` endpoint (fresh sessions, `pop_all`, list-hinted rows only — no action row was ever browsed, nothing was invoked):

1. Artist-level album rows are ordinary `hint: "list"` rows with subtitle + artwork, and the album's own level leads with a `"Play Album"` `action_list` wrapper — so classification *should* find the verb and mint a play ref:

```json
{"list":{"title":"/Passenger.","count":3,"level":3,"subtitle":"2 Albums"},
 "items":[{"title":"Play Artist","item_key":"2383:0","hint":"action_list"},
          {"title":"Flight of the Crow","subtitle":"Passenger","item_key":"2383:1","hint":"list","image_key":"e2ce..."},
          {"title":"Runaway","subtitle":"Passenger","item_key":"2383:2","hint":"list","image_key":"5b18..."}]}
```

2. The reason it never did: `peek_playability` browsed the album's `item_key` inside a **disposable `peek_<nanos>` session**, assuming keys resolve across sessions. They don't — and the real Core's failure mode is **silent**. A freshly-minted key browsed in a different session answers `action: "list"` with the **root**:

```json
// key "2419:0" minted in session issue593_probe2, browsed in issue593_peekB:
{"action":"list","list":{"title":"Explore","count":7,"level":0},
 "items":[{"title":"Library","hint":"list"}, {"title":"Playlists","hint":"list"}, ...]}
```

So every peek judged the root's rows, never found a play verb, and **no list-hinted container anywhere** (artist-level album, Albums-node album, playlist folder…) could classify as playable against a real Core — chevron only, no ▶. The whole suite stayed green because `FakeRoonCore`'s default `ItemKeyScope::Global` modeled exactly the assumption that was wrong. This also settles the epic's open empirical question (#392/#405): item keys are session-scoped, and the failure is a silent root reset, not `InvalidItemKey`.

## Fix (`src/adapters/roon.rs`)

- `peek_playability` now peeks **inside the caller's own session** and restores position with `pop_levels: 1` afterwards (pop also runs when the peek's `load` fails, so a failed peek can't leave the session one level deep). The same live probe verified the session mechanics: keys of a level still on the stack keep resolving after descending elsewhere and popping back.
- `classify_navigability`/`map_collection_page` thread the session key through; `hifi_search`'s call site (`src/mcp/tools/library.rs`) passes its own search session.
- Verb filtering (#578) and station classification (#587) are untouched — the peek's *judgment* is identical, only the *level it judges* is now the real one.

## Fixtures + tests

- `tests/mock_servers/roon_core.rs`:
  - `ItemKeyScope::PerSessionSilentRootReset` — the live-observed scoping: a foreign key answers the root list successfully (epoch-reset like `pop_all`), no refusal sent. Docs carry the probe transcript; the `ItemKeyScope` type docs and `tests/mock_servers/README.md` now record the settled answer.
  - `artist_live()` — artist level pinned to the live capture (Play Artist `action_list` wrapper + list-hinted album rows with subtitle/artwork).
- `tests/roon_protocol.rs` (85 → 89):
  - `a_foreign_item_key_silently_answers_the_root_when_session_scoping_resets` — proves the knob fires (the fixed adapter never trips it, so the pins below would otherwise be vacuously green).
  - `roon_collections_artist_level_albums_are_dual_under_session_scoped_keys` — the #593 pin: artist row dual (Play Artist verb one level down), album rows dual with artwork, and the album's play ref **resolves** via `play_ref` in the same session. Verified to FAIL against the old disposable-session peek (temporarily reintroduced, watched it fail, reverted).
  - `roon_collections_albums_node_lists_albums_dual_under_session_scoped_keys` — the top-level Albums node lists album rows dual (companion report; see caveat below).
  - `roon_collections_peeks_do_not_derail_fetch_ahead_paging` — the pop is load-bearing: fetch-ahead after in-session peeks pages the artist's remaining albums, not the last peeked album's tracks.

## Runtime verification (mandatory probe)

Production build (`dx build --release --platform web`), real `RoonAdapter` event loop connected directly to a seeded local `FakeRoonCore` under `PerSessionSilentRootReset` (no SOOD left the machine — the Roon startable was excluded while the temp `UHC_TEST_ROON_FAKE_CORE_ADDR` hook was active; fresh `UHC_CONFIG_DIR`). Temp rig (hook in `main.rs`, parked `tests/probe_fake_core.rs`) removed before push — this diff carries zero trace.

Rig: fake core seeded via a parked `tests/probe_fake_core.rs` (`FAKE_CORE_ADDR=127.0.0.1:58402`, artist/albums shape above, `PerSessionSilentRootReset`); server on port 8097 (a sibling worker owned 8093 -- untouched).

API transcript (fake zone `roon:zone_fake_1`):

- Root -> `Local Library` -> `Artists` -> artist row `/Passenger.` with `path` **and** `ref`, subtitle "2 Albums", image.
- Artist level -> both albums with **`path` and `ref`** and images (the owner's live box, same walk, shows `path` only -- the #593 symptom).
- `Albums` node -> album row dual as well.

Browser transcript (owner's Chrome via the claude-in-chrome extension, one fresh tab in the session's own group, closed after; sibling workers' tabs untouched):

1. Library page renders Browse/Playlists for the fake Roon zone; root shows `Local Library`.
2. Local Library -> Artists -> `/Passenger.` tile (subtitle "2 Albums", artwork) -> clicked the tile body.
3. **Artist level shows both album tiles with a Play button on hover** (screenshot captured; chevron = navigate, ▶ = play -- the exact affordance the issue's screenshot showed missing).
4. Clicked ▶ on "Flight of the Crow" -> status "Playing" appeared.
5. Server log proves the resolution ran against the FAKE core, in the SAME `collections_<nanos>` session the listing minted: browse album -> "Play Album" `action_list` -> `Play Now` (`item_key` carries the fake's `58402:` port nonce) -> `action: "none"` (invoked) -> HTTP 200. No real device was touched.
6. Local Library -> Albums -> the album tile lists with the same dual affordances.
7. Log cross-check: 15 `pop_levels: 1` peek-restores, **zero** `peek_` disposable sessions.

## Live datum on the Albums node (companion report, version-skew caveat)

The owner's box also shows Library / Local Library / Albums empty. Probed read-only: **the Core itself answers the Albums node with `count: 0`** (`{"title":"Albums","count":0,"level":2}`, items `[]`) while Artists (`count: 1001`) and Tracks (`count: 22242`) list fine in the same sessions — with and without a `zone_id`, across fresh sessions, and after waiting. `/roon/browse` is a raw passthrough (the installed a8fa9eb build copies `list.count` verbatim from the Core's browse response), so this is Core-side and **no UHC build, including this one, changes it**. The installed build predates #591, so collection-level behavior probed via `/api/collections` reflects pre-#591 filtering — but the raw `count: 0` is independent of that skew. If the Core ever serves album rows there, the new fixture pin proves UHC lists them dual. A possible future angle is the browse API's dedicated `albums` hierarchy — the pinned roon-api fork hardcodes `hierarchy: "browse"` — which would be a fork + adapter feature, not a classification fix.

## Gates

- `make css` + full plain `cargo test` — green (59 suites, 0 failures; 89/89 roon_protocol)
- `cargo clippy -- -D warnings` — green
- `cargo fmt --check` — green
- `cargo check --target wasm32-unknown-unknown --no-default-features --features web` — green

## Deviations

- `sg review` skipped: `sg` on this machine is ast-grep (no `review` subcommand); no superego binary installed (same deviation as PR #591).
- Read-only probes were made against the production install's `/roon/browse` and `/api/collections` (browse/list only, never entering an action-hinted row); no mutations or play calls were sent to 192.168.1.2:8088.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Roon collection browsing and search reliability when checking item playability.
  * Prevented paging from continuing when the browsing position cannot be restored.
  * Ensured item selections and playback references remain tied to the active browsing session.
  * Preserved navigation and playback for artist- and album-level collections.
  * Search now reports classification failures immediately instead of showing potentially incorrect results.

* **Tests**
  * Added coverage for session-scoped item keys, paging, recovery, and playability checks.

* **Documentation**
  * Documented observed Roon session and item-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->