### PR TITLE
Spotify tunnel: survive the OAuth redirect, the dashboard round trip, and provider URL churn

### DIFF
--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -149,11 +149,22 @@ QNAP, a different machine on the LAN — needs HTTPS. The "Using UHC from
 another device or a NAS?" panel below the callback URL has a **Get an HTTPS
 address** button for this: it asks UHC's server to open a temporary tunnel to
 itself and shows the resulting `https://…` callback URL with a copy button,
-so a first-time user never has to install or run anything. The Redirect URI
-field is pre-filled with that URL's callback path; paste the same URL into
-the Spotify dashboard's Redirect URIs, save client settings, then Connect.
-The tunnel closes itself automatically once authorization completes (success
-or failure), after 15 minutes, or via its own "Stop tunnel" button — while it
+so a first-time user never has to install or run anything. After allocation
+UHC probes its own public URL once and shows the result (reachable or not)
+before the user registers it with Spotify. The Redirect URI field is
+pre-filled with that URL's callback path while it still holds the loopback
+default; a previously saved address is never silently replaced — a
+divergence between the live tunnel and the saved Redirect URI is surfaced
+as a warning (and `oauth/start` refuses with `tunnel_redirect_mismatch`),
+because tunnel providers mint a new subdomain on every start and the
+authorize request always uses the saved Redirect URI verbatim. Paste the
+shown URL into the Spotify dashboard's Redirect URIs, save client settings,
+then Connect. The tunnel closes itself shortly after authorization
+completes (success or failure; teardown is deferred a minute so the
+callback response and settings redirect still travel through it), after 55
+minutes (under pinggy's own 60-minute anonymous-tunnel limit, and long
+enough for a first-time dashboard round trip), or via its own "Stop
+tunnel" button — while it
 is open, this UHC server is briefly reachable from the public internet at
 that address, though the callback endpoint behind it only ever accepts the
 single in-flight OAuth `state` token, so no extra trust is extended to

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -344,7 +344,7 @@ impl AppState {
         // The Spotify tunnel (#538) spawns an `ssh` child process; wire the
         // server's own shutdown token in so a graceful shutdown kills it
         // too, instead of relying solely on the manual stop / OAuth
-        // completion / fifteen-minute cap paths.
+        // completion / lifetime-cap paths.
         provider_auth.bind_shutdown(shutdown.clone());
         Self {
             roon,

--- a/src/api/provider_auth.rs
+++ b/src/api/provider_auth.rs
@@ -14,7 +14,7 @@ use crate::api::credentials::{
     EncryptedCredentialStore, MusicAssistantCredentialRecord, MusicAssistantCredentialStore,
     SpotifyCredentialRecord,
 };
-use crate::api::spotify_tunnel::{SpotifyTunnelManager, TunnelStatusResponse};
+use crate::api::spotify_tunnel::{SpotifyTunnelManager, TunnelStatus, TunnelStatusResponse};
 use axum::{
     extract::{Path, Query, State},
     http::{header::HOST, HeaderMap, StatusCode},
@@ -52,6 +52,11 @@ pub struct ProviderAuthState {
     musicassistant_credentials: Option<Arc<MusicAssistantCredentialStore>>,
     /// Temporary HTTPS tunnel for the Spotify OAuth callback (#538).
     pub spotify_tunnel: Arc<SpotifyTunnelManager>,
+    /// The port this server actually bound at boot (see `bind_local_port`).
+    /// The tunnel's `ssh -R` child targets this server directly over
+    /// loopback, so this -- not the request's `Host` header, which proxies
+    /// and ingress layers rewrite -- is the authoritative forward target.
+    local_port: Arc<std::sync::OnceLock<u16>>,
 }
 
 #[derive(Clone)]
@@ -85,6 +90,7 @@ impl Default for ProviderAuthState {
             musicassistant: Arc::new(RwLock::new(None)),
             musicassistant_credentials,
             spotify_tunnel: Arc::new(SpotifyTunnelManager::default()),
+            local_port: Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -107,6 +113,7 @@ impl ProviderAuthState {
                 .ok()
                 .map(Arc::new),
             spotify_tunnel: Arc::new(SpotifyTunnelManager::default()),
+            local_port: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -115,6 +122,21 @@ impl ProviderAuthState {
     /// just on the user-facing stop paths. Called once from `AppState::new`.
     pub fn bind_shutdown(&self, token: CancellationToken) {
         self.spotify_tunnel.bind_shutdown(token);
+    }
+
+    /// Records the port this server bound its HTTP listener to, once, at
+    /// boot. The tunnel start handler prefers this over anything derived
+    /// from request headers: behind a reverse proxy or Home Assistant
+    /// ingress the `Host` header names the proxy's port, and a tunnel
+    /// forwarding there dies as a connection reset on every public request
+    /// (#592). Later calls are ignored (`OnceLock::set` semantics).
+    pub fn bind_local_port(&self, port: u16) {
+        let _ = self.local_port.set(port);
+    }
+
+    /// The authoritative local forward target port, when known.
+    pub fn local_port(&self) -> Option<u16> {
+        self.local_port.get().copied()
     }
 
     /// Construct provider auth with an explicit Music Assistant credential
@@ -636,6 +658,27 @@ pub async fn oauth_start(
             "invalid_client_configuration",
         ));
     }
+    // pinggy (and localhost.run) mint a brand-new subdomain on every tunnel
+    // start, so a tunnel restarted after the user registered an earlier URL
+    // in Spotify's dashboard silently diverges from the saved Redirect URI.
+    // Spotify then rejects the authorize request with "redirect_uri: Not
+    // matching configuration" (#592). Catch the divergence here, before the
+    // user is sent to Spotify: the authorize request always uses the SAVED
+    // redirect URI verbatim, and a live tunnel whose address no longer
+    // matches it is a configuration conflict the user has to resolve first.
+    if let TunnelStatus::Active { url, .. } = state.provider_auth.spotify_tunnel.status().await {
+        let tunnel_callback = format!("{url}/api/providers/spotify/oauth/callback");
+        if config.redirect_uri != tunnel_callback {
+            return Err(error(
+                StatusCode::CONFLICT,
+                "Your HTTPS tunnel address changed and no longer matches the saved Redirect \
+                 URI. Save the new address, update the redirect URI registered in the Spotify \
+                 dashboard to match it, then connect -- or stop the tunnel if you meant to use \
+                 the saved address.",
+                "tunnel_redirect_mismatch",
+            ));
+        }
+    }
     let code_verifier = config.client_secret.is_none().then(generate_pkce_verifier);
     let code_challenge = code_verifier.as_deref().map(pkce_challenge);
     let state_token = random_token(32);
@@ -687,15 +730,36 @@ pub async fn oauth_callback(
     Query(query): Query<OAuthCallbackQuery>,
 ) -> Response {
     let machine = query.format.as_deref() == Some("json");
+    let is_spotify = provider == "spotify";
+    let result = oauth_callback_json(State(state.clone()), Path(provider), Query(query)).await;
     // The tunnel exists only to carry this one callback across the public
-    // internet; once the callback has been processed (whether Spotify
-    // accepted or rejected it), there is nothing left for it to do. Tear it
-    // down here regardless of outcome so a failed exchange does not leave it
-    // running until the fifteen-minute cap.
-    if provider == "spotify" {
-        state.provider_auth.spotify_tunnel.stop().await;
+    // internet; once a real in-flight attempt has concluded (whether Spotify
+    // accepted or rejected it), there is nothing left for it to do. Two
+    // hard-won rules from #592 apply, though:
+    //
+    // 1. Never stop the tunnel inline before responding -- this response
+    //    (and the settings page it redirects the browser to) travels back
+    //    through the tunnel, so an inline stop resets the very connection
+    //    carrying the "success" redirect. Teardown is deferred by a grace
+    //    period instead.
+    // 2. Only tear down for a request that matched a real pending attempt.
+    //    A request with an unknown `state` (an internet scanner probing the
+    //    public URL, a stale link, a user double-checking the address) must
+    //    not be able to kill the tunnel while the user is still working
+    //    through Spotify's dashboard.
+    if is_spotify {
+        let concluded = match &result {
+            Ok(_) => true,
+            Err((_, Json(body))) => body.code != "invalid_state",
+        };
+        if concluded {
+            state
+                .provider_auth
+                .spotify_tunnel
+                .stop_after(crate::api::spotify_tunnel::TUNNEL_CALLBACK_GRACE);
+        }
     }
-    match oauth_callback_json(State(state), Path(provider), Query(query)).await {
+    match result {
         Ok(Json(response)) if machine => Json(response).into_response(),
         Ok(Json(_)) => Redirect::to("/settings?spotify=connected").into_response(),
         Err((status, Json(error))) if machine => (status, Json(error)).into_response(),
@@ -903,21 +967,29 @@ pub async fn oauth_revoke(
 }
 
 /// The port a temporary HTTPS tunnel should forward to: this server's own
-/// listening port. Read from the request's `Host` header first -- that is
-/// exactly what the browser used to reach this server, so it is correct
-/// even behind an unusual bind address -- falling back to the `PORT`
-/// environment variable UHC itself starts from, then the documented
-/// default (`config::default_port`, kept in sync here since pulling the
-/// live `Config` into `AppState` is out of scope for this endpoint).
-fn local_tunnel_port(headers: &HeaderMap) -> u16 {
-    headers
-        .get(HOST)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|host| {
-            // `Host` is `host` or `host:port`; an IPv6 literal host looks
-            // like `[::1]:8088`, so split from the right on the last colon.
-            host.rsplit_once(':')
-                .and_then(|(_, port)| port.parse().ok())
+/// listening port. The `ssh -R` child runs on the same host as this server
+/// and targets it over loopback, so the port the server actually bound
+/// (recorded at boot via `bind_local_port`) is authoritative. The request's
+/// `Host` header is only a fallback for test/embedded setups that never
+/// call `bind_local_port`: behind a reverse proxy or Home Assistant
+/// ingress the `Host` header names the *proxy's* port, and a tunnel
+/// forwarding there answers every public request with a connection reset
+/// (#592). Final fallbacks are the `PORT` environment variable UHC starts
+/// from, then the documented default.
+fn local_tunnel_port(state: &ProviderAuthState, headers: &HeaderMap) -> u16 {
+    state
+        .local_port()
+        .or_else(|| {
+            headers
+                .get(HOST)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|host| {
+                    // `Host` is `host` or `host:port`; an IPv6 literal host
+                    // looks like `[::1]:8088`, so split from the right on
+                    // the last colon.
+                    host.rsplit_once(':')
+                        .and_then(|(_, port)| port.parse().ok())
+                })
         })
         .or_else(|| {
             std::env::var("PORT")
@@ -933,7 +1005,7 @@ pub async fn spotify_tunnel_start(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Json<TunnelStatusResponse> {
-    let port = local_tunnel_port(&headers);
+    let port = local_tunnel_port(&state.provider_auth, &headers);
     let status = state.provider_auth.spotify_tunnel.start(port).await;
     Json(status.into())
 }
@@ -948,7 +1020,7 @@ pub async fn spotify_tunnel_status(State(state): State<AppState>) -> Json<Tunnel
 /// POST /api/providers/spotify/tunnel/stop - Stop the tunnel, if any, and
 /// return to idle. Also called automatically when the OAuth callback
 /// completes; exposed here for a manual "Stop tunnel" action and so a user
-/// who abandons the flow does not have to wait for the fifteen-minute cap.
+/// who abandons the flow does not have to wait for the lifetime cap.
 pub async fn spotify_tunnel_stop(State(state): State<AppState>) -> Json<TunnelStatusResponse> {
     state.provider_auth.spotify_tunnel.stop().await;
     let status = state.provider_auth.spotify_tunnel.status().await;
@@ -1355,6 +1427,235 @@ mod tests {
                 Some("stored-secret".to_string())
             ),
             Some("replacement".to_string())
+        );
+    }
+
+    // ----- #592: tunnel/OAuth interplay ---------------------------------
+
+    use crate::api::spotify_tunnel::{
+        TunnelLaunchError, TunnelLauncher, TunnelProcess, TunnelProcessEvent, TunnelProviderKind,
+    };
+
+    /// A tunnel process that "prints" one URL line and then idles until
+    /// killed, like a healthy long-lived `ssh -R` child.
+    struct StaticUrlProcess {
+        line: Option<String>,
+        idle: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl TunnelProcess for StaticUrlProcess {
+        async fn next_event(&mut self) -> TunnelProcessEvent {
+            if let Some(line) = self.line.take() {
+                return TunnelProcessEvent::Line(line);
+            }
+            self.idle.notified().await;
+            TunnelProcessEvent::Exited {
+                stderr_tail: String::new(),
+            }
+        }
+
+        fn kill(&mut self) {
+            self.idle.notify_waiters();
+        }
+    }
+
+    struct StaticUrlLauncher(String);
+
+    #[async_trait::async_trait]
+    impl TunnelLauncher for StaticUrlLauncher {
+        async fn launch(
+            &self,
+            _provider: TunnelProviderKind,
+            _port: u16,
+        ) -> Result<Box<dyn TunnelProcess>, TunnelLaunchError> {
+            Ok(Box::new(StaticUrlProcess {
+                line: Some(self.0.clone()),
+                idle: Arc::new(tokio::sync::Notify::new()),
+            }))
+        }
+    }
+
+    /// AppState whose Spotify OAuth config is saved with `saved_redirect`
+    /// and whose tunnel manager launches a scripted tunnel that reports
+    /// `tunnel_url`. The returned tempdir keeps the credential store alive.
+    async fn tunnel_test_state(
+        saved_redirect: &str,
+        tunnel_url: &str,
+    ) -> (AppState, tempfile::TempDir) {
+        let dir = tempdir().expect("tempdir");
+        let store =
+            EncryptedCredentialStore::new(dir.path().join("spotify-credentials.enc"), [7_u8; 32]);
+        store
+            .save_record(&SpotifyCredentialRecord {
+                token: None,
+                client_id: "0123456789abcdef0123456789abcdef".to_string(),
+                client_secret: Some("shhh".to_string()),
+                redirect_uri: saved_redirect.to_string(),
+            })
+            .expect("save spotify record");
+        let mut provider_auth = ProviderAuthState::with_credential_store(store);
+        provider_auth.spotify_tunnel = Arc::new(SpotifyTunnelManager::with_launcher(Arc::new(
+            StaticUrlLauncher(tunnel_url.to_string()),
+        )));
+
+        let bus = crate::bus::create_bus();
+        let roon = Arc::new(crate::adapters::roon::RoonAdapter::new_disconnected(
+            bus.clone(),
+        ));
+        let hqp_instances = Arc::new(crate::adapters::hqplayer::HqpInstanceManager::new(
+            bus.clone(),
+        ));
+        let hqplayer = hqp_instances.get_default().await;
+        let hqp_zone_links = Arc::new(crate::adapters::hqplayer::HqpZoneLinkService::new(
+            hqp_instances.clone(),
+        ));
+        let lms = Arc::new(crate::adapters::lms::LmsAdapter::new(bus.clone()));
+        let openhome = Arc::new(crate::adapters::openhome::OpenHomeAdapter::new(bus.clone()));
+        let upnp = Arc::new(crate::adapters::upnp::UPnPAdapter::new(bus.clone()));
+        let aggregator = Arc::new(crate::aggregator::ZoneAggregator::new(bus.clone()));
+        let coordinator = Arc::new(crate::coordinator::AdapterCoordinator::new(bus.clone()));
+        let mut state = AppState::new(
+            roon,
+            hqplayer,
+            hqp_instances,
+            hqp_zone_links,
+            lms,
+            openhome,
+            upnp,
+            crate::knobs::KnobStore::new(),
+            bus,
+            aggregator,
+            coordinator,
+            Vec::new(),
+            std::time::Instant::now(),
+            CancellationToken::new(),
+        );
+        state.provider_auth = Arc::new(provider_auth);
+        (state, dir)
+    }
+
+    async fn start_tunnel_and_wait_active(state: &AppState) {
+        state.provider_auth.spotify_tunnel.start(8088).await;
+        for _ in 0..200 {
+            if matches!(
+                state.provider_auth.spotify_tunnel.status().await,
+                TunnelStatus::Active { .. }
+            ) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!(
+            "tunnel did not become active; last status: {:?}",
+            state.provider_auth.spotify_tunnel.status().await
+        );
+    }
+
+    const TUNNEL_A: &str = "https://aaaaa-1-2-3-4.run.pinggy-free.link";
+    const TUNNEL_B: &str = "https://bbbbb-5-6-7-8.run.pinggy-free.link";
+
+    fn callback_of(tunnel: &str) -> String {
+        format!("{tunnel}/api/providers/spotify/oauth/callback")
+    }
+
+    /// #592 pin: the authorize URL always carries the SAVED redirect URI
+    /// verbatim -- the live tunnel state must never be substituted in.
+    #[tokio::test]
+    async fn authorize_url_uses_the_saved_redirect_uri_verbatim() {
+        let saved = callback_of(TUNNEL_A);
+        let (state, _dir) = tunnel_test_state(&saved, TUNNEL_A).await;
+        start_tunnel_and_wait_active(&state).await;
+        let response = oauth_start(State(state), Path("spotify".to_string()))
+            .await
+            .expect("oauth_start should succeed when tunnel and saved URI match");
+        let expected = format!("redirect_uri={}", urlencoding::encode(&saved));
+        assert!(
+            response.0.authorization_url.contains(&expected),
+            "authorize URL must embed the saved redirect_uri verbatim: {}",
+            response.0.authorization_url
+        );
+    }
+
+    /// #592: tunnel providers mint a new subdomain per start, so a live
+    /// tunnel that no longer matches the saved Redirect URI means the user
+    /// is about to be bounced by Spotify ("redirect_uri: Not matching
+    /// configuration") or redirected somewhere dead. Refuse before Spotify
+    /// is contacted.
+    #[tokio::test]
+    async fn oauth_start_refuses_when_the_live_tunnel_diverges_from_the_saved_redirect() {
+        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_B).await;
+        start_tunnel_and_wait_active(&state).await;
+        let error = oauth_start(State(state), Path("spotify".to_string()))
+            .await
+            .expect_err("oauth_start must refuse a diverged tunnel");
+        assert_eq!(error.0, StatusCode::CONFLICT);
+        assert_eq!(error.1 .0.code, "tunnel_redirect_mismatch");
+    }
+
+    /// #592: a random probe of the public callback URL (internet scanner,
+    /// stale link, user double-checking the address) must not tear the
+    /// tunnel down while the user is still working in Spotify's dashboard.
+    #[tokio::test]
+    async fn callback_probe_with_unknown_state_leaves_the_tunnel_running() {
+        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
+        start_tunnel_and_wait_active(&state).await;
+        let response = oauth_callback(
+            State(state.clone()),
+            Path("spotify".to_string()),
+            Query(OAuthCallbackQuery {
+                code: Some("whatever".to_string()),
+                state: "not-a-real-state-token".to_string(),
+                error: None,
+                error_description: None,
+                format: Some("json".to_string()),
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            matches!(
+                state.provider_auth.spotify_tunnel.status().await,
+                TunnelStatus::Active { .. }
+            ),
+            "an unknown-state probe must not kill the tunnel"
+        );
+    }
+
+    /// #592: a callback that concludes a real pending attempt must NOT stop
+    /// the tunnel inline -- the response (and the settings redirect) still
+    /// travel through it. Teardown happens after a grace period instead.
+    /// The callback is also transport-independent: it is accepted here
+    /// without any tunnel-shaped Host header, matching a live enrollment
+    /// completed by replaying the redirect over the LAN.
+    #[tokio::test]
+    async fn concluded_callback_defers_teardown_past_its_own_response() {
+        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
+        start_tunnel_and_wait_active(&state).await;
+        let started = oauth_start(State(state.clone()), Path("spotify".to_string()))
+            .await
+            .expect("oauth_start");
+        let response = oauth_callback(
+            State(state.clone()),
+            Path("spotify".to_string()),
+            Query(OAuthCallbackQuery {
+                code: None,
+                state: started.0.state.clone(),
+                error: Some("access_denied".to_string()),
+                error_description: None,
+                format: Some("json".to_string()),
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            matches!(
+                state.provider_auth.spotify_tunnel.status().await,
+                TunnelStatus::Active { .. }
+            ),
+            "the tunnel must outlive the callback response it is carrying \
+             (teardown is deferred by TUNNEL_CALLBACK_GRACE)"
         );
     }
 }

--- a/src/api/spotify_tunnel.rs
+++ b/src/api/spotify_tunnel.rs
@@ -9,7 +9,7 @@
 //!
 //! The tunnel is scoped to one OAuth attempt: it starts when the user clicks
 //! "Get an HTTPS address", and is torn down when authorization completes
-//! (success or failure), when the user stops it, on a fifteen-minute safety
+//! (success or failure), when the user stops it, on a 55-minute safety
 //! timeout, or when the server shuts down. While it is active this UHC
 //! server is briefly reachable from the public internet at the tunnel's
 //! URL; the callback endpoint behind it only ever accepts the single-use,
@@ -38,7 +38,23 @@ use tokio_util::sync::CancellationToken;
 /// Hard cap on tunnel lifetime, regardless of activity. A beginner should
 /// never end up with a forgotten tunnel silently keeping this server
 /// internet-reachable.
-pub const TUNNEL_MAX_LIFETIME: Duration = Duration::from_secs(15 * 60);
+///
+/// The cap must comfortably outlast a first-time Spotify enrollment: the
+/// user copies the URL, creates an app in Spotify's developer dashboard,
+/// registers the redirect URI, copies the client ID/secret back, saves, and
+/// only then clicks Connect. A 15-minute cap was observed to expire mid-
+/// dashboard (#592), so the redirect landed on a dead tunnel as
+/// ERR_CONNECTION_RESET. pinggy's anonymous tunnels are dropped server-side
+/// at 60 minutes; capping just under that keeps the expiry message ours.
+pub const TUNNEL_MAX_LIFETIME: Duration = Duration::from_secs(55 * 60);
+
+/// How long a tunnel stays up after the OAuth callback has concluded. The
+/// callback response itself (and the settings page it redirects the browser
+/// to) travels back through the tunnel, so tearing the tunnel down inline in
+/// the callback handler reset the very TCP connection carrying the "success"
+/// redirect -- the ERR_CONNECTION_RESET defect in #592. A short grace period
+/// lets the redirect and the follow-up page load finish first.
+pub const TUNNEL_CALLBACK_GRACE: Duration = Duration::from_secs(60);
 
 /// How long to wait for one provider to print a public URL before giving up
 /// on it and falling back to the next.
@@ -82,7 +98,12 @@ impl TunnelProviderKind {
                     "ServerAliveInterval=30".to_string(),
                     "-o".to_string(),
                     "ExitOnForwardFailure=yes".to_string(),
-                    format!("-R0:localhost:{port}"),
+                    // `127.0.0.1` rather than `localhost`: inside containers
+                    // (HA add-on, NAS container station) `localhost` can
+                    // resolve to `::1` while UHC listens on IPv4 only, in
+                    // which case every public request dies as a connection
+                    // reset even though the tunnel URL was printed fine.
+                    format!("-R0:127.0.0.1:{port}"),
                     "a.pinggy.io".to_string(),
                 ],
             ),
@@ -100,7 +121,7 @@ impl TunnelProviderKind {
                     "-o".to_string(),
                     "ExitOnForwardFailure=yes".to_string(),
                     "-R".to_string(),
-                    format!("80:localhost:{port}"),
+                    format!("80:127.0.0.1:{port}"),
                     "localhost.run".to_string(),
                 ],
             ),
@@ -263,6 +284,51 @@ impl TunnelLauncher for RealTunnelLauncher {
     }
 }
 
+/// Checks that a freshly allocated public URL actually carries HTTP back to
+/// this server. A tunnel can print a URL and still be dead end-to-end (wrong
+/// forward target, relay in the wrong mode); without a probe the user only
+/// discovers that at the worst possible moment -- when Spotify redirects
+/// back (#592). Returns `Some(reachable)` or `None` when no probe is
+/// available (tests).
+#[async_trait::async_trait]
+pub(crate) trait TunnelProbe: Send + Sync {
+    async fn probe(&self, url: &str) -> Option<bool>;
+}
+
+/// Probes by fetching this server's own tunnel-status endpoint through the
+/// public URL. Any well-formed HTTP response proves the round trip; the
+/// endpoint itself is a harmless read.
+pub(crate) struct RealTunnelProbe;
+
+#[async_trait::async_trait]
+impl TunnelProbe for RealTunnelProbe {
+    async fn probe(&self, url: &str) -> Option<bool> {
+        let target = format!("{url}/api/providers/spotify/tunnel/status");
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .ok()?;
+        match client.get(&target).send().await {
+            Ok(response) => Some(response.status().is_success()),
+            Err(_) => Some(false),
+        }
+    }
+}
+
+/// A probe that reports nothing, keeping `verified` at `None`. Used by unit
+/// tests (via `with_launcher`) so exercising the state machine never
+/// performs network I/O.
+#[cfg(test)]
+pub(crate) struct NullTunnelProbe;
+
+#[cfg(test)]
+#[async_trait::async_trait]
+impl TunnelProbe for NullTunnelProbe {
+    async fn probe(&self, _url: &str) -> Option<bool> {
+        None
+    }
+}
+
 struct RealTunnelProcess {
     child: Child,
     stdout: tokio::io::Lines<BufReader<tokio::process::ChildStdout>>,
@@ -316,10 +382,16 @@ pub enum TunnelStatus {
     /// A provider is being tried.
     Starting { provider: &'static str },
     /// A public URL is live. `expires_at` is a Unix-epoch second timestamp.
+    /// `verified` reports the post-allocation self-probe through the public
+    /// URL: `None` while the probe is still running, `Some(true)` once a
+    /// real HTTP round trip succeeded, `Some(false)` when the public URL did
+    /// not answer -- shown to the user before they walk into Spotify's
+    /// dashboard with a dead address (#592).
     Active {
         url: String,
         provider: &'static str,
         expires_at: u64,
+        verified: Option<bool>,
     },
     /// Every provider failed, the tunnel timed out, or it exited
     /// unexpectedly. `message` is written to be read directly by a
@@ -339,6 +411,7 @@ fn now_secs() -> u64 {
 /// OAuth flow it exists to unblock.
 pub struct SpotifyTunnelManager {
     launcher: Arc<dyn TunnelLauncher>,
+    prober: Arc<dyn TunnelProbe>,
     status: Arc<RwLock<TunnelStatus>>,
     /// Bumped on every `start`/`stop` so a background task from a
     /// superseded attempt can tell its result is stale and stop writing to
@@ -359,14 +432,25 @@ pub struct SpotifyTunnelManager {
 
 impl Default for SpotifyTunnelManager {
     fn default() -> Self {
-        Self::with_launcher(Arc::new(RealTunnelLauncher))
+        Self::with_parts(Arc::new(RealTunnelLauncher), Arc::new(RealTunnelProbe))
     }
 }
 
 impl SpotifyTunnelManager {
+    /// Test constructor: scripted launcher, no reachability probe (so unit
+    /// tests never touch the network and `verified` stays `None`).
+    #[cfg(test)]
     pub(crate) fn with_launcher(launcher: Arc<dyn TunnelLauncher>) -> Self {
+        Self::with_parts(launcher, Arc::new(NullTunnelProbe))
+    }
+
+    pub(crate) fn with_parts(
+        launcher: Arc<dyn TunnelLauncher>,
+        prober: Arc<dyn TunnelProbe>,
+    ) -> Self {
         Self {
             launcher,
+            prober,
             status: Arc::new(RwLock::new(TunnelStatus::Idle)),
             generation: Arc::new(AtomicU64::new(0)),
             cancel: Arc::new(Mutex::new(None)),
@@ -439,6 +523,25 @@ impl SpotifyTunnelManager {
         *self.status.write().await = TunnelStatus::Idle;
     }
 
+    /// Tears the tunnel down `delay` from now, unless a newer `start`/`stop`
+    /// has superseded this tunnel in the meantime (generation-guarded, so a
+    /// deferred stop can never kill a tunnel it was not scheduled for).
+    ///
+    /// Used by the OAuth callback: the callback's own HTTP response -- and
+    /// the settings page it redirects to -- still travel through the tunnel,
+    /// so stopping inline resets the connection carrying the redirect
+    /// (#592). See `TUNNEL_CALLBACK_GRACE`.
+    pub fn stop_after(self: &Arc<Self>, delay: Duration) {
+        let manager = self.clone();
+        let generation = self.generation.load(Ordering::SeqCst);
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            if manager.generation.load(Ordering::SeqCst) == generation {
+                manager.stop().await;
+            }
+        });
+    }
+
     async fn stop_locked(&self) {
         self.generation.fetch_add(1, Ordering::SeqCst);
         if let Some(token) = self.cancel.lock().await.take() {
@@ -505,12 +608,14 @@ impl SpotifyTunnelManager {
                     self.set_status_if_current(
                         generation,
                         TunnelStatus::Active {
-                            url,
+                            url: url.clone(),
                             provider: provider.label(),
                             expires_at,
+                            verified: None,
                         },
                     )
                     .await;
+                    self.spawn_reachability_probe(generation, url);
                     self.supervise_active(process.as_mut(), generation, &token, shutdown.as_ref())
                         .await;
                     return;
@@ -544,9 +649,44 @@ impl SpotifyTunnelManager {
         .await;
     }
 
+    /// One-shot self-check through the freshly allocated public URL,
+    /// recorded into `TunnelStatus::Active::verified` if this tunnel is
+    /// still the current one when the probe returns. A URL that prints but
+    /// cannot carry HTTP back to this server is exactly the failure the user
+    /// otherwise discovers only when Spotify's redirect dies (#592).
+    fn spawn_reachability_probe(self: &Arc<Self>, generation: u64, url: String) {
+        let manager = self.clone();
+        tokio::spawn(async move {
+            let Some(reachable) = manager.prober.probe(&url).await else {
+                return;
+            };
+            if manager.generation.load(Ordering::SeqCst) != generation {
+                return;
+            }
+            let mut status = manager.status.write().await;
+            let updated = match &*status {
+                TunnelStatus::Active {
+                    url: current_url,
+                    provider,
+                    expires_at,
+                    ..
+                } if *current_url == url => Some(TunnelStatus::Active {
+                    url: url.clone(),
+                    provider,
+                    expires_at: *expires_at,
+                    verified: Some(reachable),
+                }),
+                _ => None,
+            };
+            if let Some(updated) = updated {
+                *status = updated;
+            }
+        });
+    }
+
     /// Once a URL is live, keep reading events until the tunnel is
     /// cancelled (manual stop or OAuth completion), the process exits on
-    /// its own, or the fifteen-minute cap is reached.
+    /// its own, or the lifetime cap (`TUNNEL_MAX_LIFETIME`) is reached.
     async fn supervise_active(
         &self,
         process: &mut dyn TunnelProcess,
@@ -569,8 +709,11 @@ impl SpotifyTunnelManager {
                 () = &mut deadline => {
                     process.kill();
                     self.set_status_if_current(generation, TunnelStatus::Error {
-                        message: "The tunnel timed out after 15 minutes and was closed. Click \
-                                  \"Get an HTTPS address\" again for a fresh URL.".to_string(),
+                        message: format!(
+                            "The tunnel timed out after {} minutes and was closed. Click \
+                             \"Get an HTTPS address\" again for a fresh URL.",
+                            TUNNEL_MAX_LIFETIME.as_secs() / 60
+                        ),
                     }).await;
                     return;
                 }
@@ -658,6 +801,11 @@ pub struct TunnelStatusResponse {
     pub expires_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seconds_remaining: Option<u64>,
+    /// Post-allocation self-probe result: absent while the probe is still
+    /// running, `true` once an HTTP round trip through the public URL
+    /// succeeded, `false` when the public address did not answer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
@@ -671,6 +819,7 @@ impl From<TunnelStatus> for TunnelStatusResponse {
                 url: None,
                 expires_at: None,
                 seconds_remaining: None,
+                verified: None,
                 message: None,
             },
             TunnelStatus::Starting { provider } => Self {
@@ -679,18 +828,21 @@ impl From<TunnelStatus> for TunnelStatusResponse {
                 url: None,
                 expires_at: None,
                 seconds_remaining: None,
+                verified: None,
                 message: None,
             },
             TunnelStatus::Active {
                 url,
                 provider,
                 expires_at,
+                verified,
             } => Self {
                 phase: "active",
                 provider: Some(provider),
                 url: Some(url),
                 expires_at: Some(expires_at),
                 seconds_remaining: Some(expires_at.saturating_sub(now_secs())),
+                verified,
                 message: None,
             },
             TunnelStatus::Error { message } => Self {
@@ -699,6 +851,7 @@ impl From<TunnelStatus> for TunnelStatusResponse {
                 url: None,
                 expires_at: None,
                 seconds_remaining: None,
+                verified: None,
                 message: Some(message),
             },
         }
@@ -1087,9 +1240,161 @@ mod tests {
             url: "https://example.pinggy.link".to_string(),
             provider: "pinggy.io",
             expires_at: now_secs() + 100,
+            verified: Some(true),
         });
         assert_eq!(response.phase, "active");
         assert_eq!(response.url.as_deref(), Some("https://example.pinggy.link"));
         assert!(response.seconds_remaining.unwrap() <= 100);
+        assert_eq!(response.verified, Some(true));
+    }
+
+    /// #592 regression: the `ssh -R` forward target must be the IPv4
+    /// loopback literal, not `localhost`. Inside containers `localhost` can
+    /// resolve to `::1` while UHC listens on IPv4 only, in which case the
+    /// tunnel prints a URL that resets every public request.
+    #[test]
+    fn tunnel_commands_forward_to_the_ipv4_loopback_literal() {
+        let (program, args) = TunnelProviderKind::Pinggy.command(8088);
+        assert_eq!(program, "ssh");
+        assert!(args.contains(&"-R0:127.0.0.1:8088".to_string()), "{args:?}");
+        let (program, args) = TunnelProviderKind::LocalhostRun.command(8088);
+        assert_eq!(program, "ssh");
+        assert!(args.contains(&"80:127.0.0.1:8088".to_string()), "{args:?}");
+    }
+
+    /// #592 regression: a 15-minute cap expired while the user was still
+    /// working through Spotify's developer dashboard, so the consent
+    /// redirect landed on a dead tunnel as ERR_CONNECTION_RESET. The cap
+    /// must outlast a first-time enrollment (>= 20 minutes demonstrated
+    /// live) while staying under pinggy's 60-minute anonymous-tunnel limit
+    /// so the expiry message shown to the user is ours.
+    #[test]
+    fn lifetime_cap_outlasts_a_first_time_dashboard_round_trip() {
+        assert!(TUNNEL_MAX_LIFETIME >= Duration::from_secs(20 * 60));
+        assert!(TUNNEL_MAX_LIFETIME < Duration::from_secs(60 * 60));
+    }
+
+    /// #592 state-machine regression: the tunnel stays Active through a slow
+    /// dashboard round trip (20+ minutes) and only expires at the cap.
+    #[tokio::test(start_paused = true)]
+    async fn tunnel_survives_twenty_minutes_then_expires_at_the_cap() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch::url("https://abc123.a.pinggy.link"),
+        )]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        tokio::time::advance(Duration::from_secs(20 * 60)).await;
+        assert!(
+            matches!(manager.status().await, TunnelStatus::Active { .. }),
+            "tunnel must still be up 20 minutes in; a user is often still \
+             in Spotify's dashboard at that point (#592)"
+        );
+        tokio::time::advance(TUNNEL_MAX_LIFETIME).await;
+        let status = wait_until(&manager, |s| matches!(s, TunnelStatus::Error { .. })).await;
+        match status {
+            TunnelStatus::Error { message } => {
+                assert!(message.contains("timed out"), "{message}");
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #592: the OAuth callback's teardown is deferred so the callback
+    /// response can travel back through the tunnel first.
+    #[tokio::test(start_paused = true)]
+    async fn deferred_stop_tears_down_only_after_the_grace_period() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch::url("https://abc123.a.pinggy.link"),
+        )]);
+        let launcher_ref = launcher.clone();
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        manager.stop_after(TUNNEL_CALLBACK_GRACE);
+        // Let the spawned deferred-stop task register its timer before
+        // advancing the paused clock, or the advance passes it by.
+        tokio::task::yield_now().await;
+        tokio::time::advance(TUNNEL_CALLBACK_GRACE - Duration::from_secs(1)).await;
+        assert!(
+            matches!(manager.status().await, TunnelStatus::Active { .. }),
+            "the tunnel must survive the grace window: the callback \
+             response and the settings redirect still travel through it"
+        );
+        tokio::time::advance(Duration::from_secs(2)).await;
+        wait_until(&manager, |s| matches!(s, TunnelStatus::Idle)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !launcher_ref.any_process_left_running(),
+            "tunnel process was not killed after the grace period"
+        );
+    }
+
+    /// A deferred stop scheduled for one tunnel must never kill a newer one
+    /// started after it (generation guard).
+    #[tokio::test]
+    async fn deferred_stop_never_kills_a_newer_tunnel() {
+        let launcher = FakeLauncher::new(vec![(
+            TunnelProviderKind::Pinggy,
+            ScriptedLaunch::url("https://abc123.a.pinggy.link"),
+        )]);
+        let manager = Arc::new(SpotifyTunnelManager::with_launcher(launcher));
+        manager.start(8088).await;
+        wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        manager.stop_after(Duration::from_millis(50));
+        manager.stop().await;
+        manager.start(8088).await;
+        wait_until(&manager, |s| matches!(s, TunnelStatus::Active { .. })).await;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert!(
+            matches!(manager.status().await, TunnelStatus::Active { .. }),
+            "a stale deferred stop killed the newer tunnel"
+        );
+    }
+
+    struct ScriptedProbe(Option<bool>);
+
+    #[async_trait::async_trait]
+    impl TunnelProbe for ScriptedProbe {
+        async fn probe(&self, _url: &str) -> Option<bool> {
+            self.0
+        }
+    }
+
+    /// #592: a printed URL is not a working tunnel. The post-allocation
+    /// self-probe's verdict must land in the Active status so the UI can
+    /// show red/green before the user registers the address with Spotify.
+    #[tokio::test]
+    async fn reachability_probe_verdict_lands_in_active_status() {
+        for verdict in [true, false] {
+            let launcher = FakeLauncher::new(vec![(
+                TunnelProviderKind::Pinggy,
+                ScriptedLaunch::url("https://abc123.a.pinggy.link"),
+            )]);
+            let manager = Arc::new(SpotifyTunnelManager::with_parts(
+                launcher,
+                Arc::new(ScriptedProbe(Some(verdict))),
+            ));
+            manager.start(8088).await;
+            let status = wait_until(&manager, |s| {
+                matches!(
+                    s,
+                    TunnelStatus::Active {
+                        verified: Some(_),
+                        ..
+                    }
+                )
+            })
+            .await;
+            match status {
+                TunnelStatus::Active { url, verified, .. } => {
+                    assert_eq!(url, "https://abc123.a.pinggy.link");
+                    assert_eq!(verified, Some(verdict));
+                }
+                other => panic!("expected Active, got {other:?}"),
+            }
+        }
     }
 }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -203,6 +203,11 @@ pub struct SpotifyTunnelStatus {
     pub expires_at: Option<u64>,
     #[serde(default)]
     pub seconds_remaining: Option<u64>,
+    /// Post-allocation self-probe through the public URL: `None` while the
+    /// check is still running, `Some(true)` when a real HTTP round trip
+    /// succeeded, `Some(false)` when the address did not answer.
+    #[serde(default)]
+    pub verified: Option<bool>,
     #[serde(default)]
     pub message: Option<String>,
 }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -270,6 +270,23 @@ fn redirect_to(_url: &str) -> Result<(), String> {
     Err("Provider authorization is available in the browser".to_string())
 }
 
+/// Bring an element into view by id. Used after "Save client settings":
+/// saving collapses the client-settings editor, and without an explicit
+/// scroll the browser anchors somewhere below the Connect button, forcing
+/// the user to scroll back up and reorient before the very next step.
+#[cfg(target_arch = "wasm32")]
+fn scroll_to_element(id: &str) {
+    if let Some(element) = web_sys::window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.get_element_by_id(id))
+    {
+        element.scroll_into_view();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn scroll_to_element(_id: &str) {}
+
 #[cfg(target_arch = "wasm32")]
 fn current_location_search() -> Option<String> {
     web_sys::window()?.location().search().ok()
@@ -557,6 +574,12 @@ pub fn Settings() -> Element {
     let mut spotify_tunnel = use_signal(SpotifyTunnelStatus::default);
     let mut spotify_tunnel_busy = use_signal(|| false);
     let spotify_tunnel_url_copy_state = use_signal(CopyState::default);
+    // The live tunnel's callback address no longer matches the Redirect URI
+    // field: surfaced as a warning instead of silently rewriting the field
+    // (#592), since the old address may already be registered with Spotify.
+    let mut spotify_tunnel_mismatch = use_signal(|| false);
+    // Guards the while-active status poll loop against duplicate spawns.
+    let mut spotify_tunnel_polling = use_signal(|| false);
     // Defaults to the loopback-primary layout (today's behavior, and what
     // SSR renders) so hydration has nothing to reconcile; a mount-only
     // effect below flips it once the real browser origin is known. No
@@ -902,19 +925,69 @@ pub fn Settings() -> Element {
         }
     });
 
-    // Once the tunnel is live, populate the Redirect URI field with its
-    // callback address so "Save client settings" registers the exact URL
-    // the user is about to paste into the Spotify dashboard. This only
-    // pre-fills the field; the user still has to click Save (and then
-    // register the URL with Spotify) before Connect will work.
+    // Once the tunnel is live, offer its callback address for registration.
+    // The Redirect URI field is only pre-filled automatically while it still
+    // holds the loopback default (or is empty): a value the user already
+    // entered or saved is NEVER silently replaced (#592) -- tunnel providers
+    // mint a new subdomain on every start, so silently swapping the field
+    // out from under an address that is already registered in the Spotify
+    // dashboard guarantees a "redirect_uri: Not matching configuration"
+    // rejection at Spotify. A divergence is surfaced as a warning with an
+    // explicit "Use this address" action instead, and the server refuses
+    // oauth/start outright while the live tunnel and the saved Redirect URI
+    // disagree.
     use_effect(move || {
         if let Some(url) = spotify_tunnel().url {
-            let redirect_uri = format!("{url}/api/providers/spotify/oauth/callback");
-            if spotify_redirect_uri.peek().as_str() != redirect_uri {
-                spotify_redirect_uri.set(redirect_uri);
+            let tunnel_callback = format!("{url}/api/providers/spotify/oauth/callback");
+            // Deliberately subscribed (not peeked): editing the field by
+            // hand must recompute the mismatch warning. This converges --
+            // the only write below sets the field to `tunnel_callback`,
+            // whose re-run takes the first (no-write) branch.
+            let current = spotify_redirect_uri();
+            if current == tunnel_callback {
+                spotify_tunnel_mismatch.set(false);
+            } else if current.trim().is_empty() || current == default_spotify_redirect_uri() {
+                spotify_redirect_uri.set(tunnel_callback);
                 spotify_local_setup_saved.set(false);
+                spotify_tunnel_mismatch.set(false);
+            } else {
+                spotify_tunnel_mismatch.set(true);
             }
+        } else {
+            spotify_tunnel_mismatch.set(false);
         }
+    });
+
+    // While a tunnel is active, keep its status fresh (10s cadence): the
+    // expiry countdown stays honest, the reachability self-check's result
+    // arrives without a reload, and a tunnel that dies early (relay drop,
+    // ssh exit) surfaces here as an error banner instead of the user finding
+    // out from Spotify's dead redirect (#592).
+    use_effect(move || {
+        if !spotify_tunnel().is_active() || *spotify_tunnel_polling.peek() {
+            return;
+        }
+        spotify_tunnel_polling.set(true);
+        spawn(async move {
+            loop {
+                dioxus_sdk_time::sleep(std::time::Duration::from_secs(10)).await;
+                match crate::app::api::fetch_json::<SpotifyTunnelStatus>(
+                    "/api/providers/spotify/tunnel/status",
+                )
+                .await
+                {
+                    Ok(status) => {
+                        let still_active = status.is_active();
+                        spotify_tunnel.set(status);
+                        if !still_active {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            spotify_tunnel_polling.set(false);
+        });
     });
 
     use_effect(move || {
@@ -1061,6 +1134,9 @@ pub fn Settings() -> Element {
                     spotify_action.set(ProviderActionState::Success);
                     spotify_local_setup_saved.set(true);
                     spotify_editing.set(false);
+                    // Saving collapses the editor; land the user on the next
+                    // step (Connect) instead of wherever the browser anchors.
+                    scroll_to_element("spotify-connect-button");
                 }
                 Ok(_) => {
                     spotify_action.set(ProviderActionState::Failed);
@@ -1292,6 +1368,17 @@ pub fn Settings() -> Element {
     let spotify_tunnel_minutes_remaining = spotify_tunnel_status
         .seconds_remaining
         .map(|secs| (secs / 60).max(1));
+    // The tunnel's own callback address, straight from the live tunnel
+    // status -- deliberately NOT the Redirect URI field, which the user may
+    // have registered with Spotify under an earlier tunnel URL.
+    let spotify_tunnel_callback = spotify_tunnel_status
+        .url
+        .clone()
+        .map(|url| format!("{url}/api/providers/spotify/oauth/callback"))
+        .unwrap_or_default();
+    let spotify_tunnel_callback_for_copy = spotify_tunnel_callback.clone();
+    let spotify_tunnel_callback_for_use = spotify_tunnel_callback.clone();
+    let spotify_tunnel_verified = spotify_tunnel_status.verified;
     let spotify_account = spotify_account_result
         .as_ref()
         .and_then(|response| response.account.as_ref());
@@ -1768,6 +1855,7 @@ pub fn Settings() -> Element {
                                 h4 { class: "font-medium", "Connect Spotify" }
                                 p { class: "mt-2 text-sm text-secondary", "After saving the client settings below, open Spotify’s consent page, approve playback access, and return here. Your token stays on this UHC server." }
                                 button {
+                                    id: "spotify-connect-button",
                                     r#type: "button",
                                     class: "btn btn-primary mt-4 min-h-11 w-full sm:w-auto",
                                     disabled: spotify_action() == ProviderActionState::Loading || !spotify_local_setup_saved(),
@@ -1807,19 +1895,49 @@ pub fn Settings() -> Element {
                                                         code {
                                                             id: "spotify-callback-url-display",
                                                             class: "block min-w-0 flex-1 overflow-x-auto break-all rounded-md bg-elevated px-3 py-3 text-xs select-all",
-                                                            "{spotify_redirect_uri()}"
+                                                            "{spotify_tunnel_callback}"
                                                         }
                                                         button {
                                                             r#type: "button",
                                                             class: "btn btn-outline btn-sm shrink-0",
                                                             aria_label: "Copy tunnel callback URL",
-                                                            onclick: move |_| copy_to_clipboard(spotify_redirect_uri(), spotify_tunnel_url_copy_state),
+                                                            onclick: move |_| copy_to_clipboard(spotify_tunnel_callback_for_copy.clone(), spotify_tunnel_url_copy_state),
                                                             span { aria_live: "polite", "{spotify_tunnel_url_copy_state().label(\"Copy URL\")}" }
+                                                        }
+                                                    }
+                                                    match spotify_tunnel_verified {
+                                                        Some(true) => rsx! {
+                                                            p { class: "mt-2 text-xs status-ok", "✓ Checked: this address answers from the internet." }
+                                                        },
+                                                        Some(false) => rsx! {
+                                                            p { class: "mt-2 text-xs status-err", role: "alert",
+                                                                "This address did not answer when UHC checked it from the internet. Stop the tunnel and try again before registering it with Spotify."
+                                                            }
+                                                        },
+                                                        None => rsx! {
+                                                            p { class: "mt-2 text-xs text-muted", "Checking that this address answers from the internet…" }
+                                                        },
+                                                    }
+                                                    if spotify_tunnel_mismatch() {
+                                                        div { class: "mt-2 rounded-md border border-default p-2", role: "alert",
+                                                            p { class: "text-xs status-err",
+                                                                "Your HTTPS address changed and no longer matches the Redirect URI field below. Update the redirect URI registered in the Spotify dashboard to this new address, then apply it here and save again before connecting."
+                                                            }
+                                                            button {
+                                                                r#type: "button",
+                                                                class: "btn btn-outline btn-sm mt-2",
+                                                                onclick: move |_| {
+                                                                    spotify_redirect_uri.set(spotify_tunnel_callback_for_use.clone());
+                                                                    spotify_local_setup_saved.set(false);
+                                                                    spotify_tunnel_mismatch.set(false);
+                                                                },
+                                                                "Use this address"
+                                                            }
                                                         }
                                                     }
                                                     if let Some(minutes) = spotify_tunnel_minutes_remaining {
                                                         p { class: "mt-2 text-xs text-muted",
-                                                            "Closes automatically in about {minutes} minute(s), or as soon as authorization completes -- whichever comes first."
+                                                            "Closes automatically in about {minutes} minute(s), or shortly after authorization completes -- whichever comes first."
                                                         }
                                                     }
                                                     p { class: "mt-2 text-xs text-muted", "Live via {spotify_tunnel_provider_label}. While it's open, this server is briefly reachable from the public internet at that address; only the in-progress Spotify sign-in is accepted through it." }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -574,10 +574,6 @@ pub fn Settings() -> Element {
     let mut spotify_tunnel = use_signal(SpotifyTunnelStatus::default);
     let mut spotify_tunnel_busy = use_signal(|| false);
     let spotify_tunnel_url_copy_state = use_signal(CopyState::default);
-    // The live tunnel's callback address no longer matches the Redirect URI
-    // field: surfaced as a warning instead of silently rewriting the field
-    // (#592), since the old address may already be registered with Spotify.
-    let mut spotify_tunnel_mismatch = use_signal(|| false);
     // Guards the while-active status poll loop against duplicate spawns.
     let mut spotify_tunnel_polling = use_signal(|| false);
     // Defaults to the loopback-primary layout (today's behavior, and what
@@ -932,29 +928,20 @@ pub fn Settings() -> Element {
     // mint a new subdomain on every start, so silently swapping the field
     // out from under an address that is already registered in the Spotify
     // dashboard guarantees a "redirect_uri: Not matching configuration"
-    // rejection at Spotify. A divergence is surfaced as a warning with an
-    // explicit "Use this address" action instead, and the server refuses
-    // oauth/start outright while the live tunnel and the saved Redirect URI
-    // disagree.
+    // rejection at Spotify. A divergence is surfaced as a render-derived
+    // warning (`spotify_tunnel_mismatch` below) with an explicit "Use this
+    // address" action instead, and the server refuses oauth/start outright
+    // while the live tunnel and the saved Redirect URI disagree.
     use_effect(move || {
         if let Some(url) = spotify_tunnel().url {
             let tunnel_callback = format!("{url}/api/providers/spotify/oauth/callback");
-            // Deliberately subscribed (not peeked): editing the field by
-            // hand must recompute the mismatch warning. This converges --
-            // the only write below sets the field to `tunnel_callback`,
-            // whose re-run takes the first (no-write) branch.
-            let current = spotify_redirect_uri();
-            if current == tunnel_callback {
-                spotify_tunnel_mismatch.set(false);
-            } else if current.trim().is_empty() || current == default_spotify_redirect_uri() {
+            let current = spotify_redirect_uri.peek().clone();
+            if current != tunnel_callback
+                && (current.trim().is_empty() || current == default_spotify_redirect_uri())
+            {
                 spotify_redirect_uri.set(tunnel_callback);
                 spotify_local_setup_saved.set(false);
-                spotify_tunnel_mismatch.set(false);
-            } else {
-                spotify_tunnel_mismatch.set(true);
             }
-        } else {
-            spotify_tunnel_mismatch.set(false);
         }
     });
 
@@ -1379,6 +1366,16 @@ pub fn Settings() -> Element {
     let spotify_tunnel_callback_for_copy = spotify_tunnel_callback.clone();
     let spotify_tunnel_callback_for_use = spotify_tunnel_callback.clone();
     let spotify_tunnel_verified = spotify_tunnel_status.verified;
+    // The live tunnel's callback address no longer matches the Redirect URI
+    // field: surfaced as a warning instead of silently rewriting the field
+    // (#592), since the old address may already be registered with Spotify.
+    // Render-derived (not a stored signal) so hand-editing the field
+    // recomputes it immediately.
+    let spotify_tunnel_redirect_value = spotify_redirect_uri();
+    let spotify_tunnel_mismatch = spotify_tunnel_status.url.is_some()
+        && spotify_tunnel_redirect_value != spotify_tunnel_callback
+        && !spotify_tunnel_redirect_value.trim().is_empty()
+        && spotify_tunnel_redirect_value != default_spotify_redirect_uri();
     let spotify_account = spotify_account_result
         .as_ref()
         .and_then(|response| response.account.as_ref());
@@ -1918,7 +1915,7 @@ pub fn Settings() -> Element {
                                                             p { class: "mt-2 text-xs text-muted", "Checking that this address answers from the internet…" }
                                                         },
                                                     }
-                                                    if spotify_tunnel_mismatch() {
+                                                    if spotify_tunnel_mismatch {
                                                         div { class: "mt-2 rounded-md border border-default p-2", role: "alert",
                                                             p { class: "text-xs status-err",
                                                                 "Your HTTPS address changed and no longer matches the Redirect URI field below. Update the redirect URI registered in the Spotify dashboard to this new address, then apply it here and save again before connecting."
@@ -1929,7 +1926,6 @@ pub fn Settings() -> Element {
                                                                 onclick: move |_| {
                                                                     spotify_redirect_uri.set(spotify_tunnel_callback_for_use.clone());
                                                                     spotify_local_setup_saved.set(false);
-                                                                    spotify_tunnel_mismatch.set(false);
                                                                 },
                                                                 "Use this address"
                                                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,6 +503,10 @@ mod server {
             shutdown_token.clone(),
         )
         .with_reliable_commands(reliable_commands);
+        // The Spotify tunnel forwards to this server over loopback; record
+        // the port the listener actually bound so the tunnel never trusts a
+        // proxy-rewritten Host header for its forward target (#592).
+        state.provider_auth.bind_local_port(config.port);
         if let Some(bootstrap_token) = state.controller_auth.take_bootstrap_secret().await {
             tracing::info!(
                 "UHC controller bootstrap token (display once; do not put it in a tunnel URL): {}. \


### PR DESCRIPTION
Closes #592

## Root causes (all live-reproduced)

Reproduced end-to-end with a real pinggy tunnel through UHC's own API — no Spotify account needed:

1. **`oauth_callback` stopped the tunnel inline, before its own response was delivered.** The ssh child carrying the response was killed mid-flight: the first GET to the public callback URL reached UHC and then died with no response; the very next GET got `Connection reset by peer` at the pinggy host. This is the user's ERR_CONNECTION_RESET at the exact moment of consent redirect. Worse, ANY request to the callback path (scanner, stale link, double-check) tore the tunnel down.
2. **15-minute lifetime cap vs. dashboard time.** A first-time enrollment (create app, register URI, copy creds, save, connect) routinely exceeds 15 minutes; the redirect then landed on a dead tunnel.
3. **Forward-target fragility.** `-R0:localhost:<port>` can resolve to `::1` inside containers while UHC listens on IPv4, and the port came from the request's `Host` header, which proxies/HA-ingress rewrite — either way the tunnel prints a URL that resets every public request. (Differential evidence: a byte-identical manual ssh worked while UHC's spawned tunnel reset.)
4. **Tunnel URL churn vs. saved Redirect URI.** pinggy mints a new subdomain per start; the UI silently rewrote the Redirect URI field from live tunnel state, guaranteeing "redirect_uri: Not matching configuration" once the dashboard held an older URL.

## Fixes

- Callback teardown is deferred (`stop_after`, 60s grace, generation-guarded) and happens **only for a callback that matched a real pending attempt** — unknown-`state` probes leave the tunnel alone.
- `TUNNEL_MAX_LIFETIME` 15 → 55 min (under pinggy's own 60-min anonymous limit).
- `ssh -R` targets `127.0.0.1:<actually-bound-port>` — the server records its bound port at boot (`bind_local_port`); the `Host` header is now only a fallback.
- Contract pinned: the authorize URL always carries the **saved** redirect_uri verbatim. `oauth/start` returns `409 tunnel_redirect_mismatch` when a live tunnel diverges from the saved Redirect URI. The UI never silently replaces a non-default field value; it shows a warning with an explicit "Use this address" action.
- **Tunnel liveness self-probe**: after allocation UHC fetches its own public URL once and shows red/green ("this address answers from the internet") before the user goes near Spotify; status is polled every 10s while active so an early death surfaces as an error banner.
- UX: after "Save client settings" the page scrolls to the Connect button instead of stranding the user below it.

## Live validation (25-min soak against a real pinggy tunnel)

- `verified:true` self-probe on allocation; ssh child confirmed running with `-R0:127.0.0.1:<port>`.
- authorize URL redirect_uri == saved value verbatim; `oauth/start` left the tunnel untouched.
- Diverged saved URI → live `409 tunnel_redirect_mismatch`.
- Bogus-state probe of the **public** callback URL: answered HTTP 303, tunnel stayed active.
- 22-minute public soak: a GET through the tunnel every 2 minutes, **all** answered HTTP 303, tunnel active throughout (previously died at 15 min, or on the first probe).
- Concluded callback (real `state`, `access_denied`) through the public URL: response **delivered** (HTTP 303, no reset), tunnel still up immediately after, idle ~60s later.

## Tests

- State machine: survives 20+ min under paused time and expires at the cap with the timeout message; deferred stop fires only after the grace period and never kills a newer tunnel (generation guard); probe verdict lands in `Active.verified`; command args pinned to `-R0:127.0.0.1`; lifetime-cap floor/ceiling pinned.
- Handlers: authorize URL uses saved redirect_uri verbatim; `oauth/start` 409s on tunnel divergence; unknown-state callback probe leaves the tunnel running; concluded callback defers teardown past its own response (also pins that callback delivery is transport-independent).

## Notes

- `sg review` could not run (its LLM auth is expired on this machine: "OAuth session expired and could not be refreshed"); a manual diff review was done instead, and the repo's own lint suites (incl. `reactive_loop_lint`, `hydration_safety_lint`) pass.
- Gates: `cargo test` (59 suites green), `cargo clippy -- -D warnings`, `cargo fmt --check`, wasm check (`--target wasm32-unknown-unknown --no-default-features --features web`).