### PR TITLE
Zones strip: full design pass -- unified grid, vertical control rail, elevated armed header

### DIFF
--- a/src/app/components/zones_strip.rs
+++ b/src/app/components/zones_strip.rs
@@ -68,6 +68,19 @@ struct RowNowPlaying {
     volume_step: Option<f32>,
 }
 
+/// Source badge, rendered identically by the armed header and every picker
+/// row (#596) so the two can't drift. A zone without a known source gets no
+/// badge at all rather than an empty pill.
+fn source_badge(source: Option<&str>) -> Element {
+    let Some(source) = source.filter(|s| !s.is_empty()) else {
+        return rsx! {};
+    };
+    let label = crate::app::api::source_label(source);
+    rsx! {
+        span { class: "badge badge-secondary zones-strip-source-badge", "{label}" }
+    }
+}
+
 fn row_now_playing(np: Option<&NowPlaying>) -> Option<RowNowPlaying> {
     let np = np?;
     let track = np.line1.clone().unwrap_or_default();
@@ -127,11 +140,6 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
     let volume_step = np.and_then(|n| n.volume_step);
 
     let armed_id = armed.zone_id.clone();
-    let armed_id_prev = armed_id.clone();
-    let armed_id_play = armed_id.clone();
-    let armed_id_next = armed_id.clone();
-    let armed_id_vol_down = armed_id.clone();
-    let armed_id_vol_up = armed_id.clone();
     let armed_id_transfer = armed_id.clone();
 
     let can_transfer = is_musicassistant(armed);
@@ -176,6 +184,17 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
 
     let on_control = props.on_control;
     let on_arm = props.on_arm;
+    // #596: one handler factory per event shape instead of a cloned zone-id
+    // binding per button. `ctl` covers click handlers, `vol_ctl` the
+    // volume component's unit-typed callbacks.
+    let ctl = |action: &'static str| {
+        let id = armed_id.clone();
+        move |_: Event<MouseData>| on_control.call((id.clone(), action.to_string()))
+    };
+    let vol_ctl = |action: &'static str| {
+        let id = armed_id.clone();
+        move |_: ()| on_control.call((id.clone(), action.to_string()))
+    };
     let other_zones: Vec<Zone> = props
         .zones
         .iter()
@@ -218,7 +237,13 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                         div { class: "zones-strip-art zones-strip-art--empty", "♪" }
                     }
                     div { class: "zones-strip-meta",
-                        span { class: "zones-strip-zone-name", "{armed.zone_name}" }
+                        // #596: same name+badge grammar as the picker rows --
+                        // the header is the elevated form of the same row,
+                        // not a different layout.
+                        div { class: "zones-strip-name-row",
+                            span { class: "zones-strip-zone-name zones-strip-zone-name--armed", "{armed.zone_name}" }
+                            {source_badge(armed.source.as_deref())}
+                        }
                         if !track.is_empty() {
                             span { class: "zones-strip-track", "{track}" }
                             span { class: "zones-strip-artist", "{artist}" }
@@ -239,12 +264,15 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                     }
                 }
 
-                // Transport
-                div { class: "zones-strip-transport",
+                // #596: transport + volume live in one right-aligned rail
+                // with fixed column widths, shared with every picker row, so
+                // play / - / value / + sit on the same vertical axes across
+                // the whole strip regardless of name/track length.
+                div { class: "zones-strip-rail",
                     button {
                         class: "btn btn-ghost",
                         aria_label: "Previous track",
-                        onclick: move |_| on_control.call((armed_id_prev.clone(), "previous".to_string())),
+                        onclick: ctl("previous"),
                         svg { class: "w-5 h-5", fill: "currentColor", view_box: "0 0 24 24",
                             path { d: "M6 6h2v12H6zm3.5 6l8.5 6V6z" }
                         }
@@ -252,7 +280,7 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                     button {
                         class: "btn btn-primary",
                         aria_label: if is_playing { "Pause" } else { "Play" },
-                        onclick: move |_| on_control.call((armed_id_play.clone(), "play_pause".to_string())),
+                        onclick: ctl("play_pause"),
                         if is_playing {
                             svg { class: "w-5 h-5", fill: "currentColor", view_box: "0 0 24 24",
                                 path { d: "M6 19h4V5H6v14zm8-14v14h4V5h-4z" }
@@ -266,19 +294,25 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                     button {
                         class: "btn btn-ghost",
                         aria_label: "Next track",
-                        onclick: move |_| on_control.call((armed_id_next.clone(), "next".to_string())),
+                        onclick: ctl("next"),
                         svg { class: "w-5 h-5", fill: "currentColor", view_box: "0 0 24 24",
                             path { d: "M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z" }
                         }
                     }
-                }
 
-                VolumeControlsCompact {
-                    volume: volume,
-                    volume_type: volume_type,
-                    volume_step: volume_step,
-                    on_vol_down: move |_| on_control.call((armed_id_vol_down.clone(), "vol_down".to_string())),
-                    on_vol_up: move |_| on_control.call((armed_id_vol_up.clone(), "vol_up".to_string())),
+                    // Fixed-width volume slot (see `.zones-strip-volume`):
+                    // tabular numerals in a fixed box so +/- never shift as
+                    // digits change, reserved even for fixed-volume zones so
+                    // the play column never drifts.
+                    div { class: "zones-strip-volume",
+                        VolumeControlsCompact {
+                            volume: volume,
+                            volume_type: volume_type,
+                            volume_step: volume_step,
+                            on_vol_down: vol_ctl("vol_down"),
+                            on_vol_up: vol_ctl("vol_up"),
+                        }
+                    }
                 }
             }
 
@@ -292,10 +326,16 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                                 {
                                     let zone_id = zone.zone_id.clone();
                                     let zone_id_arm = zone_id.clone();
-                                    let zone_id_play = zone_id.clone();
-                                    let zone_id_vol_down = zone_id.clone();
-                                    let zone_id_vol_up = zone_id.clone();
-                                    let source = zone.source.clone().unwrap_or_default();
+                                    // Same handler-factory pattern as the
+                                    // armed header (#596).
+                                    let row_ctl = |action: &'static str| {
+                                        let id = zone_id.clone();
+                                        move |_: Event<MouseData>| on_control.call((id.clone(), action.to_string()))
+                                    };
+                                    let row_vol_ctl = |action: &'static str| {
+                                        let id = zone_id.clone();
+                                        move |_: ()| on_control.call((id.clone(), action.to_string()))
+                                    };
                                     // Each row's own now-playing summary, read
                                     // straight from the map the Library page
                                     // already threads through props (#585) --
@@ -331,9 +371,12 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                                                         }
                                                     }
                                                     div { class: "zones-strip-picker-meta",
-                                                        div { class: "zones-strip-picker-name-row",
-                                                            span { class: "zones-strip-picker-name", "{zone.zone_name}" }
-                                                            span { class: "badge badge-secondary flex-shrink-0", "{crate::app::api::source_label(&source)}" }
+                                                        // #596: same name-row / zone-name / track
+                                                        // classes as the armed header -- one
+                                                        // grammar, the header merely elevated.
+                                                        div { class: "zones-strip-name-row",
+                                                            span { class: "zones-strip-zone-name", "{zone.zone_name}" }
+                                                            {source_badge(zone.source.as_deref())}
                                                         }
                                                         if let Some(np) = &row_np {
                                                             div { class: "zones-strip-picker-np",
@@ -342,14 +385,18 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                                                                         span {} span {} span {}
                                                                     }
                                                                 }
-                                                                span { class: "zones-strip-picker-track", "{np.track}" }
+                                                                span { class: "zones-strip-track zones-strip-track--muted", "{np.track}" }
                                                             }
                                                         }
                                                     }
                                                 }
                                                 if let Some(np) = row_np {
                                                     div {
-                                                        class: "zones-strip-picker-controls",
+                                                        // #596: same fixed-column rail as the
+                                                        // armed header; the spacer stands in for
+                                                        // the header's next-track column so the
+                                                        // play buttons share a vertical axis.
+                                                        class: "zones-strip-rail zones-strip-picker-controls",
                                                         // stop_propagation: these buttons
                                                         // control the row's zone directly, they
                                                         // must not also arm it (#585).
@@ -358,7 +405,7 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                                                             class: "btn btn-outline btn-sm",
                                                             r#type: "button",
                                                             aria_label: if np.is_playing { "Pause" } else { "Play" },
-                                                            onclick: move |_| on_control.call((zone_id_play.clone(), "play_pause".to_string())),
+                                                            onclick: row_ctl("play_pause"),
                                                             if np.is_playing {
                                                                 svg { class: "w-4 h-4", fill: "currentColor", view_box: "0 0 24 24",
                                                                     path { d: "M6 19h4V5H6v14zm8-14v14h4V5h-4z" }
@@ -369,12 +416,15 @@ pub fn ZonesStrip(props: ZonesStripProps) -> Element {
                                                                 }
                                                             }
                                                         }
-                                                        VolumeControlsCompact {
-                                                            volume: np.volume,
-                                                            volume_type: np.volume_type,
-                                                            volume_step: np.volume_step,
-                                                            on_vol_down: move |_| on_control.call((zone_id_vol_down.clone(), "vol_down".to_string())),
-                                                            on_vol_up: move |_| on_control.call((zone_id_vol_up.clone(), "vol_up".to_string())),
+                                                        span { class: "zones-strip-rail-spacer", aria_hidden: "true" }
+                                                        div { class: "zones-strip-volume",
+                                                            VolumeControlsCompact {
+                                                                volume: np.volume,
+                                                                volume_type: np.volume_type,
+                                                                volume_step: np.volume_step,
+                                                                on_vol_down: row_vol_ctl("vol_down"),
+                                                                on_vol_up: row_vol_ctl("vol_up"),
+                                                            }
                                                         }
                                                     }
                                                 }

--- a/src/input.css
+++ b/src/input.css
@@ -723,13 +723,10 @@
     border-top: 1px solid var(--border-default);
   }
 
-  /* #594: no `flex-nowrap` fallback below `sm` -- transport (~164px) and
-     volume (~152px) are fixed-width siblings that leave almost no room for
-     the art+meta target on a 375-430px screen, so the row overflowed and the
-     art thumbnail read as "clipped". Letting the target take its own full
-     row on narrow screens (see `.zones-strip-target`'s `basis-full`) and
-     wrapping the rest below fixes that without shrinking any control below
-     its 44px hit target. Reverts to the original single row at `sm`+. */
+  /* Wraps below `sm` (#594): the fixed-width control rail leaves almost no
+     room for the art+meta target on a phone, so the target takes its own
+     full row (`basis-full`) and the rail wraps beneath it -- no control
+     ever shrinks below its 44px hit target. Single row returns at `sm`+. */
   .zones-strip-inner {
     @apply mx-auto flex max-w-7xl flex-wrap items-center gap-3 px-3 py-2 sm:flex-nowrap sm:px-6 lg:px-8;
   }
@@ -745,9 +742,14 @@
     outline-offset: 2px;
   }
 
+  /* #596: the armed header is the picker-row grammar *elevated* -- larger
+     art at every width (48px vs the rows' 32px) with an accent-token ring,
+     so "which zone am I driving" reads instantly without a divergent
+     layout. */
   .zones-strip-art {
-    @apply size-10 flex-shrink-0 rounded-md object-cover sm:size-12;
+    @apply size-12 flex-shrink-0 rounded-md object-cover;
     background: var(--surface-base);
+    box-shadow: 0 0 0 2px var(--accent-color);
   }
   /* #594: a themed border so the "no artwork" tile keeps a visible edge on
      OLED, where `--surface-base` is near-black against an equally dark
@@ -762,14 +764,35 @@
   .zones-strip-meta {
     @apply flex min-w-0 flex-1 flex-col;
   }
-  .zones-strip-zone-name {
-    @apply truncate text-xs font-semibold uppercase tracking-wide;
-    color: var(--text-muted);
+  /* #596: one name+badge row grammar shared by the armed header and every
+     picker row (art | name+badge+track | rail). The badge truncates along
+     with the name instead of holding its full width, so a long name and a
+     long source label share the squeeze at mid widths rather than the
+     badge crushing the name to a few characters. */
+  .zones-strip-name-row {
+    @apply flex min-w-0 items-center gap-2;
   }
+  .zones-strip-source-badge {
+    @apply min-w-0 truncate;
+  }
+  /* #596: one zone-name treatment strip-wide -- xs semibold uppercase, in
+     the default text color so the name leads its row ("which room" is the
+     picker's primary question). The armed header's `--armed` modifier
+     swaps in the accent token as its elevation mark. */
+  .zones-strip-zone-name {
+    @apply min-w-0 truncate text-xs font-semibold uppercase tracking-wide;
+  }
+  .zones-strip-zone-name--armed {
+    color: var(--accent-color);
+  }
+  /* #596: one track treatment strip-wide: sm/medium where it is the star
+     (armed header now playing), `--muted` where it supports the zone name
+     (picker rows), `--idle` for the header's empty state. */
   .zones-strip-track {
     @apply truncate text-sm font-medium;
   }
-  .zones-strip-track--idle {
+  .zones-strip-track--idle,
+  .zones-strip-track--muted {
     color: var(--text-muted);
     font-weight: 400;
   }
@@ -795,8 +818,81 @@
     transform: rotate(180deg);
   }
 
-  .zones-strip-transport {
-    @apply flex flex-shrink-0 items-center gap-1;
+  /* ---- #596: the vertical control rail ------------------------------
+     One right-aligned rail with fixed, token-derived column widths, shared
+     by the armed header and every mini-controller picker row, so
+     play / - / volume value / + sit on the same vertical axes strip-wide
+     regardless of name/track length. Right to left, with --rail-gap
+     between every neighbor:
+
+       header:  [prev][play][next] [volume slot]
+       row:           [play][spacer] [volume slot]
+
+     The spacer stands in for the header's next-track column, so the play
+     buttons share an axis. Below `sm` the rail takes its own full-width
+     line (PR #595's wrap pattern) but stays right-anchored, so the axes
+     hold at every viewport; `flex-wrap` inside the rail is the safety
+     valve for very narrow screens (~<=340px), where the volume slot drops
+     to a second right-anchored line instead of clipping the + button off
+     a fixed-position bar -- axes still hold because every column is
+     anchored to the same right edge. */
+  .zones-strip-rail {
+    --rail-col: 2.75rem;
+    --rail-gap: 0.25rem;
+    --rail-value: 5rem;
+    @apply flex w-full flex-shrink-0 flex-wrap items-center justify-end border-t py-1 sm:ml-auto sm:w-auto sm:flex-nowrap sm:border-t-0 sm:py-0;
+    gap: var(--rail-gap);
+    border-color: var(--border-subtle);
+  }
+  /* Fixed 44px columns: `.btn` alone has no min-width and px-4 padding, so
+     icon buttons would differ in width from the picker's btn-sm ones. A
+     hard --rail-col square keeps every rail column identical while
+     preserving the 44px hit target (`min-h-11` still applies from `.btn`). */
+  .zones-strip-rail .btn {
+    @apply px-0;
+    width: var(--rail-col);
+  }
+  .zones-strip-rail-spacer {
+    @apply flex-shrink-0;
+    width: var(--rail-col);
+  }
+  /* Fixed-width volume slot, derived from the rail tokens: reserved even
+     when a zone reports fixed volume (VolumeControlsCompact renders
+     nothing) so the play column never drifts between rows with and
+     without volume control. The inner component div stretches across it;
+     `justify-between` pins - and + to the slot's edges, which also keeps
+     them on-axis for incremental zones that render no value span. */
+  .zones-strip-volume {
+    @apply flex flex-shrink-0 items-center;
+    width: calc(2 * var(--rail-col) + var(--rail-value) + 2 * var(--rail-gap));
+  }
+  .zones-strip-volume > div {
+    @apply w-full justify-between;
+  }
+  /* <=359px: even the wrapped rail line can't fit transport + volume slot,
+     and letting flex-wrap decide per-rail would wrap the header's rail but
+     not the picker rows' (whose rail is narrower), splitting the shared
+     play axis. Forcing the volume slot onto its own rail line in EVERY
+     rail keeps the wrap deterministic: play/next columns align on line
+     one, - / value / + stay a fixed right-anchored block on line two. */
+  @media (max-width: 359px) {
+    .zones-strip-volume {
+      flex-basis: 100%;
+      justify-content: flex-end;
+    }
+    .zones-strip-volume > div {
+      width: calc(2 * var(--rail-col) + var(--rail-value) + 2 * var(--rail-gap));
+      flex-grow: 0;
+    }
+  }
+  /* #596 (owner: "39 vs 40.0 jiggles"): tabular numerals in a fixed
+     --rail-value box so - / + never shift as digits change. 5rem +
+     nowrap fits the widest real value format_volume produces
+     ("-120.0 dB" device floors included) on a single line. */
+  .zones-strip-volume span {
+    @apply flex-shrink-0 whitespace-nowrap text-center;
+    width: var(--rail-value);
+    font-variant-numeric: tabular-nums;
   }
 
   .zones-strip-picker {
@@ -849,41 +945,45 @@
   .zones-strip-picker-meta {
     @apply flex min-w-0 flex-1 flex-col gap-0.5;
   }
-  /* #594: needs its own `min-w-0` -- without it, the untruncated zone-name
-     span below could push this row (and the whole picker item) wider than
-     its flex-1 parent, overflowing into `.zones-strip-picker-controls`
-     instead of truncating. Same reasoning `.zones-strip-picker-np` already
-     applied to its own track span. */
-  .zones-strip-picker-name-row {
-    @apply flex min-w-0 items-center gap-2;
-  }
-  /* #594: the zone name itself had no truncation class, so a long name
-     could overflow the row uncontained -- the one piece of text in this
-     component that didn't already truncate like its header counterpart
-     (`.zones-strip-zone-name`), which read as "uneven alignment" between
-     the armed header and the picker rows. */
-  .zones-strip-picker-name {
-    @apply min-w-0 truncate;
-  }
+  /* Picker rows reuse `.zones-strip-name-row` / `.zones-strip-zone-name` /
+     `.zones-strip-track` (#596) -- one grammar, no `-picker-` twins. */
   .zones-strip-picker-np {
     @apply flex min-w-0 items-center gap-1.5;
-  }
-  .zones-strip-picker-track {
-    @apply truncate text-xs;
-    color: var(--text-muted);
   }
 
   /* Divider (not a background) keeps the boundary between the row's
      select-target and its own controls legible without implying the
      controls are a second clickable "row" (owner feedback on #585).
-     #594: when `.zones-strip-picker-row` wraps below `sm`, this becomes
-     its own full-width line under the select-target -- a left border reads
-     as a stray vertical tick there, so the divider moves to the top and the
-     buttons right-align, then reverts to the original left-divider,
-     left-aligned layout once the row stops wrapping. */
+     #596: layout and border-color come from the shared `.zones-strip-rail`
+     on the same element; this class only adds the row's `sm`+ left divider
+     (below `sm` the rail's own wrapped top divider takes over -- a lone
+     left border reads as a stray tick on its own line, per #594). Left
+     padding never moves the right-anchored columns. */
   .zones-strip-picker-controls {
-    @apply flex w-full flex-shrink-0 items-center justify-end gap-1 border-t py-1 pl-0 pr-1 sm:w-auto sm:justify-start sm:border-t-0 sm:border-l sm:pl-2;
-    border-color: var(--border-subtle);
+    @apply sm:border-l sm:pl-2;
+  }
+
+  /* ---- #596: restrained motion ---------------------------------------
+     Arming feedback, transform/opacity only, ease-out, no bounce; disabled
+     under prefers-reduced-motion alongside the other reveal animations at
+     the bottom of this file. Arming is acknowledged where the gesture
+     happens: the pressed row settles (below), and the picker's open/close
+     reveal reuses the library's keyframes. The header itself deliberately
+     does NOT animate -- remounting it per arm change refetches the art and
+     hides the header behind opacity:0 exactly when feedback is wanted, and
+     a mount-only animation would fire only on page load. */
+  .zones-strip-picker {
+    animation: library-reveal 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .zones-strip-picker-item {
+    transition:
+      background-color 0.15s ease-out,
+      transform 0.15s ease-out,
+      opacity 0.15s ease-out;
+  }
+  .zones-strip-picker-item:active {
+    transform: translateY(1px);
+    opacity: 0.85;
   }
 
   .zones-strip-transfer {
@@ -891,8 +991,18 @@
     border-color: var(--border-subtle);
   }
 
+  /* #596: sized to the strip it reserves room for -- the wrapped
+     target+rail header measures ~150px below `sm` (~200px under 360px
+     where the volume slot takes its own rail line) vs the single ~76px
+     row at `sm`+. Undersizing this hides the tail of the library list
+     behind the fixed strip. */
   .library-strip-spacer {
-    @apply h-24;
+    @apply h-40 sm:h-24;
+  }
+  @media (max-width: 359px) {
+    .library-strip-spacer {
+      height: 13rem;
+    }
   }
 }
 
@@ -936,6 +1046,18 @@
   }
   .library-eq span {
     animation: none;
+  }
+  /* #596: zones strip picker reveal / press-settle motion off with the
+     rest. */
+  .zones-strip-picker {
+    animation: none;
+  }
+  .zones-strip-picker-item {
+    transition: background-color 0.15s ease-out;
+  }
+  .zones-strip-picker-item:active {
+    transform: none;
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
Closes #596

## Design as implemented

**Vertical control rail.** One right-aligned rail class (`.zones-strip-rail`) shared by the armed header and every mini-controller picker row, with fixed, token-derived column widths (`--rail-col: 2.75rem`, `--rail-gap: 0.25rem`, `--rail-value: 5rem`). Every rail button is a hard 44px column (`min-h-11` preserved, so hit targets stay 44px+). The picker rows carry an inert spacer where the header has its next-track button, so ▶ / − / volume value / + sit on the same vertical axes strip-wide, independent of name/track length. The volume slot (`.zones-strip-volume`, `calc(2*col + value + 2*gap)` = 176px) is **reserved even when a zone reports fixed volume or has no now-playing yet**, so the play column never drifts between rows; `justify-between` pins − and + to the slot edges, which keeps them on-axis for incremental zones that render no value span.

**One grid grammar.** Header and picker rows both render `art | name+badge+track | rail` with the *same* classes (`.zones-strip-name-row`, `.zones-strip-zone-name`, `.zones-strip-track`) and one `source_badge()` helper — the `-picker-` twin classes are deleted. The header is the same row *elevated*: 48px art at every width (rows: 32px) with a 2px accent-token ring, and the zone name in the accent color (`--armed` modifier).

**Type hierarchy.** Zone name: xs semibold uppercase tracking-wide, default text color so the name leads its row ("which room" is the picker's primary question); accent in the armed header. Track: sm/medium where it is the star (armed now-playing), `--muted` (muted, weight 400) in picker rows. Artist: xs muted. All truncate; truncation cannot collide with the rail (flex siblings, `min-w-0` throughout — probed).

**Tabular numerals.** `font-variant-numeric: tabular-nums` in a fixed `--rail-value` (5rem) nowrap box — 39 ↔ 40.0 moves nothing (probed: `+` button rect identical before/after a live text swap), and the box fits device floors like `-120.0 dB` on one line.

**Restrained motion.** Picker open reuses the existing `library-reveal` keyframes (they were byte-identical to what this needed); picker rows acknowledge the arming press with a soft transform/opacity settle (`:active`, ease-out, no bounce). Both are disabled under `prefers-reduced-motion: reduce` in the file's established `animation: none` idiom. The header itself deliberately does not animate — see disposition table.

**Narrow-screen safety valve.** Below `sm` the rail keeps PR #595's own-line wrap. Under 360px even that line can't fit transport + volume slot, and per-rail `flex-wrap` would wrap only the header's (wider) rail, splitting the play axis — so the volume slot takes its own right-anchored rail line in **every** rail, keeping the wrap deterministic and the axes intact. `.library-strip-spacer` is sized to what the strip actually measures now (h-40 below `sm`, 13rem under 360px, h-24 at `sm`+ unchanged).

## Verification (PR #595's technique, reused)

No pane tools; static harness built from the compiled `tailwind.css` + `dx-components-theme.css` with markup copied verbatim from `zones_strip.rs`'s rsx, driven by Puppeteer/CDP against system Chrome. Scenarios: armed zone with art + number volume; picker rows exercising dB (`-120.0 dB`), incremental (no value span), pathological long name + long track, idle (no rail), fixed volume (empty slot); armed zone with no art / idle / fixed volume.

Probed at **320 / 375 / 414 / 430 / 1280px**, themes **dark / OLED / light** (screenshot matrix all 15 combinations), with hard assertions — final run: **zero failures**:

- play / − / value / + center-x equal (±0.6px) across header and every controlled row, incl. the fixed-volume row's play; rail right edges equal.
- No horizontal overflow on `.zones-strip-inner`, any `.zones-strip-picker-row`, or the page, at any width.
- Every `.btn` in the strip ≥ 44x44.
- Value slots exactly 80px, `tabular-nums`, single line, no clipped text at `-120.0 dB`; live 39→40.0 swap moves `+` by 0.0px.
- Long zone name and long track ellipsize inside the row (no rail collision, no wrap-to-second-line).
- Header art 48x48 with accent ring; picker art 32px.
- `library-reveal` present under `no-preference`; `animation: none` and colors-only transition under `reduce`.
- Strip heights measured (149px @375, 197px @320, 142px idle) and the spacer sized above them.

### Gates
- `cargo fmt --check`: clean.
- `cargo clippy -- -D warnings`: clean.
- `cargo check --target wasm32-unknown-unknown --no-default-features --features web`: clean.
- `cargo test` (plain): 59 suites, all ok, 0 failures.

## Review-findings disposition (all six relayed batches)

| # | Finding | Disposition |
|---|---|---|
| R1 | arm-in keyframes duplicate `library-reveal` | **Applied** — keyframes deleted, `library-reveal` reused |
| R2 | motion gate inverted the file's `reduce` idiom | **Applied** — unconditional rules + `animation: none`/colors-only under `reduce`, alongside the existing blocks |
| R3 | `name-row` class duplicated | **Applied** — single `.zones-strip-name-row`, picker twin deleted |
| R4 | extract shared source badge (+ hqplayer.rs adoption) | **Applied in-scope** — one `source_badge()` helper for both strip sites; hqplayer.rs adoption **rejected**: issue fixes the file list to `zones_strip.rs` + `input.css` |
| R5/S4/A3/C4 | move tabular-nums/fixed box/variant prop into `volume.rs` | **Rejected (scope)** — `volume.rs` is outside the issue's explicit file list and is shared by other pages; the overrides are scoped under `.zones-strip-volume` and documented. Reasonable follow-up issue |
| R6/A3 | promote `.zones-strip-rail .btn` to a call-site `.btn-icon` | **Rejected** — the − / + buttons are rendered inside `VolumeControlsCompact` (out of scope), so a call-site class cannot reach them; one scoped descendant rule beats two mechanisms |
| S1 | extract `ArmedZoneHeader` component | **Superseded/rejected** — motivation was the keyed-loop nesting, which is gone; a props-heavy extraction adds churn to a style-only diff |
| S2 | closure-factory `ctl(action)` instead of per-button id clones | **Applied** — `ctl`/`vol_ctl` (header) and `row_ctl`/`row_vol_ctl` (rows); 9 clone bindings removed |
| S3 | collapse twin name/track classes with a modifier | **Applied** — `--armed` and `--muted` modifiers, twins deleted |
| S5 | delete `.zones-strip-transport` wrapper | **Applied** — transport buttons sit directly in the rail (identical gap arithmetic) |
| S6 | collapse comment archaeology | **Applied** — one current-rationale comment per rule |
| A1/C5 | fixed 4.5rem value box overflows/wraps at `-100.0`/`-120.0 dB` | **Applied (fixed-width kept)** — the issue explicitly mandates a fixed-width slot, so it is sized to the real maximum (5rem + nowrap; probed with `-120.0 dB`, fits with zero overflow) rather than switched to min-width, which would let − drift off-axis |
| A2 | derive rail arithmetic via custom properties | **Applied** — `--rail-col`/`--rail-gap`/`--rail-value` + `calc()` |
| E1/B5-6/C(a) | drop keyed remount; wire a use_effect animation-name parity flip | **Remount dropped (applied)**; the use_effect parity trick **rejected** — it adds runtime state machinery to a layout/style-only issue and is unverifiable in the static harness. With the remount gone, a mount-only header animation would fire only at page load (the one unwanted moment, per the same review), so the header animation was removed entirely; arming feedback lives where the gesture happens (row press-settle + picker reveal), which is the literal reading of the issue's "arming a row gets a soft transform/opacity transition" |
| E2 | drop `both` fill-mode | **Applied** (no delay, no fill needed) |
| E3 | `as_deref().unwrap_or_default()` for source | **Applied** (inside `source_badge`, no per-render String allocs) |
| E4 | duplicate `border-color` on `.zones-strip-picker-controls` | **Applied** — rail owns it on the same element |
| B1 | rail clipped + button at ≤336px (fixed bar, unreachable) | **Applied** — deterministic volume-slot wrap under 360px (see safety valve); 320px added to the assertion matrix |
| B2 | picker hierarchy inverted (track outweighed zone name) | **Applied** — zone name leads (default text color, uppercase semibold); track demoted to `--muted` in rows |
| B3 | value box wraps to two lines | **Applied** — `whitespace-nowrap` + 5rem (probed) |
| B4 | badge crushes zone name at mid widths | **Applied** — badge shares truncation (`min-w-0 truncate`) instead of holding full width; name wins space proportionally |
| B5 | `.library-strip-spacer` 96px vs ~150px strip | **Applied** — spacer sized from measured strip heights |
| C1 | empty volume gutter for fixed-volume / pre-load zones | **Rejected (deliberate)** — the reserved slot **is** the mechanism that keeps ▶ on one axis across volume/fixed/incremental zones, which is the issue's explicit ruling; collapsing it per-row reintroduces the drift. Idle rows render no rail at all (nothing to align), unchanged from #585 |
| C2 | spacer sits in a stop-propagation "dead tap zone" | **Rejected (no-op)** — no ancestor of the rail handles clicks, so the gap between controls is inert with or without `stop_propagation`; making blank rail space arm the zone would be a behavior change |
| C3 | `source: null` renders an empty badge pill | **Applied** — `source_badge()` renders nothing for `None`/empty |

## Deviations

- `sg review` is unavailable in this environment (`sg` resolves to ast-grep, no `review` subcommand); the review gate was served by the six relayed multi-lens review batches, each item dispositioned above, plus the harness assertion suite.
- Base is `integration/streaming-ha-alpha` per the issue (not `v3`).
