### PR TITLE
fix: doc comments on component fn parameters break doc-tests

### DIFF
--- a/src/app/components/error_alert.rs
+++ b/src/app/components/error_alert.rs
@@ -5,9 +5,9 @@ use dioxus::prelude::*;
 /// A dismissable error alert that displays an error message with a close button.
 #[component]
 pub fn ErrorAlert(
-    /// The error message to display
+    // The error message to display
     message: String,
-    /// Called when the dismiss button is clicked
+    // Called when the dismiss button is clicked
     on_dismiss: EventHandler<()>,
 ) -> Element {
     rsx! {

--- a/src/app/components/form_inputs.rs
+++ b/src/app/components/form_inputs.rs
@@ -7,13 +7,13 @@ use crate::app::api::PowerModeConfig;
 /// A labeled power mode timeout input with description.
 #[component]
 pub fn PowerModeInput(
-    /// Input label
+    // Input label
     label: &'static str,
-    /// Description text shown below label
+    // Description text shown below label
     description: &'static str,
-    /// Current configuration
+    // Current configuration
     config: PowerModeConfig,
-    /// Called when the value changes
+    // Called when the value changes
     on_change: EventHandler<PowerModeConfig>,
 ) -> Element {
     let timeout_sec = config.timeout_sec;
@@ -46,13 +46,13 @@ pub fn PowerModeInput(
 /// A labeled toggle switch with description.
 #[component]
 pub fn ToggleInput(
-    /// Input label
+    // Input label
     label: &'static str,
-    /// Description text shown below label
+    // Description text shown below label
     description: &'static str,
-    /// Current checked state
+    // Current checked state
     checked: bool,
-    /// Called when the toggle changes
+    // Called when the toggle changes
     on_change: EventHandler<bool>,
 ) -> Element {
     rsx! {

--- a/src/app/components/hqp_controls.rs
+++ b/src/app/components/hqp_controls.rs
@@ -7,16 +7,14 @@ use crate::app::api::{HqpMatrixProfile, HqpProfile};
 /// HQPlayer profile selector dropdown.
 #[component]
 pub fn HqpProfileSelect(
-    /// Available profiles to choose from
+    // Available profiles to choose from
     profiles: Vec<HqpProfile>,
-    /// Called when a profile is selected
+    // Called when a profile is selected
     on_select: EventHandler<String>,
-    /// Optional CSS class for the select element
-    #[props(default = "input".to_string())]
-    class: String,
-    /// Disable the select element
-    #[props(default = false)]
-    disabled: bool,
+    // Optional CSS class for the select element
+    #[props(default = "input".to_string())] class: String,
+    // Disable the select element
+    #[props(default = false)] disabled: bool,
 ) -> Element {
     rsx! {
         select {
@@ -58,18 +56,16 @@ pub fn HqpProfileSelect(
 /// HQPlayer matrix profile selector dropdown.
 #[component]
 pub fn HqpMatrixSelect(
-    /// Available matrix profiles to choose from
+    // Available matrix profiles to choose from
     profiles: Vec<HqpMatrixProfile>,
-    /// Currently active profile name. `None` is the unnamed `[Default]` matrix.
+    // Currently active profile name. `None` is the unnamed `[Default]` matrix.
     active: Option<String>,
-    /// Called with the native profile name; empty selects `[Default]`.
+    // Called with the native profile name; empty selects `[Default]`.
     on_select: EventHandler<String>,
-    /// Optional CSS class for the select element
-    #[props(default = "input".to_string())]
-    class: String,
-    /// Disable the select element
-    #[props(default = false)]
-    disabled: bool,
+    // Optional CSS class for the select element
+    #[props(default = "input".to_string())] class: String,
+    // Disable the select element
+    #[props(default = false)] disabled: bool,
 ) -> Element {
     rsx! {
         select {
@@ -94,18 +90,18 @@ pub fn HqpMatrixSelect(
 /// Compact HQP controls for use in cards (profile + matrix in a row).
 #[component]
 pub fn HqpControlsCompact(
-    /// Available profiles
+    // Available profiles
     profiles: Vec<HqpProfile>,
-    /// Available matrix profiles
+    // Available matrix profiles
     matrix_profiles: Vec<HqpMatrixProfile>,
-    /// Whether the matrix inventory was read successfully. The unnamed `[Default]` exists even
-    /// when there are no saved named profiles.
+    // Whether the matrix inventory was read successfully. The unnamed `[Default]` exists even
+    // when there are no saved named profiles.
     matrix_available: bool,
-    /// Currently active matrix profile name; `None` is the unnamed `[Default]` matrix.
+    // Currently active matrix profile name; `None` is the unnamed `[Default]` matrix.
     active_matrix: Option<String>,
-    /// Called when a profile is selected
+    // Called when a profile is selected
     on_profile_select: EventHandler<String>,
-    /// Called when a matrix profile is selected
+    // Called when a matrix profile is selected
     on_matrix_select: EventHandler<String>,
 ) -> Element {
     rsx! {


### PR DESCRIPTION
## Summary
- `cargo test --doc` failed because rustdoc rejects `///` doc comments applied directly to function parameters (rustdoc error: "documentation comments cannot be applied to function parameters")
- Affected: `src/app/components/error_alert.rs`, `src/app/components/form_inputs.rs`, and `src/app/components/hqp_controls.rs` (three `#[component]` functions there also had the pattern)
- Converted those parameter-level `///` comments to plain `//` line comments, preserving their content verbatim
- Swept the rest of `src/app/components/` for the same pattern: `layout.rs`, `nav.rs`, `volume.rs`, and `zones_strip.rs` use doc comments on struct fields (via `#[derive(Props)]` structs or plain structs/enums), which rustdoc accepts fine, so those were left untouched

## Test plan
- [x] `cargo test --doc` passes (was failing before this change)
- [x] `cargo test` (not `--all-features`) passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features --features web` passes
- Comment-only change; no UI behavior affected, no live browser probe needed