### PR TITLE
feat(mqtt): auto-configure the publisher from the environment, and say so in Settings (#605)

### DIFF
--- a/src/api/credentials.rs
+++ b/src/api/credentials.rs
@@ -321,6 +321,23 @@ impl MusicAssistantCredentialStore {
     }
 }
 
+/// Who supplied a stored [`MqttCredentialRecord`]. The distinction is what
+/// lets the startup bootstrap in [`crate::api::mqtt_bootstrap`] adopt
+/// environment-provided broker settings (the Home Assistant add-on hands
+/// them over from the Supervisor) without ever overwriting broker settings
+/// the user typed in themselves.
+///
+/// [`MqttConfigSource::User`] is the serde default on purpose: records
+/// written before this field existed came from `POST /api/mqtt/configure`,
+/// i.e. from the user, and must keep winning over the environment.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MqttConfigSource {
+    #[default]
+    User,
+    Environment,
+}
+
 /// Broker connection details for the optional Home Assistant MQTT publisher
 /// (#508), kept in one encrypted record because the broker password is a
 /// secret alongside otherwise-plain connection settings.
@@ -335,6 +352,11 @@ pub struct MqttCredentialRecord {
     pub password: Option<String>,
     pub base_topic: String,
     pub discovery_prefix: String,
+    /// Provenance (#605). Participates in `PartialEq` so the startup
+    /// bootstrap can tell "the same environment config as last boot" from
+    /// "the same settings, but the user owns them now".
+    #[serde(default)]
+    pub source: MqttConfigSource,
 }
 
 impl std::fmt::Debug for MqttCredentialRecord {
@@ -348,6 +370,7 @@ impl std::fmt::Debug for MqttCredentialRecord {
             .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
             .field("base_topic", &self.base_topic)
             .field("discovery_prefix", &self.discovery_prefix)
+            .field("source", &self.source)
             .finish()
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -44,6 +44,7 @@ pub mod browse;
 pub mod controller_auth;
 pub mod credentials;
 pub mod ingress;
+pub mod mqtt_bootstrap;
 pub mod mqtt_settings;
 pub mod provider_auth;
 pub mod spotify_tunnel;
@@ -3230,6 +3231,17 @@ fn mutate_app_settings(mutate: impl FnOnce(&mut AppSettings)) -> bool {
     let mut settings = load_app_settings();
     mutate(&mut settings);
     save_app_settings_locked(&settings)
+}
+
+/// Turn the MQTT publisher on in persisted settings during the startup
+/// environment bootstrap (#605).
+///
+/// Persisting matters as much as enabling does. Enabling only in memory would
+/// leave `app-settings.json` saying `mqtt: false`, so the *next* boot could
+/// not tell "the add-on switched this on for you" from "you switched it off",
+/// and the user's later decision to turn it off would not survive a restart.
+pub fn enable_mqtt_in_settings() -> bool {
+    mutate_app_settings(|settings| settings.adapters.mqtt = true)
 }
 
 /// Overwrite the settings wholesale. Test-only on purpose.

--- a/src/api/mqtt_bootstrap.rs
+++ b/src/api/mqtt_bootstrap.rs
@@ -1,0 +1,344 @@
+//! Startup MQTT configuration handed to UHC by its environment (#605).
+//!
+//! The Home Assistant add-on knows the broker's host, port and credentials
+//! before UHC ever starts: the Supervisor hands them to any add-on that
+//! declares `services: ["mqtt:want"]`. Without a way to pass that through,
+//! installing the add-on produced a UI panel and zero Home Assistant
+//! entities, because the discovery publisher sat unconfigured with nothing
+//! saying so.
+//!
+//! This module is the receiving end: `run.sh` exports `UHC_MQTT_*`, and the
+//! server adopts them at startup under three rules that keep the user in
+//! charge of their own installation.
+//!
+//! 1. **The user always wins.** Broker settings saved through
+//!    `POST /api/mqtt/configure` are marked [`MqttConfigSource::User`] and
+//!    are never overwritten, however the environment is set. Records written
+//!    before provenance existed default to `User` for exactly this reason.
+//! 2. **Re-applying is free.** An environment config identical to the one
+//!    already stored is adopted in memory and written nowhere, so a restart
+//!    loop cannot churn the encrypted credential file.
+//! 3. **Enabling happens once per config.** The publisher is switched on (and
+//!    that choice persisted to `app-settings.json`) only when the stored
+//!    record actually changes. Once the setting is on disk, a user who turns
+//!    the toggle back off stays off across restarts - later boots see an
+//!    unchanged record and leave the toggle alone.
+//!
+//! The bootstrap decision itself is a pure function, [`plan`], so all four
+//! rules are unit-testable without touching the filesystem or the environment.
+
+use super::credentials::{MqttConfigSource, MqttCredentialRecord};
+use crate::mqtt::{DEFAULT_BASE_TOPIC, DEFAULT_DISCOVERY_PREFIX, DEFAULT_PORT, DEFAULT_TLS_PORT};
+
+pub const HOST_ENV: &str = "UHC_MQTT_HOST";
+pub const PORT_ENV: &str = "UHC_MQTT_PORT";
+pub const USERNAME_ENV: &str = "UHC_MQTT_USERNAME";
+pub const PASSWORD_ENV: &str = "UHC_MQTT_PASSWORD";
+pub const TLS_ENV: &str = "UHC_MQTT_TLS";
+pub const BASE_TOPIC_ENV: &str = "UHC_MQTT_BASE_TOPIC";
+pub const DISCOVERY_PREFIX_ENV: &str = "UHC_MQTT_DISCOVERY_PREFIX";
+
+/// What startup should do with the environment's MQTT configuration, given
+/// what is already stored. Returned by [`plan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MqttBootstrap {
+    /// The environment supplies nothing and nothing is stored: the publisher
+    /// stays unconfigured until someone fills in the settings form.
+    Unconfigured,
+    /// Use the stored record as-is. The environment either supplies nothing
+    /// or lost to a user-owned record; either way startup writes nothing and
+    /// leaves the enable toggle entirely to `app-settings.json`.
+    UseStored(MqttCredentialRecord),
+    /// The stored record already *is* this environment config. Adopt it in
+    /// memory, write nothing, and do not re-enable - that decision was made
+    /// (and persisted) on the boot that first applied it.
+    EnvironmentUnchanged(MqttCredentialRecord),
+    /// Save this record and turn the publisher on, so entities appear without
+    /// the user having to find the toggle.
+    ApplyEnvironment(MqttCredentialRecord),
+}
+
+/// Read `UHC_MQTT_*` from the process environment.
+pub fn from_env() -> Result<Option<MqttCredentialRecord>, String> {
+    from_lookup(|key| std::env::var(key).ok())
+}
+
+/// Build the environment's broker record from an arbitrary lookup, so the
+/// parsing rules can be tested without mutating the real (process-global,
+/// test-hostile) environment.
+///
+/// `UHC_MQTT_HOST` is the trigger: with no host there is no environment
+/// config at all, and every other variable is ignored. A host that is present
+/// but unusable is an error rather than a silent `None`, because a
+/// misconfigured add-on should say so in the log instead of looking like a
+/// plain unconfigured install.
+pub fn from_lookup(
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<Option<MqttCredentialRecord>, String> {
+    let Some(host) = lookup(HOST_ENV) else {
+        return Ok(None);
+    };
+    let host = host.trim().to_string();
+    if host.is_empty() {
+        return Ok(None);
+    }
+
+    let tls = match lookup(TLS_ENV) {
+        Some(value) => parse_bool(&value)
+            .ok_or_else(|| format!("{TLS_ENV} must be true/false, got {value:?}"))?,
+        None => false,
+    };
+    let port = match lookup(PORT_ENV).map(|value| value.trim().to_string()) {
+        Some(value) if !value.is_empty() => value
+            .parse::<u16>()
+            .map_err(|_| format!("{PORT_ENV} must be a port number, got {value:?}"))?,
+        // The Supervisor omits the port only when it has nothing to say; the
+        // MQTT defaults are the same ones the settings form applies.
+        _ => {
+            if tls {
+                DEFAULT_TLS_PORT
+            } else {
+                DEFAULT_PORT
+            }
+        }
+    };
+
+    Ok(Some(MqttCredentialRecord {
+        host,
+        port,
+        tls,
+        username: non_empty(lookup(USERNAME_ENV)),
+        // The password is deliberately not trimmed: leading/trailing
+        // whitespace is legal in a broker password and trimming it would
+        // silently produce a credential that cannot authenticate.
+        password: lookup(PASSWORD_ENV).filter(|value| !value.is_empty()),
+        base_topic: non_empty(lookup(BASE_TOPIC_ENV))
+            .unwrap_or_else(|| DEFAULT_BASE_TOPIC.to_string()),
+        discovery_prefix: non_empty(lookup(DISCOVERY_PREFIX_ENV))
+            .unwrap_or_else(|| DEFAULT_DISCOVERY_PREFIX.to_string()),
+        source: MqttConfigSource::Environment,
+    }))
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Accept the spellings a shell script and the Supervisor's JSON can produce.
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" | "" => Some(false),
+        _ => None,
+    }
+}
+
+/// Decide what startup does, given the stored record and the environment's.
+///
+/// Pure on purpose: the precedence rules in this module's documentation are
+/// the whole feature, and they are the part worth pinning down in tests.
+pub fn plan(
+    stored: Option<MqttCredentialRecord>,
+    environment: Option<MqttCredentialRecord>,
+) -> MqttBootstrap {
+    match (stored, environment) {
+        (None, None) => MqttBootstrap::Unconfigured,
+        (Some(stored), None) => MqttBootstrap::UseStored(stored),
+        // Rule 1: settings the user typed in are never overwritten, and the
+        // environment does not get to re-enable a publisher they turned off.
+        (Some(stored), Some(_)) if stored.source == MqttConfigSource::User => {
+            MqttBootstrap::UseStored(stored)
+        }
+        // Rules 2 and 3: an unchanged environment config writes nothing and
+        // re-enables nothing.
+        (Some(stored), Some(environment)) if stored == environment => {
+            MqttBootstrap::EnvironmentUnchanged(stored)
+        }
+        (_, Some(environment)) => MqttBootstrap::ApplyEnvironment(environment),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_record() -> MqttCredentialRecord {
+        MqttCredentialRecord {
+            host: "core-mosquitto".to_string(),
+            port: 1883,
+            tls: false,
+            username: Some("addons".to_string()),
+            password: Some("supervisor-secret".to_string()),
+            base_topic: DEFAULT_BASE_TOPIC.to_string(),
+            discovery_prefix: DEFAULT_DISCOVERY_PREFIX.to_string(),
+            source: MqttConfigSource::Environment,
+        }
+    }
+
+    fn user_record() -> MqttCredentialRecord {
+        MqttCredentialRecord {
+            host: "broker.lan".to_string(),
+            port: 8883,
+            tls: true,
+            username: None,
+            password: None,
+            base_topic: "my-hifi".to_string(),
+            discovery_prefix: DEFAULT_DISCOVERY_PREFIX.to_string(),
+            source: MqttConfigSource::User,
+        }
+    }
+
+    /// Stand-in for `std::env::var`, so precedence and parsing are tested
+    /// without mutating the process-global environment (which would make
+    /// these tests order-dependent under the default threaded test runner).
+    fn lookup(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        move |key| {
+            owned
+                .iter()
+                .find(|(candidate, _)| candidate == key)
+                .map(|(_, value)| value.clone())
+        }
+    }
+
+    #[test]
+    fn no_host_means_no_environment_config() {
+        let parsed = from_lookup(lookup(&[(PORT_ENV, "1883")])).expect("parse");
+        assert_eq!(parsed, None);
+        // A host that is set but blank is the same as unset: `run.sh` exports
+        // whatever the Supervisor returned, and an unprovisioned service
+        // yields an empty string rather than an absent variable.
+        let blank = from_lookup(lookup(&[(HOST_ENV, "   ")])).expect("parse");
+        assert_eq!(blank, None);
+    }
+
+    #[test]
+    fn environment_config_defaults_match_the_settings_form() {
+        let parsed = from_lookup(lookup(&[(HOST_ENV, "core-mosquitto")]))
+            .expect("parse")
+            .expect("record");
+        assert_eq!(parsed.port, DEFAULT_PORT);
+        assert!(!parsed.tls);
+        assert_eq!(parsed.username, None);
+        assert_eq!(parsed.password, None);
+        assert_eq!(parsed.base_topic, DEFAULT_BASE_TOPIC);
+        assert_eq!(parsed.discovery_prefix, DEFAULT_DISCOVERY_PREFIX);
+        assert_eq!(parsed.source, MqttConfigSource::Environment);
+    }
+
+    #[test]
+    fn tls_without_an_explicit_port_uses_the_tls_default() {
+        let parsed = from_lookup(lookup(&[(HOST_ENV, "broker"), (TLS_ENV, "true")]))
+            .expect("parse")
+            .expect("record");
+        assert!(parsed.tls);
+        assert_eq!(parsed.port, DEFAULT_TLS_PORT);
+    }
+
+    #[test]
+    fn tls_accepts_the_spellings_a_shell_and_json_produce() {
+        for value in ["1", "true", "TRUE", "yes", "on"] {
+            let parsed = from_lookup(lookup(&[(HOST_ENV, "broker"), (TLS_ENV, value)]))
+                .expect("parse")
+                .expect("record");
+            assert!(parsed.tls, "{value} should be true");
+        }
+        for value in ["0", "false", "no", "off", ""] {
+            let parsed = from_lookup(lookup(&[(HOST_ENV, "broker"), (TLS_ENV, value)]))
+                .expect("parse")
+                .expect("record");
+            assert!(!parsed.tls, "{value} should be false");
+        }
+    }
+
+    #[test]
+    fn unusable_values_are_reported_rather_than_ignored() {
+        // Silently falling back would leave the add-on looking unconfigured
+        // with nothing in the log to explain it - the exact failure #605 is
+        // about.
+        assert!(from_lookup(lookup(&[(HOST_ENV, "broker"), (PORT_ENV, "no")])).is_err());
+        assert!(from_lookup(lookup(&[(HOST_ENV, "broker"), (TLS_ENV, "maybe")])).is_err());
+    }
+
+    #[test]
+    fn a_password_keeps_its_surrounding_whitespace() {
+        let parsed = from_lookup(lookup(&[(HOST_ENV, "broker"), (PASSWORD_ENV, " p a s s ")]))
+            .expect("parse")
+            .expect("record");
+        assert_eq!(parsed.password.as_deref(), Some(" p a s s "));
+    }
+
+    #[test]
+    fn environment_applies_when_nothing_is_stored() {
+        assert_eq!(
+            plan(None, Some(env_record())),
+            MqttBootstrap::ApplyEnvironment(env_record())
+        );
+    }
+
+    #[test]
+    fn user_configuration_wins_over_the_environment() {
+        // Even though the environment offers a perfectly good broker, the
+        // user's own broker is what stays configured - and because the plan
+        // is `UseStored`, nothing re-enables the publisher behind their back.
+        assert_eq!(
+            plan(Some(user_record()), Some(env_record())),
+            MqttBootstrap::UseStored(user_record())
+        );
+    }
+
+    #[test]
+    fn a_user_record_wins_even_when_its_settings_match_the_environment() {
+        // Same host/port/credentials, but the user saved them: provenance,
+        // not content, decides. Otherwise a user who re-typed the add-on's
+        // own broker would have their record treated as ours to overwrite.
+        let mut stored = env_record();
+        stored.source = MqttConfigSource::User;
+        assert_eq!(
+            plan(Some(stored.clone()), Some(env_record())),
+            MqttBootstrap::UseStored(stored)
+        );
+    }
+
+    #[test]
+    fn re_applying_an_identical_environment_config_is_idempotent() {
+        // No save, no re-enable: restarting must not churn the encrypted
+        // credential file or resurrect a toggle the user switched off.
+        assert_eq!(
+            plan(Some(env_record()), Some(env_record())),
+            MqttBootstrap::EnvironmentUnchanged(env_record())
+        );
+    }
+
+    #[test]
+    fn a_rotated_broker_password_is_re_applied() {
+        let mut rotated = env_record();
+        rotated.password = Some("rotated".to_string());
+        assert_eq!(
+            plan(Some(env_record()), Some(rotated.clone())),
+            MqttBootstrap::ApplyEnvironment(rotated)
+        );
+    }
+
+    #[test]
+    fn a_previous_environment_record_survives_the_variables_going_away() {
+        // Opting out (`publish_to_home_assistant: false`) stops the add-on
+        // exporting the variables. Startup keeps the broker it already has
+        // rather than deleting the user's encrypted record out from under
+        // them; turning the publisher off is the Settings toggle's job.
+        assert_eq!(
+            plan(Some(env_record()), None),
+            MqttBootstrap::UseStored(env_record())
+        );
+    }
+
+    #[test]
+    fn nothing_stored_and_nothing_in_the_environment_is_unconfigured() {
+        assert_eq!(plan(None, None), MqttBootstrap::Unconfigured);
+    }
+}

--- a/src/api/mqtt_settings.rs
+++ b/src/api/mqtt_settings.rs
@@ -8,7 +8,7 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
-use super::credentials::{MqttCredentialRecord, MqttCredentialStore};
+use super::credentials::{MqttConfigSource, MqttCredentialRecord, MqttCredentialStore};
 use super::AppState;
 use crate::mqtt::{DEFAULT_BASE_TOPIC, DEFAULT_DISCOVERY_PREFIX, DEFAULT_PORT, DEFAULT_TLS_PORT};
 
@@ -44,6 +44,12 @@ pub struct MqttStatusResponse {
     pub discovery_prefix: Option<String>,
     pub has_username: bool,
     pub has_password: bool,
+    /// `"user"`, `"environment"`, or absent while unconfigured (#605).
+    /// `"environment"` means the Home Assistant add-on supplied the broker
+    /// from the Supervisor, which Settings renders as managed rather than as
+    /// something the user should fill in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 impl From<crate::mqtt::MqttStatus> for MqttStatusResponse {
@@ -59,6 +65,13 @@ impl From<crate::mqtt::MqttStatus> for MqttStatusResponse {
             discovery_prefix: status.discovery_prefix,
             has_username: status.has_username,
             has_password: status.has_password,
+            source: status.source.map(|source| {
+                match source {
+                    MqttConfigSource::User => "user",
+                    MqttConfigSource::Environment => "environment",
+                }
+                .to_string()
+            }),
         }
     }
 }
@@ -122,6 +135,10 @@ pub async fn configure(
             .discovery_prefix
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| DEFAULT_DISCOVERY_PREFIX.to_string()),
+        // Saving through this endpoint is what makes the configuration the
+        // user's own: from here on the startup environment bootstrap (#605)
+        // leaves it alone, even under the Home Assistant add-on.
+        source: MqttConfigSource::User,
     };
 
     store.save(&record).map_err(|error| {
@@ -152,6 +169,7 @@ mod tests {
             discovery_prefix: Some("homeassistant".to_string()),
             has_username: true,
             has_password: true,
+            source: Some("user".to_string()),
         };
         let json = serde_json::to_string(&response).expect("serialize");
         // `has_password` (a bool) is expected; the literal secret is not -

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -284,6 +284,20 @@ pub struct MqttStatusResponse {
     pub discovery_prefix: Option<String>,
     pub has_username: bool,
     pub has_password: bool,
+    /// `"user"`, `"environment"`, or absent while unconfigured (#605).
+    /// `"environment"` means the Home Assistant add-on supplied the broker
+    /// from the Supervisor, so Settings shows it as managed rather than
+    /// inviting the user to fill in details they never entered.
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+impl MqttStatusResponse {
+    /// Whether the active broker came from the Home Assistant add-on rather
+    /// than from something the user typed in.
+    pub fn is_environment_managed(&self) -> bool {
+        self.source.as_deref() == Some("environment")
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -345,6 +345,13 @@ fn default_spotify_redirect_uri() -> String {
 const SPOTIFY_INFO_PANEL_OPEN: &str = "absolute right-0 top-full z-20 mt-1 w-72 max-w-[85vw] rounded-md border border-default bg-elevated p-3 text-left text-xs text-secondary shadow-lg";
 const SPOTIFY_INFO_PANEL_CLOSED: &str = "absolute right-0 top-full z-20 mt-1 w-72 max-w-[85vw] rounded-md border border-default bg-elevated p-3 text-left text-xs text-secondary shadow-lg hidden group-hover:block";
 
+/// The same ⓘ disclosure for the MQTT section (#605), which needs one panel
+/// rather than the stepper's one-per-step. Anchored `left-0` because it
+/// hangs off a heading at the left edge, where the Spotify panel's
+/// right-anchoring would push it off-screen.
+const MQTT_INFO_PANEL_OPEN: &str = "absolute left-0 top-full z-20 mt-1 w-80 max-w-[85vw] rounded-md border border-default bg-elevated p-3 text-left text-xs text-secondary shadow-lg";
+const MQTT_INFO_PANEL_CLOSED: &str = "absolute left-0 top-full z-20 mt-1 w-80 max-w-[85vw] rounded-md border border-default bg-elevated p-3 text-left text-xs text-secondary shadow-lg hidden group-hover:block";
+
 /// Whether *this browser* is talking to UHC over loopback. Drives which
 /// variant of the Spotify callback step (#570 follow-up) renders: a
 /// loopback browser can use the plain HTTP loopback callback directly, but
@@ -653,6 +660,12 @@ pub fn Settings() -> Element {
     let mut mqtt_base_topic = use_signal(|| "unified-hifi".to_string());
     let mut mqtt_discovery_prefix = use_signal(|| "homeassistant".to_string());
     let mut mqtt_tls = use_signal(|| false);
+    // ⓘ disclosure for what the Home Assistant side has to do (#605).
+    let mut mqtt_info_open = use_signal(|| false);
+    // When the add-on supplies the broker there is nothing for the user to
+    // fill in, so the manual form starts collapsed rather than sitting there
+    // pre-filled and inviting them to re-enter settings they never chose.
+    let mut mqtt_manual_open = use_signal(|| false);
     let mut confirmed_settings = use_signal(|| None::<AppSettings>);
 
     // Hide knobs signal (LMS/HQPlayer visibility follows adapter enabled state)
@@ -1532,6 +1545,21 @@ pub fn Settings() -> Element {
             SPOTIFY_INFO_PANEL_CLOSED
         }
     };
+    let mqtt_info_panel_class = if mqtt_info_open() {
+        MQTT_INFO_PANEL_OPEN
+    } else {
+        MQTT_INFO_PANEL_CLOSED
+    };
+    // The Home Assistant add-on hands the broker over from the Supervisor
+    // (#605). When it has, there is nothing here for the user to fill in, so
+    // the manual form collapses behind an opt-in rather than presenting
+    // itself as the setup step.
+    let mqtt_env_managed = mqtt_status
+        .read()
+        .clone()
+        .flatten()
+        .is_some_and(|status| status.is_environment_managed());
+    let mqtt_show_manual_form = !mqtt_env_managed || mqtt_manual_open();
 
     rsx! {
         Layout {
@@ -1828,18 +1856,34 @@ pub fn Settings() -> Element {
                                         span { class: "badge badge-secondary", "Alpha" }
                                     }
                                 }
+                                // The broker form lives in its own section far
+                                // below this table, so a user who flips the
+                                // toggle with no broker saved would otherwise
+                                // get silence. Say what is missing here, and
+                                // offer the jump (#605).
                                 td { class: "py-2 px-3",
                                     if mqtt_enabled() {
                                         if let Some(status) = mqtt_status.read().clone().flatten() {
                                             if status.running {
-                                                span { class: "status-ok", "✓ Connected" }
+                                                if status.is_environment_managed() {
+                                                    span { class: "status-ok", "✓ Connected · via add-on" }
+                                                } else {
+                                                    span { class: "status-ok", "✓ Connected" }
+                                                }
                                             } else if status.configured {
                                                 span { class: "text-yellow-500", "Configured · waiting" }
                                             } else {
-                                                span { class: "text-muted", "Setup required" }
+                                                button {
+                                                    r#type: "button",
+                                                    class: "text-yellow-500 underline",
+                                                    onclick: move |_| scroll_to_element("mqtt-anchor"),
+                                                    "No broker yet — set one up"
+                                                }
                                             }
                                         } else { "..." }
-                                    } else { span { class: "text-muted", "-" } }
+                                    } else {
+                                        span { class: "text-muted", "Off — no Home Assistant entities" }
+                                    }
                                 }
                             }
                             // Controllers (page only, no adapter)
@@ -2691,21 +2735,60 @@ pub fn Settings() -> Element {
                     hidden: !mqtt_enabled(),
                     aria_labelledby: "mqtt-heading",
                     div { class: "mb-4",
-                        h2 { id: "mqtt-heading", class: "text-xl font-semibold flex items-center gap-2",
-                            "MQTT / Home Assistant"
-                            span { class: "badge badge-secondary", "Alpha" }
+                        div { class: "flex items-center gap-2",
+                            h2 { id: "mqtt-heading", class: "text-xl font-semibold flex items-center gap-2",
+                                "MQTT / Home Assistant"
+                                span { class: "badge badge-secondary", "Alpha" }
+                            }
+                            // One-line summary above, the rest behind ⓘ - the
+                            // same disclosure the Spotify stepper uses (#597),
+                            // so the setup path never becomes a wall of text.
+                            span { class: "group relative shrink-0",
+                                button {
+                                    r#type: "button",
+                                    class: "flex h-8 w-8 items-center justify-center rounded-full text-muted",
+                                    aria_expanded: mqtt_info_open(),
+                                    aria_controls: "mqtt-info",
+                                    aria_label: "More about Home Assistant entities",
+                                    onclick: move |_| {
+                                        let open = *mqtt_info_open.peek();
+                                        mqtt_info_open.set(!open);
+                                    },
+                                    "ⓘ"
+                                }
+                                div { id: "mqtt-info", class: mqtt_info_panel_class, role: "note",
+                                    p { "Home Assistant discovers the zones by itself, so there is nothing to add per zone - no YAML, no entity list. Set up Home Assistant's MQTT integration, point it at the same broker you enter here, and the entities appear." }
+                                    p { class: "mt-2", "Each zone becomes a media player you can play, pause, and set the volume on. Each hardware controller becomes its own device." }
+                                    p { class: "mt-2", "Advanced: the discovery prefix below has to match the one Home Assistant's MQTT integration uses. Leave it at \"homeassistant\" unless you changed it there." }
+                                }
+                            }
                         }
-                        p { class: "text-muted text-sm", "Publish every UHC zone to Home Assistant over MQTT discovery. Broker credentials are encrypted and never returned to this page." }
+                        p { class: "text-muted text-sm mt-1", "Your zones and controllers show up in Home Assistant as entities. Point Home Assistant's MQTT integration at the same broker and they appear on their own." }
                     }
                     div { class: "card p-5 sm:p-6",
                         if let Some(status) = mqtt_status.read().clone().flatten() {
                             div { class: "text-sm",
-                                if status.running {
-                                    p { class: "status-ok", "Connected to broker" }
+                                if status.is_environment_managed() {
+                                    // The add-on already did this. Saying so
+                                    // is what keeps the form below from
+                                    // reading as an unfinished setup step.
+                                    p { class: "font-medium", "Set up by the Home Assistant add-on" }
+                                    if status.running {
+                                        p { class: "mt-1 status-ok", "Connected — your zones are in Home Assistant" }
+                                    } else {
+                                        p { class: "mt-1 text-yellow-500", "Not connected to the broker yet" }
+                                    }
+                                } else if status.running {
+                                    p { class: "status-ok", "Connected — your zones are in Home Assistant" }
                                 } else if status.configured {
                                     p { class: "text-yellow-500", "Configured, not currently connected" }
                                 } else {
-                                    p { class: "text-muted", "Setup required" }
+                                    // The failure this whole section existed
+                                    // to explain: unconfigured used to read
+                                    // "Setup required" and leave the user to
+                                    // work out what they were missing out on.
+                                    p { class: "font-medium", "No broker yet — nothing is being published" }
+                                    p { class: "mt-1 text-secondary", "Add your broker below and your zones and controllers show up in Home Assistant as entities." }
                                 }
                                 if let Some(host) = status.host.as_ref() {
                                     p { class: "mt-1 text-secondary",
@@ -2716,7 +2799,18 @@ pub fn Settings() -> Element {
                                 }
                             }
                         }
+                        if mqtt_env_managed && !mqtt_show_manual_form {
+                            button {
+                                id: "mqtt-use-own-broker",
+                                r#type: "button",
+                                class: "btn btn-secondary mt-4 min-h-11",
+                                onclick: move |_| mqtt_manual_open.set(true),
+                                "Use a different broker"
+                            }
+                            p { class: "mt-2 text-xs text-muted", "Broker settings you save here replace the add-on's and are kept across restarts." }
+                        }
                         div { class: "mt-4 grid gap-4 sm:grid-cols-2",
+                            hidden: !mqtt_show_manual_form,
                             div {
                                 label { class: "block text-sm font-medium", r#for: "mqtt-host", "Broker host" }
                                 input { id: "mqtt-host", class: "input mt-1 min-h-11 w-full", value: mqtt_host(), autocomplete: "url", placeholder: "homeassistant.local", oninput: move |event| mqtt_host.set(event.value()) }
@@ -2743,12 +2837,14 @@ pub fn Settings() -> Element {
                             }
                         }
                         label { class: "mt-4 flex items-center gap-2 text-sm",
+                            hidden: !mqtt_show_manual_form,
                             input { r#type: "checkbox", checked: mqtt_tls(), onchange: move |event| mqtt_tls.set(event.checked()) }
                             "Use TLS"
                         }
-                        button { id: "mqtt-save-settings", r#type: "button", class: "btn btn-primary mt-5 min-h-11", disabled: mqtt_action() == ProviderActionState::Loading, aria_busy: mqtt_action() == ProviderActionState::Loading, onclick: save_mqtt,
+                        button { id: "mqtt-save-settings", r#type: "button", class: "btn btn-primary mt-5 min-h-11", hidden: !mqtt_show_manual_form, disabled: mqtt_action() == ProviderActionState::Loading, aria_busy: mqtt_action() == ProviderActionState::Loading, onclick: save_mqtt,
                             if mqtt_action() == ProviderActionState::Loading { "Saving…" } else { "Save and connect" }
                         }
+                        p { class: "mt-2 text-xs text-muted", hidden: !mqtt_show_manual_form, "The broker password is encrypted and never sent back to this page." }
                         p { class: "mt-2 text-sm status-err", hidden: mqtt_error().is_none(), role: "alert", "{mqtt_error().unwrap_or_default()}" }
                     }
                 }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -1866,9 +1866,9 @@ pub fn Settings() -> Element {
                                         if let Some(status) = mqtt_status.read().clone().flatten() {
                                             if status.running {
                                                 if status.is_environment_managed() {
-                                                    span { class: "status-ok", "✓ Connected · via add-on" }
+                                                    span { class: "status-ok", "✓ Publishing · via add-on" }
                                                 } else {
-                                                    span { class: "status-ok", "✓ Connected" }
+                                                    span { class: "status-ok", "✓ Publishing" }
                                                 }
                                             } else if status.configured {
                                                 span { class: "text-yellow-500", "Configured · waiting" }
@@ -2774,12 +2774,16 @@ pub fn Settings() -> Element {
                                     // reading as an unfinished setup step.
                                     p { class: "font-medium", "Set up by the Home Assistant add-on" }
                                     if status.running {
-                                        p { class: "mt-1 status-ok", "Connected — your zones are in Home Assistant" }
+                                        // "Publishing", not "Connected":
+                                        // `running` means the publisher task
+                                        // is alive, which it stays while
+                                        // retrying an unreachable broker.
+                                        p { class: "mt-1 status-ok", "Publishing your zones to Home Assistant" }
                                     } else {
-                                        p { class: "mt-1 text-yellow-500", "Not connected to the broker yet" }
+                                        p { class: "mt-1 text-yellow-500", "Not publishing yet" }
                                     }
                                 } else if status.running {
-                                    p { class: "status-ok", "Connected — your zones are in Home Assistant" }
+                                    p { class: "status-ok", "Publishing your zones to Home Assistant" }
                                 } else if status.configured {
                                     p { class: "text-yellow-500", "Configured, not currently connected" }
                                 } else {
@@ -2803,7 +2807,7 @@ pub fn Settings() -> Element {
                             button {
                                 id: "mqtt-use-own-broker",
                                 r#type: "button",
-                                class: "btn btn-secondary mt-4 min-h-11",
+                                class: "btn btn-outline mt-4 min-h-11",
                                 onclick: move |_| mqtt_manual_open.set(true),
                                 "Use a different broker"
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,22 +636,110 @@ mod server {
         // bus consumer with no zones of its own, so it does not join
         // `startable_adapters`/the coordinator - just a background task
         // this settings toggle and encrypted broker record turn on or off.
+        //
+        // Broker settings come from one of two places (#605): the user's own
+        // encrypted record, or `UHC_MQTT_*` handed over by the Home Assistant
+        // add-on, which reads them from the Supervisor. `mqtt_bootstrap::plan`
+        // owns the precedence between them; the log line below always names
+        // the winner, so an install with no entities can be diagnosed from
+        // the add-on log alone.
         state.mqtt.set_base_url(base_url.clone());
+        let environment_mqtt = match api::mqtt_bootstrap::from_env() {
+            Ok(config) => config,
+            Err(error) => {
+                tracing::warn!(
+                    "Ignoring MQTT environment configuration: {error}. \
+                     Configure the broker in Settings instead."
+                );
+                None
+            }
+        };
         match api::credentials::MqttCredentialStore::from_env() {
             Ok(store) => match store.load() {
-                Ok(Some(record)) => {
-                    state.mqtt.configure(record).await;
-                    if app_settings.adapters.mqtt {
-                        state.mqtt.set_enabled(true).await;
+                Ok(stored) => {
+                    use api::mqtt_bootstrap::MqttBootstrap;
+                    match api::mqtt_bootstrap::plan(stored, environment_mqtt) {
+                        MqttBootstrap::ApplyEnvironment(record) => {
+                            let host = record.host.clone();
+                            let port = record.port;
+                            // Save before enabling: a publisher running off a
+                            // record that never reached disk would come back
+                            // unconfigured on the next boot.
+                            match store.save(&record) {
+                                Ok(()) => {
+                                    state.mqtt.configure(record).await;
+                                    if api::enable_mqtt_in_settings() {
+                                        state.mqtt.set_enabled(true).await;
+                                        tracing::info!(
+                                            broker = %format!("{host}:{port}"),
+                                            "MQTT configured from environment (Home Assistant add-on); publisher enabled"
+                                        );
+                                    } else {
+                                        tracing::warn!(
+                                            "MQTT configured from environment (Home Assistant add-on) \
+                                             but the setting could not be saved; enable it in Settings"
+                                        );
+                                    }
+                                }
+                                Err(error) => tracing::warn!(
+                                    "MQTT environment configuration could not be saved: {error}"
+                                ),
+                            }
+                        }
+                        MqttBootstrap::EnvironmentUnchanged(record) => {
+                            let host = record.host.clone();
+                            let port = record.port;
+                            state.mqtt.configure(record).await;
+                            // Deliberately no re-enable: the toggle was
+                            // persisted when this config was first applied, so
+                            // `app_settings` now carries the user's answer.
+                            if app_settings.adapters.mqtt {
+                                state.mqtt.set_enabled(true).await;
+                            }
+                            tracing::info!(
+                                broker = %format!("{host}:{port}"),
+                                enabled = app_settings.adapters.mqtt,
+                                "MQTT configured from environment (Home Assistant add-on); unchanged since last start"
+                            );
+                        }
+                        MqttBootstrap::UseStored(record) => {
+                            let host = record.host.clone();
+                            let port = record.port;
+                            let source = record.source;
+                            state.mqtt.configure(record).await;
+                            if app_settings.adapters.mqtt {
+                                state.mqtt.set_enabled(true).await;
+                            }
+                            match source {
+                                api::credentials::MqttConfigSource::User => tracing::info!(
+                                    broker = %format!("{host}:{port}"),
+                                    enabled = app_settings.adapters.mqtt,
+                                    "MQTT configured from your saved settings (these win over the environment)"
+                                ),
+                                api::credentials::MqttConfigSource::Environment => tracing::info!(
+                                    broker = %format!("{host}:{port}"),
+                                    enabled = app_settings.adapters.mqtt,
+                                    "MQTT using the broker a previous environment bootstrap saved; \
+                                     the environment no longer supplies one"
+                                ),
+                            }
+                        }
+                        MqttBootstrap::Unconfigured => {
+                            if app_settings.adapters.mqtt {
+                                tracing::info!(
+                                    "MQTT publisher enabled in settings but no broker is configured yet"
+                                );
+                            } else {
+                                tracing::info!(
+                                    "MQTT publisher not configured; no Home Assistant entities will be published"
+                                );
+                            }
+                        }
                     }
                 }
-                Ok(None) => {
-                    if app_settings.adapters.mqtt {
-                        tracing::info!(
-                            "MQTT publisher enabled in settings but no broker is configured yet"
-                        );
-                    }
-                }
+                // An unreadable record is never overwritten: the environment
+                // bootstrap would otherwise destroy a user's broker settings
+                // over a transient decryption failure.
                 Err(error) => tracing::warn!("MQTT credential record unavailable: {error}"),
             },
             Err(error) => tracing::warn!("MQTT credential store unavailable: {error}"),

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -53,7 +53,7 @@ use crate::bus::{BusEvent, SharedBus, Zone};
 use crate::knobs::store::Knob;
 use crate::knobs::KnobStore;
 
-pub use crate::api::credentials::MqttCredentialRecord;
+pub use crate::api::credentials::{MqttConfigSource, MqttCredentialRecord};
 
 /// How often knob state/discovery is re-published, since the knob store has
 /// no bus events of its own to react to (see module doc).
@@ -109,6 +109,10 @@ pub struct MqttStatus {
     pub discovery_prefix: Option<String>,
     pub has_username: bool,
     pub has_password: bool,
+    /// Who supplied the active broker settings (#605). `None` while
+    /// unconfigured. Lets Settings show an add-on-managed broker as managed
+    /// instead of inviting the user to re-type details they never entered.
+    pub source: Option<MqttConfigSource>,
 }
 
 impl MqttPublisher {
@@ -261,6 +265,7 @@ impl MqttPublisher {
                 .record
                 .as_ref()
                 .is_some_and(|r| r.password.as_ref().is_some_and(|p| !p.is_empty())),
+            source: runtime.record.as_ref().map(|r| r.source),
         }
     }
 

--- a/tests/mqtt_integration.rs
+++ b/tests/mqtt_integration.rs
@@ -345,6 +345,7 @@ async fn discovers_publishes_state_and_routes_commands_over_a_real_broker() {
             password: None,
             base_topic: "unified-hifi".to_string(),
             discovery_prefix: "homeassistant".to_string(),
+            source: Default::default(),
         })
         .await;
     publisher.set_enabled(true).await;
@@ -561,6 +562,7 @@ async fn tolerates_an_unreachable_broker() {
             password: None,
             base_topic: "unified-hifi".to_string(),
             discovery_prefix: "homeassistant".to_string(),
+            source: Default::default(),
         })
         .await;
     publisher.set_enabled(true).await;
@@ -655,6 +657,7 @@ async fn mqtt_command_for_a_legacy_zone_routes_through_the_command_gateway_to_lm
             password: None,
             base_topic: "unified-hifi".to_string(),
             discovery_prefix: "homeassistant".to_string(),
+            source: Default::default(),
         })
         .await;
     publisher.set_enabled(true).await;
@@ -784,6 +787,7 @@ async fn knob_discovery_state_and_zone_select_round_trip_over_a_real_broker() {
             password: None,
             base_topic: "unified-hifi".to_string(),
             discovery_prefix: "homeassistant".to_string(),
+            source: Default::default(),
         })
         .await;
     publisher.set_enabled(true).await;


### PR DESCRIPTION
Part 1 of #605. The Home Assistant add-on side is a separate PR on
`open-horizon-labs/uhc-home-assistant-addon` (linked in a comment).

## The problem

Installing the add-on gave you the UI panel inside Home Assistant and zero
HA entities. `/api/mqtt/status` reported `configured: false`, and nothing in
the UI said so or suggested where to go. The owner's reaction was "this
should auto-configure on install no?!"

The Supervisor can hand an add-on the broker's host, port, and credentials.
UHC just had no way to receive them: MQTT was configurable only through
`POST /api/mqtt/configure`.

## Part 1a — environment bootstrap

New `src/api/mqtt_bootstrap.rs` reads `UHC_MQTT_HOST` / `_PORT` /
`_USERNAME` / `_PASSWORD` / `_TLS` (plus `_BASE_TOPIC` /
`_DISCOVERY_PREFIX`) at startup, following the
`musicassistant_bootstrap_config` precedent of an encrypted-store-backed
boot config.

`MqttCredentialRecord` gains a `source` field (`user` | `environment`).
Records written before it existed default to `user`, which is what makes
the precedence rules work on an existing install:

| Situation | Result |
|---|---|
| Nothing stored | Apply env, save, enable the publisher |
| Stored `user` record | User wins; env ignored entirely |
| Stored `environment` record, identical to env | Adopt in memory; **no** store write, **no** re-enable |
| Stored `environment` record, env changed (rotated password) | Re-apply and re-enable |
| Stored `environment` record, env now absent | Keep the stored broker; enable follows settings |

Enabling is persisted to `app-settings.json` rather than being set only in
memory. That is what makes an explicit user disable survive a restart: once
the setting is on disk, later boots see an unchanged record, leave the
toggle alone, and the user's `false` stands. Enabling only in memory would
make "the add-on switched this on" indistinguishable from "you switched it
off" on the next boot.

The decision is a pure function (`plan`), so all of the above is unit-tested
without touching the filesystem or the process environment — 13 new tests.

Startup now always logs which path won, so an install with no entities can
be diagnosed from the add-on log alone.

## Part 1b — Settings UI

Also in scope per the owner's follow-up ("do we need a checkbox to turn on
the MQTT publisher and spell out how to config a consumer for it?"). The
toggle already existed, so this adds what was actually missing rather than a
second one:

- **Unconfigured is now honest.** "No broker yet — nothing is being
  published", plus one line on what turning it on gets you. Previously:
  "Setup required".
- **Consumer-side guidance.** A one-line summary says to point Home
  Assistant's MQTT integration at the same broker; discovery details, what
  the entities are, and the discovery prefix as an advanced detail sit
  behind the same ⓘ disclosure the #597 Spotify stepper uses, reusing its
  panel pattern rather than inventing an affordance.
- **Feedback gap closed.** The adapter toggle lives in a table far above the
  broker form, so enabling it with no broker produced silence. The status
  cell now names that state and jumps to the form; with the toggle off it
  says no entities are being published instead of showing a dash.
- **Add-on case.** An env-supplied broker is shown as managed by the add-on
  with the manual form collapsed behind "Use a different broker", so the
  user is not invited to re-enter details they never chose.

`/api/mqtt/status` gains `source` to drive that last one. It is still
structurally incapable of returning the password.

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings` (the invocation CI uses),
`cargo test` (59 test binaries, all green), `cargo test --doc`, and
`cargo check --target wasm32-unknown-unknown --no-default-features
--features web` — all on the repo's pinned 1.97.1 toolchain.

Browser probe of the Settings page in a comment below.

Base is `integration/streaming-ha-alpha`, not v3.
