### PR TITLE
fix(mqtt): report real broker connectivity, not task liveness (#607)

### DIFF
--- a/src/api/mqtt_settings.rs
+++ b/src/api/mqtt_settings.rs
@@ -36,7 +36,19 @@ pub struct MqttConfigureRequest {
 pub struct MqttStatusResponse {
     pub configured: bool,
     pub enabled: bool,
+    /// The publisher's background task exists. NOT connectivity: the task
+    /// stays alive while `rumqttc` retries a broker that never answers
+    /// (#607). Use `connection` for "are we actually publishing".
     pub running: bool,
+    /// `"disconnected"` (no task), `"connecting"` (task running, broker has
+    /// not accepted us - or dropped us and we are retrying), or
+    /// `"connected"` (#607).
+    pub connection: String,
+    /// Why the last connection attempt failed, if one has. Present while
+    /// retrying, absent once connected. Carried through to Settings because
+    /// "wrong password" and "wrong host" are entirely different fixes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
     pub host: Option<String>,
     pub port: Option<u16>,
     pub tls: Option<bool>,
@@ -58,6 +70,8 @@ impl From<crate::mqtt::MqttStatus> for MqttStatusResponse {
             configured: status.configured,
             enabled: status.enabled,
             running: status.running,
+            connection: status.connection.as_str().to_string(),
+            last_error: status.last_error,
             host: status.host,
             port: status.port,
             tls: status.tls,
@@ -155,13 +169,15 @@ pub async fn configure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mqtt::{MqttConnectionState, MqttStatus};
 
-    #[test]
-    fn status_response_never_serializes_the_password() {
-        let response = MqttStatusResponse {
+    fn sample_response() -> MqttStatusResponse {
+        MqttStatusResponse {
             configured: true,
             enabled: true,
             running: true,
+            connection: "connected".to_string(),
+            last_error: None,
             host: Some("broker.local".to_string()),
             port: Some(1883),
             tls: Some(false),
@@ -170,11 +186,81 @@ mod tests {
             has_username: true,
             has_password: true,
             source: Some("user".to_string()),
-        };
-        let json = serde_json::to_string(&response).expect("serialize");
+        }
+    }
+
+    #[test]
+    fn status_response_never_serializes_the_password() {
+        let json = serde_json::to_string(&sample_response()).expect("serialize");
         // `has_password` (a bool) is expected; the literal secret is not -
         // `MqttStatusResponse` has no field that could carry it, and this
         // pins that down structurally rather than trusting the field list.
         assert!(!json.contains("\"password\":"));
+    }
+
+    /// The regression #607 is about: `running` alone said "true" for a
+    /// broker whose hostname does not resolve. `connection` and
+    /// `last_error` have to carry the truth alongside it, and `running`
+    /// has to keep its old meaning rather than being redefined.
+    #[test]
+    fn a_retrying_publisher_serializes_as_running_but_not_connected() {
+        let status = MqttStatus {
+            configured: true,
+            enabled: true,
+            running: true,
+            connection: MqttConnectionState::Connecting,
+            last_error: Some(
+                "I/O: failed to lookup address information: nodename nor servname provided, \
+                 or not known"
+                    .to_string(),
+            ),
+            host: Some("core-mosquitto".to_string()),
+            port: Some(1883),
+            tls: Some(false),
+            base_topic: Some("unified-hifi".to_string()),
+            discovery_prefix: Some("homeassistant".to_string()),
+            has_username: false,
+            has_password: false,
+            source: Some(MqttConfigSource::Environment),
+        };
+        let response = MqttStatusResponse::from(status);
+        assert!(response.running, "the task is alive - that much was true");
+        assert_eq!(response.connection, "connecting");
+        assert!(response
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("lookup address information")));
+    }
+
+    /// A connected publisher reports no error, so Settings has nothing
+    /// stale to display next to a working broker.
+    #[test]
+    fn connected_status_carries_no_error_and_omits_the_field() {
+        let json = serde_json::to_value(sample_response()).expect("serialize");
+        assert_eq!(json["connection"], "connected");
+        assert!(
+            json.get("last_error").is_none(),
+            "an absent error must not serialize as null: {json}"
+        );
+    }
+
+    #[test]
+    fn an_idle_publisher_reports_disconnected() {
+        let response = MqttStatusResponse::from(MqttStatus {
+            configured: false,
+            enabled: false,
+            running: false,
+            connection: MqttConnectionState::default(),
+            last_error: None,
+            host: None,
+            port: None,
+            tls: None,
+            base_topic: None,
+            discovery_prefix: None,
+            has_username: false,
+            has_password: false,
+            source: None,
+        });
+        assert_eq!(response.connection, "disconnected");
     }
 }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -276,7 +276,19 @@ pub struct MqttConfigureRequest {
 pub struct MqttStatusResponse {
     pub configured: bool,
     pub enabled: bool,
+    /// The publisher task exists. Not the same as reaching the broker
+    /// (#607) - see [`MqttStatusResponse::is_connected`].
     pub running: bool,
+    /// `"disconnected"`, `"connecting"`, or `"connected"` (#607). Defaults
+    /// to empty against a server that predates the field, which
+    /// [`MqttStatusResponse::is_connected`] treats as "not connected".
+    #[serde(default)]
+    pub connection: String,
+    /// Raw reason the last connection attempt failed (#607). Rendered
+    /// through [`MqttStatusResponse::connection_problem`] rather than shown
+    /// verbatim.
+    #[serde(default)]
+    pub last_error: Option<String>,
     pub host: Option<String>,
     pub port: Option<u16>,
     pub tls: Option<bool>,
@@ -297,6 +309,75 @@ impl MqttStatusResponse {
     /// than from something the user typed in.
     pub fn is_environment_managed(&self) -> bool {
         self.source.as_deref() == Some("environment")
+    }
+
+    /// The broker really answered and entities are being published (#607).
+    /// This - not `running` - is the only honest basis for saying so.
+    pub fn is_connected(&self) -> bool {
+        self.connection == "connected"
+    }
+
+    /// The publisher is up but has not reached the broker: either the first
+    /// attempt has not landed yet, or it keeps failing. `connection_problem`
+    /// tells those two apart.
+    pub fn is_connecting(&self) -> bool {
+        self.connection == "connecting"
+    }
+
+    /// `mqtt://host:port` for the configured broker, so an error can name
+    /// the address it is about instead of leaving the user to guess.
+    pub fn broker_address(&self) -> Option<String> {
+        let host = self.host.as_ref()?;
+        let scheme = if self.tls.unwrap_or(false) {
+            "mqtts"
+        } else {
+            "mqtt"
+        };
+        Some(format!("{scheme}://{host}:{}", self.port.unwrap_or_default()))
+    }
+
+    /// One plain sentence explaining `last_error`, or `None` when there is
+    /// nothing wrong to report (#607).
+    ///
+    /// The raw `rumqttc` text is accurate but unreadable ("I/O: failed to
+    /// lookup address information: nodename nor servname provided, or not
+    /// known"). Each branch below names the *fix*, because that is the
+    /// whole reason the issue asked for the error to reach the user:
+    /// "wrong password" and "wrong hostname" look identical otherwise.
+    /// Anything unrecognised falls through verbatim rather than being
+    /// flattened into a useless generic - an unknown failure the user can
+    /// paste into a search beats a reassuring lie.
+    pub fn connection_problem(&self) -> Option<String> {
+        // A live connection supersedes whatever went wrong before it.
+        if self.is_connected() {
+            return None;
+        }
+        let error = self.last_error.as_ref()?;
+        let lowered = error.to_lowercase();
+        let explanation = if lowered.contains("lookup address")
+            || lowered.contains("nodename nor servname")
+            || lowered.contains("name or service not known")
+            || lowered.contains("no such host")
+        {
+            "That address could not be found. Check the broker's name for a typo."
+        } else if lowered.contains("connection refused") {
+            "Nothing answered there. Check the port, and that the broker is switched on."
+        } else if lowered.contains("not authorized")
+            || lowered.contains("notauthorized")
+            || lowered.contains("bad user name")
+            || lowered.contains("badusername")
+        {
+            "The broker turned us away. Check the username and password."
+        } else if lowered.contains("no route to host") || lowered.contains("network unreachable") {
+            "That address could not be reached from here. Check they are on the same network."
+        } else if lowered.contains("timed out") || lowered.contains("timeout") {
+            "The broker did not answer in time."
+        } else if lowered.contains("certificate") || lowered.contains("tls") {
+            "The secure connection was refused. Check the Use TLS setting matches the broker."
+        } else {
+            return Some(error.clone());
+        };
+        Some(explanation.to_string())
     }
 }
 
@@ -1143,4 +1224,112 @@ async fn response_error(resp: web_sys::Response) -> String {
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn post_json_no_response<T: Serialize>(_url: &str, _body: &T) -> Result<(), String> {
     Err("post_json_no_response is only available in browser".to_string())
+}
+
+#[cfg(test)]
+mod mqtt_status_tests {
+    use super::MqttStatusResponse;
+
+    fn retrying(last_error: &str) -> MqttStatusResponse {
+        MqttStatusResponse {
+            configured: true,
+            enabled: true,
+            // The #607 shape: the task is alive, the broker is not there.
+            running: true,
+            connection: "connecting".to_string(),
+            last_error: Some(last_error.to_string()),
+            host: Some("core-mosquitto".to_string()),
+            port: Some(1883),
+            tls: Some(false),
+            ..MqttStatusResponse::default()
+        }
+    }
+
+    #[test]
+    fn running_alone_is_never_read_as_connected() {
+        let status = retrying("I/O: failed to lookup address information");
+        assert!(status.running);
+        assert!(!status.is_connected());
+        assert!(status.is_connecting());
+    }
+
+    #[test]
+    fn an_unknown_host_is_explained_as_a_typo_to_check() {
+        let status = retrying(
+            "I/O: failed to lookup address information: nodename nor servname provided, or not known",
+        );
+        assert_eq!(
+            status.connection_problem().as_deref(),
+            Some("That address could not be found. Check the broker's name for a typo.")
+        );
+    }
+
+    #[test]
+    fn rejected_credentials_are_explained_as_credentials() {
+        let status = retrying("Connection refused, return code `NotAuthorized`");
+        // Deliberately not the "nothing answered there" branch: the raw
+        // text contains "refused" too, and telling the user to check the
+        // port when the password is wrong sends them the wrong way.
+        assert_eq!(
+            status.connection_problem().as_deref(),
+            Some("The broker turned us away. Check the username and password.")
+        );
+    }
+
+    #[test]
+    fn a_dead_port_is_explained_as_a_port_or_a_stopped_broker() {
+        let status = retrying("I/O: Connection refused (os error 61)");
+        assert_eq!(
+            status.connection_problem().as_deref(),
+            Some("Nothing answered there. Check the port, and that the broker is switched on.")
+        );
+    }
+
+    #[test]
+    fn an_unrecognised_failure_is_passed_through_rather_than_swallowed() {
+        let status = retrying("Mqtt state: Invalid state for a given operation");
+        assert_eq!(
+            status.connection_problem().as_deref(),
+            Some("Mqtt state: Invalid state for a given operation")
+        );
+    }
+
+    #[test]
+    fn a_connected_publisher_reports_no_problem() {
+        let mut status = retrying("I/O: Connection refused (os error 61)");
+        status.connection = "connected".to_string();
+        status.last_error = None;
+        assert!(status.is_connected());
+        assert_eq!(status.connection_problem(), None);
+    }
+
+    /// A server that predates #607 sends no `connection` field. Absent
+    /// evidence of a connection must not read as one.
+    #[test]
+    fn a_status_without_the_field_is_not_treated_as_connected() {
+        let status: MqttStatusResponse = serde_json::from_str(
+            r#"{"configured":true,"enabled":true,"running":true,"host":"a","port":1883,
+                "tls":false,"base_topic":"unified-hifi","discovery_prefix":"homeassistant",
+                "has_username":false,"has_password":false}"#,
+        )
+        .expect("deserialize");
+        assert!(status.running);
+        assert!(!status.is_connected());
+        assert_eq!(status.connection_problem(), None);
+    }
+
+    #[test]
+    fn the_broker_address_names_the_scheme_and_port() {
+        let mut status = retrying("boom");
+        assert_eq!(
+            status.broker_address().as_deref(),
+            Some("mqtt://core-mosquitto:1883")
+        );
+        status.tls = Some(true);
+        status.port = Some(8883);
+        assert_eq!(
+            status.broker_address().as_deref(),
+            Some("mqtts://core-mosquitto:8883")
+        );
+    }
 }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -333,7 +333,10 @@ impl MqttStatusResponse {
         } else {
             "mqtt"
         };
-        Some(format!("{scheme}://{host}:{}", self.port.unwrap_or_default()))
+        Some(format!(
+            "{scheme}://{host}:{}",
+            self.port.unwrap_or_default()
+        ))
     }
 
     /// One plain sentence explaining `last_error`, or `None` when there is
@@ -354,7 +357,18 @@ impl MqttStatusResponse {
         }
         let error = self.last_error.as_ref()?;
         let lowered = error.to_lowercase();
-        let explanation = if lowered.contains("lookup address")
+        // Credentials are tested FIRST and deliberately: `rumqttc` renders a
+        // rejected CONNACK as "Connection refused, return code
+        // `NotAuthorized`", which also matches the dead-port branch below.
+        // Matching that one first would tell a user with a wrong password to
+        // go and check their port number.
+        let explanation = if lowered.contains("not authorized")
+            || lowered.contains("notauthorized")
+            || lowered.contains("bad user name")
+            || lowered.contains("badusername")
+        {
+            "The broker turned us away. Check the username and password."
+        } else if lowered.contains("lookup address")
             || lowered.contains("nodename nor servname")
             || lowered.contains("name or service not known")
             || lowered.contains("no such host")
@@ -362,12 +376,6 @@ impl MqttStatusResponse {
             "That address could not be found. Check the broker's name for a typo."
         } else if lowered.contains("connection refused") {
             "Nothing answered there. Check the port, and that the broker is switched on."
-        } else if lowered.contains("not authorized")
-            || lowered.contains("notauthorized")
-            || lowered.contains("bad user name")
-            || lowered.contains("badusername")
-        {
-            "The broker turned us away. Check the username and password."
         } else if lowered.contains("no route to host") || lowered.contains("network unreachable") {
             "That address could not be reached from here. Check they are on the same network."
         } else if lowered.contains("timed out") || lowered.contains("timeout") {

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -352,6 +352,18 @@ const SPOTIFY_INFO_PANEL_CLOSED: &str = "absolute right-0 top-full z-20 mt-1 w-7
 const MQTT_INFO_PANEL_OPEN: &str = "absolute left-0 top-full z-20 mt-1 w-80 max-w-[85vw] rounded-md border border-default bg-elevated p-3 text-left text-xs text-secondary shadow-lg";
 const MQTT_INFO_PANEL_CLOSED: &str = "absolute left-0 top-full z-20 mt-1 w-80 max-w-[85vw] rounded-md border border-default bg-elevated p-3 text-left text-xs text-secondary shadow-lg hidden group-hover:block";
 
+/// How often Settings re-reads `/api/mqtt/status` while the publisher is on
+/// (#607). A broker going away produces no SSE event, so without this the
+/// section would keep claiming whatever was true when the page loaded.
+const MQTT_STATUS_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// How long to wait after saving broker settings before re-reading the
+/// status (#607). The connection has not been attempted yet at the moment
+/// the POST returns, so the immediate refresh can only ever say
+/// "connecting"; this second look is what turns into a verdict while the
+/// user is still watching.
+const MQTT_POST_SAVE_RECHECK: std::time::Duration = std::time::Duration::from_millis(1500);
+
 /// Whether *this browser* is talking to UHC over loopback. Drives which
 /// variant of the Spotify callback step (#570 follow-up) renders: a
 /// loopback browser can use the plain HTTP loopback callback directly, but
@@ -1075,6 +1087,31 @@ pub fn Settings() -> Element {
         }
     });
 
+    // Broker connectivity changes with the network, not with UHC's own bus,
+    // so a broker dying (or a corrected hostname starting to answer) emits
+    // no SSE event and the discovery-refresh above never fires for it. Poll
+    // while the publisher is switched on (#607), in the same shape as the
+    // Spotify tunnel poll above: the guard signal is only `peek`ed, and the
+    // refresh happens inside `spawn` rather than in the effect body, so
+    // neither subscribes this effect to its own write.
+    let mut mqtt_polling = use_signal(|| false);
+    use_effect(move || {
+        if !mqtt_enabled() || *mqtt_polling.peek() {
+            return;
+        }
+        mqtt_polling.set(true);
+        spawn(async move {
+            loop {
+                dioxus_sdk_time::sleep(MQTT_STATUS_POLL_INTERVAL).await;
+                if !*mqtt_enabled.peek() {
+                    break;
+                }
+                mqtt_status.restart();
+            }
+            mqtt_polling.set(false);
+        });
+    });
+
     // Refresh discovery on SSE events
     let event_count = sse.event_count;
     use_effect(move || {
@@ -1374,6 +1411,13 @@ pub fn Settings() -> Element {
                 Ok(_) => {
                     mqtt_action.set(ProviderActionState::Success);
                     mqtt_password.set(String::new());
+                    mqtt_status.restart();
+                    // The POST returns before the publisher has dialled the
+                    // new broker, so that first refresh can only say
+                    // "connecting". Look again once there has been time to
+                    // succeed or fail (#607) - a typo'd host should produce
+                    // its explanation while the user is still on the button.
+                    dioxus_sdk_time::sleep(MQTT_POST_SAVE_RECHECK).await;
                     mqtt_status.restart();
                 }
                 Err(error) => {
@@ -1864,12 +1908,26 @@ pub fn Settings() -> Element {
                                 td { class: "py-2 px-3",
                                     if mqtt_enabled() {
                                         if let Some(status) = mqtt_status.read().clone().flatten() {
-                                            if status.running {
+                                            // "Publishing" now means the broker
+                                            // answered, not merely that the task
+                                            // started (#607). A broker that never
+                                            // answers used to land in this same
+                                            // branch and read as success.
+                                            if status.is_connected() {
                                                 if status.is_environment_managed() {
                                                     span { class: "status-ok", "✓ Publishing · via add-on" }
                                                 } else {
                                                     span { class: "status-ok", "✓ Publishing" }
                                                 }
+                                            } else if status.connection_problem().is_some() {
+                                                button {
+                                                    r#type: "button",
+                                                    class: "status-err underline",
+                                                    onclick: move |_| scroll_to_element("mqtt-anchor"),
+                                                    "Can't reach the broker — see why"
+                                                }
+                                            } else if status.running {
+                                                span { class: "text-yellow-500", "Connecting…" }
                                             } else if status.configured {
                                                 span { class: "text-yellow-500", "Configured · waiting" }
                                             } else {
@@ -2767,23 +2825,29 @@ pub fn Settings() -> Element {
                     }
                     div { class: "card p-5 sm:p-6",
                         if let Some(status) = mqtt_status.read().clone().flatten() {
-                            div { class: "text-sm",
+                            div { class: "text-sm", id: "mqtt-connection-status",
                                 if status.is_environment_managed() {
                                     // The add-on already did this. Saying so
                                     // is what keeps the form below from
                                     // reading as an unfinished setup step.
-                                    p { class: "font-medium", "Set up by the Home Assistant add-on" }
-                                    if status.running {
-                                        // "Publishing", not "Connected":
-                                        // `running` means the publisher task
-                                        // is alive, which it stays while
-                                        // retrying an unreachable broker.
-                                        p { class: "mt-1 status-ok", "Publishing your zones to Home Assistant" }
-                                    } else {
-                                        p { class: "mt-1 text-yellow-500", "Not publishing yet" }
-                                    }
-                                } else if status.running {
+                                    p { class: "font-medium mb-1", "Set up by the Home Assistant add-on" }
+                                }
+                                // One line for what is actually happening,
+                                // driven by real broker connectivity rather
+                                // than by "the task exists" (#607). Only the
+                                // first branch is success; a broker that
+                                // never answers now has to say so.
+                                if status.is_connected() {
                                     p { class: "status-ok", "Publishing your zones to Home Assistant" }
+                                } else if let Some(problem) = status.connection_problem() {
+                                    p { class: "status-err font-medium",
+                                        "Can't reach your broker at "
+                                        "{status.broker_address().unwrap_or_default()}"
+                                    }
+                                    p { class: "mt-1 text-secondary", "{problem}" }
+                                    p { class: "mt-1 text-secondary", "Nothing is reaching Home Assistant until this is fixed. UHC keeps trying, so correcting the details below is enough — no restart needed." }
+                                } else if status.running {
+                                    p { class: "text-yellow-500", "Connecting to your broker…" }
                                 } else if status.configured {
                                     p { class: "text-yellow-500", "Configured, not currently connected" }
                                 } else {
@@ -2794,11 +2858,12 @@ pub fn Settings() -> Element {
                                     p { class: "font-medium", "No broker yet — nothing is being published" }
                                     p { class: "mt-1 text-secondary", "Add your broker below and your zones and controllers show up in Home Assistant as entities." }
                                 }
-                                if let Some(host) = status.host.as_ref() {
-                                    p { class: "mt-1 text-secondary",
-                                        "Current broker: "
-                                        if status.tls.unwrap_or(false) { "mqtts://" } else { "mqtt://" }
-                                        "{host}:{status.port.unwrap_or_default()}"
+                                // The address is already in the error line
+                                // above when there is one; repeating it there
+                                // would just pad the failure state out.
+                                if status.connection_problem().is_none() {
+                                    if let Some(address) = status.broker_address() {
+                                        p { class: "mt-1 text-secondary", "Current broker: {address}" }
                                     }
                                 }
                             }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -1067,7 +1067,19 @@ pub fn Settings() -> Element {
         });
     });
 
+    // Fill the broker form from the saved settings ONCE, on the first status
+    // that arrives. Deliberately not on every status: `mqtt_status` is now
+    // re-read on a timer (#607, below) and on SSE discovery refreshes, and
+    // an unguarded rehydrate would reset the fields under a user who is
+    // part-way through typing a new broker address - observed live, where a
+    // corrected host was silently replaced by the stored one between typing
+    // it and pressing Save. Same rule as the Spotify Redirect URI above
+    // (#592): a value the user has entered is never silently replaced.
+    let mut mqtt_form_hydrated = use_signal(|| false);
     use_effect(move || {
+        if *mqtt_form_hydrated.peek() {
+            return;
+        }
         if let Some(Some(status)) = mqtt_status.read().as_ref() {
             if let Some(host) = status.host.as_ref() {
                 mqtt_host.set(host.clone());
@@ -1084,6 +1096,7 @@ pub fn Settings() -> Element {
             if let Some(discovery_prefix) = status.discovery_prefix.as_ref() {
                 mqtt_discovery_prefix.set(discovery_prefix.clone());
             }
+            mqtt_form_hydrated.set(true);
         }
     });
 

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -68,13 +68,110 @@ pub const DEFAULT_DISCOVERY_PREFIX: &str = "homeassistant";
 pub const DEFAULT_PORT: u16 = 1883;
 pub const DEFAULT_TLS_PORT: u16 = 8883;
 
+/// Whether the publisher is actually talking to a broker (#607).
+///
+/// Deliberately *not* the same question as [`MqttStatus::running`], which
+/// only says the background task exists. `rumqttc` retries a broker it
+/// cannot reach forever, so a task can be alive and healthy while nothing
+/// has ever been published - which is what made a typo'd broker host look
+/// identical to a working one in Settings.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MqttConnectionState {
+    /// No publisher task is running at all (switched off, or configured but
+    /// not enabled).
+    #[default]
+    Disconnected,
+    /// A task is running and trying to reach the broker. Because `rumqttc`
+    /// retries indefinitely, this is also where a *failed* attempt lands -
+    /// [`MqttStatus::last_error`] carries why the last one failed.
+    Connecting,
+    /// The broker accepted the connection (`ConnAck`) and it has not failed
+    /// since. Only this state means entities are really being published.
+    Connected,
+}
+
+impl MqttConnectionState {
+    /// Wire form for `/api/mqtt/status`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Disconnected => "disconnected",
+            Self::Connecting => "connecting",
+            Self::Connected => "connected",
+        }
+    }
+}
+
+/// Live connection state shared between one publisher task and
+/// [`MqttPublisher::status`] (#607).
+///
+/// A `std::sync::RwLock` rather than the runtime's async `Mutex`: the task
+/// records transitions inline in its `select!` arms, and awaiting the
+/// runtime lock there would tie the event loop to whatever
+/// `configure`/`set_enabled` is doing (they hold it across `stop_task`,
+/// which waits up to 5s for this very task to exit).
+#[derive(Debug)]
+struct ConnectionMonitor {
+    inner: std::sync::RwLock<ConnectionSnapshot>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ConnectionSnapshot {
+    state: MqttConnectionState,
+    last_error: Option<String>,
+}
+
+impl ConnectionMonitor {
+    /// A monitor for a task that is about to start dialling the broker.
+    fn connecting() -> Self {
+        Self {
+            inner: std::sync::RwLock::new(ConnectionSnapshot {
+                state: MqttConnectionState::Connecting,
+                last_error: None,
+            }),
+        }
+    }
+
+    fn snapshot(&self) -> ConnectionSnapshot {
+        self.inner
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// The broker accepted us. Clears any previous error: it described an
+    /// attempt that has since been superseded by a working one.
+    fn connected(&self) {
+        if let Ok(mut guard) = self.inner.write() {
+            guard.state = MqttConnectionState::Connected;
+            guard.last_error = None;
+        }
+    }
+
+    /// The connection failed, or dropped after having succeeded. Never
+    /// latches `Connected`: `rumqttc` will dial again, so the honest state
+    /// is "connecting", annotated with why the last attempt ended.
+    fn interrupted(&self, error: impl Into<String>) {
+        if let Ok(mut guard) = self.inner.write() {
+            guard.state = MqttConnectionState::Connecting;
+            guard.last_error = Some(error.into());
+        }
+    }
+}
+
+/// One live publisher task, with the connection state it reports into.
+struct RunningTask {
+    shutdown: CancellationToken,
+    handle: JoinHandle<()>,
+    connection: Arc<ConnectionMonitor>,
+}
+
 /// Lifecycle state guarded together so configure/enable/disable never race
 /// each other into starting two publisher tasks.
 #[derive(Default)]
 struct Runtime {
     record: Option<MqttCredentialRecord>,
     enabled: bool,
-    task: Option<(CancellationToken, JoinHandle<()>)>,
+    task: Option<RunningTask>,
 }
 
 /// Optional MQTT publisher. Held on `AppState` as `Arc<MqttPublisher>`;
@@ -101,7 +198,17 @@ pub struct MqttPublisher {
 pub struct MqttStatus {
     pub configured: bool,
     pub enabled: bool,
+    /// Whether the publisher's background task exists. Kept as-is (#607):
+    /// it answers "did we start", not "are we connected" - see
+    /// [`MqttStatus::connection`] for the latter.
     pub running: bool,
+    /// Real broker connectivity (#607), independent of `running`.
+    pub connection: MqttConnectionState,
+    /// Why the last connection attempt failed, verbatim from `rumqttc`.
+    /// Present while retrying; cleared on a successful `ConnAck`. "bad
+    /// credentials" and "unknown host" need different fixes, so the text
+    /// has to survive as far as the user.
+    pub last_error: Option<String>,
     pub host: Option<String>,
     pub port: Option<u16>,
     pub tls: Option<bool>,
@@ -190,8 +297,8 @@ impl MqttPublisher {
             let previous_task = if !enabled { runtime.task.take() } else { None };
             (runtime.record.clone(), previous_task)
         };
-        if let Some((shutdown, handle)) = previous_task {
-            stop_task(shutdown, handle).await;
+        if let Some(task) = previous_task {
+            stop_task(task).await;
         }
         if enabled {
             self.restart(record).await;
@@ -204,8 +311,8 @@ impl MqttPublisher {
             let mut runtime = self.runtime.lock().await;
             runtime.task.take()
         };
-        if let Some((shutdown, handle)) = previous_task {
-            stop_task(shutdown, handle).await;
+        if let Some(task) = previous_task {
+            stop_task(task).await;
         }
 
         let Some(record) = record else {
@@ -216,7 +323,8 @@ impl MqttPublisher {
         };
 
         let shutdown = CancellationToken::new();
-        let task = tokio::spawn(run(
+        let connection = Arc::new(ConnectionMonitor::connecting());
+        let handle = tokio::spawn(run(
             record,
             self.bus.clone(),
             self.aggregator.clone(),
@@ -224,17 +332,23 @@ impl MqttPublisher {
             self.knobs.clone(),
             self.reliable_commands_snapshot(),
             self.base_url_snapshot(),
+            connection.clone(),
             shutdown.clone(),
         ));
+        let task = RunningTask {
+            shutdown,
+            handle,
+            connection,
+        };
 
         let mut runtime = self.runtime.lock().await;
         // Another caller may have already disabled/reconfigured while this
         // task was spawning; only keep it if still enabled.
         if runtime.enabled {
-            runtime.task = Some((shutdown, task));
+            runtime.task = Some(task);
         } else {
             drop(runtime);
-            stop_task(shutdown, task).await;
+            stop_task(task).await;
         }
     }
 
@@ -246,12 +360,26 @@ impl MqttPublisher {
         self.runtime.lock().await.record.is_some()
     }
 
+    /// Real broker connectivity, as opposed to [`Self::is_running`] (#607).
+    pub async fn connection_state(&self) -> MqttConnectionState {
+        self.status().await.connection
+    }
+
     pub async fn status(&self) -> MqttStatus {
         let runtime = self.runtime.lock().await;
+        // No task means no connection, whatever the last one reported: the
+        // monitor is owned by the task and dies with it.
+        let connection = runtime
+            .task
+            .as_ref()
+            .map(|task| task.connection.snapshot())
+            .unwrap_or_default();
         MqttStatus {
             configured: runtime.record.is_some(),
             enabled: runtime.enabled,
             running: runtime.task.is_some(),
+            connection: connection.state,
+            last_error: connection.last_error,
             host: runtime.record.as_ref().map(|r| r.host.clone()),
             port: runtime.record.as_ref().map(|r| r.port),
             tls: runtime.record.as_ref().map(|r| r.tls),
@@ -276,15 +404,15 @@ impl MqttPublisher {
             let mut runtime = self.runtime.lock().await;
             runtime.task.take()
         };
-        if let Some((shutdown, handle)) = previous_task {
-            stop_task(shutdown, handle).await;
+        if let Some(task) = previous_task {
+            stop_task(task).await;
         }
     }
 }
 
-async fn stop_task(shutdown: CancellationToken, handle: JoinHandle<()>) {
-    shutdown.cancel();
-    if tokio::time::timeout(Duration::from_secs(5), handle)
+async fn stop_task(task: RunningTask) {
+    task.shutdown.cancel();
+    if tokio::time::timeout(Duration::from_secs(5), task.handle)
         .await
         .is_err()
     {
@@ -668,6 +796,11 @@ async fn handle_incoming_publish(
 /// the underlying TCP/TLS connection on its own; this loop only needs to
 /// re-announce state on every fresh `ConnAck`, since a new MQTT session (or
 /// a broker restart) has no memory of what was previously retained here.
+///
+/// It also reports what the event loop is actually doing into `connection`
+/// (#607), because "this task is alive" and "the broker answered" are not
+/// the same fact - the task stays alive indefinitely retrying a host that
+/// will never resolve.
 #[allow(clippy::too_many_arguments)]
 async fn run(
     record: MqttCredentialRecord,
@@ -677,6 +810,7 @@ async fn run(
     knobs: KnobStore,
     reliable_commands: Option<CommandGateway>,
     base_url: String,
+    connection: Arc<ConnectionMonitor>,
     shutdown: CancellationToken,
 ) {
     let availability_topic = topics::availability_topic(&record.base_topic);
@@ -714,6 +848,9 @@ async fn run(
             event = eventloop.poll() => {
                 match event {
                     Ok(Event::Incoming(Packet::ConnAck(_))) => {
+                        // The one moment we know entities are really
+                        // reaching a broker (#607).
+                        connection.connected();
                         announce_all_zones(
                             &client,
                             &record,
@@ -747,8 +884,16 @@ async fn run(
                         )
                         .await;
                     }
+                    // The broker hung up on us. `rumqttc` dials again, so
+                    // this is "connecting", never a latched "connected".
+                    Ok(Event::Incoming(Packet::Disconnect)) => {
+                        connection.interrupted("the broker closed the connection");
+                    }
                     Ok(_) => {}
                     Err(error) => {
+                        // Recorded before the log line, so /api/mqtt/status
+                        // and the log can never disagree about why.
+                        connection.interrupted(error.to_string());
                         tracing::warn!("MQTT publisher connection error: {error}");
                         tokio::time::sleep(Duration::from_secs(2)).await;
                     }

--- a/tests/mqtt_integration.rs
+++ b/tests/mqtt_integration.rs
@@ -40,7 +40,7 @@ use unified_hifi_control::bus::{
 };
 use unified_hifi_control::knobs::store::KnobStatusUpdate;
 use unified_hifi_control::knobs::KnobStore;
-use unified_hifi_control::mqtt::MqttPublisher;
+use unified_hifi_control::mqtt::{MqttConnectionState, MqttPublisher, MqttStatus};
 
 /// Isolate `UHC_CONFIG_DIR` for the one test below that starts a real
 /// `LmsAdapter`, which persists its configured host to disk. No other test
@@ -305,6 +305,74 @@ async fn wait_until<F: Fn() -> bool>(predicate: F, deadline: Duration) -> bool {
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
     predicate()
+}
+
+/// Poll [`MqttPublisher::status`] until it reports `expected`, returning the
+/// status either way so the caller can assert on `last_error` too (#607).
+async fn wait_for_connection(
+    publisher: &MqttPublisher,
+    expected: MqttConnectionState,
+    deadline: Duration,
+) -> MqttStatus {
+    let started = tokio::time::Instant::now();
+    loop {
+        let status = publisher.status().await;
+        if status.connection == expected || started.elapsed() >= deadline {
+            return status;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// A TCP pass-through in front of the real broker, so a test can cut a
+/// *live, already-connected* session at will. `rumqttd::Broker::start`
+/// blocks its thread for the broker's lifetime and exposes no shutdown
+/// hook, so killing the broker itself is not an option; dropping the
+/// sockets underneath the publisher produces the same thing the publisher
+/// cares about - a connection that worked and then stopped working.
+struct BrokerProxy {
+    port: u16,
+    accept: tokio::task::JoinHandle<()>,
+    connections: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>>,
+}
+
+impl BrokerProxy {
+    async fn start(target_port: u16) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind proxy");
+        let port = listener.local_addr().expect("proxy addr").port();
+        let connections: Arc<Mutex<Vec<tokio::task::JoinHandle<()>>>> = Arc::default();
+        let tracked = connections.clone();
+        let accept = tokio::spawn(async move {
+            while let Ok((mut inbound, _)) = listener.accept().await {
+                let handle = tokio::spawn(async move {
+                    if let Ok(mut outbound) =
+                        tokio::net::TcpStream::connect(("127.0.0.1", target_port)).await
+                    {
+                        let _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await;
+                    }
+                });
+                #[allow(clippy::unwrap_used)] // test-local mutex, nothing here panics under it
+                tracked.lock().unwrap().push(handle);
+            }
+        });
+        Self {
+            port,
+            accept,
+            connections,
+        }
+    }
+
+    /// Stop forwarding and drop every live socket, so the publisher's
+    /// connection dies and its reconnect attempts find nothing listening.
+    fn cut(&self) {
+        self.accept.abort();
+        #[allow(clippy::unwrap_used)] // test-local mutex
+        for handle in self.connections.lock().unwrap().drain(..) {
+            handle.abort();
+        }
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -572,12 +640,177 @@ async fn tolerates_an_unreachable_broker() {
         "task keeps retrying, not crashed"
     );
 
+    // #607: `running` stayed true here, and used to be the *only* thing
+    // Settings could ask - which is why a broker that never answers looked
+    // exactly like one that did. The connection state has to disagree with
+    // `running`, and has to carry the reason.
+    let status = wait_for_connection(
+        &publisher,
+        MqttConnectionState::Connecting,
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(status.running, "the task is alive - that much was true");
+    assert_eq!(
+        status.connection,
+        MqttConnectionState::Connecting,
+        "an unreachable broker is never 'connected'"
+    );
+    let error = status
+        .last_error
+        .expect("a failed connection must say why it failed");
+    assert!(
+        error.to_lowercase().contains("refused") || error.to_lowercase().contains("connection"),
+        "the reason must be usable, got {error:?}"
+    );
+
     // Must still stop promptly even mid-retry-loop.
     let stopped = timeout(Duration::from_secs(6), publisher.shutdown()).await;
     assert!(
         stopped.is_ok(),
         "shutdown must not hang on an unreachable broker"
     );
+    // With no task there is no connection, whatever the last one reported.
+    let status = publisher.status().await;
+    assert!(!status.running);
+    assert_eq!(status.connection, MqttConnectionState::Disconnected);
+    assert_eq!(status.last_error, None);
+}
+
+/// The positive half of #607: against a broker that really answers, the
+/// status says `connected` and carries no error. Without this the fix could
+/// be satisfied by never reporting success at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_reachable_broker_is_reported_as_connected() {
+    let port = free_port();
+    start_test_broker(port);
+    wait_for_broker_ready(port, Duration::from_secs(5)).await;
+
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let aggregator_task = aggregator.clone();
+    tokio::spawn(async move {
+        aggregator_task.run_with_ready(ready_tx).await;
+    });
+    ready_rx.await.expect("aggregator ready");
+
+    let publisher = MqttPublisher::new(
+        bus.clone(),
+        aggregator.clone(),
+        Arc::new(AdapterRegistry::default()),
+        isolated_knob_store(),
+    );
+    publisher
+        .configure(MqttCredentialRecord {
+            host: "127.0.0.1".to_string(),
+            port,
+            tls: false,
+            username: None,
+            password: None,
+            base_topic: "unified-hifi".to_string(),
+            discovery_prefix: "homeassistant".to_string(),
+            source: Default::default(),
+        })
+        .await;
+    publisher.set_enabled(true).await;
+
+    let status = wait_for_connection(
+        &publisher,
+        MqttConnectionState::Connected,
+        Duration::from_secs(10),
+    )
+    .await;
+    assert_eq!(
+        status.connection,
+        MqttConnectionState::Connected,
+        "a broker that accepted the CONNECT must read as connected, got {status:?}"
+    );
+    assert_eq!(
+        status.last_error, None,
+        "a working connection must not keep showing a stale error"
+    );
+
+    publisher.shutdown().await;
+}
+
+/// The un-latching case the issue calls out: a connection that succeeded and
+/// then died must fall back out of `connected`, not stay there forever on
+/// the strength of one `ConnAck`.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_connection_that_dies_stops_being_reported_as_connected() {
+    let broker_port = free_port();
+    start_test_broker(broker_port);
+    wait_for_broker_ready(broker_port, Duration::from_secs(5)).await;
+    // The publisher talks to the proxy, not the broker, so the test can cut
+    // a live session (see `BrokerProxy`).
+    let proxy = BrokerProxy::start(broker_port).await;
+
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let aggregator_task = aggregator.clone();
+    tokio::spawn(async move {
+        aggregator_task.run_with_ready(ready_tx).await;
+    });
+    ready_rx.await.expect("aggregator ready");
+
+    let publisher = MqttPublisher::new(
+        bus.clone(),
+        aggregator.clone(),
+        Arc::new(AdapterRegistry::default()),
+        isolated_knob_store(),
+    );
+    publisher
+        .configure(MqttCredentialRecord {
+            host: "127.0.0.1".to_string(),
+            port: proxy.port,
+            tls: false,
+            username: None,
+            password: None,
+            base_topic: "unified-hifi".to_string(),
+            discovery_prefix: "homeassistant".to_string(),
+            source: Default::default(),
+        })
+        .await;
+    publisher.set_enabled(true).await;
+
+    let connected = wait_for_connection(
+        &publisher,
+        MqttConnectionState::Connected,
+        Duration::from_secs(10),
+    )
+    .await;
+    assert_eq!(
+        connected.connection,
+        MqttConnectionState::Connected,
+        "precondition: the publisher must reach the broker first, got {connected:?}"
+    );
+
+    proxy.cut();
+
+    let after = wait_for_connection(
+        &publisher,
+        MqttConnectionState::Connecting,
+        Duration::from_secs(20),
+    )
+    .await;
+    assert_eq!(
+        after.connection,
+        MqttConnectionState::Connecting,
+        "a dropped connection must not stay 'connected', got {after:?}"
+    );
+    assert!(
+        after.last_error.is_some(),
+        "the drop must be explained, got {after:?}"
+    );
+    assert!(
+        after.running,
+        "the task is still alive and retrying - which is exactly why `running` \
+         could never have answered this question"
+    );
+
+    publisher.shutdown().await;
 }
 
 /// Command round-trip for a legacy (non-registry) zone (#529): an HA `volume_set` and a `play`


### PR DESCRIPTION
Closes #607.

`MqttStatus.running` was `runtime.task.is_some()` — true the moment the publisher task spawns, and it stays true while rumqttc retries a broker that will never answer. Settings had no other signal to go on, so a typo'd broker host rendered identically to a working one.

This tracks the real thing and reports it as a separate field, leaving `running` alone.

## What changed

**`src/mqtt/mod.rs`** — a `ConnectionMonitor` owned by each publisher task, written from the rumqttc event loop:
- `Event::Incoming(Packet::ConnAck)` → `Connected`, clearing any previous error.
- `Err(error)` → back to `Connecting`, recording `error.to_string()`.
- `Event::Incoming(Packet::Disconnect)` → back to `Connecting`.

`connected` therefore never latches: one `ConnAck` does not buy immunity from the next failure. No task at all reports `Disconnected`. The monitor is a `std::sync::RwLock`, not the runtime's async mutex — the event loop must record transitions inline without awaiting a lock that `configure`/`set_enabled` hold across `stop_task` (which waits up to 5s on that same task).

**`MqttStatus` / `MqttStatusResponse`** gain `connection` (`disconnected` / `connecting` / `connected`) and `last_error`. `running` keeps its old meaning and its old value — the two answer different questions, and other code and tests depend on it.

**`src/app/api.rs`** — `is_connected()`, `broker_address()`, and `connection_problem()`, which turns the raw rumqttc text into one plain sentence naming the *fix*. "Wrong password" and "wrong hostname" are the whole point of surfacing the error, so they must not collapse into the same message. Anything unrecognised passes through verbatim rather than being flattened into a reassuring generic.

One ordering subtlety, caught by its own test: rumqttc renders rejected credentials as ``Connection refused, return code `NotAuthorized` ``, which also matches the dead-port branch. Credentials are tested first, or a user with a bad password gets sent to check their port number.

**`src/app/pages/settings.rs`** — extends the #605 copy rather than rewriting it. "Publishing" is now gated on `is_connected()`, so a broker that never answers reads as a problem. A failure shows the address and the reason:

> **Can't reach your broker at mqtt://core-mosquitto:1883**
> That address could not be found. Check the broker's name for a typo.
> Nothing is reaching Home Assistant until this is fixed. UHC keeps trying, so correcting the details below is enough — no restart needed.

The summary table row becomes a red "Can't reach the broker — see why" that jumps to the section.

Connectivity changes produce no SSE event, so Settings polls `/api/mqtt/status` every 5s while the publisher is on, plus one re-check 1.5s after saving (the POST returns before the broker has been dialled, so the immediate refresh can only ever say "connecting").

**One bug the polling exposed, fixed here:** the existing rehydrate effect refilled the broker form from the server on *every* status change. With a timer now firing those, a poll landing between typing a corrected host and pressing Save silently replaced it with the stored one — reproduced live, twice, before I found it. The effect now hydrates once, on the first status to arrive. Same rule as the Spotify Redirect URI directly above it (#592): a value the user has entered is never silently replaced.

## Live repro — before and after

Both runs: `UHC_MQTT_HOST=core-mosquitto` (does not resolve outside Home Assistant), `adapters.roon=false`, isolated config dir.

**Before** (`integration/streaming-ha-alpha`, `GET /api/mqtt/status`):

```json
{"configured":true,"enabled":true,"running":true,
 "host":"core-mosquitto","port":1883,"tls":false,
 "base_topic":"unified-hifi","discovery_prefix":"homeassistant",
 "has_username":false,"has_password":false,"source":"environment"}
```

…while the log emitted, seven times over:

```
WARN unified_hifi_control::mqtt: MQTT publisher connection error:
  I/O: failed to lookup address information: nodename nor servname provided, or not known
```

Settings rendered that as a green "Publishing your zones to Home Assistant".

**After**, same environment:

```json
{"configured":true,"enabled":true,"running":true,
 "connection":"connecting",
 "last_error":"I/O: failed to lookup address information: nodename nor servname provided, or not known",
 "host":"core-mosquitto","port":1883,"tls":false,
 "base_topic":"unified-hifi","discovery_prefix":"homeassistant",
 "has_username":false,"has_password":false,"source":"environment"}
```

`running` is unchanged. `connection` disagrees with it, which is the entire point.

### Full round trip against a real broker

Real Chrome (claude-in-chrome) at `http://192.168.1.176:8607/settings`, against a `eclipse-mosquitto:2` container on `127.0.0.1:18830`. Every transition below was observed in the browser without a reload.

1. **Start unreachable** — table row: "Can't reach the broker — see why". Section: "Can't reach your broker at mqtt://core-mosquitto:1883" / "That address could not be found. Check the broker's name for a typo."
2. **Save the real broker** via the form — "✓ Publishing", "Current broker: mqtt://127.0.0.1:18830". API: `"connection":"connected"`, no `last_error`.
3. **`docker stop`** — falls back on its own to "Can't reach your broker at mqtt://127.0.0.1:18830" / "Nothing answered there. Check the port, and that the broker is switched on." API: `"connection":"connecting"`, `"last_error":"I/O: Connection refused (os error 61)"`. Note the different sentence: a stopped broker and an unknown hostname no longer read alike.
4. **`docker start`** — recovers to "✓ Publishing" unaided. `connected` was not latched by step 2, and not poisoned by step 3.

## Tests

`tests/mqtt_integration.rs`, against the in-process `rumqttd` broker:
- `tolerates_an_unreachable_broker` extended — asserts `running == true` *and* `connection == Connecting` with a `last_error`, then that shutdown returns `Disconnected` with no stale error.
- `a_reachable_broker_is_reported_as_connected` — the positive half, so the fix cannot be satisfied by never reporting success.
- `a_connection_that_dies_stops_being_reported_as_connected` — connects through a `BrokerProxy` TCP pass-through, cuts it, asserts the state leaves `Connected` while `running` stays true. `rumqttd::Broker::start` blocks its thread with no shutdown hook, so the proxy is how a *live* session gets cut.

Plus 8 unit tests on the copy mapping in `src/app/api.rs` (including the credentials-vs-port ordering above, and a status with no `connection` field not reading as connected), and 3 on the wire shape in `src/api/mqtt_settings.rs`.

## Gates

| Gate | Result |
| --- | --- |
| `cargo test` | 2242 passed, 0 failed |
| `cargo clippy -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `cargo test --doc` | clean (19 ignored) |
| `cargo check --target wasm32-unknown-unknown --no-default-features --features web` | clean |
| Real-browser probe | claude-in-chrome, LAN IP, round trip above |

Includes `reactive_loop_lint` and `hydration_safety_lint` — the new poll effect follows the sanctioned shape (guard signal only `peek`ed, refresh inside `spawn`).

No CI runs on PRs based on a non-default branch; the above is local.
