### PR TITLE
fix(mqtt): say when Home Assistant isn't consuming what we publish (#610)

### DIFF
--- a/src/api/mqtt_settings.rs
+++ b/src/api/mqtt_settings.rs
@@ -62,6 +62,18 @@ pub struct MqttStatusResponse {
     /// something the user should fill in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Whether Home Assistant is actually reading what we publish (#610):
+    /// `"consuming"`, `"not_configured"`, or `"unknown"`.
+    ///
+    /// The layer above `connection`. #607 made "we reached the broker"
+    /// honest; this one exists because a broker we reach happily can still
+    /// have nobody on the other side of it - which is exactly what produced
+    /// a perfect status block and zero Home Assistant entities.
+    pub home_assistant: String,
+    /// Why we cannot tell, when `home_assistant` is `"unknown"`. Absent
+    /// otherwise, the same convention as `last_error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub home_assistant_detail: Option<String>,
 }
 
 impl From<crate::mqtt::MqttStatus> for MqttStatusResponse {
@@ -79,6 +91,8 @@ impl From<crate::mqtt::MqttStatus> for MqttStatusResponse {
             discovery_prefix: status.discovery_prefix,
             has_username: status.has_username,
             has_password: status.has_password,
+            home_assistant: status.home_assistant.as_str().to_string(),
+            home_assistant_detail: status.home_assistant_detail,
             source: status.source.map(|source| {
                 match source {
                     MqttConfigSource::User => "user",
@@ -169,6 +183,7 @@ pub async fn configure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mqtt::consumer::HomeAssistantState;
     use crate::mqtt::{MqttConnectionState, MqttStatus};
 
     fn sample_response() -> MqttStatusResponse {
@@ -186,6 +201,8 @@ mod tests {
             has_username: true,
             has_password: true,
             source: Some("user".to_string()),
+            home_assistant: "consuming".to_string(),
+            home_assistant_detail: None,
         }
     }
 
@@ -222,6 +239,8 @@ mod tests {
             has_username: false,
             has_password: false,
             source: Some(MqttConfigSource::Environment),
+            home_assistant: HomeAssistantState::Unknown,
+            home_assistant_detail: None,
         };
         let response = MqttStatusResponse::from(status);
         assert!(response.running, "the task is alive - that much was true");
@@ -260,7 +279,79 @@ mod tests {
             has_username: false,
             has_password: false,
             source: None,
+            home_assistant: HomeAssistantState::default(),
+            home_assistant_detail: None,
         });
         assert_eq!(response.connection, "disconnected");
+    }
+
+    /// The #610 shape: everything about *our* side is perfect - configured,
+    /// enabled, running, connected - and the thing the user actually wanted
+    /// still is not happening. That combination has to be expressible in one
+    /// status block, or Settings has no way to tell the truth about it.
+    #[test]
+    fn a_connected_publisher_can_still_report_that_nobody_is_consuming() {
+        let response = MqttStatusResponse::from(MqttStatus {
+            configured: true,
+            enabled: true,
+            running: true,
+            connection: MqttConnectionState::Connected,
+            last_error: None,
+            host: Some("core-mosquitto".to_string()),
+            port: Some(1883),
+            tls: Some(false),
+            base_topic: Some("unified-hifi".to_string()),
+            discovery_prefix: Some("homeassistant".to_string()),
+            has_username: true,
+            has_password: true,
+            source: Some(MqttConfigSource::Environment),
+            home_assistant: HomeAssistantState::NotConfigured,
+            home_assistant_detail: None,
+        });
+        assert_eq!(response.connection, "connected");
+        assert_eq!(response.home_assistant, "not_configured");
+    }
+
+    /// "We cannot tell" has to survive to the wire with its reason attached.
+    /// Serializing it as anything else would either invent a problem or
+    /// invent a success.
+    #[test]
+    fn an_undetermined_consumer_state_carries_its_reason() {
+        let json = serde_json::to_value(MqttStatusResponse::from(MqttStatus {
+            configured: true,
+            enabled: true,
+            running: true,
+            connection: MqttConnectionState::Connected,
+            last_error: None,
+            host: Some("broker.lan".to_string()),
+            port: Some(1883),
+            tls: Some(false),
+            base_topic: Some("unified-hifi".to_string()),
+            discovery_prefix: Some("homeassistant".to_string()),
+            has_username: false,
+            has_password: false,
+            source: Some(MqttConfigSource::User),
+            home_assistant: HomeAssistantState::Unknown,
+            home_assistant_detail: Some("not running as a Home Assistant add-on".to_string()),
+        }))
+        .expect("serialize");
+        assert_eq!(json["home_assistant"], "unknown");
+        assert_eq!(
+            json["home_assistant_detail"],
+            "not running as a Home Assistant add-on"
+        );
+    }
+
+    /// A settled answer carries no dangling explanation, so Settings has
+    /// nothing stale to render beside it - the same rule `last_error`
+    /// follows once connected (#607).
+    #[test]
+    fn a_settled_consumer_state_omits_the_detail_field() {
+        let json = serde_json::to_value(sample_response()).expect("serialize");
+        assert_eq!(json["home_assistant"], "consuming");
+        assert!(
+            json.get("home_assistant_detail").is_none(),
+            "an absent detail must not serialize as null: {json}"
+        );
     }
 }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -302,6 +302,15 @@ pub struct MqttStatusResponse {
     /// inviting the user to fill in details they never entered.
     #[serde(default)]
     pub source: Option<String>,
+    /// Whether Home Assistant is actually reading what we publish (#610):
+    /// `"consuming"`, `"not_configured"`, or `"unknown"`. Defaults to empty
+    /// against a server that predates the field, which every helper below
+    /// treats as "cannot tell" - the safe direction.
+    #[serde(default)]
+    pub home_assistant: String,
+    /// Why we cannot tell, when we cannot (#610). Diagnostic, not copy.
+    #[serde(default)]
+    pub home_assistant_detail: Option<String>,
 }
 
 impl MqttStatusResponse {
@@ -322,6 +331,37 @@ impl MqttStatusResponse {
     /// tells those two apart.
     pub fn is_connecting(&self) -> bool {
         self.connection == "connecting"
+    }
+
+    /// Home Assistant's MQTT integration is set up and reading the broker,
+    /// so the zones we publish really do become entities (#610).
+    pub fn home_assistant_is_consuming(&self) -> bool {
+        self.home_assistant == "consuming"
+    }
+
+    /// The #610 case, and the only one that earns a call to action: we are
+    /// genuinely publishing, and Home Assistant has positively been found
+    /// *not* to have its MQTT integration set up.
+    ///
+    /// Gated on [`Self::is_connected`] on purpose. An unreachable broker is
+    /// its own, louder problem with its own fix (#607), and stacking a
+    /// second alarm on top of it would send the user to configure an
+    /// integration that could not have helped yet.
+    ///
+    /// Gated on the *positive* `not_configured` on purpose too: `unknown`
+    /// deliberately does not reach here, because accusing someone of not
+    /// having set up an integration we simply could not check would be the
+    /// same dishonesty in the opposite direction.
+    pub fn home_assistant_missing(&self) -> bool {
+        self.is_connected() && self.home_assistant == "not_configured"
+    }
+
+    /// We are publishing but cannot establish whether anyone reads it -
+    /// typically a UHC that is not running as a Home Assistant add-on, so
+    /// there is no Supervisor to ask. Worth one quiet, non-accusatory line;
+    /// never a warning.
+    pub fn home_assistant_undetermined(&self) -> bool {
+        self.is_connected() && !self.home_assistant_is_consuming() && !self.home_assistant_missing()
     }
 
     /// `mqtt://host:port` for the configured broker, so an error can name

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -1927,7 +1927,20 @@ pub fn Settings() -> Element {
                                             // answers used to land in this same
                                             // branch and read as success.
                                             if status.is_connected() {
-                                                if status.is_environment_managed() {
+                                                // Publishing into a broker
+                                                // nobody reads is not success,
+                                                // however well the publishing
+                                                // itself is going (#610). This
+                                                // row used to show a green tick
+                                                // for exactly that case.
+                                                if status.home_assistant_missing() {
+                                                    button {
+                                                        r#type: "button",
+                                                        class: "text-yellow-500 underline text-left",
+                                                        onclick: move |_| scroll_to_element("mqtt-anchor"),
+                                                        "Publishing, but Home Assistant isn't set up to receive it"
+                                                    }
+                                                } else if status.is_environment_managed() {
                                                     span { class: "status-ok", "✓ Publishing · via add-on" }
                                                 } else {
                                                     span { class: "status-ok", "✓ Publishing" }
@@ -2829,6 +2842,12 @@ pub fn Settings() -> Element {
                                 }
                                 div { id: "mqtt-info", class: mqtt_info_panel_class, role: "note",
                                     p { "Home Assistant discovers the zones by itself, so there is nothing to add per zone - no YAML, no entity list. Set up Home Assistant's MQTT integration, point it at the same broker you enter here, and the entities appear." }
+                                    // The two questions the on-screen call to
+                                    // action provokes but should not grow to
+                                    // answer (#610): "which broker?" and
+                                    // "do I have to restart anything?".
+                                    p { class: "mt-2", "Adding that integration is a separate step in Home Assistant, under Settings → Devices & services → Add integration → MQTT. If you use the Mosquitto add-on it normally fills the broker in for you." }
+                                    p { class: "mt-2", "Nothing here needs restarting afterwards - UHC notices Home Assistant arriving and re-sends everything within a few seconds." }
                                     p { class: "mt-2", "Each zone becomes a media player you can play, pause, and set the volume on. Each hardware controller becomes its own device." }
                                     p { class: "mt-2", "Advanced: the discovery prefix below has to match the one Home Assistant's MQTT integration uses. Leave it at \"homeassistant\" unless you changed it there." }
                                 }
@@ -2850,7 +2869,24 @@ pub fn Settings() -> Element {
                                 // than by "the task exists" (#607). Only the
                                 // first branch is success; a broker that
                                 // never answers now has to say so.
-                                if status.is_connected() {
+                                if status.home_assistant_missing() {
+                                    // The failure #610 is about: our own half
+                                    // is flawless, and the user still has no
+                                    // entities. The click path is the whole
+                                    // fix, so it stays on screen rather than
+                                    // behind the ⓘ - only the reassurance
+                                    // moves in there.
+                                    p { id: "mqtt-ha-missing", class: "text-yellow-500 font-medium",
+                                        "Your zones are being published, but Home Assistant isn't set up to receive them"
+                                    }
+                                    p { class: "mt-1 text-secondary",
+                                        "In Home Assistant, go to Settings → Devices & services → Add integration → MQTT. Your zones then appear on their own."
+                                    }
+                                } else if status.home_assistant_is_consuming() {
+                                    p { id: "mqtt-ha-consuming", class: "status-ok",
+                                        "Publishing your zones — Home Assistant is receiving them"
+                                    }
+                                } else if status.is_connected() {
                                     p { class: "status-ok", "Publishing your zones to Home Assistant" }
                                 } else if let Some(problem) = status.connection_problem() {
                                     p { class: "status-err font-medium",
@@ -2870,6 +2906,16 @@ pub fn Settings() -> Element {
                                     // work out what they were missing out on.
                                     p { class: "font-medium", "No broker yet — nothing is being published" }
                                     p { class: "mt-1 text-secondary", "Add your broker below and your zones and controllers show up in Home Assistant as entities." }
+                                }
+                                // We are publishing and genuinely cannot tell
+                                // whether anyone reads it - a UHC that is not
+                                // an add-on has no Supervisor to ask (#610).
+                                // Muted and factual: "we did not check" must
+                                // never be dressed up as "you did not do it".
+                                if status.home_assistant_undetermined() {
+                                    p { id: "mqtt-ha-unknown", class: "mt-1 text-xs text-muted",
+                                        "These only become entities once Home Assistant's own MQTT integration is added (Settings → Devices & services → Add integration → MQTT). UHC can't check that from here."
+                                    }
                                 }
                                 // The address is already in the error line
                                 // above when there is one; repeating it there

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 mod server {
     use unified_hifi_control::{
         adapters, aggregator, api, app, bus, config, coordinator, embedded, firmware, knobs, mcp,
-        mdns,
+        mdns, mqtt,
     };
 
     // Import load_app_settings for checking adapter enabled state
@@ -744,6 +744,21 @@ mod server {
             },
             Err(error) => tracing::warn!("MQTT credential store unavailable: {error}"),
         }
+
+        // Whether anyone is actually *reading* what the publisher publishes
+        // (#610). Everything above only establishes UHC's own half: a broker
+        // it reaches, discovery messages it sends. Home Assistant will not
+        // show a single entity unless its own MQTT integration has been added
+        // by hand, and that is invisible from the broker side - which is how
+        // an install with a flawless MQTT status block produced no entities
+        // at all.
+        //
+        // Started unconditionally, not just when the publisher is on: the
+        // question is about Home Assistant, and having the answer ready is
+        // what lets Settings say something useful the moment publishing is
+        // switched on. Outside the add-on this returns immediately without
+        // spawning anything.
+        mqtt::consumer::spawn_core_poll(state.mqtt.consumer_monitor());
 
         // Clone state for shutdown diagnostics
         let state_for_shutdown = state.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -758,7 +758,7 @@ mod server {
         // what lets Settings say something useful the moment publishing is
         // switched on. Outside the add-on this returns immediately without
         // spawning anything.
-        mqtt::consumer::spawn_core_poll(state.mqtt.consumer_monitor());
+        mqtt::consumer::spawn_core_poll(state.mqtt.consumer_monitor(), shutdown_token.clone());
 
         // Clone state for shutdown diagnostics
         let state_for_shutdown = state.clone();

--- a/src/mqtt/consumer.rs
+++ b/src/mqtt/consumer.rs
@@ -27,9 +27,13 @@
 //!    zones appear seconds after the integration is added.
 //!
 //! Neither source is complete on its own. The core API is unavailable when
-//! UHC is not running as an add-on (or when `homeassistant_api` is missing);
-//! the birth message is published with `retain: false`, so an HA that
-//! connected *before* UHC subscribed is invisible until it next reconnects.
+//! UHC is not running as an add-on (or when `homeassistant_api` is missing).
+//! The birth message, for its part, only tells us anything when Home
+//! Assistant happens to connect while we are subscribed: an HA that was
+//! already connected before UHC started may not announce itself again for
+//! hours, and its retain flag is configurable rather than guaranteed, so
+//! silence on that topic proves nothing either way.
+//!
 //! Hence three states, not two - see [`HomeAssistantState`]. "We cannot tell"
 //! is a real answer and gets said out loud rather than being rounded to
 //! either good news or an accusation.

--- a/src/mqtt/consumer.rs
+++ b/src/mqtt/consumer.rs
@@ -1,0 +1,625 @@
+//! Is anything on the other side actually *reading* what we publish? (#610)
+//!
+//! #607 made "we reached the broker" honest. This module answers the next
+//! question up, which turned out to be the one that actually bit: UHC can be
+//! connected to the broker, publishing discovery messages perfectly, and
+//! still produce zero Home Assistant entities - because Home Assistant's own
+//! MQTT integration was never added. Discovery messages then sit in the
+//! broker with nothing consuming them, while every status UHC showed said
+//! "success".
+//!
+//! Two independent sources of evidence feed one [`ConsumerMonitor`], and
+//! [`apply`] - a pure function - is the whole decision:
+//!
+//! 1. **The Supervisor's proxy to the Home Assistant core API.** Under the
+//!    add-on, `GET http://supervisor/core/api/config` returns the running
+//!    core's `components` list, and `mqtt` is in it exactly when the MQTT
+//!    integration is set up. This is the only source that can say *no*, and
+//!    it needs `homeassistant_api: true` in the add-on's `config.yaml`.
+//! 2. **Home Assistant's birth announcement.** HA's MQTT integration
+//!    publishes `online` to `<discovery_prefix>/status` whenever it connects
+//!    to the broker. UHC is already connected to that broker, so subscribing
+//!    to that topic upgrades the state the moment the user adds the
+//!    integration - no add-on restart, no waiting for the next poll.
+//!
+//! Neither source is complete on its own. The core API is unavailable when
+//! UHC is not running as an add-on (or when `homeassistant_api` is missing);
+//! the birth message is published with `retain: false`, so an HA that
+//! connected *before* UHC subscribed is invisible until it next reconnects.
+//! Hence three states, not two - see [`HomeAssistantState`]. "We cannot tell"
+//! is a real answer and gets said out loud rather than being rounded to
+//! either good news or an accusation.
+
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+/// Add-on environment variable carrying the Supervisor API token. Its
+/// absence is the signal that UHC is not running as a Home Assistant add-on,
+/// in which case there is no core API to ask.
+pub const SUPERVISOR_TOKEN_ENV: &str = "SUPERVISOR_TOKEN";
+
+/// The Supervisor's proxy to the Home Assistant core REST API.
+pub const CORE_CONFIG_URL: &str = "http://supervisor/core/api/config";
+
+/// The integration domain that has to be loaded for our discovery messages
+/// to be read by anybody.
+pub const MQTT_COMPONENT: &str = "mqtt";
+
+/// How often the core API is re-asked. Slow on purpose: this is a
+/// configuration fact that changes when a human clicks something, and the
+/// birth-message subscription already covers the moment it changes.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// A single request should not be able to wedge the poll loop.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Whether Home Assistant is actually consuming the discovery messages UHC
+/// publishes (#610).
+///
+/// Deliberately three-valued, and deliberately *not* folded into
+/// [`crate::mqtt::MqttConnectionState`]: "the broker took our messages" and
+/// "Home Assistant read them" are different facts with different fixes, and
+/// #610 is precisely the case where the first is true and the second is not.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum HomeAssistantState {
+    /// We have not established either answer. The honest default, and where
+    /// UHC stays for a non-add-on install that has never seen Home Assistant
+    /// announce itself. Must never be rendered as a problem: it is an
+    /// absence of evidence, not evidence of absence.
+    #[default]
+    Unknown,
+    /// Positively established that Home Assistant's MQTT integration is not
+    /// set up: the core API answered, and `mqtt` was not among its loaded
+    /// components. This is the only state that earns the "add the MQTT
+    /// integration" call to action.
+    NotConfigured,
+    /// Home Assistant's MQTT integration is loaded and reading the broker.
+    Consuming,
+}
+
+impl HomeAssistantState {
+    /// Wire form for `/api/mqtt/status`, alongside `connection` (#607).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::NotConfigured => "not_configured",
+            Self::Consuming => "consuming",
+        }
+    }
+}
+
+/// One observation about Home Assistant, from either source.
+///
+/// Modelled as data rather than as direct mutations so that [`apply`] can
+/// hold the precedence rules in one testable place - the same shape
+/// [`crate::api::mqtt_bootstrap::plan`] uses for the broker-config
+/// precedence rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Evidence {
+    /// The core API answered and `mqtt` was among its components.
+    CoreReportsMqttLoaded,
+    /// The core API answered and `mqtt` was *not* among its components.
+    CoreReportsMqttAbsent,
+    /// The core API could not be asked, did not answer, or answered in a
+    /// shape we do not understand. Carries the reason.
+    CoreUnavailable(String),
+    /// Home Assistant announced itself `online` on the discovery status
+    /// topic - it has just connected to the very broker we publish into.
+    BirthAnnouncement,
+}
+
+/// What UHC currently believes, and why.
+///
+/// `detail` mirrors [`crate::mqtt::MqttStatus::last_error`]: a raw,
+/// diagnosable reason string that the UI renders its own copy from rather
+/// than showing verbatim. It is only ever populated for [`
+/// HomeAssistantState::Unknown`], where "we cannot tell" is useless without
+/// "because...".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConsumerSnapshot {
+    pub state: HomeAssistantState,
+    pub detail: Option<String>,
+}
+
+/// Fold one observation into what we already believed.
+///
+/// The rules, in the order they matter:
+///
+/// * **The core API is authoritative when it answers.** It is the only
+///   source that can establish a negative, and it re-answers every
+///   [`POLL_INTERVAL`], so a stale positive cannot outlive the integration
+///   being removed by more than one poll.
+/// * **A birth announcement only ever upgrades.** Seeing Home Assistant
+///   connect to our broker is proof it is consuming; *not* seeing one proves
+///   nothing at all, because the message is not retained. So `online` sets
+///   [`HomeAssistantState::Consuming`] and nothing else on the MQTT side
+///   ever downgrades. In particular an `offline` will-message is ignored
+///   entirely: Home Assistant restarts routinely, and turning a restart into
+///   "your integration is missing" would be exactly the false alarm #610
+///   exists to stop us shipping.
+/// * **A failed probe erases nothing.** Losing the ability to ask is not
+///   news about Home Assistant, so an unavailable core API keeps whatever
+///   was last established and only explains itself when we had nothing to
+///   begin with.
+pub fn apply(previous: ConsumerSnapshot, evidence: Evidence) -> ConsumerSnapshot {
+    match evidence {
+        Evidence::CoreReportsMqttLoaded | Evidence::BirthAnnouncement => ConsumerSnapshot {
+            state: HomeAssistantState::Consuming,
+            detail: None,
+        },
+        Evidence::CoreReportsMqttAbsent => ConsumerSnapshot {
+            state: HomeAssistantState::NotConfigured,
+            detail: None,
+        },
+        Evidence::CoreUnavailable(reason) => {
+            if previous.state == HomeAssistantState::Unknown {
+                ConsumerSnapshot {
+                    state: HomeAssistantState::Unknown,
+                    detail: Some(reason),
+                }
+            } else {
+                previous
+            }
+        }
+    }
+}
+
+/// Shared belief about Home Assistant, written by the core-API poll task and
+/// by the publisher's event loop, read by `/api/mqtt/status`.
+///
+/// A `std::sync::RwLock` for the same reason [`crate::mqtt::ConnectionMonitor`]
+/// uses one: the publisher records observations inline in its `select!` arms,
+/// where awaiting the runtime lock would tie the MQTT event loop to whatever
+/// `configure`/`set_enabled` is doing.
+///
+/// Lives on [`crate::mqtt::MqttPublisher`] rather than on the publisher task,
+/// because "Home Assistant's MQTT integration is set up" is a fact about Home
+/// Assistant, not about our connection - it survives the publisher being
+/// reconfigured or restarted.
+#[derive(Debug, Default)]
+pub struct ConsumerMonitor {
+    inner: RwLock<ConsumerSnapshot>,
+}
+
+impl ConsumerMonitor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn snapshot(&self) -> ConsumerSnapshot {
+        self.inner
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// Record an observation, resolving it against the current belief via
+    /// [`apply`].
+    pub fn observe(&self, evidence: Evidence) {
+        if let Ok(mut guard) = self.inner.write() {
+            let previous = guard.clone();
+            let next = apply(previous.clone(), evidence);
+            if next != previous {
+                tracing::debug!(
+                    from = previous.state.as_str(),
+                    to = next.state.as_str(),
+                    "Home Assistant consumer state changed"
+                );
+            }
+            *guard = next;
+        }
+    }
+}
+
+/// Home Assistant's default birth/will topic.
+///
+/// Deliberately a constant rather than something derived from the discovery
+/// prefix. In Home Assistant core the birth/will topic is built from its own
+/// `DEFAULT_PREFIX` at module load and is configured separately from the
+/// discovery prefix - the two merely share the same default string. Deriving
+/// it from the prefix would silently subscribe to the wrong topic for anyone
+/// who changed the prefix but left birth/will alone, which is the default
+/// behaviour.
+pub const DEFAULT_STATUS_TOPIC: &str = "homeassistant/status";
+
+/// Every topic worth listening on for Home Assistant's birth announcement.
+///
+/// Always includes Home Assistant's own default, because that is where the
+/// message actually goes unless the user moved it. A non-default discovery
+/// prefix additionally contributes `<prefix>/status`, since moving both
+/// together is the obvious convention for someone who renamed the prefix -
+/// and an extra subscription to a topic nobody publishes on costs nothing.
+pub fn status_topics(discovery_prefix: &str) -> Vec<String> {
+    let mut topics = vec![DEFAULT_STATUS_TOPIC.to_string()];
+    let derived = format!("{}/status", discovery_prefix.trim_end_matches('/'));
+    if derived != DEFAULT_STATUS_TOPIC {
+        topics.push(derived);
+    }
+    topics
+}
+
+/// Whether a topic is one Home Assistant announces itself on, so the
+/// publisher's inbound handler can tell a birth message apart from the
+/// command topics it otherwise routes.
+pub fn is_status_topic(discovery_prefix: &str, topic: &str) -> bool {
+    status_topics(discovery_prefix)
+        .iter()
+        .any(|candidate| candidate == topic)
+}
+
+/// Read a payload on the status topic as evidence, or as nothing.
+///
+/// Only `online` means anything. See [`apply`] for why `offline` is
+/// deliberately not treated as bad news.
+pub fn parse_status_payload(payload: &[u8]) -> Option<Evidence> {
+    let text = String::from_utf8_lossy(payload);
+    if text.trim().eq_ignore_ascii_case("online") {
+        Some(Evidence::BirthAnnouncement)
+    } else {
+        None
+    }
+}
+
+/// Turn a `GET /core/api/config` body into evidence.
+///
+/// Pure, so the shape-handling is testable without a Supervisor: an answer
+/// we cannot parse has to land on [`Evidence::CoreUnavailable`] rather than
+/// on "no mqtt", because "the response looked unfamiliar" and "the
+/// integration is missing" would otherwise be indistinguishable - and only
+/// one of them should tell the user to go and add an integration.
+pub fn classify_core_config(body: &serde_json::Value) -> Evidence {
+    let Some(components) = body.get("components").and_then(|value| value.as_array()) else {
+        return Evidence::CoreUnavailable(
+            "the Home Assistant API answered without a components list".to_string(),
+        );
+    };
+    let loaded = components
+        .iter()
+        .filter_map(|value| value.as_str())
+        // `components` carries both `mqtt` and platform entries like
+        // `sensor.mqtt`; the bare domain is the one that means the
+        // integration itself is set up.
+        .any(|component| component == MQTT_COMPONENT);
+    if loaded {
+        Evidence::CoreReportsMqttLoaded
+    } else {
+        Evidence::CoreReportsMqttAbsent
+    }
+}
+
+/// Ask the Home Assistant core API, through the Supervisor proxy, whether
+/// the MQTT integration is loaded.
+///
+/// Every failure path yields [`Evidence::CoreUnavailable`] with a reason
+/// rather than a guess. A 401 in particular means the add-on is missing
+/// `homeassistant_api: true`, which is worth saying in as many words: it is
+/// a packaging mistake, not a user mistake.
+pub async fn probe_core(client: &reqwest::Client, token: &str, url: &str) -> Evidence {
+    let response = match client
+        .get(url)
+        .bearer_auth(token)
+        .timeout(PROBE_TIMEOUT)
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            return Evidence::CoreUnavailable(format!(
+                "could not reach the Home Assistant API: {error}"
+            ))
+        }
+    };
+
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Evidence::CoreUnavailable(
+            "the Home Assistant API refused the add-on's token; the add-on needs \
+             homeassistant_api: true"
+                .to_string(),
+        );
+    }
+    if !status.is_success() {
+        return Evidence::CoreUnavailable(format!(
+            "the Home Assistant API answered with HTTP {}",
+            status.as_u16()
+        ));
+    }
+
+    match response.json::<serde_json::Value>().await {
+        Ok(body) => classify_core_config(&body),
+        Err(error) => Evidence::CoreUnavailable(format!(
+            "the Home Assistant API answer could not be read: {error}"
+        )),
+    }
+}
+
+/// Override for [`CORE_CONFIG_URL`], so an install that is not an add-on can
+/// still be pointed at a Home Assistant instance (and so both detection
+/// outcomes can be exercised against a stand-in during development).
+pub const CORE_URL_ENV: &str = "UHC_HA_API_URL";
+
+/// Override for [`SUPERVISOR_TOKEN_ENV`]: a Home Assistant long-lived access
+/// token, for the same non-add-on case.
+pub const CORE_TOKEN_ENV: &str = "UHC_HA_API_TOKEN";
+
+/// Why we cannot tell, when UHC is simply not running inside Home Assistant.
+/// Not a fault, and Settings must not render it as one.
+pub const NOT_AN_ADDON: &str =
+    "UHC is not running as a Home Assistant add-on, so it cannot ask Home Assistant \
+     whether the MQTT integration is set up";
+
+/// Resolve the core API endpoint and token from the environment.
+///
+/// Separated from [`spawn_core_poll`] so the precedence is visible: an
+/// explicit override always wins over the Supervisor's own token, because
+/// someone who set one is deliberately pointing at a specific instance.
+fn core_api_credentials() -> Option<(String, String)> {
+    let non_empty = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
+    let url = non_empty(CORE_URL_ENV).unwrap_or_else(|| CORE_CONFIG_URL.to_string());
+    let token = non_empty(CORE_TOKEN_ENV).or_else(|| non_empty(SUPERVISOR_TOKEN_ENV))?;
+    Some((url, token))
+}
+
+/// Start the background poll that asks Home Assistant whether its MQTT
+/// integration is loaded (#610).
+///
+/// Polls immediately and then every [`POLL_INTERVAL`], so Settings has a real
+/// answer seconds after startup rather than a minute later. Runs regardless
+/// of whether the publisher is switched on: the question is about Home
+/// Assistant, and the answer is worth having ready before the user turns
+/// publishing on.
+///
+/// With no token available there is nothing to poll, so no task is spawned at
+/// all - the monitor keeps its honest default and records why.
+pub fn spawn_core_poll(monitor: Arc<ConsumerMonitor>) {
+    let Some((url, token)) = core_api_credentials() else {
+        monitor.observe(Evidence::CoreUnavailable(NOT_AN_ADDON.to_string()));
+        tracing::debug!(
+            "No Home Assistant API token available; \
+             not polling for the MQTT integration's presence"
+        );
+        return;
+    };
+
+    let client = match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+        Ok(client) => client,
+        Err(error) => {
+            monitor.observe(Evidence::CoreUnavailable(format!(
+                "could not build an HTTP client for the Home Assistant API: {error}"
+            )));
+            return;
+        }
+    };
+
+    tokio::spawn(async move {
+        // `interval` fires its first tick immediately, which is the point:
+        // the startup answer is the one that decides what Settings says to a
+        // user who just installed the add-on.
+        let mut ticker = tokio::time::interval(POLL_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut previous: Option<HomeAssistantState> = None;
+        loop {
+            ticker.tick().await;
+            let evidence = probe_core(&client, &token, &url).await;
+            monitor.observe(evidence);
+            let current = monitor.snapshot().state;
+            // Log transitions only. At one poll a minute, logging every
+            // answer would bury the add-on log in noise, but the moment the
+            // answer changes is exactly what someone diagnosing "no entities"
+            // needs to see.
+            if previous != Some(current) {
+                match current {
+                    HomeAssistantState::Consuming => tracing::info!(
+                        "Home Assistant's MQTT integration is set up; discovery is being consumed"
+                    ),
+                    HomeAssistantState::NotConfigured => tracing::warn!(
+                        "Home Assistant's MQTT integration is NOT set up, so no entities will \
+                         appear however well UHC publishes. Add it in Home Assistant under \
+                         Settings > Devices & services > Add integration > MQTT."
+                    ),
+                    HomeAssistantState::Unknown => tracing::debug!(
+                        "Cannot determine whether Home Assistant's MQTT integration is set up"
+                    ),
+                }
+                previous = Some(current);
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unknown() -> ConsumerSnapshot {
+        ConsumerSnapshot::default()
+    }
+
+    fn consuming() -> ConsumerSnapshot {
+        ConsumerSnapshot {
+            state: HomeAssistantState::Consuming,
+            detail: None,
+        }
+    }
+
+    fn not_configured() -> ConsumerSnapshot {
+        ConsumerSnapshot {
+            state: HomeAssistantState::NotConfigured,
+            detail: None,
+        }
+    }
+
+    #[test]
+    fn the_default_belief_is_that_we_cannot_tell() {
+        // The honest starting point, and the one a non-add-on install stays
+        // at. Anything else would be a claim we have not earned.
+        assert_eq!(unknown().state, HomeAssistantState::Unknown);
+        assert_eq!(HomeAssistantState::default().as_str(), "unknown");
+    }
+
+    #[test]
+    fn the_core_api_establishes_both_answers() {
+        assert_eq!(
+            apply(unknown(), Evidence::CoreReportsMqttLoaded),
+            consuming()
+        );
+        assert_eq!(
+            apply(unknown(), Evidence::CoreReportsMqttAbsent),
+            not_configured()
+        );
+    }
+
+    /// The live-upgrade path #610 asks for: the user adds the MQTT
+    /// integration minutes after starting the add-on, Home Assistant
+    /// connects to the broker, and UHC corrects itself without a restart.
+    #[test]
+    fn a_birth_announcement_upgrades_a_negative_without_a_restart() {
+        let after_probe = apply(unknown(), Evidence::CoreReportsMqttAbsent);
+        assert_eq!(after_probe.state, HomeAssistantState::NotConfigured);
+        assert_eq!(
+            apply(after_probe, Evidence::BirthAnnouncement),
+            consuming(),
+            "watching HA connect to our own broker outranks a poll taken before it did"
+        );
+    }
+
+    /// The false alarm this whole module exists to avoid. Home Assistant
+    /// restarts routinely and fires its will-message every time; if that
+    /// downgraded us, Settings would accuse the user of not having set up an
+    /// integration they set up weeks ago.
+    #[test]
+    fn an_offline_will_message_is_not_evidence_of_anything() {
+        assert_eq!(parse_status_payload(b"offline"), None);
+        assert_eq!(parse_status_payload(b""), None);
+        assert_eq!(parse_status_payload(b"something else"), None);
+    }
+
+    #[test]
+    fn an_online_birth_message_is_recognised_whatever_its_spelling() {
+        for payload in [&b"online"[..], b"ONLINE", b" online\n"] {
+            assert_eq!(
+                parse_status_payload(payload),
+                Some(Evidence::BirthAnnouncement),
+                "{:?} should read as a birth announcement",
+                String::from_utf8_lossy(payload)
+            );
+        }
+    }
+
+    /// Losing the ability to ask is news about us, not about Home Assistant.
+    /// Clobbering a established answer with "cannot tell" on one dropped
+    /// request would make Settings flap between an answer and a shrug.
+    #[test]
+    fn an_unavailable_core_api_never_erases_what_we_already_established() {
+        let unavailable = Evidence::CoreUnavailable("boom".to_string());
+        assert_eq!(
+            apply(consuming(), unavailable.clone()),
+            consuming(),
+            "a dropped request does not un-consume Home Assistant"
+        );
+        assert_eq!(
+            apply(not_configured(), unavailable),
+            not_configured(),
+            "nor does it retract a positively established negative"
+        );
+    }
+
+    #[test]
+    fn an_unavailable_core_api_explains_itself_when_we_had_nothing() {
+        let resolved = apply(
+            unknown(),
+            Evidence::CoreUnavailable("no SUPERVISOR_TOKEN".to_string()),
+        );
+        assert_eq!(resolved.state, HomeAssistantState::Unknown);
+        assert_eq!(resolved.detail.as_deref(), Some("no SUPERVISOR_TOKEN"));
+    }
+
+    /// The core API's own answer is what retracts a stale positive - within
+    /// one poll interval, which is the bound this design accepts.
+    #[test]
+    fn removing_the_integration_is_picked_up_by_the_next_poll() {
+        let believed = apply(unknown(), Evidence::BirthAnnouncement);
+        assert_eq!(believed.state, HomeAssistantState::Consuming);
+        assert_eq!(
+            apply(believed, Evidence::CoreReportsMqttAbsent),
+            not_configured()
+        );
+    }
+
+    #[test]
+    fn a_components_list_containing_mqtt_reads_as_loaded() {
+        let body = serde_json::json!({
+            "components": ["sensor", "mqtt", "sensor.mqtt", "media_player"],
+        });
+        assert_eq!(classify_core_config(&body), Evidence::CoreReportsMqttLoaded);
+    }
+
+    /// The exact live failure from #610: a working Home Assistant with no
+    /// MQTT integration. Note `sensor.mqtt`-style platform entries are
+    /// absent too, but the bare domain is what we key on.
+    #[test]
+    fn a_components_list_without_mqtt_reads_as_not_configured() {
+        let body = serde_json::json!({
+            "components": ["sensor", "media_player", "zone", "person"],
+        });
+        assert_eq!(classify_core_config(&body), Evidence::CoreReportsMqttAbsent);
+    }
+
+    /// A platform entry alone must not be mistaken for the integration. This
+    /// is the substring bug the `==` in `classify_core_config` avoids: a
+    /// `contains("mqtt")` would call this configured.
+    #[test]
+    fn a_platform_entry_alone_is_not_the_integration() {
+        let body = serde_json::json!({ "components": ["sensor.mqtt_eventstream"] });
+        assert_eq!(classify_core_config(&body), Evidence::CoreReportsMqttAbsent);
+    }
+
+    /// An answer we do not understand is not a negative. Reporting "your
+    /// integration is missing" because Home Assistant changed its response
+    /// shape would be the same class of lie as #607's.
+    #[test]
+    fn an_unfamiliar_response_shape_is_unavailable_not_absent() {
+        for body in [
+            serde_json::json!({}),
+            serde_json::json!({ "components": "mqtt" }),
+            serde_json::json!([]),
+            serde_json::json!("nope"),
+        ] {
+            assert!(
+                matches!(
+                    classify_core_config(&body),
+                    Evidence::CoreUnavailable(_)
+                ),
+                "{body} should be unavailable, not a claim about Home Assistant"
+            );
+        }
+    }
+
+    /// The default prefix must yield exactly one subscription, not a
+    /// duplicate pair - subscribing twice to one topic delivers every birth
+    /// message twice.
+    #[test]
+    fn the_default_prefix_yields_one_status_topic() {
+        assert_eq!(status_topics("homeassistant"), vec!["homeassistant/status"]);
+        // A trailing slash would otherwise produce `homeassistant//status`,
+        // a different topic that would both duplicate and never match.
+        assert_eq!(
+            status_topics("homeassistant/"),
+            vec!["homeassistant/status"]
+        );
+    }
+
+    /// Home Assistant's birth topic does not move when the discovery prefix
+    /// does, so the default has to stay subscribed either way - listening
+    /// only to `<prefix>/status` would miss every real birth message.
+    #[test]
+    fn a_renamed_prefix_adds_a_topic_without_dropping_the_default() {
+        assert_eq!(
+            status_topics("ha-prod"),
+            vec!["homeassistant/status", "ha-prod/status"]
+        );
+        assert!(is_status_topic("ha-prod", "homeassistant/status"));
+        assert!(is_status_topic("ha-prod", "ha-prod/status"));
+        assert!(!is_status_topic("ha-prod", "unified-hifi/media_player/x/y/set"));
+    }
+}

--- a/src/mqtt/consumer.rs
+++ b/src/mqtt/consumer.rs
@@ -17,10 +17,14 @@
 //!    integration is set up. This is the only source that can say *no*, and
 //!    it needs `homeassistant_api: true` in the add-on's `config.yaml`.
 //! 2. **Home Assistant's birth announcement.** HA's MQTT integration
-//!    publishes `online` to `<discovery_prefix>/status` whenever it connects
-//!    to the broker. UHC is already connected to that broker, so subscribing
-//!    to that topic upgrades the state the moment the user adds the
-//!    integration - no add-on restart, no waiting for the next poll.
+//!    publishes `online` to `homeassistant/status` whenever it connects to
+//!    the broker (see [`DEFAULT_STATUS_TOPIC`] - that topic is *not* derived
+//!    from the discovery prefix). UHC is already connected to that broker, so
+//!    subscribing to it upgrades the state the moment the user adds the
+//!    integration - no add-on restart, no waiting for the next poll. Home
+//!    Assistant's own integration docs name this message as the intended
+//!    trigger for publishers to re-send discovery, which is what makes the
+//!    zones appear seconds after the integration is added.
 //!
 //! Neither source is complete on its own. The core API is unavailable when
 //! UHC is not running as an add-on (or when `homeassistant_api` is missing);
@@ -32,6 +36,8 @@
 
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
 
 /// Add-on environment variable carrying the Supervisor API token. Its
 /// absence is the signal that UHC is not running as a Home Assistant add-on,
@@ -371,7 +377,11 @@ fn core_api_credentials() -> Option<(String, String)> {
 ///
 /// With no token available there is nothing to poll, so no task is spawned at
 /// all - the monitor keeps its honest default and records why.
-pub fn spawn_core_poll(monitor: Arc<ConsumerMonitor>) {
+///
+/// `shutdown` is the server's own token: the poll would otherwise outlive a
+/// Ctrl+C and hang graceful shutdown, since nothing else can interrupt a
+/// sleeping ticker (`tests/spawn_cancellation_lint.rs`).
+pub fn spawn_core_poll(monitor: Arc<ConsumerMonitor>, shutdown: CancellationToken) {
     let Some((url, token)) = core_api_credentials() else {
         monitor.observe(Evidence::CoreUnavailable(NOT_AN_ADDON.to_string()));
         tracing::debug!(
@@ -399,7 +409,10 @@ pub fn spawn_core_poll(monitor: Arc<ConsumerMonitor>) {
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let mut previous: Option<HomeAssistantState> = None;
         loop {
-            ticker.tick().await;
+            tokio::select! {
+                _ = shutdown.cancelled() => break,
+                _ = ticker.tick() => {}
+            }
             let evidence = probe_core(&client, &token, &url).await;
             monitor.observe(evidence);
             let current = monitor.snapshot().state;
@@ -586,10 +599,7 @@ mod tests {
             serde_json::json!("nope"),
         ] {
             assert!(
-                matches!(
-                    classify_core_config(&body),
-                    Evidence::CoreUnavailable(_)
-                ),
+                matches!(classify_core_config(&body), Evidence::CoreUnavailable(_)),
                 "{body} should be unavailable, not a claim about Home Assistant"
             );
         }
@@ -620,6 +630,9 @@ mod tests {
         );
         assert!(is_status_topic("ha-prod", "homeassistant/status"));
         assert!(is_status_topic("ha-prod", "ha-prod/status"));
-        assert!(!is_status_topic("ha-prod", "unified-hifi/media_player/x/y/set"));
+        assert!(!is_status_topic(
+            "ha-prod",
+            "unified-hifi/media_player/x/y/set"
+        ));
     }
 }

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -30,6 +30,7 @@
 //! the next tick.
 
 pub mod command;
+pub mod consumer;
 pub mod discovery;
 pub mod knob_command;
 pub mod knob_discovery;
@@ -52,6 +53,7 @@ use crate::bus::runtime::CommandGateway;
 use crate::bus::{BusEvent, SharedBus, Zone};
 use crate::knobs::store::Knob;
 use crate::knobs::KnobStore;
+use consumer::{ConsumerMonitor, HomeAssistantState};
 
 pub use crate::api::credentials::{MqttConfigSource, MqttCredentialRecord};
 
@@ -190,6 +192,13 @@ pub struct MqttPublisher {
     /// this struct lives behind, exactly like `AppState::reliable_commands` starts `None` and is
     /// attached via `AppState::with_reliable_commands`.
     reliable_commands: std::sync::RwLock<Option<CommandGateway>>,
+    /// Whether Home Assistant is actually reading what we publish (#610).
+    ///
+    /// Held here rather than on the publisher task because it is a fact
+    /// about Home Assistant, not about our broker connection: it has to
+    /// survive the publisher being reconfigured, and the Supervisor poll
+    /// task that writes to it runs whether or not the publisher is on.
+    consumer: Arc<ConsumerMonitor>,
 }
 
 /// Snapshot of publisher state for the settings API, deliberately excluding
@@ -220,6 +229,14 @@ pub struct MqttStatus {
     /// unconfigured. Lets Settings show an add-on-managed broker as managed
     /// instead of inviting the user to re-type details they never entered.
     pub source: Option<MqttConfigSource>,
+    /// Whether Home Assistant's own MQTT integration is reading what we
+    /// publish (#610). The layer above `connection`: a broker we reach
+    /// happily can still have nobody on the other side of it.
+    pub home_assistant: HomeAssistantState,
+    /// Why we cannot tell, when we cannot. Only ever set alongside
+    /// [`consumer::HomeAssistantState::Unknown`]; the same raw-reason
+    /// convention as [`MqttStatus::last_error`].
+    pub home_assistant_detail: Option<String>,
 }
 
 impl MqttPublisher {
@@ -237,7 +254,15 @@ impl MqttPublisher {
             base_url: std::sync::RwLock::new(String::new()),
             runtime: Mutex::new(Runtime::default()),
             reliable_commands: std::sync::RwLock::new(None),
+            consumer: Arc::new(ConsumerMonitor::new()),
         }
+    }
+
+    /// The Home Assistant consumer belief (#610), shared so the Supervisor
+    /// poll task in `main` can record its own observations into the same
+    /// place the publisher's event loop records birth announcements.
+    pub fn consumer_monitor(&self) -> Arc<ConsumerMonitor> {
+        self.consumer.clone()
     }
 
     /// Attach the reliable command gateway (#529) so inbound HA commands for legacy
@@ -333,6 +358,7 @@ impl MqttPublisher {
             self.reliable_commands_snapshot(),
             self.base_url_snapshot(),
             connection.clone(),
+            self.consumer.clone(),
             shutdown.clone(),
         ));
         let task = RunningTask {
@@ -366,6 +392,7 @@ impl MqttPublisher {
     }
 
     pub async fn status(&self) -> MqttStatus {
+        let consumer = self.consumer.snapshot();
         let runtime = self.runtime.lock().await;
         // No task means no connection, whatever the last one reported: the
         // monitor is owned by the task and dies with it.
@@ -394,6 +421,8 @@ impl MqttPublisher {
                 .as_ref()
                 .is_some_and(|r| r.password.as_ref().is_some_and(|p| !p.is_empty())),
             source: runtime.record.as_ref().map(|r| r.source),
+            home_assistant: consumer.state,
+            home_assistant_detail: consumer.detail,
         }
     }
 
@@ -811,6 +840,7 @@ async fn run(
     reliable_commands: Option<CommandGateway>,
     base_url: String,
     connection: Arc<ConnectionMonitor>,
+    consumer: Arc<ConsumerMonitor>,
     shutdown: CancellationToken,
 ) {
     let availability_topic = topics::availability_topic(&record.base_topic);
@@ -851,6 +881,18 @@ async fn run(
                         // The one moment we know entities are really
                         // reaching a broker (#607).
                         connection.connected();
+                        // Listen for Home Assistant announcing itself on the
+                        // same broker (#610). Re-subscribed on every fresh
+                        // connection because a new MQTT session carries no
+                        // subscriptions over.
+                        for topic in consumer::status_topics(&record.discovery_prefix) {
+                            if let Err(error) = client.subscribe(&topic, QoS::AtLeastOnce).await {
+                                tracing::warn!(
+                                    topic,
+                                    "MQTT Home Assistant status subscription failed: {error}"
+                                );
+                            }
+                        }
                         announce_all_zones(
                             &client,
                             &record,
@@ -870,6 +912,53 @@ async fn run(
                             &mut knob_slugs,
                         )
                         .await;
+                    }
+                    Ok(Event::Incoming(Packet::Publish(publish)))
+                        if consumer::is_status_topic(
+                            &record.discovery_prefix,
+                            &publish.topic,
+                        ) =>
+                    {
+                        // Home Assistant just said something on its own
+                        // status topic (#610). Only `online` means anything;
+                        // an `offline` will-message is deliberately not
+                        // treated as bad news - see `consumer::apply`.
+                        if let Some(evidence) =
+                            consumer::parse_status_payload(&publish.payload)
+                        {
+                            consumer.observe(evidence);
+                            // Home Assistant's own integration docs ask
+                            // publishers to treat the birth message as the
+                            // trigger to (re)send their discovery payloads.
+                            // Ours are retained, so HA would find them
+                            // anyway, but re-announcing here is what makes
+                            // "add the MQTT integration and the zones
+                            // appear" true within seconds rather than on
+                            // HA's next discovery sweep.
+                            tracing::info!(
+                                "Home Assistant announced itself on the broker; \
+                                 re-publishing discovery"
+                            );
+                            announce_all_zones(
+                                &client,
+                                &record,
+                                &aggregator,
+                                &base_url,
+                                &availability_topic,
+                                &mut zone_slugs,
+                            )
+                            .await;
+                            announce_all_knobs(
+                                &client,
+                                &record,
+                                &knobs,
+                                &aggregator,
+                                &availability_topic,
+                                &mut known_knob_ids,
+                                &mut knob_slugs,
+                            )
+                            .await;
+                        }
                     }
                     Ok(Event::Incoming(Packet::Publish(publish))) => {
                         handle_incoming_publish(


### PR DESCRIPTION
Closes #610. Based on `integration/streaming-ha-alpha` (not v3).

Add-on half: open-horizon-labs/uhc-home-assistant-addon#2

## The problem

#607 made "we reached the broker" honest. This is the next question up, and the
one that actually bit. On the owner's HA with 3.7.0-alpha.5, UHC's MQTT side was
flawless — `connection: "connected"`, publishing discovery — and **no entities
appeared**, because Home Assistant's own MQTT integration was never added. We
publish into a broker nobody consumes, and every status we show says "success".

## How detection works

Two independent evidence sources feed one three-valued belief. `consumer::apply`
is a pure function holding all the precedence rules, following the shape
`mqtt_bootstrap::plan` already established for broker-config precedence.

**1. The Supervisor's proxy to HA's core API** (`src/mqtt/consumer.rs`,
`spawn_core_poll`). `GET http://supervisor/core/api/config` returns the running
core's `components` list; `mqtt` is in it exactly when the integration is set
up. Polled immediately at startup, then every 60s. This is **the only source
that can establish a negative**. It needs `homeassistant_api: true`, added in
the add-on PR.

**2. HA's birth announcement** on `homeassistant/status`. UHC is already
connected to that broker, so subscribing gives a live upgrade the moment the
user adds the integration — no restart, no waiting for the next poll.

Note `DEFAULT_STATUS_TOPIC` is a **constant, not derived from the discovery
prefix**: in HA core the birth/will topic is built from its own `DEFAULT_PREFIX`
and configured separately; the two merely share a default string. Deriving it
would silently subscribe to the wrong topic for anyone who changed the prefix.
UHC subscribes to HA's default always, plus `<prefix>/status` when the prefix
differs.

**Bonus, and it matters:** HA's integration docs state "A device or service that
exposes the MQTT discovery should subscribe to the Birth message and use this as
a trigger to send the discovery payload." UHC now does exactly that. Our
discovery is retained so HA would find it anyway, but this makes "add the
integration and the zones appear" true within seconds rather than merely
*reported*. (HA also suggests a random delay to avoid broker overload; that
advice targets fleets of devices — one UHC re-announcing a handful of zones is
negligible, so no delay was added.)

## Failure and unknown modes — the honesty rules

Each is pinned by a test in `src/mqtt/consumer.rs`.

| Situation | Reported | Why |
|---|---|---|
| Core API says `mqtt` present | `consuming` | Authoritative |
| Core API says `mqtt` absent | `not_configured` | Authoritative; the only state that earns a call to action |
| Birth message seen | `consuming` | We watched HA connect to our own broker |
| **`offline` will-message** | **ignored entirely** | HA restarts routinely. Downgrading on it would be exactly the false alarm this issue is about |
| **Probe fails (network, 5xx)** | **previous answer kept** | Losing the ability to ask is news about us, not about HA. Otherwise Settings flaps between an answer and a shrug |
| **401/403** | `unknown` + "the add-on needs `homeassistant_api: true`" | A packaging mistake, named as one |
| **Response shape unfamiliar** | `unknown`, never `not_configured` | "HA changed its response format" and "your integration is missing" must not be confused — only one sends the user to add an integration |
| No `SUPERVISOR_TOKEN` (not an add-on) | `unknown` + reason | No task is spawned at all |

Stale-positive bound: an MQTT-derived `consuming` is corrected by the core API
within one poll interval (≤60s). That bound is accepted deliberately and
documented.

**UI gating.** `home_assistant_missing()` requires `is_connected()` — an
unreachable broker is its own louder problem (#607), and stacking a second alarm
would send the user to configure an integration that could not have helped yet.
It also requires the *positive* `not_configured`; `unknown` deliberately cannot
reach it.

## Settings copy (#605/#607/#597 patterns extended, not rewritten)

- **Not consuming** — the row's green tick becomes `Publishing, but Home
  Assistant isn't set up to receive it` (links to the section). The card reads
  `Your zones are being published, but Home Assistant isn't set up to receive
  them` + `In Home Assistant, go to Settings → Devices & services → Add
  integration → MQTT. Your zones then appear on their own.` The click path stays
  on screen — it *is* the fix.
- **Consuming** — `Publishing your zones — Home Assistant is receiving them`.
- **Can't tell** — one muted line, no colour, no alarm: `These only become
  entities once Home Assistant's own MQTT integration is added (…). UHC can't
  check that from here.`
- The ⓘ panel absorbs the two follow-up questions (which broker; anything to
  restart) so the visible copy stays short.

## Live evidence

Real Mosquitto (docker) + a stand-in core API serving HA's documented
`/api/config` shape. Roon disabled in the test config. Browser probe via
**claude-in-chrome** against the LAN IP `192.168.1.176:8610` (not 127.0.0.1).

**Reproduced the #610 shape exactly** — our side perfect, nobody consuming:
```json
{"configured":true,"enabled":true,"running":true,"connection":"connected",
 "host":"127.0.0.1","port":11883,"source":"environment",
 "home_assistant":"not_configured"}
```
Log: `Home Assistant's MQTT integration is NOT set up, so no entities will appear
however well UHC publishes. Add it in Home Assistant under Settings > Devices &
services > Add integration > MQTT.`

**`not_configured` renders** — row shows `Publishing, but Home Assistant isn't
set up to receive it`; card shows the warning + click path.

**Live upgrade, no restart** — published `online` to `homeassistant/status`;
status flipped to `consuming` in ~1s and the log showed `Home Assistant
announced itself on the broker; re-publishing discovery`. Watched the **browser
page flip on its own 5s poll, without a reload**, from the yellow warning to
`✓ Publishing · via add-on` / `Publishing your zones — Home Assistant is
receiving them`.

**Core API corrects a stale positive** — with the birth-derived `consuming` in
place and the core API still reporting absent, the next poll reverted it to
`not_configured`. The ≤60s bound, observed.

**`consuming` via the core API** — flipped the stand-in to include `mqtt`;
status became `consuming`, detail absent.

**A failed probe erases nothing** — flipped the stand-in to 401 while
`consuming`; state stayed `consuming`.

**401 from a cold start → `unknown`, not a false alarm** — restarted with the
API refusing: `home_assistant: "unknown"`, detail `the Home Assistant API
refused the add-on's token; the add-on needs homeassistant_api: true`. Rendered
as the muted line only; no warning, no green tick claim.

## Verification

`cargo test` (full suite, green), `cargo clippy -- -D warnings`, `cargo fmt
--check`, `cargo test --doc`, `cargo check --target wasm32-unknown-unknown
--no-default-features --features web`. `make css` first.

Two things caught and fixed in the process:
- `tests/spawn_cancellation_lint` flagged the poll loop as a graceful-shutdown
  hang — a real bug. It now selects on the server's `shutdown_token` (confirmed
  live: the server exits cleanly on SIGTERM).
- `tests/web_bundle_consistency_contract` failed from two wasm bundles left by
  my own concurrent `dx` builds, not a source defect; a clean rebuild is green.

Note `cargo clippy --tests -D warnings` is not a usable gate on this branch —
base has 843 pre-existing errors of that shape.

## Out of scope: triggering HA's MQTT discovery flow (issue item 3)

Not built, as instructed. What I learned, read from Supervisor/Core **source**
(the developer docs are silent on all of it — `endpoints.md` documents only the
payload shape):

- It is possible in principle. An add-on declaring `discovery: [mqtt]` can
  `POST http://supervisor/discovery` with `{"service","config"}`; Supervisor
  pushes it to Core's `/api/hassio_push/discovery/{uuid}`, which creates a config
  flow with `source: hassio` — what appears under "Discovered". This is how the
  **Mosquitto add-on** does it (`discovery: [mqtt]` in its `config.yaml`).
- Supervisor does **not** restrict this by provider role — the only check is that
  the service is in the sending add-on's own `discovery:` list. But both the
  option's documented description ("services that this app **provides**") and
  Supervisor's own error string frame it as the provider's mechanism. UHC is a
  consumer. Doing it would be permitted-but-contrary-to-intent.
- **It would very likely be a no-op anyway.** MQTT's manifest sets
  `single_config_entry: true`, and `async_step_hassio` calls
  `_async_handle_discovery_without_unique_id()`, which aborts `already_configured`
  when entries exist — with `include_ignore=True`, so a *dismissed* discovery
  counts. On any system where Mosquitto already announced MQTT, a second offer
  silently aborts with nothing user-visible.
- **This plausibly explains the owner's symptom** that MQTT was not offered under
  Discovered at all: if Mosquitto's discovery was already dismissed/ignored, HA
  will not re-offer it. The documented path back is removing the config entry
  (Core's `signal_discovered_config_entry_removed` → `async_rediscover`).

So the honest conclusion is that item 3 would add real complexity for an offer
that is most often suppressed — telling the user plainly, which this PR does, is
the more reliable fix.
