### PR TITLE
feat: the HA add-on installs the UHC integration (no MQTT, no manual copy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,11 @@ RUN apt-get update && apt-get install -y \
 # Copy binary with embedded web assets (ADR 002 - no public/ directory)
 COPY --from=builder /app/unified-hifi-control-bin /app/unified-hifi-control
 
+# Home Assistant custom integration (#613) - see Dockerfile.release.
+COPY custom_components/unified_hifi_control /app/custom_components/unified_hifi_control
+RUN rm -rf /app/custom_components/unified_hifi_control/tests \
+    /app/custom_components/unified_hifi_control/requirements_test.txt
+
 # Create data directory for config persistence
 RUN mkdir -p /data
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -13,6 +13,13 @@ ARG TARGETARCH
 COPY binaries/unified-hifi-linux-${TARGETARCH} /app/unified-hifi-control
 RUN chmod +x /app/unified-hifi-control
 
+# Home Assistant custom integration (#613) - see Dockerfile.release. Kept
+# identical here so branch/PR images behave like release images when the
+# add-on is pointed at one for testing.
+COPY custom_components/unified_hifi_control /app/custom_components/unified_hifi_control
+RUN rm -rf /app/custom_components/unified_hifi_control/tests \
+    /app/custom_components/unified_hifi_control/requirements_test.txt
+
 # Create data directory for config persistence
 RUN mkdir -p /data
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,6 +14,17 @@ COPY dist/unified-hifi-control /app/
 # Make binary executable
 RUN chmod +x /app/unified-hifi-control
 
+# Home Assistant custom integration (#613). The add-on image is built FROM
+# this one, and its run.sh copies this directory into Home Assistant's
+# config directory on start. Shipping it here rather than fetching it in the
+# add-on's Dockerfile is what locks the integration to the exact UHC release
+# it was built alongside: same tag, same API contract, no second version to
+# keep in sync. The test suite is stripped because Home Assistant loads this
+# directory as a Python package and the tests are not part of it.
+COPY custom_components/unified_hifi_control /app/custom_components/unified_hifi_control
+RUN rm -rf /app/custom_components/unified_hifi_control/tests \
+    /app/custom_components/unified_hifi_control/requirements_test.txt
+
 # Create data directory for config persistence
 RUN mkdir -p /data
 

--- a/docs/home_assistant_integration.md
+++ b/docs/home_assistant_integration.md
@@ -154,12 +154,50 @@ subdirectory. Rationale:
   session, or leave the flag unset for the interface this integration
   is pointed at.
 
+## Delivery: the add-on installs this (#613)
+
+The image this integration ships in is the one the Home Assistant add-on
+runs. `Dockerfile.release` (and `Dockerfile`/`Dockerfile.ci`, kept
+identical) copy `custom_components/unified_hifi_control` to
+`/app/custom_components/unified_hifi_control`, minus `tests/` — Home
+Assistant loads that directory as a Python package and the test suite is
+not part of it.
+
+Baking it into the base image rather than having the add-on's own
+Dockerfile fetch it from GitHub is deliberate: the add-on pins a UHC image
+tag, so the integration it installs is exactly the one built alongside
+that UHC release. A build-time fetch would introduce a second version to
+keep in sync, and a ref that can drift from the server it talks to.
+
+The add-on's `run.sh` copies it into `/homeassistant/custom_components` on
+start (install when absent, update when the bundled `manifest.json`
+`version` is newer, never over a newer copy, a copy the add-on did not
+install, or one the user has edited), then exports what it did as
+`UHC_HA_INTEGRATION_STATUS`/`_VERSION`/`_DETAIL` plus `UHC_ADDON=1`.
+`src/api/ha_integration.rs` reads those and asks Home Assistant's core API
+whether our domain is in its `components` list, which is how Settings can
+say "restart Home Assistant once" — the one step that is otherwise
+invisible, since HA only loads custom integrations at startup.
+
+Bumping `manifest.json`'s `version` is what makes an upgrade land on an
+existing add-on install. Without a bump, `run.sh` sees equal versions and
+does nothing.
+
+HACS installs are unaffected: a copy the add-on did not place carries no
+`.installed_by_uhc_addon` stamp, and the add-on leaves it alone.
+
 ## Choosing MQTT vs. this integration
 
+- **Under the add-on, this integration is the default and MQTT is off**
+  (#613). The add-on installs this for you and fills in the Supervisor's
+  broker details without switching publishing on, so MQTT is a one-click
+  opt-in for people who want it rather than something that happens to
+  them.
 - Use the MQTT path (PR #518 / issue #508) for lightweight dashboards
   and automations without installing a custom component, or when HA and
   UHC can't reach each other over plain HTTP but already share an MQTT
-  broker.
+  broker. For a **standalone** (non-add-on) UHC this remains the primary
+  route and its behaviour is unchanged.
 - Use this integration for real `media_player` entities: Assist voice
   control, media-player dashboard cards, and `media_player.*` service
   calls (play/pause/volume/seek/grouping) — none of which HA's MQTT

--- a/src/api/credentials.rs
+++ b/src/api/credentials.rs
@@ -338,6 +338,28 @@ pub enum MqttConfigSource {
     Environment,
 }
 
+/// Who switched the MQTT publisher on (#613).
+///
+/// Separate from [`MqttConfigSource`], which is about the broker *settings*:
+/// a user can perfectly well turn publishing on against a broker the add-on
+/// filled in for them, and that is a deliberate choice even though the
+/// settings are not theirs. The distinction decides one thing - whether UHC
+/// warns that Home Assistant is not consuming what it publishes. Warning
+/// someone about a setting they never chose is how #605 ended up nagging
+/// add-on users about MQTT they did not ask for.
+///
+/// [`MqttEnableSource::Automatic`] is the serde default on purpose. Records
+/// written before this field existed came from the add-on's own startup
+/// bootstrap, which enabled publishing without asking; treating them as the
+/// user's choice would resurrect exactly the warning this removes.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MqttEnableSource {
+    #[default]
+    Automatic,
+    User,
+}
+
 /// Broker connection details for the optional Home Assistant MQTT publisher
 /// (#508), kept in one encrypted record because the broker password is a
 /// secret alongside otherwise-plain connection settings.

--- a/src/api/ha_integration.rs
+++ b/src/api/ha_integration.rs
@@ -174,10 +174,9 @@ pub fn install_report_from_lookup(
             .filter(|value| !value.is_empty())
     };
     Some(InstallReport {
-        outcome: non_empty(STATUS_ENV)
-            .map_or(InstallOutcome::Unknown, |value| {
-                InstallOutcome::parse(&value)
-            }),
+        outcome: non_empty(STATUS_ENV).map_or(InstallOutcome::Unknown, |value| {
+            InstallOutcome::parse(&value)
+        }),
         version: non_empty(VERSION_ENV),
         detail: non_empty(DETAIL_ENV),
     })
@@ -430,11 +429,10 @@ mod tests {
 
     #[test]
     fn no_report_outside_the_addon() {
-        assert!(install_report_from_lookup(lookup(&[(
-            "UHC_HA_INTEGRATION_STATUS",
-            "installed"
-        )]))
-        .is_none());
+        assert!(
+            install_report_from_lookup(lookup(&[("UHC_HA_INTEGRATION_STATUS", "installed")]))
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/api/ha_integration.rs
+++ b/src/api/ha_integration.rs
@@ -1,0 +1,635 @@
+//! Where the Home Assistant custom integration stands (#613).
+//!
+//! An add-on cannot register entities - only an integration running inside
+//! Home Assistant core can. What an add-on *can* do is put that integration
+//! where core will find it, which is exactly what the add-on's `run.sh`
+//! does on every start: it copies `custom_components/unified_hifi_control`
+//! (baked into the UHC image) into Home Assistant's config directory.
+//!
+//! Copying the files is not the end of it. Home Assistant only loads custom
+//! integrations at startup, so a fresh install sits on disk doing nothing
+//! until the user restarts Home Assistant once - and nothing anywhere tells
+//! them that. This module is what lets Settings say it, from two pieces of
+//! evidence:
+//!
+//! 1. **What `run.sh` did**, handed over in `UHC_HA_INTEGRATION_*`. The
+//!    add-on already had to decide between install/update/no-op/refuse, so
+//!    it reports its own verdict rather than making UHC re-derive it from
+//!    a filesystem it may not even have mapped.
+//! 2. **Whether Home Assistant has loaded it**, from the same
+//!    `GET /core/api/config` `components` list that #610 uses for MQTT. Our
+//!    domain appears in that list exactly when core has the integration
+//!    loaded, so "files are there but the domain is missing" is precisely
+//!    the state that means "restart Home Assistant".
+//!
+//! Both halves degrade to "cannot tell" rather than to a guess: outside the
+//! add-on there is no report and no Supervisor token, and Settings must say
+//! nothing rather than invent a restart instruction for someone running
+//! UHC standalone.
+
+use std::sync::{Arc, OnceLock, RwLock};
+
+use tokio_util::sync::CancellationToken;
+
+use crate::mqtt::consumer::{core_api_credentials, POLL_INTERVAL, PROBE_TIMEOUT};
+
+/// Set by the add-on's `run.sh` and by nothing else. Its presence is what
+/// makes add-on-specific behaviour (integration messaging, MQTT staying off
+/// unless asked for) apply to add-on installs only.
+pub const ADDON_ENV: &str = "UHC_ADDON";
+/// The add-on's own verdict for this start; one of [`InstallOutcome`].
+pub const STATUS_ENV: &str = "UHC_HA_INTEGRATION_STATUS";
+/// Version of the integration that is now in Home Assistant's config
+/// directory, whether this start put it there or a previous one did.
+pub const VERSION_ENV: &str = "UHC_HA_INTEGRATION_VERSION";
+/// Why, in words, when the outcome alone is not enough to act on.
+pub const DETAIL_ENV: &str = "UHC_HA_INTEGRATION_DETAIL";
+
+/// The integration's Home Assistant domain, and therefore the string that
+/// appears in core's `components` list once it is loaded.
+pub const COMPONENT: &str = "unified_hifi_control";
+
+/// What the add-on did with the integration on this start.
+///
+/// Deliberately a closed set shared with `run.sh`: the shell script decides,
+/// UHC only reports. Anything unrecognised becomes [`InstallOutcome::Unknown`]
+/// so an add-on newer than this binary can never make Settings claim
+/// something false.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallOutcome {
+    /// Freshly copied in; Home Assistant has never seen it.
+    Installed,
+    /// Replaced an older copy the add-on had installed itself.
+    Updated,
+    /// Already the same version; nothing was written.
+    Current,
+    /// `install_integration: false`.
+    SkippedDisabled,
+    /// A copy the add-on did not install (HACS, or copied by hand).
+    SkippedForeign,
+    /// The add-on's own copy, but edited since. Never overwritten.
+    SkippedModified,
+    /// What is installed is newer than what this image carries.
+    SkippedNewer,
+    /// Home Assistant's config directory is not mapped into the add-on.
+    SkippedUnmapped,
+    /// Mapped, but read-only.
+    SkippedReadOnly,
+    /// This UHC image does not carry the integration at all.
+    Unavailable,
+    /// Something went wrong; `detail` says what.
+    Failed,
+    /// A value this binary does not know.
+    Unknown,
+}
+
+impl InstallOutcome {
+    pub fn parse(value: &str) -> Self {
+        match value.trim() {
+            "installed" => Self::Installed,
+            "updated" => Self::Updated,
+            "current" => Self::Current,
+            "skipped_disabled" => Self::SkippedDisabled,
+            "skipped_foreign" => Self::SkippedForeign,
+            "skipped_modified" => Self::SkippedModified,
+            "skipped_newer" => Self::SkippedNewer,
+            "skipped_unmapped" => Self::SkippedUnmapped,
+            "skipped_readonly" => Self::SkippedReadOnly,
+            "unavailable" => Self::Unavailable,
+            "failed" => Self::Failed,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Installed => "installed",
+            Self::Updated => "updated",
+            Self::Current => "current",
+            Self::SkippedDisabled => "skipped_disabled",
+            Self::SkippedForeign => "skipped_foreign",
+            Self::SkippedModified => "skipped_modified",
+            Self::SkippedNewer => "skipped_newer",
+            Self::SkippedUnmapped => "skipped_unmapped",
+            Self::SkippedReadOnly => "skipped_readonly",
+            Self::Unavailable => "unavailable",
+            Self::Failed => "failed",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Whether integration files are sitting in Home Assistant's config
+    /// directory as a result of this outcome.
+    ///
+    /// This is the gate on the "restart Home Assistant" message, so it errs
+    /// towards silence: [`InstallOutcome::Failed`] leaves whatever was there
+    /// before in place, which may be nothing, and telling someone to restart
+    /// for a copy that might not exist is worse than saying nothing.
+    pub fn integration_is_present(self) -> bool {
+        matches!(
+            self,
+            Self::Installed
+                | Self::Updated
+                | Self::Current
+                | Self::SkippedForeign
+                | Self::SkippedModified
+                | Self::SkippedNewer
+        )
+    }
+
+    /// Whether this start is what put a *new* version on disk. Only these
+    /// need the user to do anything at all.
+    pub fn changed_on_disk(self) -> bool {
+        matches!(self, Self::Installed | Self::Updated)
+    }
+}
+
+/// The add-on's report for this start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstallReport {
+    pub outcome: InstallOutcome,
+    pub version: Option<String>,
+    pub detail: Option<String>,
+}
+
+/// Read the report from the process environment. `None` when UHC is not
+/// running as the add-on, which is also the answer for a standalone install
+/// that happens to have an integration installed some other way - UHC has no
+/// business reporting on a copy it did not place.
+pub fn install_report() -> Option<InstallReport> {
+    install_report_from_lookup(|key| std::env::var(key).ok())
+}
+
+/// [`install_report`] against an arbitrary lookup, so the parsing rules are
+/// testable without mutating the process-global environment.
+pub fn install_report_from_lookup(
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<InstallReport> {
+    if !running_as_addon_from_lookup(&lookup) {
+        return None;
+    }
+    let non_empty = |key: &str| {
+        lookup(key)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    };
+    Some(InstallReport {
+        outcome: non_empty(STATUS_ENV)
+            .map_or(InstallOutcome::Unknown, |value| {
+                InstallOutcome::parse(&value)
+            }),
+        version: non_empty(VERSION_ENV),
+        detail: non_empty(DETAIL_ENV),
+    })
+}
+
+/// Whether this process was started by the Home Assistant add-on's `run.sh`.
+pub fn running_as_addon() -> bool {
+    running_as_addon_from_lookup(|key| std::env::var(key).ok())
+}
+
+pub fn running_as_addon_from_lookup(lookup: impl Fn(&str) -> Option<String>) -> bool {
+    matches!(
+        lookup(ADDON_ENV).as_deref().map(str::trim),
+        Some("1" | "true" | "TRUE" | "yes" | "on")
+    )
+}
+
+/// Whether Home Assistant core has our integration loaded.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LoadState {
+    /// Core lists our domain: the integration is running.
+    Loaded,
+    /// Core answered, and our domain is not in the list. The only state that
+    /// justifies telling someone to restart Home Assistant.
+    NotLoaded,
+    /// We could not ask, or could not understand the answer.
+    #[default]
+    Unknown,
+}
+
+impl LoadState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Loaded => "loaded",
+            Self::NotLoaded => "not_loaded",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Turn a `GET /core/api/config` body into a [`LoadState`].
+///
+/// Pure, and unfamiliar shapes land on [`LoadState::Unknown`] rather than on
+/// `NotLoaded` for the same reason #610 does it: "the answer looked
+/// unfamiliar" and "the integration is missing" must not be conflated when
+/// only one of them should send the user off to restart Home Assistant.
+pub fn classify_components(body: &serde_json::Value) -> LoadState {
+    let Some(components) = body.get("components").and_then(|value| value.as_array()) else {
+        return LoadState::Unknown;
+    };
+    if components
+        .iter()
+        .filter_map(|value| value.as_str())
+        // `components` carries platform entries like `media_player.foo`
+        // alongside bare domains; the bare domain is the one that means the
+        // integration itself is set up.
+        .any(|component| component == COMPONENT)
+    {
+        LoadState::Loaded
+    } else {
+        LoadState::NotLoaded
+    }
+}
+
+/// The latest answer, shared between the poll task and the settings API.
+#[derive(Debug, Default)]
+pub struct LoadMonitor {
+    state: RwLock<LoadState>,
+}
+
+impl LoadMonitor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self) -> LoadState {
+        self.state.read().map(|guard| *guard).unwrap_or_default()
+    }
+
+    pub fn set(&self, state: LoadState) {
+        if let Ok(mut guard) = self.state.write() {
+            *guard = state;
+        }
+    }
+}
+
+static LOAD_MONITOR: OnceLock<Arc<LoadMonitor>> = OnceLock::new();
+
+/// Process-wide, like the environment report it sits next to: whether Home
+/// Assistant has loaded our integration is a fact about the machine UHC runs
+/// on, not about any one request or `AppState`.
+pub fn load_monitor() -> Arc<LoadMonitor> {
+    LOAD_MONITOR
+        .get_or_init(|| Arc::new(LoadMonitor::new()))
+        .clone()
+}
+
+/// Poll Home Assistant for whether our integration is loaded yet.
+///
+/// Only meaningful under the add-on, where the Supervisor supplies a token;
+/// with no token there is nothing to ask and no task is spawned, leaving the
+/// monitor on its honest [`LoadState::Unknown`] default.
+///
+/// `shutdown` is the server's own token - a sleeping ticker would otherwise
+/// outlive Ctrl+C and hang graceful shutdown
+/// (`tests/spawn_cancellation_lint.rs`).
+pub fn spawn_load_poll(monitor: Arc<LoadMonitor>, shutdown: CancellationToken) {
+    let Some((url, token)) = core_api_credentials() else {
+        tracing::debug!(
+            "No Home Assistant API token available; \
+             not polling for the UHC integration's presence"
+        );
+        return;
+    };
+
+    let client = match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+        Ok(client) => client,
+        Err(error) => {
+            tracing::warn!(
+                "Could not build an HTTP client for the Home Assistant API: {error}; \
+                 not polling for the UHC integration's presence"
+            );
+            return;
+        }
+    };
+
+    tokio::spawn(async move {
+        // The first tick fires immediately: a user who just installed the
+        // add-on is looking at Settings now, not in a minute.
+        let mut ticker = tokio::time::interval(POLL_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut previous: Option<LoadState> = None;
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => break,
+                _ = ticker.tick() => {}
+            }
+            let state = probe_load(&client, &token, &url).await;
+            if previous != Some(state) {
+                match state {
+                    LoadState::Loaded => tracing::info!(
+                        "Home Assistant has loaded the Unified Hi-Fi Control integration"
+                    ),
+                    LoadState::NotLoaded => tracing::info!(
+                        "Home Assistant has not loaded the Unified Hi-Fi Control integration yet; \
+                         it needs one restart"
+                    ),
+                    LoadState::Unknown => tracing::debug!(
+                        "Could not determine whether Home Assistant has loaded the \
+                         Unified Hi-Fi Control integration"
+                    ),
+                }
+                previous = Some(state);
+            }
+            monitor.set(state);
+        }
+    });
+}
+
+/// One `GET /core/api/config`, classified. Every failure is
+/// [`LoadState::Unknown`]: this drives a "restart Home Assistant" message,
+/// and a transient network error must never produce one.
+pub async fn probe_load(client: &reqwest::Client, token: &str, url: &str) -> LoadState {
+    let Ok(response) = client
+        .get(url)
+        .bearer_auth(token)
+        .timeout(PROBE_TIMEOUT)
+        .send()
+        .await
+    else {
+        return LoadState::Unknown;
+    };
+    if !response.status().is_success() {
+        return LoadState::Unknown;
+    }
+    match response.json::<serde_json::Value>().await {
+        Ok(body) => classify_components(&body),
+        Err(_) => LoadState::Unknown,
+    }
+}
+
+/// `GET /api/home-assistant/integration` - what Settings needs to say
+/// whether the integration is there and whether Home Assistant has picked it
+/// up yet.
+///
+/// Every field is `"unknown"`/`false`/absent outside the add-on, so a
+/// standalone install renders nothing rather than an instruction that makes
+/// no sense there.
+#[derive(Debug, serde::Serialize, PartialEq, Eq)]
+pub struct IntegrationStatusResponse {
+    /// Whether UHC is running as the Home Assistant add-on.
+    pub addon: bool,
+    /// The add-on's verdict for this start; see [`InstallOutcome::as_str`].
+    /// Absent when UHC is not the add-on.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install: Option<String>,
+    /// Version now sitting in Home Assistant's config directory.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Why, when the outcome alone is not actionable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// `"loaded"`, `"not_loaded"`, or `"unknown"`.
+    pub loaded: String,
+    /// The one thing Settings acts on: files are in place, Home Assistant
+    /// has not loaded them, so the user needs to restart Home Assistant once.
+    /// Never true on a guess - [`LoadState::Unknown`] does not qualify.
+    pub needs_restart: bool,
+}
+
+pub async fn status() -> axum::Json<IntegrationStatusResponse> {
+    axum::Json(build_status(install_report(), load_monitor().get()))
+}
+
+/// The pure half of [`status`], so the "needs restart" rule is testable
+/// without an environment or a Home Assistant.
+pub fn build_status(report: Option<InstallReport>, loaded: LoadState) -> IntegrationStatusResponse {
+    let Some(report) = report else {
+        return IntegrationStatusResponse {
+            addon: false,
+            install: None,
+            version: None,
+            detail: None,
+            loaded: LoadState::Unknown.as_str().to_string(),
+            needs_restart: false,
+        };
+    };
+    IntegrationStatusResponse {
+        addon: true,
+        needs_restart: report.outcome.integration_is_present() && loaded == LoadState::NotLoaded,
+        install: Some(report.outcome.as_str().to_string()),
+        version: report.version,
+        detail: report.detail,
+        loaded: loaded.as_str().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| (*value).to_string())
+        }
+    }
+
+    #[test]
+    fn no_report_outside_the_addon() {
+        assert!(install_report_from_lookup(lookup(&[(
+            "UHC_HA_INTEGRATION_STATUS",
+            "installed"
+        )]))
+        .is_none());
+    }
+
+    #[test]
+    fn reads_the_addons_report() {
+        let report = install_report_from_lookup(lookup(&[
+            ("UHC_ADDON", "1"),
+            ("UHC_HA_INTEGRATION_STATUS", "installed"),
+            ("UHC_HA_INTEGRATION_VERSION", "1.2.0"),
+        ]))
+        .expect("running as the add-on");
+        assert_eq!(report.outcome, InstallOutcome::Installed);
+        assert_eq!(report.version.as_deref(), Some("1.2.0"));
+        assert_eq!(report.detail, None);
+    }
+
+    #[test]
+    fn an_unrecognised_status_never_claims_success() {
+        let report = install_report_from_lookup(lookup(&[
+            ("UHC_ADDON", "1"),
+            ("UHC_HA_INTEGRATION_STATUS", "teleported"),
+        ]))
+        .expect("running as the add-on");
+        assert_eq!(report.outcome, InstallOutcome::Unknown);
+        assert!(!report.outcome.integration_is_present());
+        assert!(!report.outcome.changed_on_disk());
+    }
+
+    #[test]
+    fn a_missing_status_is_unknown_not_installed() {
+        let report =
+            install_report_from_lookup(lookup(&[("UHC_ADDON", "1")])).expect("running as add-on");
+        assert_eq!(report.outcome, InstallOutcome::Unknown);
+    }
+
+    #[test]
+    fn empty_strings_are_absent_not_empty_values() {
+        let report = install_report_from_lookup(lookup(&[
+            ("UHC_ADDON", "1"),
+            ("UHC_HA_INTEGRATION_STATUS", "current"),
+            ("UHC_HA_INTEGRATION_VERSION", "   "),
+            ("UHC_HA_INTEGRATION_DETAIL", ""),
+        ]))
+        .expect("running as the add-on");
+        assert_eq!(report.version, None);
+        assert_eq!(report.detail, None);
+    }
+
+    #[test]
+    fn outcomes_round_trip_through_their_wire_strings() {
+        for outcome in [
+            InstallOutcome::Installed,
+            InstallOutcome::Updated,
+            InstallOutcome::Current,
+            InstallOutcome::SkippedDisabled,
+            InstallOutcome::SkippedForeign,
+            InstallOutcome::SkippedModified,
+            InstallOutcome::SkippedNewer,
+            InstallOutcome::SkippedUnmapped,
+            InstallOutcome::SkippedReadOnly,
+            InstallOutcome::Unavailable,
+            InstallOutcome::Failed,
+        ] {
+            assert_eq!(InstallOutcome::parse(outcome.as_str()), outcome);
+        }
+    }
+
+    #[test]
+    fn presence_is_about_files_not_about_success() {
+        // Refusing to touch someone else's copy still leaves a copy there.
+        assert!(InstallOutcome::SkippedForeign.integration_is_present());
+        assert!(InstallOutcome::SkippedModified.integration_is_present());
+        assert!(InstallOutcome::SkippedNewer.integration_is_present());
+        // These leave nothing we can vouch for.
+        assert!(!InstallOutcome::SkippedDisabled.integration_is_present());
+        assert!(!InstallOutcome::SkippedReadOnly.integration_is_present());
+        assert!(!InstallOutcome::SkippedUnmapped.integration_is_present());
+        assert!(!InstallOutcome::Unavailable.integration_is_present());
+        assert!(!InstallOutcome::Failed.integration_is_present());
+    }
+
+    #[test]
+    fn only_a_fresh_write_asks_the_user_to_do_anything() {
+        assert!(InstallOutcome::Installed.changed_on_disk());
+        assert!(InstallOutcome::Updated.changed_on_disk());
+        assert!(!InstallOutcome::Current.changed_on_disk());
+        assert!(!InstallOutcome::SkippedForeign.changed_on_disk());
+    }
+
+    #[test]
+    fn addon_flag_accepts_the_spellings_a_shell_script_produces() {
+        for value in ["1", "true", "yes", "on", " 1 "] {
+            assert!(running_as_addon_from_lookup(|_| Some(value.to_string())));
+        }
+        for value in ["0", "false", "no", "off", ""] {
+            assert!(!running_as_addon_from_lookup(|_| Some(value.to_string())));
+        }
+        assert!(!running_as_addon_from_lookup(|_| None));
+    }
+
+    #[test]
+    fn our_domain_in_components_means_loaded() {
+        let body = serde_json::json!({
+            "components": ["sensor", "mqtt", "unified_hifi_control", "media_player"]
+        });
+        assert_eq!(classify_components(&body), LoadState::Loaded);
+    }
+
+    #[test]
+    fn our_domain_absent_means_not_loaded() {
+        let body = serde_json::json!({ "components": ["sensor", "mqtt"] });
+        assert_eq!(classify_components(&body), LoadState::NotLoaded);
+    }
+
+    #[test]
+    fn a_platform_entry_is_not_the_integration() {
+        // `media_player.unified_hifi_control` appears once entities exist,
+        // but the bare domain is what says core loaded the integration.
+        let body = serde_json::json!({ "components": ["media_player.unified_hifi_control"] });
+        assert_eq!(classify_components(&body), LoadState::NotLoaded);
+    }
+
+    fn report(outcome: InstallOutcome) -> Option<InstallReport> {
+        Some(InstallReport {
+            outcome,
+            version: Some("1.2.0".to_string()),
+            detail: None,
+        })
+    }
+
+    #[test]
+    fn standalone_says_nothing_at_all() {
+        let status = build_status(None, LoadState::NotLoaded);
+        assert!(!status.addon);
+        assert!(!status.needs_restart);
+        assert_eq!(status.install, None);
+        assert_eq!(status.loaded, "unknown");
+    }
+
+    #[test]
+    fn installed_but_not_loaded_is_the_restart_case() {
+        let status = build_status(report(InstallOutcome::Installed), LoadState::NotLoaded);
+        assert!(status.needs_restart);
+        assert_eq!(status.install.as_deref(), Some("installed"));
+        assert_eq!(status.version.as_deref(), Some("1.2.0"));
+    }
+
+    #[test]
+    fn once_home_assistant_has_it_there_is_nothing_to_do() {
+        assert!(!build_status(report(InstallOutcome::Installed), LoadState::Loaded).needs_restart);
+        assert!(!build_status(report(InstallOutcome::Current), LoadState::Loaded).needs_restart);
+    }
+
+    #[test]
+    fn never_asks_for_a_restart_on_a_guess() {
+        // Cannot reach the Home Assistant API: saying "restart Home
+        // Assistant" would be inventing a problem.
+        assert!(!build_status(report(InstallOutcome::Installed), LoadState::Unknown).needs_restart);
+    }
+
+    #[test]
+    fn never_asks_for_a_restart_when_there_is_nothing_to_load() {
+        for outcome in [
+            InstallOutcome::SkippedDisabled,
+            InstallOutcome::SkippedReadOnly,
+            InstallOutcome::SkippedUnmapped,
+            InstallOutcome::Unavailable,
+            InstallOutcome::Failed,
+        ] {
+            assert!(
+                !build_status(report(outcome), LoadState::NotLoaded).needs_restart,
+                "{} should not ask for a restart",
+                outcome.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn a_copy_we_refused_to_touch_still_needs_loading() {
+        // HACS put it there, or the user edited ours. Either way the files
+        // exist and Home Assistant still has to be restarted to see them.
+        assert!(
+            build_status(report(InstallOutcome::SkippedForeign), LoadState::NotLoaded)
+                .needs_restart
+        );
+    }
+
+    #[test]
+    fn an_unfamiliar_answer_is_unknown_not_missing() {
+        assert_eq!(
+            classify_components(&serde_json::json!({ "version": "2026.8.0" })),
+            LoadState::Unknown
+        );
+        assert_eq!(
+            classify_components(&serde_json::json!({ "components": "everything" })),
+            LoadState::Unknown
+        );
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,6 +43,7 @@ pub mod apple_bridge;
 pub mod browse;
 pub mod controller_auth;
 pub mod credentials;
+pub mod ha_integration;
 pub mod ingress;
 pub mod mqtt_bootstrap;
 pub mod mqtt_settings;
@@ -3065,6 +3066,18 @@ pub struct AppSettings {
     pub hide_lms_page: bool,
     #[serde(default)]
     pub adapters: AdapterSettings,
+    /// Who turned `adapters.mqtt` on (#613).
+    ///
+    /// Not part of `AdapterSettings` because it is not an adapter toggle: it
+    /// is provenance for one, and the only thing that reads it is the
+    /// decision about whether to warn that Home Assistant is not consuming
+    /// what UHC publishes. Under the add-on, publishing that nobody asked
+    /// for must not produce a warning about nobody receiving it.
+    ///
+    /// `POST /api/settings` sets this itself rather than trusting the body,
+    /// so the client never has to know the field exists.
+    #[serde(default)]
+    pub mqtt_enabled_by: crate::api::credentials::MqttEnableSource,
     /// Zone IDs the user has hidden from every zone list.
     ///
     /// `Option` rather than `Vec` because this type is both the stored shape *and* the request body
@@ -3175,6 +3188,7 @@ impl Default for AppSettings {
                 musicassistant: false,
                 mqtt: false,
             },
+            mqtt_enabled_by: crate::api::credentials::MqttEnableSource::Automatic,
         }
     }
 }
@@ -3241,7 +3255,13 @@ fn mutate_app_settings(mutate: impl FnOnce(&mut AppSettings)) -> bool {
 /// not tell "the add-on switched this on for you" from "you switched it off",
 /// and the user's later decision to turn it off would not survive a restart.
 pub fn enable_mqtt_in_settings() -> bool {
-    mutate_app_settings(|settings| settings.adapters.mqtt = true)
+    mutate_app_settings(|settings| {
+        settings.adapters.mqtt = true;
+        // Nobody chose this; the environment did (#613). Recording that is
+        // what keeps the "Home Assistant isn't receiving this" warning off a
+        // publisher the user never asked for.
+        settings.mqtt_enabled_by = credentials::MqttEnableSource::Automatic;
+    })
 }
 
 /// Overwrite the settings wholesale. Test-only on purpose.
@@ -3368,6 +3388,21 @@ pub async fn api_settings_post_handler(
         if new_settings.zone_names.is_none() {
             new_settings.zone_names = current.zone_names.clone();
         }
+        // Provenance for the MQTT toggle (#613), decided here rather than
+        // taken from the body: a request that flips `mqtt` from off to on is
+        // a person clicking a switch, which is exactly what makes the
+        // "Home Assistant isn't receiving this" warning fair to show. Turning
+        // it off clears the flag, so a later automatic enable does not
+        // inherit a choice made about a different broker.
+        new_settings.mqtt_enabled_by = if new_settings.adapters.mqtt {
+            if current.adapters.mqtt {
+                current.mqtt_enabled_by
+            } else {
+                credentials::MqttEnableSource::User
+            }
+        } else {
+            credentials::MqttEnableSource::Automatic
+        };
         *current = new_settings.clone();
     });
 
@@ -3493,6 +3528,14 @@ pub async fn api_settings_post_handler(
     // simply turns its background publisher task on or off.
     if old_adapters.mqtt != new_adapters.mqtt {
         state.mqtt.set_enabled(new_adapters.mqtt).await;
+        // Keep the live publisher's copy of the provenance in step with the
+        // one just persisted (#613), so the status endpoint stops or starts
+        // qualifying for the "Home Assistant isn't receiving this" warning
+        // in the same request that flipped the toggle.
+        state
+            .mqtt
+            .set_enable_source(new_settings.mqtt_enabled_by)
+            .await;
         applied_transitions.push("mqtt");
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3254,13 +3254,17 @@ fn mutate_app_settings(mutate: impl FnOnce(&mut AppSettings)) -> bool {
 /// leave `app-settings.json` saying `mqtt: false`, so the *next* boot could
 /// not tell "the add-on switched this on for you" from "you switched it off",
 /// and the user's later decision to turn it off would not survive a restart.
-pub fn enable_mqtt_in_settings() -> bool {
+pub fn enable_mqtt_in_settings(source: credentials::MqttEnableSource) -> bool {
     mutate_app_settings(|settings| {
         settings.adapters.mqtt = true;
-        // Nobody chose this; the environment did (#613). Recording that is
-        // what keeps the "Home Assistant isn't receiving this" warning off a
-        // publisher the user never asked for.
-        settings.mqtt_enabled_by = credentials::MqttEnableSource::Automatic;
+        // Who gets the blame, and therefore the warning (#613). Outside the
+        // add-on, `UHC_MQTT_*` is the operator's own docker-compose or
+        // systemd unit - a deliberate choice, so
+        // [`credentials::MqttEnableSource::User`]. Under the add-on nothing
+        // reaches here at all any more; the only records left carrying
+        // `Automatic` are the ones an older add-on wrote before this
+        // distinction existed, which is exactly whose warning must stay off.
+        settings.mqtt_enabled_by = source;
     })
 }
 

--- a/src/api/mqtt_bootstrap.rs
+++ b/src/api/mqtt_bootstrap.rs
@@ -23,8 +23,22 @@
 //!    record actually changes. Once the setting is on disk, a user who turns
 //!    the toggle back off stays off across restarts - later boots see an
 //!    unchanged record and leave the toggle alone.
+//! 4. **Under the add-on, nothing is switched on at all (#613).** The add-on
+//!    installs UHC's own Home Assistant integration, which needs no broker,
+//!    so publishing every zone to MQTT by default means publishing to
+//!    something nobody asked for. The broker details are still adopted and
+//!    saved, which is the part with real value: the settings form comes up
+//!    filled in, and turning MQTT on is one click with nothing to type.
+//!    Standalone installs are unaffected - there, MQTT is the route into
+//!    Home Assistant, and auto-enabling it is the right default.
 //!
-//! The bootstrap decision itself is a pure function, [`plan`], so all four
+//!    This applies only to a configuration UHC has *not* seen before. An
+//!    install that was already publishing keeps publishing: its record is
+//!    unchanged, so it takes the `EnvironmentUnchanged` path and the toggle
+//!    in `app-settings.json` - already `true` - is left exactly as it is.
+//!    Upgrading never tears down something that works.
+//!
+//! The bootstrap decision itself is a pure function, [`plan`], so all five
 //! rules are unit-testable without touching the filesystem or the environment.
 
 use super::credentials::{MqttConfigSource, MqttCredentialRecord};
@@ -53,9 +67,15 @@ pub enum MqttBootstrap {
     /// memory, write nothing, and do not re-enable - that decision was made
     /// (and persisted) on the boot that first applied it.
     EnvironmentUnchanged(MqttCredentialRecord),
-    /// Save this record and turn the publisher on, so entities appear without
-    /// the user having to find the toggle.
-    ApplyEnvironment(MqttCredentialRecord),
+    /// Save this record. `enable` says whether to switch the publisher on
+    /// as well: true for a standalone install, where MQTT is the only route
+    /// into Home Assistant, and false under the add-on, where the installed
+    /// integration already is that route and the broker details are being
+    /// saved only so the user can opt in with one click (#613).
+    ApplyEnvironment {
+        record: MqttCredentialRecord,
+        enable: bool,
+    },
 }
 
 /// Read `UHC_MQTT_*` from the process environment.
@@ -137,11 +157,16 @@ fn parse_bool(value: &str) -> Option<bool> {
 
 /// Decide what startup does, given the stored record and the environment's.
 ///
+/// `running_as_addon` is the only piece of context that is not about the two
+/// records, and it decides rule 4: whether adopting a new environment config
+/// also switches publishing on.
+///
 /// Pure on purpose: the precedence rules in this module's documentation are
 /// the whole feature, and they are the part worth pinning down in tests.
 pub fn plan(
     stored: Option<MqttCredentialRecord>,
     environment: Option<MqttCredentialRecord>,
+    running_as_addon: bool,
 ) -> MqttBootstrap {
     match (stored, environment) {
         (None, None) => MqttBootstrap::Unconfigured,
@@ -152,11 +177,17 @@ pub fn plan(
             MqttBootstrap::UseStored(stored)
         }
         // Rules 2 and 3: an unchanged environment config writes nothing and
-        // re-enables nothing.
+        // re-enables nothing. This is also the migration path for an add-on
+        // install that was already publishing before rule 4 existed - it
+        // keeps whatever `app-settings.json` says, which is `true`.
         (Some(stored), Some(environment)) if stored == environment => {
             MqttBootstrap::EnvironmentUnchanged(stored)
         }
-        (_, Some(environment)) => MqttBootstrap::ApplyEnvironment(environment),
+        (_, Some(environment)) => MqttBootstrap::ApplyEnvironment {
+            record: environment,
+            // Rule 4.
+            enable: !running_as_addon,
+        },
     }
 }
 
@@ -276,8 +307,11 @@ mod tests {
     #[test]
     fn environment_applies_when_nothing_is_stored() {
         assert_eq!(
-            plan(None, Some(env_record())),
-            MqttBootstrap::ApplyEnvironment(env_record())
+            plan(None, Some(env_record()), false),
+            MqttBootstrap::ApplyEnvironment {
+                record: env_record(),
+                enable: true,
+            }
         );
     }
 
@@ -287,7 +321,7 @@ mod tests {
         // user's own broker is what stays configured - and because the plan
         // is `UseStored`, nothing re-enables the publisher behind their back.
         assert_eq!(
-            plan(Some(user_record()), Some(env_record())),
+            plan(Some(user_record()), Some(env_record()), false),
             MqttBootstrap::UseStored(user_record())
         );
     }
@@ -300,7 +334,7 @@ mod tests {
         let mut stored = env_record();
         stored.source = MqttConfigSource::User;
         assert_eq!(
-            plan(Some(stored.clone()), Some(env_record())),
+            plan(Some(stored.clone()), Some(env_record()), false),
             MqttBootstrap::UseStored(stored)
         );
     }
@@ -310,7 +344,7 @@ mod tests {
         // No save, no re-enable: restarting must not churn the encrypted
         // credential file or resurrect a toggle the user switched off.
         assert_eq!(
-            plan(Some(env_record()), Some(env_record())),
+            plan(Some(env_record()), Some(env_record()), false),
             MqttBootstrap::EnvironmentUnchanged(env_record())
         );
     }
@@ -320,8 +354,11 @@ mod tests {
         let mut rotated = env_record();
         rotated.password = Some("rotated".to_string());
         assert_eq!(
-            plan(Some(env_record()), Some(rotated.clone())),
-            MqttBootstrap::ApplyEnvironment(rotated)
+            plan(Some(env_record()), Some(rotated.clone()), false),
+            MqttBootstrap::ApplyEnvironment {
+                record: rotated,
+                enable: true,
+            }
         );
     }
 
@@ -332,13 +369,77 @@ mod tests {
         // rather than deleting the user's encrypted record out from under
         // them; turning the publisher off is the Settings toggle's job.
         assert_eq!(
-            plan(Some(env_record()), None),
+            plan(Some(env_record()), None, false),
             MqttBootstrap::UseStored(env_record())
         );
     }
 
     #[test]
     fn nothing_stored_and_nothing_in_the_environment_is_unconfigured() {
-        assert_eq!(plan(None, None), MqttBootstrap::Unconfigured);
+        assert_eq!(plan(None, None, false), MqttBootstrap::Unconfigured);
+    }
+
+    #[test]
+    fn under_the_addon_a_new_broker_is_filled_in_but_not_switched_on() {
+        // #613: the add-on installs the Home Assistant integration, so MQTT
+        // is optional there. Saving the record is what makes opting in one
+        // click with nothing to type; enabling it would be publishing every
+        // zone to a broker the user never asked to publish to.
+        assert_eq!(
+            plan(None, Some(env_record()), true),
+            MqttBootstrap::ApplyEnvironment {
+                record: env_record(),
+                enable: false,
+            }
+        );
+    }
+
+    #[test]
+    fn standalone_still_switches_a_new_broker_on() {
+        // Outside the add-on there is no integration doing the job instead,
+        // so MQTT remains the route into Home Assistant and #605's behaviour
+        // is exactly right.
+        assert_eq!(
+            plan(None, Some(env_record()), false),
+            MqttBootstrap::ApplyEnvironment {
+                record: env_record(),
+                enable: true,
+            }
+        );
+    }
+
+    #[test]
+    fn an_addon_install_that_was_already_publishing_is_left_alone() {
+        // The migration case: someone upgrading with MQTT already running.
+        // The stored record is unchanged, so this is `EnvironmentUnchanged`,
+        // which touches neither the record nor the toggle - whatever
+        // `app-settings.json` says (for them, enabled) still holds.
+        assert_eq!(
+            plan(Some(env_record()), Some(env_record()), true),
+            MqttBootstrap::EnvironmentUnchanged(env_record())
+        );
+    }
+
+    #[test]
+    fn under_the_addon_a_rotated_password_does_not_switch_publishing_on() {
+        // Credentials the Supervisor rotates must not become a back door for
+        // re-enabling a publisher the user left off.
+        let mut rotated = env_record();
+        rotated.password = Some("rotated".to_string());
+        assert_eq!(
+            plan(Some(env_record()), Some(rotated.clone()), true),
+            MqttBootstrap::ApplyEnvironment {
+                record: rotated,
+                enable: false,
+            }
+        );
+    }
+
+    #[test]
+    fn the_users_own_broker_still_wins_under_the_addon() {
+        assert_eq!(
+            plan(Some(user_record()), Some(env_record()), true),
+            MqttBootstrap::UseStored(user_record())
+        );
     }
 }

--- a/src/api/mqtt_settings.rs
+++ b/src/api/mqtt_settings.rs
@@ -8,7 +8,9 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
-use super::credentials::{MqttConfigSource, MqttCredentialRecord, MqttCredentialStore};
+use super::credentials::{
+    MqttConfigSource, MqttCredentialRecord, MqttCredentialStore, MqttEnableSource,
+};
 use super::AppState;
 use crate::mqtt::{DEFAULT_BASE_TOPIC, DEFAULT_DISCOVERY_PREFIX, DEFAULT_PORT, DEFAULT_TLS_PORT};
 
@@ -62,6 +64,16 @@ pub struct MqttStatusResponse {
     /// something the user should fill in.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Whether a person deliberately chose to publish over MQTT (#613),
+    /// rather than the add-on having switched it on for them.
+    ///
+    /// Either half counts: saving broker settings through
+    /// `POST /api/mqtt/configure` (which marks the record `"user"`), or
+    /// flipping the toggle in Settings. It gates one thing - the
+    /// "Home Assistant isn't receiving this" warning - because warning
+    /// someone about a publisher they never asked for is noise, and #605
+    /// auto-enabling MQTT under the add-on made that the common case.
+    pub user_opted_in: bool,
     /// Whether Home Assistant is actually reading what we publish (#610):
     /// `"consuming"`, `"not_configured"`, or `"unknown"`.
     ///
@@ -91,6 +103,8 @@ impl From<crate::mqtt::MqttStatus> for MqttStatusResponse {
             discovery_prefix: status.discovery_prefix,
             has_username: status.has_username,
             has_password: status.has_password,
+            user_opted_in: status.source == Some(MqttConfigSource::User)
+                || status.enable_source == MqttEnableSource::User,
             home_assistant: status.home_assistant.as_str().to_string(),
             home_assistant_detail: status.home_assistant_detail,
             source: status.source.map(|source| {

--- a/src/api/mqtt_settings.rs
+++ b/src/api/mqtt_settings.rs
@@ -215,6 +215,7 @@ mod tests {
             has_username: true,
             has_password: true,
             source: Some("user".to_string()),
+            user_opted_in: true,
             home_assistant: "consuming".to_string(),
             home_assistant_detail: None,
         }
@@ -253,6 +254,7 @@ mod tests {
             has_username: false,
             has_password: false,
             source: Some(MqttConfigSource::Environment),
+            enable_source: MqttEnableSource::Automatic,
             home_assistant: HomeAssistantState::Unknown,
             home_assistant_detail: None,
         };
@@ -293,6 +295,7 @@ mod tests {
             has_username: false,
             has_password: false,
             source: None,
+            enable_source: MqttEnableSource::Automatic,
             home_assistant: HomeAssistantState::default(),
             home_assistant_detail: None,
         });
@@ -319,6 +322,7 @@ mod tests {
             has_username: true,
             has_password: true,
             source: Some(MqttConfigSource::Environment),
+            enable_source: MqttEnableSource::Automatic,
             home_assistant: HomeAssistantState::NotConfigured,
             home_assistant_detail: None,
         });
@@ -345,6 +349,7 @@ mod tests {
             has_username: false,
             has_password: false,
             source: Some(MqttConfigSource::User),
+            enable_source: MqttEnableSource::Automatic,
             home_assistant: HomeAssistantState::Unknown,
             home_assistant_detail: Some("not running as a Home Assistant add-on".to_string()),
         }))

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -311,6 +311,63 @@ pub struct MqttStatusResponse {
     /// Why we cannot tell, when we cannot (#610). Diagnostic, not copy.
     #[serde(default)]
     pub home_assistant_detail: Option<String>,
+    /// Whether a person deliberately chose to publish over MQTT, rather than
+    /// the Home Assistant add-on having switched it on for them (#613).
+    ///
+    /// Defaults to `false` against a server that predates the field, which
+    /// is the quiet direction: an old server pairs with old behaviour, where
+    /// the add-on auto-enabled MQTT, and that is precisely the case that
+    /// should not produce a warning.
+    #[serde(default)]
+    pub user_opted_in: bool,
+}
+
+/// Where UHC's own Home Assistant integration stands (#613), from
+/// `GET /api/home-assistant/integration`.
+///
+/// Every field is inert outside the Home Assistant add-on, so a standalone
+/// install renders none of this rather than instructions that make no sense
+/// there.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct HomeAssistantIntegrationStatus {
+    /// Whether UHC is running as the Home Assistant add-on.
+    #[serde(default)]
+    pub addon: bool,
+    /// What the add-on did on this start: `"installed"`, `"updated"`,
+    /// `"current"`, `"skipped_*"`, `"unavailable"`, `"failed"`.
+    #[serde(default)]
+    pub install: Option<String>,
+    /// Version now in Home Assistant's config directory.
+    #[serde(default)]
+    pub version: Option<String>,
+    /// Why, when the outcome alone is not actionable. Diagnostic, not copy.
+    #[serde(default)]
+    pub detail: Option<String>,
+    /// `"loaded"`, `"not_loaded"`, or `"unknown"`.
+    #[serde(default)]
+    pub loaded: String,
+    /// The integration is installed and Home Assistant has not loaded it:
+    /// one restart away from working. The server never sets this on a guess.
+    #[serde(default)]
+    pub needs_restart: bool,
+}
+
+impl HomeAssistantIntegrationStatus {
+    /// Home Assistant has the integration running. Nothing to tell the user.
+    pub fn is_loaded(&self) -> bool {
+        self.loaded == "loaded"
+    }
+
+    /// The add-on could not put the integration in place, and the user has
+    /// to do something about it. Not the same as `!needs_restart`: skipping
+    /// because a copy is already there, or because the user opted out, is
+    /// not a problem.
+    pub fn install_blocked(&self) -> bool {
+        matches!(
+            self.install.as_deref(),
+            Some("skipped_readonly" | "skipped_unmapped" | "unavailable" | "failed")
+        )
+    }
 }
 
 impl MqttStatusResponse {
@@ -356,12 +413,33 @@ impl MqttStatusResponse {
         self.is_connected() && self.home_assistant == "not_configured"
     }
 
+    /// Whether to *warn* about [`Self::home_assistant_missing`] (#613).
+    ///
+    /// The fact and the warning came apart when the add-on started
+    /// installing UHC's own Home Assistant integration. MQTT is then
+    /// optional, and an add-on that switched it on by itself would otherwise
+    /// have UHC scolding the user for not finishing a setup they never
+    /// started. So the warning needs a person behind it: someone who saved
+    /// broker settings, or who flipped the toggle.
+    ///
+    /// Standalone installs are unaffected in practice - they have no add-on
+    /// to auto-enable anything, so anyone publishing there opted in.
+    pub fn should_warn_home_assistant_missing(&self) -> bool {
+        self.home_assistant_missing() && self.user_opted_in
+    }
+
     /// We are publishing but cannot establish whether anyone reads it -
     /// typically a UHC that is not running as a Home Assistant add-on, so
     /// there is no Supervisor to ask. Worth one quiet, non-accusatory line;
     /// never a warning.
     pub fn home_assistant_undetermined(&self) -> bool {
         self.is_connected() && !self.home_assistant_is_consuming() && !self.home_assistant_missing()
+    }
+
+    /// The broker is filled in and waiting, but publishing is off (#613).
+    /// The one-click opt-in state an add-on user lands in.
+    pub fn ready_to_opt_in(&self) -> bool {
+        self.configured && !self.enabled && self.is_environment_managed()
     }
 
     /// `mqtt://host:port` for the configured broker, so an error can name

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -674,6 +674,8 @@ pub fn Settings() -> Element {
     let mut mqtt_tls = use_signal(|| false);
     // ⓘ disclosure for what the Home Assistant side has to do (#605).
     let mut mqtt_info_open = use_signal(|| false);
+    // The same disclosure for the integration card (#613).
+    let mut ha_info_open = use_signal(|| false);
     // When the add-on supplies the broker there is nothing for the user to
     // fill in, so the manual form starts collapsed rather than sitting there
     // pre-filled and inviting them to re-enter settings they never chose.
@@ -988,6 +990,18 @@ pub fn Settings() -> Element {
         crate::app::api::fetch_json::<MqttStatusResponse>("/api/mqtt/status")
             .await
             .ok()
+    });
+    // Where UHC's own Home Assistant integration stands (#613). Fetched once
+    // rather than polled: the two things it reports - what the add-on did on
+    // this start, and whether Home Assistant has loaded the result - only
+    // change when the add-on restarts or Home Assistant does, and either of
+    // those reloads this page anyway.
+    let ha_integration = use_resource(|| async {
+        crate::app::api::fetch_json::<crate::app::api::HomeAssistantIntegrationStatus>(
+            "/api/home-assistant/integration",
+        )
+        .await
+        .ok()
     });
 
     use_effect(move || {
@@ -1607,6 +1621,11 @@ pub fn Settings() -> Element {
     } else {
         MQTT_INFO_PANEL_CLOSED
     };
+    let ha_info_panel_class = if ha_info_open() {
+        MQTT_INFO_PANEL_OPEN
+    } else {
+        MQTT_INFO_PANEL_CLOSED
+    };
     // The Home Assistant add-on hands the broker over from the Supervisor
     // (#605). When it has, there is nothing here for the user to fill in, so
     // the manual form collapses behind an opt-in rather than presenting
@@ -1617,6 +1636,11 @@ pub fn Settings() -> Element {
         .flatten()
         .is_some_and(|status| status.is_environment_managed());
     let mqtt_show_manual_form = !mqtt_env_managed || mqtt_manual_open();
+    // Running as the Home Assistant add-on (#613). Everything add-on-specific
+    // on this page hangs off this: the integration card, and the fact that
+    // MQTT is optional here rather than the way in.
+    let ha_status = ha_integration.read().clone().flatten();
+    let is_addon = ha_status.as_ref().is_some_and(|status| status.addon);
 
     rsx! {
         Layout {
@@ -1933,7 +1957,7 @@ pub fn Settings() -> Element {
                                                 // itself is going (#610). This
                                                 // row used to show a green tick
                                                 // for exactly that case.
-                                                if status.home_assistant_missing() {
+                                                if status.should_warn_home_assistant_missing() {
                                                     button {
                                                         r#type: "button",
                                                         class: "text-yellow-500 underline text-left",
@@ -1965,6 +1989,13 @@ pub fn Settings() -> Element {
                                                 }
                                             }
                                         } else { "..." }
+                                    } else if is_addon {
+                                        // Under the add-on this is not a
+                                        // missing feature (#613): the
+                                        // integration above already puts
+                                        // zones into Home Assistant, and
+                                        // MQTT is a second, optional route.
+                                        span { class: "text-muted", "Off — not needed, the integration handles this" }
                                     } else {
                                         span { class: "text-muted", "Off — no Home Assistant entities" }
                                     }
@@ -2813,6 +2844,120 @@ pub fn Settings() -> Element {
                 }
             }
 
+            // Home Assistant integration (#613). Add-on only: on a standalone
+            // install the add-on never ran, so there is no install to report
+            // and no restart to ask for, and this whole block stays out of
+            // the way.
+            if let Some(ha) = ha_status.clone() {
+                if ha.addon {
+                    section {
+                        id: "ha-integration",
+                        class: "mb-8",
+                        aria_labelledby: "ha-integration-heading",
+                        div { class: "mb-4",
+                            div { class: "flex items-center gap-2",
+                                h2 { id: "ha-integration-heading", class: "text-xl font-semibold",
+                                    "Home Assistant"
+                                }
+                                // Same ⓘ disclosure as the MQTT section
+                                // (#597): one line on screen, the detail
+                                // one click away.
+                                span { class: "group relative shrink-0",
+                                    button {
+                                        r#type: "button",
+                                        class: "flex h-8 w-8 items-center justify-center rounded-full text-muted",
+                                        aria_expanded: ha_info_open(),
+                                        aria_controls: "ha-integration-info",
+                                        aria_label: "More about the Home Assistant integration",
+                                        onclick: move |_| {
+                                            let open = *ha_info_open.peek();
+                                            ha_info_open.set(!open);
+                                        },
+                                        "ⓘ"
+                                    }
+                                    div { id: "ha-integration-info", class: ha_info_panel_class, role: "note",
+                                        p { "This add-on copies the Unified Hi-Fi Control integration into Home Assistant for you. Home Assistant only picks up new integrations when it starts, which is why it needs one restart." }
+                                        p { class: "mt-2", "After the restart, look under Settings → Devices & services → Discovered. UHC finds itself on your network, so there is nothing to type." }
+                                        p { class: "mt-2", "Each zone becomes a media player you can play, pause, seek, group, and set the volume on." }
+                                        p { class: "mt-2", "A copy you installed yourself through HACS, or one you have edited, is never overwritten." }
+                                        p { class: "mt-2", "Turn this off with the add-on's install_integration option if you would rather manage it yourself." }
+                                    }
+                                }
+                            }
+                            p { class: "text-muted text-sm mt-1",
+                                "Your zones as Home Assistant media players. No broker needed."
+                            }
+                        }
+                        div { class: "card p-5 sm:p-6",
+                            div { class: "text-sm",
+                                if ha.needs_restart {
+                                    // The one thing on this page that asks
+                                    // the user to act. It is also invisible
+                                    // everywhere else: nothing in Home
+                                    // Assistant says "an add-on left an
+                                    // integration here for you".
+                                    p { id: "ha-needs-restart", class: "text-yellow-500 font-medium",
+                                        "Restart Home Assistant once to finish setting this up"
+                                    }
+                                    p { class: "mt-1 text-secondary",
+                                        "The integration is installed and waiting. Go to Settings → System, then use the restart button at the top right."
+                                    }
+                                    p { class: "mt-1 text-secondary",
+                                        "After that, Unified Hi-Fi Control appears under Settings → Devices & services → Discovered."
+                                    }
+                                } else if ha.is_loaded() {
+                                    p { id: "ha-integration-loaded", class: "status-ok",
+                                        "Home Assistant has the integration — your zones are media players there"
+                                    }
+                                    p { class: "mt-1 text-secondary",
+                                        "If you have not added it yet, it is waiting under Settings → Devices & services → Discovered."
+                                    }
+                                } else if ha.install_blocked() {
+                                    // Everything the add-on could not do.
+                                    // One line each, and always an
+                                    // alternative - UHC itself is fine.
+                                    p { id: "ha-integration-blocked", class: "status-err font-medium",
+                                        "The integration could not be installed"
+                                    }
+                                    p { class: "mt-1 text-secondary",
+                                        match ha.install.as_deref() {
+                                            Some("skipped_readonly") | Some("skipped_unmapped") => "The add-on could not write to Home Assistant's configuration folder. Everything else here keeps working.",
+                                            Some("unavailable") => "This version of the add-on does not carry the integration yet. Updating the add-on is the fix.",
+                                            _ => "Check the add-on's Log tab for the reason. Everything else here keeps working.",
+                                        }
+                                    }
+                                    p { class: "mt-1 text-secondary",
+                                        "You can also install it through HACS, or set up MQTT below instead."
+                                    }
+                                } else if ha.install.as_deref() == Some("skipped_disabled") {
+                                    p { class: "text-secondary",
+                                        "Not installed — the add-on's install_integration option is off."
+                                    }
+                                } else if ha.install.as_deref() == Some("skipped_foreign") {
+                                    p { class: "text-secondary",
+                                        "You have your own copy of the integration installed. The add-on leaves it alone."
+                                    }
+                                } else if ha.install.as_deref() == Some("skipped_modified") {
+                                    p { class: "text-secondary",
+                                        "Your edited copy of the integration is being kept as-is."
+                                    }
+                                } else {
+                                    // Files are in place; whether Home
+                                    // Assistant has them is `unknown` - a
+                                    // restart instruction here would be a
+                                    // guess, so say only what is certain.
+                                    p { class: "text-secondary",
+                                        "The integration is installed. If your zones are not in Home Assistant yet, restart Home Assistant once and look under Settings → Devices & services → Discovered."
+                                    }
+                                }
+                                if let Some(version) = ha.version.clone() {
+                                    p { class: "mt-2 text-muted text-xs", "Integration version {version}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             div { id: "mqtt-anchor",
                 section {
                     class: "mb-8",
@@ -2853,7 +2998,14 @@ pub fn Settings() -> Element {
                                 }
                             }
                         }
-                        p { class: "text-muted text-sm mt-1", "Your zones and controllers show up in Home Assistant as entities. Point Home Assistant's MQTT integration at the same broker and they appear on their own." }
+                        p { class: "text-muted text-sm mt-1",
+                            if is_addon {
+                                // #613: MQTT is no longer the way in here.
+                                "Optional. The integration above already puts your zones in Home Assistant; this publishes them over MQTT as well, for setups that want it."
+                            } else {
+                                "Your zones and controllers show up in Home Assistant as entities. Point Home Assistant's MQTT integration at the same broker and they appear on their own."
+                            }
+                        }
                     }
                     div { class: "card p-5 sm:p-6",
                         if let Some(status) = mqtt_status.read().clone().flatten() {
@@ -2869,18 +3021,32 @@ pub fn Settings() -> Element {
                                 // than by "the task exists" (#607). Only the
                                 // first branch is success; a broker that
                                 // never answers now has to say so.
-                                if status.home_assistant_missing() {
+                                if status.should_warn_home_assistant_missing() {
                                     // The failure #610 is about: our own half
                                     // is flawless, and the user still has no
                                     // entities. The click path is the whole
                                     // fix, so it stays on screen rather than
                                     // behind the ⓘ - only the reassurance
                                     // moves in there.
+                                    //
+                                    // #613 added the gate: only warn someone
+                                    // who chose to publish. The add-on used
+                                    // to switch MQTT on by itself, and this
+                                    // warning then blamed the user for not
+                                    // finishing a setup they never started.
                                     p { id: "mqtt-ha-missing", class: "text-yellow-500 font-medium",
                                         "Your zones are being published, but Home Assistant isn't set up to receive them"
                                     }
                                     p { class: "mt-1 text-secondary",
                                         "In Home Assistant, go to Settings → Devices & services → Add integration → MQTT. Your zones then appear on their own."
+                                    }
+                                } else if status.home_assistant_missing() {
+                                    // Same fact, nobody asked for it. State
+                                    // it plainly and point at the thing that
+                                    // does work, rather than raising an alarm
+                                    // about a setting the add-on chose.
+                                    p { id: "mqtt-ha-missing-quiet", class: "text-secondary",
+                                        "Publishing to your broker. Home Assistant's MQTT integration isn't set up, so nothing is reading it — which is fine if you are using the integration above instead."
                                     }
                                 } else if status.home_assistant_is_consuming() {
                                     p { id: "mqtt-ha-consuming", class: "status-ok",

--- a/src/main.rs
+++ b/src/main.rs
@@ -688,13 +688,39 @@ mod server {
                                         // so switching MQTT on as well would
                                         // publish to a broker nobody asked to
                                         // publish to.
+                                        //
+                                        // "Do not turn it on" is not "turn it
+                                        // off". Someone already publishing
+                                        // whose Supervisor rotated the broker
+                                        // password arrives here with a changed
+                                        // record and `mqtt: true` on disk;
+                                        // dropping them to silent would be
+                                        // this change breaking the very setup
+                                        // it promises not to touch.
+                                        let already_on = app_settings.adapters.mqtt;
+                                        if already_on {
+                                            state.mqtt.set_enabled(true).await;
+                                        }
                                         tracing::info!(
                                             broker = %format!("{host}:{port}"),
+                                            enabled = already_on,
                                             "MQTT broker details from the Home Assistant add-on saved; \
-                                             publishing stays off until you turn it on in Settings"
+                                             publishing is left exactly as it was"
                                         );
-                                    } else if api::enable_mqtt_in_settings() {
+                                    } else if api::enable_mqtt_in_settings(
+                                        api::credentials::MqttEnableSource::User,
+                                    ) {
                                         state.mqtt.set_enabled(true).await;
+                                        // Standalone: whoever set UHC_MQTT_*
+                                        // chose this, so the #610 warning
+                                        // about Home Assistant not consuming
+                                        // it still belongs to them (#613).
+                                        state
+                                            .mqtt
+                                            .set_enable_source(
+                                                api::credentials::MqttEnableSource::User,
+                                            )
+                                            .await;
                                         tracing::info!(
                                             broker = %format!("{host}:{port}"),
                                             "MQTT configured from environment; publisher enabled"

--- a/src/main.rs
+++ b/src/main.rs
@@ -644,6 +644,18 @@ mod server {
         // the winner, so an install with no entities can be diagnosed from
         // the add-on log alone.
         state.mqtt.set_base_url(base_url.clone());
+        // Whether the add-on's run.sh started us (#613). It decides one thing
+        // here: a broker handed over by the Supervisor is adopted either way,
+        // but only a standalone install has MQTT switched on for it, because
+        // only there is MQTT the route into Home Assistant.
+        let running_as_addon = api::ha_integration::running_as_addon();
+        // Mirror the persisted provenance of the MQTT toggle so
+        // `GET /api/mqtt/status` can answer "did a person choose this?"
+        // without reading app-settings.json on every poll.
+        state
+            .mqtt
+            .set_enable_source(app_settings.mqtt_enabled_by)
+            .await;
         let environment_mqtt = match api::mqtt_bootstrap::from_env() {
             Ok(config) => config,
             Err(error) => {
@@ -658,8 +670,8 @@ mod server {
             Ok(store) => match store.load() {
                 Ok(stored) => {
                     use api::mqtt_bootstrap::MqttBootstrap;
-                    match api::mqtt_bootstrap::plan(stored, environment_mqtt) {
-                        MqttBootstrap::ApplyEnvironment(record) => {
+                    match api::mqtt_bootstrap::plan(stored, environment_mqtt, running_as_addon) {
+                        MqttBootstrap::ApplyEnvironment { record, enable } => {
                             let host = record.host.clone();
                             let port = record.port;
                             // Save before enabling: a publisher running off a
@@ -668,15 +680,28 @@ mod server {
                             match store.save(&record) {
                                 Ok(()) => {
                                     state.mqtt.configure(record).await;
-                                    if api::enable_mqtt_in_settings() {
+                                    if !enable {
+                                        // Add-on install (#613): the broker is
+                                        // now filled in, and that is all. The
+                                        // integration this add-on installs is
+                                        // what puts zones into Home Assistant,
+                                        // so switching MQTT on as well would
+                                        // publish to a broker nobody asked to
+                                        // publish to.
+                                        tracing::info!(
+                                            broker = %format!("{host}:{port}"),
+                                            "MQTT broker details from the Home Assistant add-on saved; \
+                                             publishing stays off until you turn it on in Settings"
+                                        );
+                                    } else if api::enable_mqtt_in_settings() {
                                         state.mqtt.set_enabled(true).await;
                                         tracing::info!(
                                             broker = %format!("{host}:{port}"),
-                                            "MQTT configured from environment (Home Assistant add-on); publisher enabled"
+                                            "MQTT configured from environment; publisher enabled"
                                         );
                                     } else {
                                         tracing::warn!(
-                                            "MQTT configured from environment (Home Assistant add-on) \
+                                            "MQTT configured from environment \
                                              but the setting could not be saved; enable it in Settings"
                                         );
                                     }
@@ -760,6 +785,16 @@ mod server {
         // spawning anything.
         mqtt::consumer::spawn_core_poll(state.mqtt.consumer_monitor(), shutdown_token.clone());
 
+        // Whether Home Assistant has actually loaded the integration the
+        // add-on installed (#613). Same core API, different question: the
+        // files being on disk is not the same as core having them, and the
+        // gap between the two is one Home Assistant restart that nothing
+        // else would tell the user about.
+        api::ha_integration::spawn_load_poll(
+            api::ha_integration::load_monitor(),
+            shutdown_token.clone(),
+        );
+
         // Clone state for shutdown diagnostics
         let state_for_shutdown = state.clone();
 
@@ -791,6 +826,7 @@ mod server {
         let controller_bootstrap = api::controller_auth::bootstrap;
         let controller_status = api::controller_auth::status;
         let api_mqtt_status = api::mqtt_settings::status;
+        let api_ha_integration_status = api::ha_integration::status;
         let api_mqtt_configure = api::mqtt_settings::configure;
         #[rustfmt::skip]
         let router = Router::new()
@@ -812,6 +848,7 @@ mod server {
             // MQTT/Home Assistant discovery publisher settings (#508)
             .route("/api/mqtt/status", get(api_mqtt_status))
             .route("/api/mqtt/configure", post(api_mqtt_configure))
+            .route("/api/home-assistant/integration", get(api_ha_integration_status))
             .route("/api/bridges/applemusic/pair", post(api_bridge_pair))
             .route("/api/bridges/applemusic/discover", post(api_bridge_discover_pairing))
             .route("/api/bridges/applemusic/claim", post(api_bridge_claim))

--- a/src/mqtt/consumer.rs
+++ b/src/mqtt/consumer.rs
@@ -363,7 +363,7 @@ pub const NOT_AN_ADDON: &str =
 /// Separated from [`spawn_core_poll`] so the precedence is visible: an
 /// explicit override always wins over the Supervisor's own token, because
 /// someone who set one is deliberately pointing at a specific instance.
-fn core_api_credentials() -> Option<(String, String)> {
+pub fn core_api_credentials() -> Option<(String, String)> {
     let non_empty = |key: &str| std::env::var(key).ok().filter(|value| !value.is_empty());
     let url = non_empty(CORE_URL_ENV).unwrap_or_else(|| CORE_CONFIG_URL.to_string());
     let token = non_empty(CORE_TOKEN_ENV).or_else(|| non_empty(SUPERVISOR_TOKEN_ENV))?;

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -55,7 +55,7 @@ use crate::knobs::store::Knob;
 use crate::knobs::KnobStore;
 use consumer::{ConsumerMonitor, HomeAssistantState};
 
-pub use crate::api::credentials::{MqttConfigSource, MqttCredentialRecord};
+pub use crate::api::credentials::{MqttConfigSource, MqttCredentialRecord, MqttEnableSource};
 
 /// How often knob state/discovery is re-published, since the knob store has
 /// no bus events of its own to react to (see module doc).
@@ -173,6 +173,10 @@ struct RunningTask {
 struct Runtime {
     record: Option<MqttCredentialRecord>,
     enabled: bool,
+    /// Who last switched `enabled` on (#613), mirrored from
+    /// `app-settings.json` so the settings API can answer it without a disk
+    /// read on every five-second poll.
+    enable_source: MqttEnableSource,
     task: Option<RunningTask>,
 }
 
@@ -229,6 +233,12 @@ pub struct MqttStatus {
     /// unconfigured. Lets Settings show an add-on-managed broker as managed
     /// instead of inviting the user to re-type details they never entered.
     pub source: Option<MqttConfigSource>,
+    /// Who turned the publisher on (#613). Distinct from [`MqttStatus::source`],
+    /// which is about the broker settings: an add-on user can deliberately
+    /// enable publishing against a broker they never typed in. Only a
+    /// deliberate enable earns the "Home Assistant isn't receiving this"
+    /// warning.
+    pub enable_source: MqttEnableSource,
     /// Whether Home Assistant's own MQTT integration is reading what we
     /// publish (#610). The layer above `connection`: a broker we reach
     /// happily can still have nobody on the other side of it.
@@ -421,9 +431,18 @@ impl MqttPublisher {
                 .as_ref()
                 .is_some_and(|r| r.password.as_ref().is_some_and(|p| !p.is_empty())),
             source: runtime.record.as_ref().map(|r| r.source),
+            enable_source: runtime.enable_source,
             home_assistant: consumer.state,
             home_assistant_detail: consumer.detail,
         }
+    }
+
+    /// Record who switched the publisher on (#613). Called at startup from
+    /// the persisted setting and again whenever `POST /api/settings` changes
+    /// the toggle, so the answer survives a restart the same way the toggle
+    /// itself does.
+    pub async fn set_enable_source(&self, source: MqttEnableSource) {
+        self.runtime.lock().await.enable_source = source;
     }
 
     /// Stop the publisher for shutdown, publishing "offline" for a clean

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -21,6 +21,7 @@ GET /api/bridges/applemusic/content
 GET /api/bridges/applemusic/status
 GET /api/collections/image
 GET /api/controller/status
+GET /api/home-assistant/integration
 GET /api/mqtt/status
 GET /api/providers/musicassistant/status
 GET /api/providers/spotify/account


### PR DESCRIPTION
Closes #613.

An add-on cannot register entities — only an integration running inside Home Assistant core can. But it can put that integration where core will find it. This is the UHC half of that: ship `custom_components/unified_hifi_control` inside the UHC image, report what the add-on did with it, and stop steering add-on users toward MQTT they never asked for.

Add-on half: **open-horizon-labs/uhc-home-assistant-addon** → PR link in the comment below (branch `issue/613-install-integration`).

Acceptance from the issue — install the add-on, restart HA once, zones are `media_player` entities with no broker, no HACS, no file copying — is met by the two PRs together.

---

## What gets copied where

`Dockerfile.release`, `Dockerfile.ci`, and `Dockerfile` each add:

```
COPY custom_components/unified_hifi_control /app/custom_components/unified_hifi_control
RUN rm -rf .../tests .../requirements_test.txt
```

**Why the base image and not the add-on's Dockerfile.** The add-on pins a UHC image tag, so baking the integration in means the copy it installs is *exactly* the one built alongside that UHC release — same tag, same API contract. Having the add-on's Dockerfile fetch it from GitHub at build time would create a second version to keep in sync and a ref that can drift from the server it talks to. `tests/` is stripped because Home Assistant loads the directory as a Python package.

The add-on's `run.sh` copies `/app/custom_components/unified_hifi_control` → `/homeassistant/custom_components/unified_hifi_control`.

**Note for the coordinator:** the add-on's currently pinned tag (`3.7.0-alpha.6`) predates this, so it carries no `custom_components`. `run.sh` handles that explicitly (`unavailable`, one log line, UHC starts normally). The first UHC release built from this branch is the first one that can actually install anything.

## Version rules

Comparison is on `manifest.json` `version` (semver core, with a release outranking a pre-release of the same core). The add-on:

- installs when the destination is absent,
- updates when the bundled version is newer,
- does nothing when equal,
- **refuses** when the installed copy is newer, was not installed by the add-on (no `.installed_by_uhc_addon` stamp — HACS or a manual copy), or has been edited since the add-on wrote it (sha256 manifest recorded at install; `__pycache__` Home Assistant creates is not counted as an edit).

Bumping `manifest.json` `version` is what makes an upgrade land on an existing install. Without a bump, `run.sh` sees equal versions and no-ops. Recorded in `docs/home_assistant_integration.md`.

## Failure modes (all non-fatal — UHC always starts)

| Situation | `UHC_HA_INTEGRATION_STATUS` | What the user sees |
|---|---|---|
| Copied in fresh | `installed` | Log + Settings: restart HA once |
| Replaced an older copy of ours | `updated` | Log + Settings: restart HA once |
| Same version already there | `current` | Log: already up to date |
| `install_integration: false` | `skipped_disabled` | Settings: not installed, option is off |
| HACS/manual copy present | `skipped_foreign` | Settings: your own copy is left alone |
| Our copy, edited by the user | `skipped_modified` | Settings: your edits are kept |
| Installed copy is newer | `skipped_newer` | Log: leaving it alone |
| `/homeassistant` not mapped | `skipped_unmapped` | Settings: could not write; use HACS or MQTT |
| `/homeassistant` read-only | `skipped_readonly` | same |
| Image has no bundled integration | `unavailable` | Settings: update the add-on |
| Write failed mid-way | `failed` | Settings: check the add-on log; previous copy restored |

Settings never says "restart Home Assistant" on a guess: it needs files positively present **and** core positively reporting our domain absent. An unreachable core API is `unknown` and renders nothing.

## The MQTT default change

**Under the add-on, MQTT no longer switches itself on.** Broker details from the Supervisor are still adopted and saved, so the settings form comes up filled in and opting in is one click with nothing to type — #605's real value, without publishing uninvited.

`mqtt_bootstrap::plan` gains a `running_as_addon` argument (from `UHC_ADDON=1`, set only by the add-on's `run.sh`) and `ApplyEnvironment` becomes `{ record, enable }`. Standalone keeps `enable: true` — there MQTT *is* the route into Home Assistant and auto-enabling is correct.

### Migration: nothing is torn down

You currently have MQTT auto-enabled and connected to core-mosquitto. On upgrade:

- Your stored record is unchanged, so the plan is `EnvironmentUnchanged`, which writes nothing and touches no toggle. `app-settings.json` still says `mqtt: true`, so **you keep publishing exactly as you do now.**
- If the Supervisor ever rotates the broker password, the record *changes* and lands on `ApplyEnvironment { enable: false }`. That branch explicitly re-enables when `adapters.mqtt` is already `true`: "do not turn it on" is not "turn it off", and silently dropping a working publisher to nothing would be this change breaking the setup it promises not to touch. (This was a real bug in my first draft, caught during the live probe.)
- What *does* change for you: the "publishing, but Home Assistant isn't receiving it" warning goes quiet, because you never chose MQTT — the add-on chose it for you.

### The warning now needs a person behind it

`MqttCredentialRecord.source` alone could not express this: someone can deliberately flip the MQTT toggle against a broker the add-on filled in, and that record's source is still `environment`. So there is a second, persisted signal — `AppSettings.mqtt_enabled_by: MqttEnableSource` (`automatic` | `user`, serde default `automatic`):

- `POST /api/settings` sets it to `user` itself when `mqtt` goes off→on. The client never has to know the field exists.
- The standalone startup bootstrap sets `user` — whoever set `UHC_MQTT_*` in their compose file chose this.
- The default is `automatic` so that **legacy files written by the old add-on auto-enable read as "nobody chose this"** — precisely the case whose warning must stop.

`GET /api/mqtt/status` exposes the combination as `user_opted_in` (`record.source == user || mqtt_enabled_by == user`), and the UI gates the warning on `should_warn_home_assistant_missing()`. The fact is still stated when it is not a warning, in a quiet, non-accusatory line.

**Standalone is unchanged** — verified live, see below. #607/#610's honest states stay exactly as they were.

### `publish_to_home_assistant` default

Kept at `true`, with its meaning narrowed to "hand the broker details over so opting in is one click", and the option's description rewritten to say so. Flipping it to `false` would also stop the auto-fill, which is the half worth keeping — the actual publishing decision moved into UHC where it can be gated on being the add-on. Renaming the key would invalidate stored options on every existing install for no behavioural gain.

## New in Settings

A **Home Assistant** section, add-on only, above the (now demoted) MQTT section. Uses the ⓘ disclosure pattern from #597 that the MQTT section already uses. Beginner-first: one line on screen, detail one click away.

- Installed, HA hasn't loaded it → "Restart Home Assistant once to finish setting this up", the click path, and where UHC then appears.
- Loaded → "Home Assistant has the integration — your zones are media players there".
- Blocked → what failed, in one line, plus the alternatives (HACS, or MQTT below).
- MQTT section summary under the add-on becomes "Optional. The integration above already puts your zones in Home Assistant…"; the adapter row's off-state becomes "Off — not needed, the integration handles this".

#605/#610's work in `settings.rs` is reframed and reordered, not deleted.

## New API

`GET /api/home-assistant/integration` → `{ addon, install, version, detail, loaded, needs_restart }`. Pinned in `tests/fixtures/api_routes.txt`; **needs the `api-change-approved` label.** Every field is inert outside the add-on.

## Evidence

**Add-on install logic** — 46 assertions against a stub config directory, run as a non-root user inside `alpine:3.20` with busybox sh + jq (production's exact shell), all passing: fresh install, no-op when current, older upgrade, pre-release vs release ordering, newer refused, HACS copy refused, edited copy refused, `__pycache__` not counted as an edit, opt-out respected (including the `jq '.foo // true'` trap — explicit `false`, explicit `true`, and absent are all covered), read-only dir, unmapped dir, blocked path, no bundled integration, no `options.json`. `run.sh` exits 0 in every failure case. Test lives in the add-on PR.

**Rust gates** (toolchain 1.97.1, `RUSTC_WRAPPER=""`): `cargo test` all green (~1,900 assertions across 60 binaries), `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean, `cargo test --doc` clean, `cargo check --target wasm32-unknown-unknown --no-default-features --features web` clean.

**Live browser probe** — release build served on the LAN IP (`http://192.168.1.176:8091`), driven with claude-in-chrome against system Chrome. Real mosquitto in Docker as the broker; a stub Home Assistant core API reporting a `components` list with neither `mqtt` nor `unified_hifi_control` loaded.

*Add-on simulation, migration state* (`UHC_ADDON=1`, integration installed, `mqtt: true` + `mqtt_enabled_by: automatic` seeded, i.e. your current setup):

- Log: `MQTT broker details from the Home Assistant add-on saved; publishing is left exactly as it was broker=127.0.0.1:1884 enabled=true` — **still publishing.**
- `/api/mqtt/status`: `connection: connected`, `home_assistant: not_configured`, `user_opted_in: false`.
- Page: Home Assistant card renders "Restart Home Assistant once to finish setting this up" + version. `#mqtt-ha-missing` (yellow warning) **absent**; the quiet line renders instead. Adapter row reads `✓ Publishing · via add-on`, not a scolding.
- Toggling MQTT off: adapter row reads "Off — not needed, the integration handles this"; MQTT section hides.
- Toggling it back on **through the UI**: `user_opted_in: true` (persisted as `"mqtt_enabled_by": "user"`), and the yellow warning returns in both the adapter row and the section — #610 intact for anyone who actually chose MQTT.

*Standalone, same binary and broker, `UHC_ADDON` unset:*

- Log: `MQTT configured from environment; publisher enabled` — #605 unchanged.
- `/api/home-assistant/integration`: `{"addon":false,"loaded":"unknown","needs_restart":false}`; the Home Assistant card does not render at all.
- `user_opted_in: true`, yellow warning shows, MQTT summary keeps its original wording. **Standalone is untouched.**

All probe processes and containers were stopped by PID/name afterwards. `adapters.roon=false` throughout.

## Not in scope

The integration's own functionality (#613 says so) and the HACS default listing (#614). No add-on version or pinned image tag bumped — that is the coordinator's.

## No CI

Per this repo's stacked-PR convention, a PR based on `integration/streaming-ha-alpha` runs no workflows. Everything above was verified locally.
