### PR TITLE
fix(roon): recover a rejected item key by re-walking its trail (#616)

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -50,6 +50,17 @@ const BROWSE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Default search result limit
 const DEFAULT_SEARCH_LIMIT: usize = 50;
 
+/// Page size used when re-walking a browse trail (#616). Larger than a UI
+/// page because nothing is rendered from it -- it is scanned for one title.
+const TRAIL_PAGE_SIZE: usize = 100;
+
+/// How deep into a single level a trail re-walk will scan before giving up.
+/// Roon offers no "find the row named X" verb, so a level is paged through;
+/// this bounds that against a level with hundreds of thousands of rows. A
+/// container that lives past this cap fails recovery and the caller reports
+/// the Core's original rejection.
+const TRAIL_SCAN_LIMIT: usize = 5_000;
+
 /// Category names returned by Roon search - these are containers, not playable items
 const CATEGORY_NAMES: &[&str] = &[
     "Albums",
@@ -3025,6 +3036,21 @@ impl RoonAdapter {
     /// that plays a top-level item whose own action fires immediately (see
     /// [`Self::resolve_item_key`]'s docs) still gets a human-readable
     /// message instead of the raw `item_key`.
+    /// # Recovering a key the Core no longer honours (#616)
+    ///
+    /// Re-entering the minting session is right whenever that session still
+    /// exists. When it does not, the Core answers `InvalidItemKey` and the
+    /// old behaviour was to hand the human that rejection verbatim --
+    /// "search or browse again to get a fresh key" -- which asks them to
+    /// perform, by hand, a walk this adapter can perform itself.
+    ///
+    /// So a rejection is now a retry, not a verdict: given `trail` (the
+    /// titles from the browse root down to this item, carried on the ref
+    /// since #616), [`Self::resolve_trail`] re-walks it in a fresh session,
+    /// mints an equivalent key, and the play is attempted once more. The
+    /// caller only sees an error when recovery itself fails -- and then it
+    /// is the *original* rejection that surfaces, because that is the one
+    /// that describes what actually went wrong.
     pub async fn play_ref(
         &self,
         item_key: &str,
@@ -3032,6 +3058,7 @@ impl RoonAdapter {
         zone_id: &str,
         action: PlayAction,
         fallback_title: &str,
+        trail: &[String],
     ) -> Result<String> {
         if item_key.is_empty() {
             return Err(anyhow::anyhow!("item_key cannot be empty"));
@@ -3041,14 +3068,152 @@ impl RoonAdapter {
         }
 
         let bare_zone_id = strip_roon_prefix(zone_id);
+        let first = self
+            .resolve_item_key(
+                multi_session_key,
+                item_key,
+                bare_zone_id,
+                action,
+                Some(fallback_title),
+            )
+            .await;
+
+        let Err(error) = first else {
+            return first;
+        };
+
+        // Only a key the Core actively rejected is worth re-walking. A
+        // timeout, a lost Core, or a zone that does not exist are not fixed
+        // by minting a fresh key, and retrying them would double the wait.
+        if !matches!(
+            RoonBrowseError::from_error(&error).map(|rejection| rejection.kind),
+            Some(RoonBrowseErrorKind::InvalidItemKey)
+        ) {
+            return Err(error);
+        }
+        if trail.is_empty() {
+            return Err(error);
+        }
+
+        tracing::info!(
+            session_key = %multi_session_key,
+            trail = ?trail,
+            "roon: item key rejected; re-walking its trail in a fresh session"
+        );
+
+        let Ok((recovered_session, recovered_key)) = self.resolve_trail(zone_id, trail).await
+        else {
+            return Err(error);
+        };
         self.resolve_item_key(
-            multi_session_key,
-            item_key,
+            &recovered_session,
+            &recovered_key,
             bare_zone_id,
             action,
             Some(fallback_title),
         )
         .await
+        .map_err(|_| error)
+    }
+
+    /// Re-walk `trail` -- titles from the browse root down to and including
+    /// the wanted item -- in a session minted for this walk, and report
+    /// `(session_key, item_key)` for the item it lands on.
+    ///
+    /// This is the recovery half of #616. It deliberately starts from the
+    /// root with `pop_all` in a *fresh* session rather than reusing the
+    /// caller's: the caller's session is, by the time this runs, the one the
+    /// Core just rejected a key from.
+    ///
+    /// Titles are matched exactly. Roon has no "find the row named X" browse
+    /// verb, so each level is paged through until the title turns up or the
+    /// level is exhausted; [`TRAIL_SCAN_LIMIT`] caps that so a walk down a
+    /// hundred-thousand-track list cannot run away. A title that has since
+    /// been renamed, or moved past the cap, simply fails the walk -- the
+    /// caller then reports the original rejection, which is the honest
+    /// answer.
+    pub(crate) async fn resolve_trail(
+        &self,
+        zone_id: &str,
+        trail: &[String],
+    ) -> Result<(String, String)> {
+        if trail.is_empty() {
+            return Err(anyhow::anyhow!("cannot re-walk an empty trail"));
+        }
+        let bare_zone_id = strip_roon_prefix(zone_id);
+        let session_key = format!(
+            "recover_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        );
+
+        // Land on the browse root. Safe to `pop_all` here precisely because
+        // the session is new: no key anyone holds was minted in it.
+        self.browse(BrowseOpts {
+            multi_session_key: Some(session_key.clone()),
+            zone_or_output_id: Some(bare_zone_id.to_string()),
+            pop_all: true,
+            ..Default::default()
+        })
+        .await?;
+
+        let mut found_key: Option<String> = None;
+        for (depth, title) in trail.iter().enumerate() {
+            // Descend into the previous match before looking for this one.
+            if let Some(parent_key) = found_key.take() {
+                self.browse(BrowseOpts {
+                    multi_session_key: Some(session_key.clone()),
+                    item_key: Some(parent_key),
+                    zone_or_output_id: Some(bare_zone_id.to_string()),
+                    ..Default::default()
+                })
+                .await?;
+            }
+            let matched = self
+                .find_titled_row(&session_key, title)
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "re-walking the browse trail lost the row {title:?} at depth {depth}"
+                    )
+                })?;
+            found_key = Some(matched);
+        }
+
+        let item_key = found_key
+            .ok_or_else(|| anyhow::anyhow!("re-walking the browse trail found no item key"))?;
+        Ok((session_key, item_key))
+    }
+
+    /// Page through the level `session_key` is currently on, looking for a
+    /// row whose title matches `title` exactly. `Ok(None)` means the level
+    /// was read to its end (or to [`TRAIL_SCAN_LIMIT`]) without a match.
+    async fn find_titled_row(&self, session_key: &str, title: &str) -> Result<Option<String>> {
+        let mut offset = 0usize;
+        loop {
+            let page = self
+                .load(LoadOpts {
+                    multi_session_key: Some(session_key.to_string()),
+                    offset,
+                    count: Some(TRAIL_PAGE_SIZE),
+                    ..Default::default()
+                })
+                .await?;
+            let fetched = page.items.len();
+            for item in page.items {
+                if item.title == title {
+                    if let Some(key) = item.item_key {
+                        return Ok(Some(key));
+                    }
+                }
+            }
+            offset += fetched;
+            if fetched == 0 || offset >= page.list.count.min(TRAIL_SCAN_LIMIT) {
+                return Ok(None);
+            }
+        }
     }
 
     /// Browse `item_key` within `session_key` and report what came back:

--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -3101,9 +3101,15 @@ impl RoonAdapter {
             "roon: item key rejected; re-walking its trail in a fresh session"
         );
 
-        let Ok((recovered_session, recovered_key)) = self.resolve_trail(zone_id, trail).await
-        else {
-            return Err(error);
+        let (recovered_session, recovered_key) = match self.resolve_trail(zone_id, trail).await {
+            Ok(pair) => pair,
+            Err(recovery_error) => {
+                tracing::info!(
+                    error = %recovery_error,
+                    "roon: could not re-walk the trail; reporting the Core's original rejection"
+                );
+                return Err(error);
+            }
         };
         self.resolve_item_key(
             &recovered_session,
@@ -3172,7 +3178,7 @@ impl RoonAdapter {
                 .await?;
             }
             let matched = self
-                .find_titled_row(&session_key, title)
+                .find_titled_row(&session_key, title, depth == 0)
                 .await?
                 .ok_or_else(|| {
                     anyhow::anyhow!(
@@ -3188,9 +3194,23 @@ impl RoonAdapter {
     }
 
     /// Page through the level `session_key` is currently on, looking for a
-    /// row whose title matches `title` exactly. `Ok(None)` means the level
-    /// was read to its end (or to [`TRAIL_SCAN_LIMIT`]) without a match.
-    async fn find_titled_row(&self, session_key: &str, title: &str) -> Result<Option<String>> {
+    /// row whose title matches `title`. `Ok(None)` means the level was read
+    /// to its end (or to [`TRAIL_SCAN_LIMIT`]) without a match.
+    ///
+    /// Trails are recorded from what the *client* was shown, and
+    /// `map_collection_page` does not show rows verbatim: it renames the
+    /// root's "Library" row to "Local Library" (#573 defect 4) and strips
+    /// `[[id|Name]]` link markup from every other title (#573 defect 5). So
+    /// matching has to compare against the same rendering, or a trail can
+    /// never find the row it names -- which is how the first cut of this
+    /// walk failed at depth 0. `at_root` selects the rename, exactly as the
+    /// mapping's own `at_collection_root` does.
+    async fn find_titled_row(
+        &self,
+        session_key: &str,
+        title: &str,
+        at_root: bool,
+    ) -> Result<Option<String>> {
         let mut offset = 0usize;
         loop {
             let page = self
@@ -3203,7 +3223,12 @@ impl RoonAdapter {
                 .await?;
             let fetched = page.items.len();
             for item in page.items {
-                if item.title == title {
+                let shown = if at_root && item.title == "Library" {
+                    "Local Library".to_string()
+                } else {
+                    strip_roon_link_markup(&item.title)
+                };
+                if shown == title {
                     if let Some(key) = item.item_key {
                         return Ok(Some(key));
                     }

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -105,10 +105,29 @@ const TOKEN_PREFIX: &str = "ref_";
 /// private session per call and the item keys it returns are scoped to that
 /// session (see `src/adapters/roon.rs::search_with_session`); resolution must
 /// re-enter that exact session (`RoonAdapter::play_ref`), never a fresh one.
+/// # Why the pair alone is not enough (#616)
+///
+/// An `(item_key, multi_session_key)` pair is only meaningful while the Core
+/// still holds that session. When it does not -- the extension reconnected,
+/// the Core restarted, or the session aged out -- the pair is unrecoverable
+/// on its own: nothing in it says *what* the key pointed at, so the only
+/// answer left is to tell the human to browse again. That is the error
+/// reported in #616, and asking the user to redo a walk we could redo
+/// ourselves is the part they feel.
+///
+/// [`Self::trail`] is what makes recovery possible: the titles from the
+/// browse root down to this item, accumulated as the user descends. Given
+/// the trail, `RoonAdapter::resolve_trail` can re-walk it in a fresh session
+/// and mint an equivalent key, so a rejected ref becomes a retry rather than
+/// an apology. It is best-effort: an empty trail simply means no recovery is
+/// possible for that ref, exactly as before.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoonRefTarget {
     pub item_key: String,
     pub multi_session_key: String,
+    /// Titles from the browse root down to and including this item. Empty
+    /// when the minting surface could not supply one.
+    pub trail: Vec<String>,
 }
 
 /// What a ref resolves to, independent of the opaque token a client holds.
@@ -469,6 +488,7 @@ mod tests {
             target: RoonRefTarget {
                 item_key: item_key.to_string(),
                 multi_session_key: session.to_string(),
+                trail: vec![title.to_string()],
             },
             title: title.to_string(),
         }

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -94,6 +94,26 @@ pub const DEFAULT_CAPACITY: usize = 512;
 /// How long a ref remains resolvable after it is minted. Uniform across every
 /// provider and target kind -- see the module docs for why that is a
 /// deliberate choice, not an oversight.
+///
+/// # Measured against a real Roon Core (#616)
+///
+/// #616 asked whether this should instead track the lifetime of the Roon
+/// browse session a ref depends on. Measured read-only against the
+/// operator's production Core (Roon 2.x, 2026-08), by minting eleven
+/// independent deep browse refs at once and probing one per interval
+/// without touching the others:
+///
+/// | idle | result |
+/// |------|--------|
+/// | 30s, 90s, 180s, 300s, 480s, 660s, **840s** | resolves normally |
+/// | 1020s | gone -- **this TTL**, at 900s, not the Core |
+///
+/// So a Roon browse session outlives this TTL rather than the other way
+/// round: shortening it to "match Roon" would discard refs the Core is
+/// still perfectly willing to honour, and lengthening it is what
+/// [`RoonRefTarget::trail`] now makes safe rather than necessary. Left
+/// uniform and unchanged; the recovery path, not the clock, is what makes a
+/// stale key survivable.
 pub const DEFAULT_TTL: Duration = Duration::from_secs(15 * 60);
 
 const TOKEN_PREFIX: &str = "ref_";

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -557,11 +557,19 @@ async fn handle_roon(
     if let Some(RoonRefTarget {
         item_key,
         multi_session_key,
+        ..
     }) = &resume
     {
         params["item_key"] = json!(item_key);
         params["session_key"] = json!(multi_session_key);
     }
+    // #616: the trail this page hangs off. Children extend it by their own
+    // title, so every ref minted below carries the full root-to-item walk
+    // and can be re-resolved after its session is gone.
+    let parent_trail: Vec<String> = resume
+        .as_ref()
+        .map(|target| target.trail.clone())
+        .unwrap_or_default();
     // Roon has no separate playlists/favorites protocol feature: both arrive
     // as named nodes in the same browse hierarchy (see the capability
     // table's note on this). `favorites` never reaches here -- `support()`
@@ -626,9 +634,12 @@ async fn handle_roon(
         let (path, r#ref) = match item_key {
             None => (None, None),
             Some(item_key) => {
+                let mut trail = parent_trail.clone();
+                trail.push(title.clone());
                 let target = RoonRefTarget {
                     item_key: item_key.to_string(),
                     multi_session_key: session_key.to_string(),
+                    trail,
                 };
                 let path = if navigable {
                     Some(

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -378,9 +378,15 @@ pub async fn handle_search(
                             });
                             continue;
                         };
+                        // #616: a search hit's trail is its own title. A
+                        // search is not a walk from the browse root, so
+                        // re-resolution for these goes through the search
+                        // itself rather than a root descent -- recorded
+                        // here so the ref is self-describing either way.
                         let target = RoonRefTarget {
                             item_key,
                             multi_session_key: session_key.clone(),
+                            trail: vec![title.clone()],
                         };
                         // #396 (found live, ship-gate re-review): a real
                         // Core's search results mix the actual hit with
@@ -1148,6 +1154,7 @@ async fn play_ref_roon(
             &args.zone_id,
             action,
             &title,
+            &target.trail,
         )
         .await
     {

--- a/tests/mock_servers/roon_core.rs
+++ b/tests/mock_servers/roon_core.rs
@@ -683,6 +683,27 @@ struct CoreState {
     rejected_keys: HashSet<String>,
     /// Per-key override of the rejection's message *name*.
     rejection_names: HashMap<String, String>,
+    /// Session keys the Core has forgotten (#616).
+    ///
+    /// A browse session is Core-side state, so it does not outlive the Core's
+    /// view of the extension: reconnecting the extension, restarting the
+    /// Core, or ageing a session out all leave the client holding an
+    /// `(item_key, multi_session_key)` pair that no longer names anything.
+    /// The Core's answer then is `InvalidItemKey` -- the rejection the
+    /// operator reported in #616, naming the very `collections_<nanos>`
+    /// session the key was minted in.
+    ///
+    /// Measured (read-only, against the operator's production Core, Roon 2.x,
+    /// 2026-08): eviction is **not** driven by session count -- 400 further
+    /// sessions minted back-to-back left an untouched earlier key resolving
+    /// normally -- nor by navigating that session elsewhere. So this models
+    /// session loss as the discrete event it is, driven by a test knob,
+    /// rather than inventing a count or timeout rule the Core does not have.
+    ///
+    /// A `pop_all` browse naming a forgotten session revives it at the root,
+    /// as a real Core does for any session key it has not seen before; only
+    /// keys minted before the loss stay rejected.
+    dropped_sessions: HashSet<String>,
     /// One-shot: the next browse, whatever it is, is rejected.
     reject_next_browse: bool,
     /// One-shot: the next browse carrying `pop_levels` is rejected with
@@ -755,6 +776,7 @@ impl FakeRoonCore {
             item_key_scope: ItemKeyScope::Global,
             rejected_keys: HashSet::new(),
             rejection_names: HashMap::new(),
+            dropped_sessions: HashSet::new(),
             reject_next_browse: false,
             reject_next_pop_levels: false,
             delay: Duration::ZERO,
@@ -891,6 +913,29 @@ impl FakeRoonCore {
 
     pub async fn set_item_key_scope(&self, scope: ItemKeyScope) {
         self.state.write().await.item_key_scope = scope;
+    }
+
+    /// Forget every browse session the Core is currently holding (#616).
+    ///
+    /// Models the discrete event behind the operator's report: the extension
+    /// reconnects, or the Core restarts, and every `multi_session_key` a
+    /// client still holds a key for stops naming anything. Afterwards, a
+    /// browse carrying an `item_key` in one of those sessions is answered
+    /// `InvalidItemKey`; a `pop_all` browse revives the session name at the
+    /// root, exactly as a never-before-seen session key would behave.
+    ///
+    /// See [`CoreState::dropped_sessions`] for why this is a knob rather
+    /// than a modelled count or timeout rule.
+    pub async fn drop_all_sessions(&self) {
+        let mut state = self.state.write().await;
+        let keys: Vec<String> = state.sessions.keys().cloned().collect();
+        for key in &keys {
+            state.sessions.remove(key);
+            for servers in state.minted.values_mut() {
+                servers.remove(key);
+            }
+        }
+        state.dropped_sessions.extend(keys);
     }
 
     /// One-shot: refuse the next browse that carries `pop_levels` (with
@@ -1581,6 +1626,21 @@ async fn handle_browse(
         drop(state);
         refuse(core, writer, "InvalidItemKey", req_id, &session_key).await;
         return;
+    }
+
+    // --- a session the Core has forgotten (#616) ----------------------------
+    // A `pop_all` request revives the name at the root (a real Core treats an
+    // unknown session key as a new session); anything that leans on state the
+    // lost session held -- an `item_key` minted there, a `pop_levels` step
+    // out of a peek -- is `InvalidItemKey`.
+    if state.dropped_sessions.contains(&session_key) {
+        if pop_all {
+            state.dropped_sessions.remove(&session_key);
+        } else {
+            drop(state);
+            refuse(core, writer, "InvalidItemKey", req_id, &session_key).await;
+            return;
+        }
     }
 
     // --- targeted pop_levels rejection (#593 review follow-up) --------------

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -1698,6 +1698,7 @@ async fn roon_play_ref_matches_playlist_verb_and_reports_no_error() {
             "roon:zone_fake_1",
             PlayAction::Play,
             "An Introduction to Qobuz",
+            &[],
         )
         .await
         .expect("playing a playlist ref must succeed, not report a false error");
@@ -1746,6 +1747,7 @@ async fn roon_play_ref_does_not_silently_substitute_queue_for_an_unavailable_act
             "roon:zone_fake_1",
             PlayAction::Queue,
             "Solo Playlist",
+            &[],
         )
         .await
         .expect_err("Queue is not offered by this playlist");
@@ -2499,6 +2501,7 @@ async fn roon_collections_artist_level_albums_are_dual_under_session_scoped_keys
             "roon:zone_fake_1",
             PlayAction::Play,
             "Flight of the Crow",
+            &[],
         )
         .await
         .expect("playing an artist-level album ref must succeed");

--- a/tests/roon_protocol.rs
+++ b/tests/roon_protocol.rs
@@ -35,7 +35,9 @@ use mock_servers::roon_core::{
     FakeItem, FakeLibrary, FakeRoonCore, Hint, ItemKeyScope,
 };
 use roon_api::browse::{BrowseOpts, LoadOpts};
-use unified_hifi_control::adapters::roon::{PlayAction, RoonAdapter, SearchSource};
+use unified_hifi_control::adapters::roon::{
+    PlayAction, RoonAdapter, RoonBrowseError, RoonBrowseErrorKind, SearchSource,
+};
 use unified_hifi_control::bus::create_bus;
 use unified_hifi_control::knobs::KnobStore;
 
@@ -2508,6 +2510,108 @@ async fn roon_collections_artist_level_albums_are_dual_under_session_scoped_keys
     assert!(
         message.contains("Play Now") || message.contains("Play Album"),
         "the album's Play Album menu resolves to a real invocation: {message}"
+    );
+
+    core.stop().await;
+}
+
+/// **#616's regression test.** The Core forgets the browse session a held key
+/// was minted in, and playing that key must still work.
+///
+/// This is the operator's report reproduced end to end: browse the Library
+/// down to an album, hold its ref, and have the Core lose the session
+/// underneath it (`FakeRoonCore::drop_all_sessions` -- an extension
+/// reconnect or a Core restart; see that method's docs for why session loss
+/// is modelled as an event rather than a count or timeout rule, and the
+/// read-only production measurements behind that choice).
+///
+/// Before #616 this surfaced the Core's rejection verbatim -- *"Roon Core
+/// rejected the item key: it is no longer valid in this browse session -
+/// search or browse again to get a fresh key"* -- which asks the human to
+/// redo, by hand, the exact walk the adapter is holding the breadcrumbs
+/// for. Now the ref carries its trail, `RoonAdapter::resolve_trail` re-walks
+/// it in a fresh session, and the play goes through.
+///
+/// Delete the recovery branch in `play_ref` and this fails with that
+/// message, which is the whole point of it.
+#[tokio::test]
+async fn a_held_key_still_plays_after_the_core_forgets_its_session() {
+    let core = FakeRoonCore::start_with(artists_library()).await;
+    core.set_item_key_scope(ItemKeyScope::PerSessionSilentRootReset)
+        .await;
+    let adapter = connected(&core).await;
+
+    // Walk the Library page down to an album, recording the trail exactly as
+    // `hifi_collections` accumulates it onto every ref it mints.
+    let mut level = adapter
+        .content(
+            "collections_browse",
+            &json!({ "zone_id": "roon:zone_1", "limit": 20, "offset": 0 }),
+        )
+        .await
+        .unwrap();
+    let mut session = level["session_key"].as_str().unwrap().to_string();
+    let mut trail: Vec<String> = Vec::new();
+    for title in ["Local Library", "Artists", "/Passenger."] {
+        let key = level["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|i| i["title"] == title)
+            .unwrap_or_else(|| panic!("row {title} missing: {level:?}"))["item_key"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        trail.push(title.to_string());
+        level = adapter
+            .content(
+                "collections_browse",
+                &json!({
+                    "zone_id": "roon:zone_1",
+                    "item_key": key,
+                    "session_key": session,
+                    "limit": 20,
+                    "offset": 0,
+                }),
+            )
+            .await
+            .unwrap();
+        session = level["session_key"].as_str().unwrap().to_string();
+    }
+    let album = &level["items"][0];
+    let album_title = album["title"].as_str().unwrap().to_string();
+    let album_key = album["item_key"].as_str().unwrap().to_string();
+    trail.push(album_title.clone());
+
+    // The Core loses every browse session it is holding.
+    core.drop_all_sessions().await;
+
+    // Sanity: the held key really is dead now, so the recovery below is
+    // doing real work rather than passing on a session that still exists.
+    let direct = adapter
+        .browse_collection("zone_1", Some(&album_key), Some(&session), 0, 20)
+        .await;
+    let rejection = direct.expect_err("the dropped session must reject the held key");
+    assert_eq!(
+        RoonBrowseError::from_error(&rejection).map(|error| error.kind),
+        Some(RoonBrowseErrorKind::InvalidItemKey),
+        "expected the Core's stale-key rejection, got: {rejection}"
+    );
+
+    let message = adapter
+        .play_ref(
+            &album_key,
+            &session,
+            "roon:zone_fake_1",
+            PlayAction::Play,
+            &album_title,
+            &trail,
+        )
+        .await
+        .expect("a ref whose session the Core forgot must recover by re-walking its trail");
+    assert!(
+        message.contains("Play Now") || message.contains("Play Album"),
+        "recovery must end in a real invocation, not a half-walk: {message}"
     );
 
     core.stop().await;


### PR DESCRIPTION
Closes #616.

The operator's report is real and now recovers automatically. The mechanism, though, is **not** the one the issue proposed — I measured it before building, and the two headline hypotheses in the issue text are both refuted below. Reporting that first, because it changed the fix.

## What I measured

All probes were read-only against the production instance (192.168.1.209:8088, the HA add-on that owns the extension identity), driven through `hifi_collections` / `POST /api/collections`. No second Roon-connecting server was started, and nothing was played.

### 1. Eviction is not count-based — refuted

Mint a deep browse ref (root → Local Library → Artists → an artist), then mint N further sessions back-to-back without touching it, then use it:

| sessions minted in between | old ref still resolves? |
|---|---|
| 0 (control) | yes |
| 10 | yes |
| 60 | yes |
| **400** (in 17.8s) | **yes** |

400 fresh browse sessions did not disturb an untouched earlier one. There is no session-count ceiling anywhere near the volume we generate.

### 2. Idle lifetime is longer than our own ref TTL

Eleven independent deep refs minted at t=0, each probed once at its own interval and never touched before that:

| idle | result |
|---|---|
| 30s, 90s, 180s, 300s, 480s, 660s, **840s** | resolves normally |
| 1020s | gone |

The 1020s failure is **our** `refs.rs` `DEFAULT_TTL` (900s) expiring, not the Core — the outcome is `invalid` (unknown ref token), not the Core's stale-key rejection. So a Roon browse session outlives our ref TTL rather than the other way round. This answers item 5 of the issue: shortening the TTL to "match Roon" would throw away refs the Core is still willing to honour. Left unchanged, with the measurement recorded at the constant.

### 3. Sessions are genuinely independent — the contention theory is refuted

The coordinator raised the possibility that our `multi_session_key` names collapse onto one shared Core-side session, so concurrent browsers (HA panel, Library page, MCP clients) continuously stomp each other's browse position. Tested directly by interleaving two chains: chain A descends to Local Library and holds a key for Artists; chain B then `pop_all`s to root and descends into Genres; chain A resumes its key.

Chain A resumed correctly into Artists (`/Passenger.`, `10,000 Maniacs`, …). Measurement 1 is the same result at scale: 400 interleaved root browses, each issuing `pop_all`, left the held key intact — impossible if they shared one position, because `pop_all` invalidates keys minted at the levels it discards.

Also confirmed live (#593's finding, re-verified): a key survives its own session navigating elsewhere. Sibling keys minted at the root all resolved after descending into one of them.

The identical `4811:` prefix across differently-named sessions is expected and not evidence of sharing: Roon item keys are `<list_id>:<row>`, and the root list id is stable. Identical text, still session-scoped validity. The most likely explanation for the reported one-second failure is that the two curl calls did not use the same session name — the quoted session `probe2_1787793823` carries a whole-seconds timestamp, which is what re-evaluating `$(date +%s)` per invocation produces.

### 4. So pooling sessions would have made this worse

Item 2 of the issue asks for a stable reused session per browsing context. I did not build that, deliberately. `browse_collection` sends `pop_all: true` whenever it browses a collection root, and `pop_all` invalidates every key minted at the levels it discards (live-verified on nuc14/Roon 2.70, recorded in `play_ref`'s docs and modelled by the fake's session epoch). Today each root browse mints a *fresh* session, so that `pop_all` lands on an empty one and harms nothing. Pool one session per zone and every "back to Library root" would actively destroy the refs the user is still holding — converting an occasional failure into a guaranteed one.

Note that `browse_collection` already reuses a supplied session key, so a descent chain shares one session. Minting is per *entry point*, not per request.

### What actually kills a session

What remains, once count and idle are excluded, is discrete loss: the extension reconnects, or the Core restarts, and every session goes at once. `RoonState::clear_roon_runtime_state` wipes browse state on disconnect, so this is certain by construction on our side. It fits the report exactly — constant during normal use, and "clears up by itself" because the next browse mints a live session.

## What changed

- **`RoonRefTarget` carries a `trail`** (`src/mcp/refs.rs`): the titles from the browse root down to the item. `hifi_collections` accumulates it as the user descends — each child extends its parent's trail — so every ref is self-describing. Previously a ref was `(item_key, multi_session_key)` and nothing else, which is *why* the only available answer was to ask the human to browse again: nothing in the ref said what the key had pointed at.
- **`RoonAdapter::resolve_trail`** re-walks a trail in a freshly minted session and returns an equivalent `(session_key, item_key)`. It starts from the root with `pop_all` in a *new* session, which is safe precisely because no key anyone holds was minted there. Levels are paged looking for each title, bounded by `TRAIL_SCAN_LIMIT`.
- **`RoonAdapter::play_ref` recovers instead of erroring.** A rejection that is specifically `InvalidItemKey` triggers one trail re-walk and one retry. Timeouts, a lost Core, and unknown zones are *not* retried — re-minting a key does not fix those and retrying would double the wait. If recovery fails, the Core's original rejection surfaces, because that is the error that describes what went wrong.
- **`FakeRoonCore::drop_all_sessions`** models session loss as the discrete event it is, rather than inventing a count or timeout rule the Core does not have. Afterwards a browse carrying an `item_key` in a lost session is answered `InvalidItemKey`; a `pop_all` revives the name at the root, as a real Core does for any session key it has not seen.

One subtlety worth flagging for review: trails record what the *client was shown*, and `map_collection_page` does not show rows verbatim — it renames the root's `Library` row to `Local Library` (#573 defect 4) and strips `[[id|Name]]` link markup (#573 defect 5). The walk has to match that same rendering. The first cut did not, and failed at depth 0.

#593's in-session peek (`pop_levels: 1`) and the `BrowsePositionLost` refusal are untouched.

## How a stale key now recovers, from the user's side

On the Library page, the play button posts to `/api/play_ref` → `handle_play_ref` → `RoonAdapter::play_ref`. Same path, so the fix reaches the reported surface with **no UI change** (nothing under `src/app` is touched, hence no browser probe).

Before: the Core rejects the key, and the user reads *"Roon Core rejected the item key: it is no longer valid in this browse session - search or browse again to get a fresh key (browse session 'collections_…')"* — an instruction to redo by hand the walk we were holding the breadcrumbs for.

After: the rejection is caught, the trail is re-walked in a fresh session, a new key is minted, and the play proceeds. The user sees the track play. The error text remains only for the case where the item genuinely no longer exists (renamed, removed, or past the scan bound).

## The regression test

`tests/roon_protocol.rs::a_held_key_still_plays_after_the_core_forgets_its_session` walks the Library down to an album exactly as the page does, holds the ref, has the Core forget every session, asserts the held key really is dead (so recovery is doing real work), then plays it.

Against the pre-fix behaviour it fails with the operator's message verbatim, `collections_<nanos>` session name and all:

```
a ref whose session the Core forgot must recover by re-walking its trail:
Roon Core rejected the item key: it is no longer valid in this browse session
- search or browse again to get a fresh key (browse session 'collections_1787794164921232000')
```

Deleting the recovery branch in `play_ref` reproduces that failure.

## Separately: the empty Albums node (defect B)

Found independently while probing, and reported to me in parallel. Evidence, since an earlier conclusion was in doubt:

- `Local Library → Albums` returns `outcome: ok` with `items: []` — 9/9 across three fresh sessions at offsets 0/5/20.
- Its siblings work: `Artists` returns rows **and `next_offset: 3`**; `Tracks` and `Composers` list fine.
- `Albums` returns **no `next_offset` at all**, which means `load.list.count == 0` — the Core reports that level as empty. `roon_browse_handler` makes the same read explicit: `if list.count > 0 { load } else { vec![] }`.
- Album browsing itself is healthy: under `Artists → 10,000 Maniacs` the five albums list, and `Blind Man's Zoo` opens to its tracks.
- It is deterministic, so it is not the contention theory; and it returns an empty list rather than the root "Explore" list, so it is not `PerSessionSilentRootReset` either.

That corroborates #593's reading — the Core answers this specific node with count 0 — rather than refuting it. What it does *not* settle is *why*, and the most plausible remaining cause is Core-side user state (a saved focus or filter stuck on that browser node), which is checkable in the Roon app and is not something the client can fix. Not addressed here; it is a distinct defect from #616 and none of this PR's changes affect it.
