### PR TITLE
fix: container images have no ssh, so the Spotify tunnel can't start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ WORKDIR /app
 # Install runtime dependencies (minimal - using rustls, no OpenSSL needed)
 RUN apt-get update && apt-get install -y \
     ca-certificates \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy binary with embedded web assets (ADR 002 - no public/ directory)

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,7 +6,7 @@ FROM ghcr.io/linuxcontainers/alpine:3.20
 WORKDIR /app
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates openssh-client
 
 # Copy pre-built binary (web assets are embedded)
 ARG TARGETARCH

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -5,8 +5,11 @@ FROM ghcr.io/linuxcontainers/alpine:3.20
 
 WORKDIR /app
 
-# Only need ca-certificates for HTTPS
-RUN apk add --no-cache ca-certificates
+# ca-certificates for HTTPS; openssh-client because the guided Spotify setup
+# opens its HTTPS callback tunnel by running `ssh -R` (see
+# src/api/spotify_tunnel.rs). Without it that flow dies telling a container
+# user to "install the OpenSSH client", which they cannot act on.
+RUN apk add --no-cache ca-certificates openssh-client
 
 # Copy pre-built binary (web assets are embedded)
 COPY dist/unified-hifi-control /app/

--- a/src/api/spotify_tunnel.rs
+++ b/src/api/spotify_tunnel.rs
@@ -579,9 +579,15 @@ impl SpotifyTunnelManager {
                     self.set_status_if_current(
                         generation,
                         TunnelStatus::Error {
-                            message: "ssh was not found on this system. Install the OpenSSH \
-                                      client (most Linux, macOS, and NAS systems already have \
-                                      it) or use \"Advanced: bring your own HTTPS\" below."
+                            // "Install the OpenSSH client" is useless advice
+                            // inside a container, which is where this is most
+                            // likely to be hit -- the images now ship it, so
+                            // point at the update first.
+                            message: "ssh was not found on this system. If you run Unified \
+                                      Hi-Fi Control as a Home Assistant add-on or a Docker \
+                                      container, update to the latest version -- it includes \
+                                      ssh. Otherwise install the OpenSSH client, or use \
+                                      \"Advanced: bring your own HTTPS\" below."
                                 .to_string(),
                         },
                     )


### PR DESCRIPTION
Reported on the Home Assistant add-on: the guided Spotify setup fails with

> ssh was not found on this system. Install the OpenSSH client (most Linux, macOS, and NAS systems already have it)

**Cause**: packaging. The tunnel that provides Spotify's required HTTPS callback is opened by running `ssh -R` (`src/api/spotify_tunnel.rs`), but no runtime image installs an SSH client. `Dockerfile.release` — the one that builds the published multi-arch image — installed only `ca-certificates`. So the feature could never work in any container: add-on, plain Docker, or QNAP container.

**Fix**: add `openssh-client` to `Dockerfile.release`, `Dockerfile.ci`, and the Debian runtime stage of `Dockerfile`, so all three agree. Verified in the real base image rather than assumed:

```
docker run --rm ghcr.io/linuxcontainers/alpine:3.20 sh -c 'apk add --no-cache ca-certificates openssh-client && command -v ssh && ssh -V'
  /usr/bin/ssh
  OpenSSH_9.7p1, OpenSSL 3.3.3
```

Also reworded the error: telling someone inside a container to install a package is a dead end, so it now points at updating the add-on/image first and keeps the manual-install and bring-your-own-HTTPS paths as fallbacks.

**Gates**: full `cargo test` (61 suites, 0 failures), `clippy -D warnings`, `fmt --check` — all on the pinned 1.97.1.