### PR TITLE
Extract UHCKit and add an Apple Watch controller (#619)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ __pycache__/
 .venv*/
 .pytest_cache/
 .ruff_cache/
+
+# Swift package build products (companion/*)
+companion/**/.build/
+companion/**/.swiftpm/

--- a/companion/apple_music_ios/Sources/AppleMusicIOSCompanion/Companion.swift
+++ b/companion/apple_music_ios/Sources/AppleMusicIOSCompanion/Companion.swift
@@ -536,6 +536,19 @@ public actor AppleMusicCompanionHost {
         try installationStore.clear()
     }
 
+    /// Forget a credential only after the server explicitly rejects it. This
+    /// is deliberately separate from transport recovery: a timeout, DNS
+    /// failure, or 5xx must never destroy a valid Keychain pairing.
+    ///
+    /// Mirrors `AppleMusicCompanionHost.forgetAuthorization()` in the macOS
+    /// bridge. `ContentView` has always called this on an authorization
+    /// failure; the iOS host simply never grew the method, so the iOS target
+    /// did not compile. Unlike `revoke()`, this does not tell the server
+    /// anything -- the server is the party that just rejected us.
+    public func forgetAuthorization() throws {
+        try installationStore.clear()
+    }
+
     public func pollAndHandleContent(
         _ handler: @Sendable (MusicKitContentCommand) async throws -> MusicKitContentResult
     ) async throws {

--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHost.xcodeproj/project.pbxproj
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHost.xcodeproj/project.pbxproj
@@ -7,11 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8BA61900000000000000000B /* UHCKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8BA61900000000000000000A /* UHCKit */; };
+		8BA61900000000000000000D /* UHCWatchApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 8BA619000000000000000001 /* UHCWatchApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8B41F6832DEDD23B001A66F9 /* AppleMusicIOSCompanionHostFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6822DEDD23B001A66F9 /* AppleMusicIOSCompanionHostFeature */; };
 		8B41F6852DEDD25C001A66F9 /* AppleMusicIOSCompanionHostFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6842DEDD25C001A66F9 /* AppleMusicIOSCompanionHostFeature */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		8BA61900000000000000000F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B41F63D2DEDD0D5001A66F9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8BA619000000000000000000;
+			remoteInfo = UHCWatchApp;
+		};
 		8B41F65D2DEDD0D6001A66F9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8B41F63D2DEDD0D5001A66F9 /* Project object */;
@@ -21,12 +30,41 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		8BA61900000000000000000C /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				8BA61900000000000000000D /* UHCWatchApp.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		8BA619000000000000000001 /* UHCWatchApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UHCWatchApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B41F6452DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppleMusicIOSCompanionHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B41F65C2DEDD0D6001A66F9 /* AppleMusicIOSCompanionHost.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AppleMusicIOSCompanionHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		8BA619000000000000000010 /* Exceptions for "Config" folder in "UHCWatchApp" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AppleMusicIOSCompanionHost-Info.plist,
+				AppleMusicIOSCompanionHost.entitlements,
+				Debug.xcconfig,
+				Release.xcconfig,
+				Shared.xcconfig,
+				Tests.xcconfig,
+				UHCWatchApp-Info.plist,
+				Watch.xcconfig,
+			);
+			target = 8BA619000000000000000000 /* UHCWatchApp */;
+		};
 		8BD71C0A2DEE41E000CEDD92 /* Exceptions for "Config" folder in "AppleMusicIOSCompanionHost" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -34,12 +72,19 @@
 				Release.xcconfig,
 				Shared.xcconfig,
 				Tests.xcconfig,
+				UHCWatchApp-Info.plist,
+				Watch.xcconfig,
 			);
 			target = 8B41F6442DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		8BA619000000000000000002 /* UHCWatchApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = UHCWatchApp;
+			sourceTree = "<group>";
+		};
 		8B41F6472DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = AppleMusicIOSCompanionHost;
@@ -54,6 +99,7 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				8BD71C0A2DEE41E000CEDD92 /* Exceptions for "Config" folder in "AppleMusicIOSCompanionHost" target */,
+				8BA619000000000000000010 /* Exceptions for "Config" folder in "UHCWatchApp" target */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -61,6 +107,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8BA619000000000000000004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BA61900000000000000000B /* UHCKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B41F6422DEDD0D5001A66F9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -85,6 +139,7 @@
 			children = (
 				8BD71C052DEE41D800CEDD92 /* Config */,
 				8B41F6472DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost */,
+				8BA619000000000000000002 /* UHCWatchApp */,
 				8B41F65F2DEDD0D6001A66F9 /* AppleMusicIOSCompanionHostUITests */,
 				8B41F6812DEDD23B001A66F9 /* Frameworks */,
 				8B41F6462DEDD0D5001A66F9 /* Products */,
@@ -96,6 +151,7 @@
 			children = (
 				8B41F6452DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost.app */,
 				8B41F65C2DEDD0D6001A66F9 /* AppleMusicIOSCompanionHost.xctest */,
+				8BA619000000000000000001 /* UHCWatchApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -110,6 +166,30 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		8BA619000000000000000000 /* UHCWatchApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8BA619000000000000000006 /* Build configuration list for PBXNativeTarget "UHCWatchApp" */;
+			buildPhases = (
+				8BA619000000000000000003 /* Sources */,
+				8BA619000000000000000004 /* Frameworks */,
+				8BA619000000000000000005 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				8BA619000000000000000002 /* UHCWatchApp */,
+				8BD71C052DEE41D800CEDD92 /* Config */,
+			);
+			name = UHCWatchApp;
+			packageProductDependencies = (
+				8BA61900000000000000000A /* UHCKit */,
+			);
+			productName = UHCWatchApp;
+			productReference = 8BA619000000000000000001 /* UHCWatchApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		8B41F6442DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B41F6662DEDD0D6001A66F9 /* Build configuration list for PBXNativeTarget "AppleMusicIOSCompanionHost" */;
@@ -117,10 +197,12 @@
 				8B41F6412DEDD0D5001A66F9 /* Sources */,
 				8B41F6422DEDD0D5001A66F9 /* Frameworks */,
 				8B41F6432DEDD0D5001A66F9 /* Resources */,
+				8BA61900000000000000000C /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				8BA61900000000000000000E /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				8B41F6472DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost */,
@@ -175,6 +257,9 @@
 						CreatedOnToolsVersion = 16.3;
 						TestTargetID = 8B41F6442DEDD0D5001A66F9;
 					};
+					8BA619000000000000000000 = {
+						CreatedOnToolsVersion = 26.6;
+					};
 				};
 			};
 			buildConfigurationList = 8B41F6402DEDD0D5001A66F9 /* Build configuration list for PBXProject "AppleMusicIOSCompanionHost" */;
@@ -188,6 +273,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				8BD71C0B2DEE41E000CEDD92 /* XCLocalSwiftPackageReference */,
+				8BA619000000000000000009 /* XCLocalSwiftPackageReference "../../uhckit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8B41F6462DEDD0D5001A66F9 /* Products */;
@@ -195,12 +281,20 @@
 			projectRoot = "";
 			targets = (
 				8B41F6442DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost */,
+				8BA619000000000000000000 /* UHCWatchApp */,
 				8B41F65B2DEDD0D6001A66F9 /* AppleMusicIOSCompanionHostUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		8BA619000000000000000005 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B41F6432DEDD0D5001A66F9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -218,6 +312,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		8BA619000000000000000003 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B41F6412DEDD0D5001A66F9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -235,6 +336,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		8BA61900000000000000000E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8BA619000000000000000000 /* UHCWatchApp */;
+			targetProxy = 8BA61900000000000000000F /* PBXContainerItemProxy */;
+		};
 		8B41F65E2DEDD0D6001A66F9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 8B41F6442DEDD0D5001A66F9 /* AppleMusicIOSCompanionHost */;
@@ -243,6 +349,29 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		8BA619000000000000000007 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8BD71C052DEE41D800CEDD92 /* Config */;
+			baseConfigurationReferenceRelativePath = Watch.xcconfig;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ENABLE_PREVIEWS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		8BA619000000000000000008 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8BD71C052DEE41D800CEDD92 /* Config */;
+			baseConfigurationReferenceRelativePath = Watch.xcconfig;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ENABLE_PREVIEWS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+			};
+			name = Release;
+		};
 		8B41F6642DEDD0D6001A66F9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -441,6 +570,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		8BA619000000000000000006 /* Build configuration list for PBXNativeTarget "UHCWatchApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8BA619000000000000000007 /* Debug */,
+				8BA619000000000000000008 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		8B41F6402DEDD0D5001A66F9 /* Build configuration list for PBXProject "AppleMusicIOSCompanionHost" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -471,6 +609,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
+		8BA619000000000000000009 /* XCLocalSwiftPackageReference "../../uhckit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../uhckit;
+		};
 		8BD71C0B2DEE41E000CEDD92 /* XCLocalSwiftPackageReference */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = AppleMusicIOSCompanionHostPackage;
@@ -478,6 +620,11 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		8BA61900000000000000000A /* UHCKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8BA619000000000000000009 /* XCLocalSwiftPackageReference "../../uhckit" */;
+			productName = UHCKit;
+		};
 		8B41F6822DEDD23B001A66F9 /* AppleMusicIOSCompanionHostFeature */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8BD71C0B2DEE41E000CEDD92 /* XCLocalSwiftPackageReference */;

--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHost.xcodeproj/xcshareddata/xcschemes/UHCWatchApp.xcscheme
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHost.xcodeproj/xcshareddata/xcschemes/UHCWatchApp.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <!--
+     Shared, and deliberately builds ONLY the watchOS target (#619).
+
+     Xcode's auto-generated watch scheme also builds the companion iOS app.
+     That is normally convenient, but here it couples the Watch app to an
+     unrelated compile error in AppleMusicIOSCompanionHostFeature that predates
+     this work, and it turns "does the Watch app build?" into a question about
+     the MusicKit bridge. buildImplicitDependencies is off for the same reason:
+     the iOS target depends on this one (Embed Watch Content), never the
+     reverse, so nothing here needs it.
+   -->
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8BA619000000000000000000"
+               BuildableName = "UHCWatchApp.app"
+               BlueprintName = "UHCWatchApp"
+               ReferencedContainer = "container:AppleMusicIOSCompanionHost.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BA619000000000000000000"
+            BuildableName = "UHCWatchApp.app"
+            BlueprintName = "UHCWatchApp"
+            ReferencedContainer = "container:AppleMusicIOSCompanionHost.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BA619000000000000000000"
+            BuildableName = "UHCWatchApp.app"
+            BlueprintName = "UHCWatchApp"
+            ReferencedContainer = "container:AppleMusicIOSCompanionHost.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Package.swift
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Package.swift
@@ -14,7 +14,11 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(path: "../../")
+        .package(path: "../../"),
+        // The shared UHC control client (#619). Discovery lives here now, so
+        // the iOS companion and the watchOS controller browse for _uhc._tcp
+        // through exactly one implementation.
+        .package(path: "../../../uhckit"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -22,7 +26,8 @@ let package = Package(
         .target(
             name: "AppleMusicIOSCompanionHostFeature",
             dependencies: [
-                .product(name: "AppleMusicIOSCompanion", package: "apple_music_ios")
+                .product(name: "AppleMusicIOSCompanion", package: "apple_music_ios"),
+                .product(name: "UHCKit", package: "uhckit"),
             ]
         ),
         .testTarget(

--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/UHCBonjourDiscovery.swift
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/UHCBonjourDiscovery.swift
@@ -1,79 +1,16 @@
 import Foundation
+import UHCKit
 
-/// Discovers UHC servers advertising the native companion endpoint on the
-/// local network. The resolved service hostname is preferred over TXT: a
-/// server may be configured with a loopback or container hostname in its
-/// advertised base URL, while NetService has already resolved a LAN-reachable
-/// name for this phone.
-final class UHCBonjourDiscovery: NSObject, NetServiceBrowserDelegate, NetServiceDelegate {
-    var onBaseURL: ((URL) -> Void)?
-    var onFailure: ((String) -> Void)?
-
-    private let browser = NetServiceBrowser()
-    private var services: [NetService] = []
-    private var finished = false
-    private var timeoutWork: DispatchWorkItem?
-
-    func start() {
-        finished = false
-        services.removeAll()
-        browser.delegate = self
-        browser.searchForServices(ofType: "_uhc._tcp.", inDomain: "local.")
-        let timeout = DispatchWorkItem { [weak self] in
-            guard let self, !self.finished else { return }
-            self.finished = true
-            self.stop()
-            self.onFailure?("No UHC server was found on the local network.")
-        }
-        timeoutWork = timeout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 8, execute: timeout)
-    }
-
-    func stop() {
-        timeoutWork?.cancel()
-        timeoutWork = nil
-        browser.stop()
-        services.forEach { $0.stop() }
-        services.removeAll()
-    }
-
-    func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {
-        guard !finished else { return }
-        services.append(service)
-        service.delegate = self
-        service.resolve(withTimeout: 5)
-    }
-
-    func netServiceDidResolveAddress(_ sender: NetService) {
-        guard !finished else { return }
-        if let host = sender.hostName?.trimmingCharacters(in: CharacterSet(charactersIn: ".")),
-           !host.isEmpty, sender.port > 0,
-           let url = URL(string: "http://\(host):\(sender.port)") {
-            finish(url)
-            return
-        }
-
-        // Fall back to the explicit base URL for proxies/tunnels where the
-        // service hostname is not usable as an HTTP host.
-        let txt = sender.txtRecordData().map(NetService.dictionary(fromTXTRecord:)) ?? [:]
-        if let raw = txt["base"].flatMap({ String(data: $0, encoding: .utf8) }),
-           let url = URL(string: raw), url.host != nil {
-            finish(url)
-        }
-    }
-
-    func netService(_ sender: NetService, didNotResolve errorDict: [String: NSNumber]) {
-        guard !finished, services.allSatisfy({ $0 === sender || $0.port > 0 }) else { return }
-        onFailure?("Could not resolve UHC on the local network.")
-    }
-
-    func netServiceBrowser(_ browser: NetServiceBrowser, didNotSearch errorDict: [String: NSNumber]) {
-        onFailure?("Could not search for UHC on the local network.")
-    }
-
-    private func finish(_ url: URL) {
-        finished = true
-        stop()
-        onBaseURL?(url)
-    }
-}
+/// The implementation moved to `UHCKit.UHCDiscovery` (#619).
+///
+/// The Watch controller needs the same capability, and two copies of a Bonjour
+/// browser is the duplication that issue exists to stop — the same failure mode
+/// as #611, where four surfaces each built artwork URLs their own way and all
+/// four broke together.
+///
+/// This alias keeps the call sites in `ContentView` unchanged. `UHCDiscovery`
+/// preserves the iOS behaviour exactly: it is the same `NetService` code, moved
+/// rather than rewritten, and it prefers the resolved service hostname over the
+/// TXT `base` record just as this type always did. (watchOS gets a separate
+/// `NWBrowser` path inside `UHCKit`, because `NetService` is unavailable there.)
+typealias UHCBonjourDiscovery = UHCDiscovery

--- a/companion/apple_music_ios/Xcode/Config/UHCWatchApp-Info.plist
+++ b/companion/apple_music_ios/Xcode/Config/UHCWatchApp-Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Spelled out rather than left to Xcode: with GENERATE_INFOPLIST_FILE = NO
+	  the watchOS build does not synthesise these the way the iOS build does,
+	  and a bundle without CFBundleIdentifier fails to install with only
+	  "Missing bundle ID" to go on.
+	-->
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleDisplayName</key>
+	<string>UHC</string>
+	<!-- Modern single-target watchOS app (no legacy WatchKit extension). -->
+	<key>WKApplication</key>
+	<true/>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.openhorizonlabs.uhc.applemusiccompanion</string>
+	<key>WKRunsIndependentlyOfCompanionApp</key>
+	<true/>
+	<!--
+	  #619: the open question is whether watchOS honours these at all. The
+	  iOS companion in the same bundle already declares the identical pair,
+	  which is the configuration the Apple forum thread claims is what makes
+	  a Watch app's LAN access work. Declaring them here too costs nothing
+	  and removes one variable from the on-device test.
+	-->
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>UHC uses your local network to reach your music server.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_uhc._tcp</string>
+	</array>
+</dict>
+</plist>

--- a/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
@@ -1,0 +1,32 @@
+// Watch.xcconfig
+// Build settings for the UHC watchOS controller app (#619).
+//
+// Note this file does NOT #include Shared.xcconfig: that file pins
+// SDKROOT/INFOPLIST_FILE/entitlements for the iOS app, and inheriting them
+// here would try to build the Watch app against the iOS SDK.
+
+PRODUCT_NAME = UHCWatchApp
+PRODUCT_DISPLAY_NAME = UHC
+// Must be the iOS app's identifier plus a suffix for the two to ship as one
+// bundle; the Watch app is embedded in the iOS app's Watch container.
+PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.applemusiccompanion.watchkitapp
+DEVELOPMENT_TEAM = B69HKNTV5Q
+MARKETING_VERSION = 0.1.0
+CURRENT_PROJECT_VERSION = 1
+
+SDKROOT = watchos
+WATCHOS_DEPLOYMENT_TARGET = 10.0
+TARGETED_DEVICE_FAMILY = 4
+SUPPORTED_PLATFORMS = watchos watchsimulator
+
+GENERATE_INFOPLIST_FILE = NO
+INFOPLIST_FILE = Config/UHCWatchApp-Info.plist
+
+SWIFT_VERSION = 5.0
+CODE_SIGN_STYLE = Automatic
+// No signing identity is configured in CI or on a fresh clone; the simulator
+// build does not need one. Device builds pick up the team above in Xcode.
+CODE_SIGNING_ALLOWED[sdk=watchsimulator*] = NO
+
+SKIP_INSTALL = NO
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO

--- a/companion/apple_music_ios/Xcode/UHCWatchApp/NowPlayingView.swift
+++ b/companion/apple_music_ios/Xcode/UHCWatchApp/NowPlayingView.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+import UHCKit
+
+/// Artwork, three lines of text, transport, and the Digital Crown bound to
+/// volume.
+struct NowPlayingView: View {
+    @Environment(WatchController.self) private var controller
+
+    /// Crown state. Kept local and pushed to the server on change rather than
+    /// bound straight through: the crown emits a continuous stream and one
+    /// request per tick would flood a zone.
+    @State private var crownVolume: Double = 0
+    @State private var crownPrimed = false
+    @State private var volumeCommit: Task<Void, Never>?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 6) {
+                artwork
+                titles
+                transportControls
+                volumeReadout
+            }
+            .padding(.horizontal, 4)
+        }
+        .navigationTitle(controller.selectedZone?.name ?? "Now Playing")
+        .navigationBarTitleDisplayMode(.inline)
+        .focusable()
+        .digitalCrownRotation(
+            $crownVolume,
+            from: controller.volumeControl?.min ?? 0,
+            through: controller.volumeControl?.max ?? 100,
+            by: controller.volumeControl?.step ?? 1,
+            sensitivity: .medium,
+            isContinuous: false,
+            isHapticFeedbackEnabled: true
+        )
+        .onChange(of: crownVolume) { _, newValue in
+            // Ignore the first value: SwiftUI seeds the binding before the
+            // zone's real volume is known, and acting on it would yank the
+            // volume to zero the moment the screen appears.
+            guard crownPrimed else { return }
+            scheduleVolumeCommit(newValue)
+        }
+        .onChange(of: controller.nowPlaying?.volume) { _, newValue in
+            guard !crownPrimed, let newValue else { return }
+            crownVolume = newValue
+            crownPrimed = true
+        }
+        .task {
+            await controller.refreshNowPlaying()
+            if let volume = controller.nowPlaying?.volume {
+                crownVolume = volume
+                crownPrimed = true
+            }
+        }
+    }
+
+    // MARK: - Pieces
+
+    @ViewBuilder
+    private var artwork: some View {
+        Group {
+            if let image = controller.artwork {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(.quaternary)
+                    .overlay {
+                        Image(systemName: "music.note")
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                    }
+                    .aspectRatio(1, contentMode: .fit)
+            }
+        }
+        .frame(maxWidth: 90)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private var titles: some View {
+        VStack(spacing: 1) {
+            Text(controller.nowPlaying?.title ?? "—")
+                .font(.headline)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+            if let artist = controller.nowPlaying?.artist, !artist.isEmpty {
+                Text(artist)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            if let album = controller.nowPlaying?.album, !album.isEmpty {
+                Text(album)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var transportControls: some View {
+        let np = controller.nowPlaying
+        HStack(spacing: 10) {
+            Button {
+                Task { await controller.previous() }
+            } label: {
+                Image(systemName: "backward.fill")
+            }
+            .disabled(!(np?.isPreviousAllowed ?? false))
+
+            Button {
+                Task { await controller.playPause() }
+            } label: {
+                Image(systemName: (np?.isPlaying ?? false) ? "pause.fill" : "play.fill")
+                    .font(.title3)
+            }
+            // The server publishes which commands the zone will accept; honour
+            // it rather than offering a button that is guaranteed to fail.
+            .disabled(!((np?.isPlayAllowed ?? false) || (np?.isPauseAllowed ?? false)))
+
+            Button {
+                Task { await controller.next() }
+            } label: {
+                Image(systemName: "forward.fill")
+            }
+            .disabled(!(np?.isNextAllowed ?? false))
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+    }
+
+    @ViewBuilder
+    private var volumeReadout: some View {
+        if let control = controller.volumeControl {
+            HStack(spacing: 4) {
+                Image(systemName: "speaker.wave.2.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(formatted(control.value))
+                    .font(.caption2)
+                    .monospacedDigit()
+            }
+            .accessibilityLabel("Volume \(formatted(control.value))")
+        }
+        if let message = controller.errorMessage {
+            Text(message)
+                .font(.caption2)
+                .foregroundStyle(.orange)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private func formatted(_ value: Double) -> String {
+        value == value.rounded()
+            ? String(Int(value))
+            : String(format: "%.1f", value)
+    }
+
+    /// Coalesce crown motion into one request per quiet period. Without this a
+    /// single flick of the crown becomes dozens of `vol_abs` commands.
+    private func scheduleVolumeCommit(_ value: Double) {
+        volumeCommit?.cancel()
+        volumeCommit = Task {
+            try? await Task.sleep(for: .milliseconds(250))
+            guard !Task.isCancelled else { return }
+            await controller.setVolume(value)
+        }
+    }
+}

--- a/companion/apple_music_ios/Xcode/UHCWatchApp/ServerSetupView.swift
+++ b/companion/apple_music_ios/Xcode/UHCWatchApp/ServerSetupView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import UHCKit
+
+/// Server discovery, manual entry, and the diagnostics readout.
+///
+/// The diagnostics section is not decoration: on real Watch hardware it is the
+/// instrument that answers #619's open question. If a direct LAN request is
+/// blocked by the OS rather than by a missing server, the underlying `URLError`
+/// shows up here, and that string is what the owner reports back.
+struct ServerSetupView: View {
+    @Environment(WatchController.self) private var controller
+    @State private var manualHost: String = ""
+
+    var body: some View {
+        List {
+            Section {
+                Button {
+                    Task { await controller.discover() }
+                } label: {
+                    Label("Find UHC", systemImage: "antenna.radiowaves.left.and.right")
+                }
+
+                if let server = controller.serverDescription {
+                    LabeledContent("Server") {
+                        Text(server).font(.caption2).lineLimit(2)
+                    }
+                }
+            } header: {
+                Text("Connection")
+            } footer: {
+                Text("Browses for _uhc._tcp on your network.")
+                    .font(.caption2)
+            }
+
+            Section("Manual address") {
+                // Dictation/scribble entry — a watch has no keyboard, so this
+                // is the fallback when Bonjour is unavailable, which on watchOS
+                // is a real possibility (see Transport.md).
+                TextField("192.168.1.209:8088", text: $manualHost)
+                    .textContentType(.URL)
+
+                Button("Connect") {
+                    guard let url = Self.normalizedURL(from: manualHost) else { return }
+                    Task { await controller.connect(to: url) }
+                }
+                .disabled(Self.normalizedURL(from: manualHost) == nil)
+            }
+
+            if controller.errorMessage != nil || controller.lastTransportFailure != nil {
+                Section("Diagnostics") {
+                    if let message = controller.errorMessage {
+                        Text(message)
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                    }
+                    if let failure = controller.lastTransportFailure {
+                        Text(failure)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section {
+                Button("Forget server", role: .destructive) {
+                    controller.forgetServer()
+                }
+            }
+        }
+    }
+
+    /// Accepts "host", "host:port", or a full URL, and always yields an
+    /// `http://` URL. Typing a scheme on a watch is miserable, so it is
+    /// optional.
+    static func normalizedURL(from raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let candidate = trimmed.contains("://") ? trimmed : "http://\(trimmed)"
+        guard let url = URL(string: candidate), let host = url.host, !host.isEmpty else {
+            return nil
+        }
+        return url
+    }
+}

--- a/companion/apple_music_ios/Xcode/UHCWatchApp/UHCWatchApp.swift
+++ b/companion/apple_music_ios/Xcode/UHCWatchApp/UHCWatchApp.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import UHCKit
+
+/// UHC on the wrist (#619).
+///
+/// Deliberately small: pick a zone, see what is playing, drive transport and
+/// volume. No library browsing — a watch is a remote, not a catalogue, and the
+/// browse endpoints are the expensive half of the API.
+@main
+struct UHCWatchApp: App {
+    @State private var controller = WatchController()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environment(controller)
+        }
+    }
+}
+
+struct RootView: View {
+    @Environment(WatchController.self) private var controller
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch controller.connection {
+                case .needsServer:
+                    ServerSetupView()
+                case .connecting:
+                    ProgressView("Finding UHC…")
+                case .connected:
+                    ZoneListView()
+                }
+            }
+            .navigationTitle("UHC")
+        }
+        .task {
+            await controller.startup()
+        }
+    }
+}

--- a/companion/apple_music_ios/Xcode/UHCWatchApp/WatchController.swift
+++ b/companion/apple_music_ios/Xcode/UHCWatchApp/WatchController.swift
@@ -1,0 +1,257 @@
+import Foundation
+import Observation
+import SwiftUI
+import UHCKit
+
+/// The Watch app's single source of truth.
+///
+/// Holds a `UHCClient` and never a transport directly, so the direct-WiFi vs
+/// phone-relay question (#619, `Transport.md`) is settled in exactly one place:
+/// `makeClient(for:)`. Nothing else in the app knows how bytes reach UHC.
+@MainActor
+@Observable
+final class WatchController {
+    enum Connection {
+        case needsServer
+        case connecting
+        case connected
+    }
+
+    private(set) var connection: Connection = .connecting
+    private(set) var zones: [Zone] = []
+    private(set) var nowPlaying: NowPlaying?
+    private(set) var artwork: UIImage?
+    private(set) var errorMessage: String?
+    /// Shown verbatim on the diagnostics screen. On real hardware this is the
+    /// evidence that settles whether watchOS may reach the LAN at all, so it
+    /// keeps the underlying error rather than a friendly paraphrase.
+    private(set) var lastTransportFailure: String?
+    private(set) var serverDescription: String?
+
+    var selectedZoneID: String? {
+        didSet {
+            guard selectedZoneID != oldValue else { return }
+            UserDefaults.standard.set(selectedZoneID, forKey: Self.zoneKey)
+            artwork = nil
+            loadedArtworkKey = nil
+            nowPlaying = nil
+        }
+    }
+
+    private static let serverKey = "uhc.baseURL"
+    private static let zoneKey = "uhc.selectedZoneID"
+
+    private var client: UHCClient?
+    private var pollTask: Task<Void, Never>?
+    private var loadedArtworkKey: String?
+    /// Set while a command is in flight, so optimistic UI does not get stomped
+    /// by a poll that started before the command landed.
+    private var suppressPollUntil: Date = .distantPast
+
+    // MARK: - Lifecycle
+
+    func startup() async {
+        selectedZoneID = UserDefaults.standard.string(forKey: Self.zoneKey)
+
+        if let saved = UserDefaults.standard.string(forKey: Self.serverKey),
+           let url = URL(string: saved) {
+            await connect(to: url)
+            return
+        }
+        await discover()
+    }
+
+    /// Browse for `_uhc._tcp.` and connect to the first server that answers.
+    func discover() async {
+        connection = .connecting
+        errorMessage = nil
+        do {
+            let url = try await UHCDiscovery.firstServer()
+            await connect(to: url)
+        } catch {
+            lastTransportFailure = (error as? UHCError)?.errorDescription ?? "\(error)"
+            errorMessage = "No UHC server found."
+            connection = .needsServer
+        }
+    }
+
+    /// Connect to an explicitly named server (manual entry, or a discovery hit).
+    func connect(to url: URL) async {
+        connection = .connecting
+        errorMessage = nil
+
+        // The single line that would change to move onto the phone relay.
+        let client = UHCClient(transport: DirectHTTPTransport(baseURL: url))
+        self.client = client
+        serverDescription = client.describedEndpoint
+
+        do {
+            _ = try await client.status()
+            UserDefaults.standard.set(url.absoluteString, forKey: Self.serverKey)
+            connection = .connected
+            lastTransportFailure = nil
+            await refreshZones()
+            startPolling()
+        } catch {
+            recordFailure(error)
+            connection = .needsServer
+        }
+    }
+
+    func forgetServer() {
+        pollTask?.cancel()
+        pollTask = nil
+        client = nil
+        zones = []
+        nowPlaying = nil
+        artwork = nil
+        UserDefaults.standard.removeObject(forKey: Self.serverKey)
+        connection = .needsServer
+    }
+
+    // MARK: - Reads
+
+    func refreshZones() async {
+        guard let client else { return }
+        do {
+            let fetched = try await client.zones()
+            zones = fetched
+            if selectedZoneID == nil || !fetched.contains(where: { $0.id == selectedZoneID }) {
+                // Prefer a zone that is actually playing — on a watch, the
+                // thing you reach for is almost always the thing making noise.
+                selectedZoneID = fetched.first(where: { $0.state.isPlaying })?.id ?? fetched.first?.id
+            }
+            errorMessage = nil
+        } catch {
+            recordFailure(error)
+        }
+    }
+
+    func refreshNowPlaying() async {
+        guard let client, let zoneID = selectedZoneID else { return }
+        guard Date() >= suppressPollUntil else { return }
+        do {
+            let np = try await client.nowPlaying(zoneID: zoneID)
+            nowPlaying = np
+            // `/now_playing` echoes the zone list, so the picker stays fresh
+            // without a second request.
+            if !np.zones.isEmpty { zones = np.zones }
+            errorMessage = nil
+            await refreshArtworkIfNeeded(for: np)
+        } catch {
+            recordFailure(error)
+        }
+    }
+
+    private func refreshArtworkIfNeeded(for np: NowPlaying) async {
+        guard let client else { return }
+        // `image_key` is the server's own cache key: re-fetch only when the art
+        // actually changed, not on every poll.
+        guard let key = np.imageKey else {
+            artwork = nil
+            loadedArtworkKey = nil
+            return
+        }
+        guard key != loadedArtworkKey else { return }
+
+        do {
+            guard let data = try await client.artwork(zoneID: np.zoneID, width: 200, height: 200),
+                  let image = UIImage(data: data.data) else {
+                artwork = nil
+                loadedArtworkKey = key
+                return
+            }
+            artwork = image
+            loadedArtworkKey = key
+        } catch {
+            // Missing art is not worth surfacing as a connection error.
+            artwork = nil
+        }
+    }
+
+    private func startPolling() {
+        pollTask?.cancel()
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refreshNowPlaying()
+                // 2s matches the server's own aggregator poll interval; faster
+                // buys nothing but battery.
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    // MARK: - Commands
+
+    func playPause() async {
+        guard let zoneID = selectedZoneID else { return }
+        // Optimistic: the watch should feel instant, and the next poll
+        // reconciles against the server's truth.
+        if var np = nowPlaying {
+            np.isPlaying.toggle()
+            nowPlaying = np
+        }
+        await send { try await $0.playPause(zoneID: zoneID) }
+    }
+
+    func next() async {
+        guard let zoneID = selectedZoneID else { return }
+        await send { try await $0.next(zoneID: zoneID) }
+    }
+
+    func previous() async {
+        guard let zoneID = selectedZoneID else { return }
+        await send { try await $0.previous(zoneID: zoneID) }
+    }
+
+    /// Absolute volume from the Digital Crown, snapped to the zone's own step.
+    func setVolume(_ value: Double) async {
+        guard let zoneID = selectedZoneID else { return }
+        let control = nowPlaying?.volumeControl
+            ?? zones.first(where: { $0.id == zoneID })?.volumeControl
+        if var np = nowPlaying {
+            np.volume = control?.normalized(value) ?? value
+            nowPlaying = np
+        }
+        await send { try await $0.setVolume(zoneID: zoneID, to: value, within: control) }
+    }
+
+    private func send(_ body: @escaping (UHCClient) async throws -> Void) async {
+        guard let client else { return }
+        // Hold off the poller briefly so it cannot overwrite the optimistic
+        // state with a snapshot taken before the command was applied.
+        suppressPollUntil = Date().addingTimeInterval(0.8)
+        do {
+            try await body(client)
+            errorMessage = nil
+        } catch {
+            recordFailure(error)
+        }
+        await refreshNowPlaying()
+    }
+
+    private func recordFailure(_ error: Error) {
+        let uhc = error as? UHCError
+        errorMessage = uhc?.errorDescription ?? error.localizedDescription
+        if case .unreachable(let underlying) = uhc {
+            lastTransportFailure = underlying
+        } else if case .timedOut = uhc {
+            lastTransportFailure = "timed out"
+        }
+    }
+
+    // MARK: - Derived
+
+    var selectedZone: Zone? {
+        zones.first { $0.id == selectedZoneID }
+    }
+
+    var volumeControl: VolumeControl? {
+        nowPlaying?.volumeControl ?? selectedZone?.volumeControl
+    }
+}

--- a/companion/apple_music_ios/Xcode/UHCWatchApp/ZoneListView.swift
+++ b/companion/apple_music_ios/Xcode/UHCWatchApp/ZoneListView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import UHCKit
+
+/// Every zone UHC knows about. Playing zones sort to the top: on a watch the
+/// list is scrolled with a crown and the thing making noise should not be
+/// below the fold.
+struct ZoneListView: View {
+    @Environment(WatchController.self) private var controller
+
+    private var orderedZones: [Zone] {
+        controller.zones.sorted { lhs, rhs in
+            if lhs.state.isPlaying != rhs.state.isPlaying { return lhs.state.isPlaying }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    var body: some View {
+        List {
+            if let message = controller.errorMessage {
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.orange)
+            }
+
+            ForEach(orderedZones) { zone in
+                NavigationLink {
+                    NowPlayingView()
+                        .onAppear { controller.selectedZoneID = zone.id }
+                } label: {
+                    ZoneRow(zone: zone)
+                }
+            }
+
+            NavigationLink("Server") { ServerSetupView() }
+                .font(.footnote)
+        }
+        .listStyle(.carousel)
+        .refreshable { await controller.refreshZones() }
+    }
+}
+
+struct ZoneRow: View {
+    let zone: Zone
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(zone.state.isPlaying ? Color.green : Color.secondary)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(zone.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Text(zone.state.rawValue.capitalized)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var icon: String {
+        switch zone.state {
+        case .playing: return "speaker.wave.2.fill"
+        case .paused: return "pause.fill"
+        case .loading, .buffering: return "clock"
+        default: return "speaker.slash"
+        }
+    }
+}

--- a/companion/uhckit/Package.swift
+++ b/companion/uhckit/Package.swift
@@ -24,10 +24,9 @@ let package = Package(
     ],
     targets: [
         .target(name: "UHCKit"),
-        .testTarget(
-            name: "UHCKitTests",
-            dependencies: ["UHCKit"],
-            resources: [.copy("Fixtures")]
-        ),
+        // The contract suite reads tests/fixtures/uhckit_contract.json from the
+        // repository root — the same file tests/uhckit_contract.rs guards — so
+        // there is deliberately no bundled resource copy to drift from it.
+        .testTarget(name: "UHCKitTests", dependencies: ["UHCKit"]),
     ]
 )

--- a/companion/uhckit/Package.swift
+++ b/companion/uhckit/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.9
+//
+// UHCKit — the platform-neutral UHC *control* client (#619).
+//
+// Deliberately free of MusicKit and of every other iOS-only framework: the
+// watchOS build links this package, and a single `import MusicKit` anywhere in
+// it breaks that build. The Apple Music bridge stays where it is, in
+// `companion/apple_music_ios`, which is the opposite direction of travel (UHC
+// drives the phone) and is not a control client at all.
+//
+// macOS is listed only so `swift test` runs the contract suite on the host
+// toolchain without a simulator.
+import PackageDescription
+
+let package = Package(
+    name: "UHCKit",
+    platforms: [
+        .iOS(.v17),
+        .watchOS(.v10),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "UHCKit", targets: ["UHCKit"]),
+    ],
+    targets: [
+        .target(name: "UHCKit"),
+        .testTarget(
+            name: "UHCKitTests",
+            dependencies: ["UHCKit"],
+            resources: [.copy("Fixtures")]
+        ),
+    ]
+)

--- a/companion/uhckit/Sources/UHCKit/DirectHTTPTransport.swift
+++ b/companion/uhckit/Sources/UHCKit/DirectHTTPTransport.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Talks to UHC straight over the LAN with `URLSession`.
+///
+/// This is the transport whose viability on watchOS is the open question of
+/// #619. It is written to make that question *answerable* rather than to guess
+/// at the answer: a refused or blocked LAN connection surfaces as
+/// `UHCError.unreachable` carrying the underlying `URLError` code, which is the
+/// evidence the owner needs to report from real hardware. See `Transport.md`.
+public final class DirectHTTPTransport: UHCTransport, @unchecked Sendable {
+    private let baseURL: URL
+    private let session: URLSession
+    private let defaultTimeout: TimeInterval
+
+    public init(baseURL: URL, timeout: TimeInterval = 8, session: URLSession? = nil) {
+        self.baseURL = baseURL
+        self.defaultTimeout = timeout
+        if let session {
+            self.session = session
+        } else {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = timeout
+            config.timeoutIntervalForResource = timeout * 2
+            // A controller wants the live state, never a cached one. Artwork is
+            // re-fetched only when `image_key` changes, so the cache buys
+            // nothing and can show a stale track.
+            config.requestCachePolicy = .reloadIgnoringLocalCacheData
+            config.waitsForConnectivity = false
+            self.session = URLSession(configuration: config)
+        }
+    }
+
+    public var describedEndpoint: String {
+        baseURL.absoluteString
+    }
+
+    public func perform(_ request: UHCRequest) async throws -> UHCResponse {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw UHCError.invalidBaseURL
+        }
+
+        // Append rather than replace: a base URL may legitimately carry a path
+        // prefix when UHC sits behind a reverse proxy, and dropping it is
+        // exactly the bug class `tests/base_path_lint.rs` guards on the Rust
+        // side (#611).
+        let basePath = components.path.hasSuffix("/")
+            ? String(components.path.dropLast())
+            : components.path
+        components.path = basePath + request.path
+
+        if !request.query.isEmpty {
+            // Sorted so a request is reproducible and comparable in logs.
+            components.queryItems = request.query
+                .sorted { $0.key < $1.key }
+                .map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+
+        guard let url = components.url else { throw UHCError.invalidBaseURL }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = request.method.rawValue
+        urlRequest.timeoutInterval = request.timeout ?? defaultTimeout
+        if let body = request.body {
+            urlRequest.httpBody = body
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        do {
+            let (data, response) = try await session.data(for: urlRequest)
+            let http = response as? HTTPURLResponse
+            return UHCResponse(
+                statusCode: http?.statusCode ?? 0,
+                body: data,
+                contentType: http?.value(forHTTPHeaderField: "Content-Type")
+            )
+        } catch let error as URLError {
+            if error.code == .timedOut { throw UHCError.timedOut }
+            // The distinguishing detail for the on-device LAN question. Keep
+            // the raw code: on watchOS a policy block and a genuinely absent
+            // server look similar to a user but differ here.
+            throw UHCError.unreachable(underlying: "\(error.code.rawValue) \(error.localizedDescription)")
+        } catch {
+            throw UHCError.unreachable(underlying: error.localizedDescription)
+        }
+    }
+}

--- a/companion/uhckit/Sources/UHCKit/Models.swift
+++ b/companion/uhckit/Sources/UHCKit/Models.swift
@@ -1,0 +1,389 @@
+import Foundation
+
+// Wire models for UHC's source-agnostic controller protocol.
+//
+// Every field below was read off the running production server
+// (192.168.1.209:8088, UHC 3.7.0-alpha.9) rather than inferred from the Rust
+// types, and the Rust types were then read to find which fields are *omitted*
+// rather than null — a distinction a single live sample cannot show. The
+// endpoints are the ones the knob firmware already speaks:
+//
+//   GET  /zones                       -> ZoneListResponse
+//   GET  /now_playing?zone_id=...     -> NowPlaying   (also carries `zones`)
+//   GET  /now_playing/image?zone_id=  -> image/jpeg bytes
+//   POST /control                     <- ControlRequest
+//
+// Optionality here is load-bearing, not defensive. `volume_control` really is
+// absent for zones with no volume (the live server's "HQPlayer Embedded" zone
+// is one), so making it non-optional would fail to decode the real zone list.
+
+/// Transport state of a zone, as UHC's aggregator publishes it.
+///
+/// Unknown cases decode rather than throw: a new backend adapter teaching the
+/// server a state string this client has never heard of must not take down the
+/// zone list. The contract test is what catches that drift; runtime just copes.
+public enum PlaybackState: RawRepresentable, Codable, Hashable, Sendable {
+    case playing
+    case paused
+    case stopped
+    case loading
+    case buffering
+    case unknown
+    case other(String)
+
+    public init(rawValue: String) {
+        switch rawValue {
+        case "playing": self = .playing
+        case "paused": self = .paused
+        case "stopped": self = .stopped
+        case "loading": self = .loading
+        case "buffering": self = .buffering
+        case "unknown": self = .unknown
+        default: self = .other(rawValue)
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .playing: return "playing"
+        case .paused: return "paused"
+        case .stopped: return "stopped"
+        case .loading: return "loading"
+        case .buffering: return "buffering"
+        case .unknown: return "unknown"
+        case .other(let raw): return raw
+        }
+    }
+
+    public var isPlaying: Bool { self == .playing }
+}
+
+/// A zone's volume capability and current position within it.
+///
+/// `min`/`max`/`step` are per-zone and genuinely vary on real hardware — the
+/// live server publishes ranges of 0…98 step 0.5 and 0…42 step 1 side by side —
+/// so the Digital Crown must be bound to *this* range, never to a hardcoded
+/// 0…100.
+public struct VolumeControl: Codable, Hashable, Sendable {
+    public var value: Double
+    public var min: Double
+    public var max: Double
+    public var step: Double
+    public var isMuted: Bool
+    /// "percentage", "db", "number" — advisory, for display only.
+    public var scale: String?
+    /// The Roon *output* id, distinct from the zone id. Present for zones whose
+    /// volume is addressed per-output.
+    public var outputID: String?
+
+    public init(
+        value: Double,
+        min: Double,
+        max: Double,
+        step: Double,
+        isMuted: Bool = false,
+        scale: String? = nil,
+        outputID: String? = nil
+    ) {
+        self.value = value
+        self.min = min
+        self.max = max
+        self.step = step
+        self.isMuted = isMuted
+        self.scale = scale
+        self.outputID = outputID
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case value, min, max, step
+        case isMuted = "is_muted"
+        case scale
+        case outputID = "output_id"
+    }
+
+    /// `value` clamped into `min...max` and snapped to `step`, which is what a
+    /// crown-driven control must send: an unsnapped absolute volume is either
+    /// rejected or silently rounded by the backend, and the two backends
+    /// disagree about which.
+    public func normalized(_ raw: Double) -> Double {
+        guard step > 0, max > min else { return Swift.min(Swift.max(raw, min), max) }
+        let clamped = Swift.min(Swift.max(raw, min), max)
+        let snapped = (clamped / step).rounded() * step
+        return Swift.min(Swift.max(snapped, min), max)
+    }
+}
+
+/// One entry of `GET /zones`.
+public struct Zone: Codable, Hashable, Identifiable, Sendable {
+    /// Prefixed and globally unique: "roon:1601…", "lms:…", "hqplayer:…".
+    /// The prefix is how `POST /control` routes to a backend, so it must be
+    /// carried through verbatim and never stripped for display.
+    public var id: String
+    public var name: String
+    /// "roon", "lms", "openhome", "upnp", "hqplayer", …
+    public var source: String
+    public var state: PlaybackState
+    /// Absent for zones with no volume control at all.
+    public var volumeControl: VolumeControl?
+    /// Present only for zones fronted by an HQPlayer DSP pipeline. The Watch
+    /// does not act on it; it is decoded so the type stays a faithful mirror of
+    /// the wire and the contract test can see the field.
+    public var dsp: DSPInfo?
+    public var browseSupported: Bool
+    public var libraryTabs: [String]
+
+    public init(
+        id: String,
+        name: String,
+        source: String,
+        state: PlaybackState,
+        volumeControl: VolumeControl? = nil,
+        dsp: DSPInfo? = nil,
+        browseSupported: Bool = false,
+        libraryTabs: [String] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.source = source
+        self.state = state
+        self.volumeControl = volumeControl
+        self.dsp = dsp
+        self.browseSupported = browseSupported
+        self.libraryTabs = libraryTabs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id = "zone_id"
+        case name = "zone_name"
+        case source, state
+        case volumeControl = "volume_control"
+        case dsp
+        case browseSupported = "browse_supported"
+        case libraryTabs = "library_tabs"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        source = try c.decode(String.self, forKey: .source)
+        state = try c.decode(PlaybackState.self, forKey: .state)
+        volumeControl = try c.decodeIfPresent(VolumeControl.self, forKey: .volumeControl)
+        dsp = try c.decodeIfPresent(DSPInfo.self, forKey: .dsp)
+        browseSupported = try c.decodeIfPresent(Bool.self, forKey: .browseSupported) ?? false
+        libraryTabs = try c.decodeIfPresent([String].self, forKey: .libraryTabs) ?? []
+    }
+}
+
+/// The `dsp` object a zone carries when an HQPlayer pipeline fronts it.
+public struct DSPInfo: Codable, Hashable, Sendable {
+    public var type: String
+    public var instance: String?
+    public var pipeline: String?
+    public var profiles: String?
+
+    public init(type: String, instance: String? = nil, pipeline: String? = nil, profiles: String? = nil) {
+        self.type = type
+        self.instance = instance
+        self.pipeline = pipeline
+        self.profiles = profiles
+    }
+}
+
+/// `GET /zones`.
+public struct ZoneListResponse: Codable, Sendable {
+    public var zones: [Zone]
+
+    public init(zones: [Zone]) { self.zones = zones }
+}
+
+/// `GET /now_playing?zone_id=…`.
+///
+/// The server names the text fields `line1`/`line2`/`line3` because the knob
+/// firmware renders three lines without caring what they mean. They are in
+/// practice title / artist / album, and this type exposes both spellings: the
+/// positional names stay faithful to the wire, the semantic ones are what a
+/// SwiftUI view should bind to.
+public struct NowPlaying: Codable, Hashable, Sendable {
+    public var zoneID: String
+    public var line1: String?
+    public var line2: String?
+    public var line3: String?
+    public var isPlaying: Bool
+    public var volume: Double?
+    /// "number" or "db" — how `volume` should be formatted.
+    public var volumeType: String?
+    public var volumeMin: Double?
+    public var volumeMax: Double?
+    public var volumeStep: Double?
+    /// Server-built, server-relative artwork path. Never construct this
+    /// client-side: #611 was four surfaces independently building artwork URLs
+    /// and all four breaking at once, which is why `tests/base_path_lint.rs`
+    /// exists. Resolve it against the base URL and otherwise leave it alone.
+    public var imageURLPath: String?
+    /// Changes when the art changes; the correct cache key.
+    public var imageKey: String?
+    public var seekPosition: Double?
+    public var length: Double?
+    public var isPlayAllowed: Bool
+    public var isPauseAllowed: Bool
+    public var isNextAllowed: Bool
+    public var isPreviousAllowed: Bool
+    /// The full zone list, echoed so a client can render a picker from one
+    /// round trip instead of two.
+    public var zones: [Zone]
+    /// Short hash of the zone list. Cheap change detection for a polling
+    /// client: unchanged sha means the picker need not be rebuilt.
+    public var zonesSHA: String?
+    /// Non-null only for knob clients that identify themselves; always null
+    /// here. Decoded for wire fidelity.
+    public var configSHA: String?
+
+    public var title: String? { line1 }
+    public var artist: String? { line2 }
+    public var album: String? { line3 }
+
+    /// Volume as a `VolumeControl`, so the crown binds to one type whether the
+    /// value came from `/zones` or `/now_playing`.
+    public var volumeControl: VolumeControl? {
+        guard let volume else { return nil }
+        return VolumeControl(
+            value: volume,
+            min: volumeMin ?? 0,
+            max: volumeMax ?? 100,
+            step: volumeStep ?? 1,
+            isMuted: false,
+            scale: volumeType
+        )
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case zoneID = "zone_id"
+        case line1, line2, line3
+        case isPlaying = "is_playing"
+        case volume
+        case volumeType = "volume_type"
+        case volumeMin = "volume_min"
+        case volumeMax = "volume_max"
+        case volumeStep = "volume_step"
+        case imageURLPath = "image_url"
+        case imageKey = "image_key"
+        case seekPosition = "seek_position"
+        case length
+        case isPlayAllowed = "is_play_allowed"
+        case isPauseAllowed = "is_pause_allowed"
+        case isNextAllowed = "is_next_allowed"
+        case isPreviousAllowed = "is_previous_allowed"
+        case zones
+        case zonesSHA = "zones_sha"
+        case configSHA = "config_sha"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        zoneID = try c.decode(String.self, forKey: .zoneID)
+        line1 = try c.decodeIfPresent(String.self, forKey: .line1)
+        line2 = try c.decodeIfPresent(String.self, forKey: .line2)
+        line3 = try c.decodeIfPresent(String.self, forKey: .line3)
+        isPlaying = try c.decodeIfPresent(Bool.self, forKey: .isPlaying) ?? false
+        volume = try c.decodeIfPresent(Double.self, forKey: .volume)
+        volumeType = try c.decodeIfPresent(String.self, forKey: .volumeType)
+        volumeMin = try c.decodeIfPresent(Double.self, forKey: .volumeMin)
+        volumeMax = try c.decodeIfPresent(Double.self, forKey: .volumeMax)
+        volumeStep = try c.decodeIfPresent(Double.self, forKey: .volumeStep)
+        imageURLPath = try c.decodeIfPresent(String.self, forKey: .imageURLPath)
+        imageKey = try c.decodeIfPresent(String.self, forKey: .imageKey)
+        seekPosition = try c.decodeIfPresent(Double.self, forKey: .seekPosition)
+        length = try c.decodeIfPresent(Double.self, forKey: .length)
+        isPlayAllowed = try c.decodeIfPresent(Bool.self, forKey: .isPlayAllowed) ?? false
+        isPauseAllowed = try c.decodeIfPresent(Bool.self, forKey: .isPauseAllowed) ?? false
+        isNextAllowed = try c.decodeIfPresent(Bool.self, forKey: .isNextAllowed) ?? false
+        isPreviousAllowed = try c.decodeIfPresent(Bool.self, forKey: .isPreviousAllowed) ?? false
+        zones = try c.decodeIfPresent([Zone].self, forKey: .zones) ?? []
+        zonesSHA = try c.decodeIfPresent(String.self, forKey: .zonesSHA)
+        configSHA = try c.decodeIfPresent(String.self, forKey: .configSHA)
+    }
+
+    public init(
+        zoneID: String,
+        line1: String? = nil,
+        line2: String? = nil,
+        line3: String? = nil,
+        isPlaying: Bool = false,
+        volume: Double? = nil,
+        volumeType: String? = nil,
+        volumeMin: Double? = nil,
+        volumeMax: Double? = nil,
+        volumeStep: Double? = nil,
+        imageURLPath: String? = nil,
+        imageKey: String? = nil,
+        seekPosition: Double? = nil,
+        length: Double? = nil,
+        isPlayAllowed: Bool = false,
+        isPauseAllowed: Bool = false,
+        isNextAllowed: Bool = false,
+        isPreviousAllowed: Bool = false,
+        zones: [Zone] = [],
+        zonesSHA: String? = nil,
+        configSHA: String? = nil
+    ) {
+        self.zoneID = zoneID
+        self.line1 = line1
+        self.line2 = line2
+        self.line3 = line3
+        self.isPlaying = isPlaying
+        self.volume = volume
+        self.volumeType = volumeType
+        self.volumeMin = volumeMin
+        self.volumeMax = volumeMax
+        self.volumeStep = volumeStep
+        self.imageURLPath = imageURLPath
+        self.imageKey = imageKey
+        self.seekPosition = seekPosition
+        self.length = length
+        self.isPlayAllowed = isPlayAllowed
+        self.isPauseAllowed = isPauseAllowed
+        self.isNextAllowed = isNextAllowed
+        self.isPreviousAllowed = isPreviousAllowed
+        self.zones = zones
+        self.zonesSHA = zonesSHA
+        self.configSHA = configSHA
+    }
+}
+
+/// The `action` strings `POST /control` accepts.
+///
+/// Spelled out rather than left as free strings so a typo is a compile error.
+/// The server also accepts synonyms ("playpause", "prev", "volume_up",
+/// "volume"); this client sends one canonical spelling per action.
+public enum ControlAction: String, Codable, Sendable {
+    case play
+    case pause
+    case playPause = "play_pause"
+    case stop
+    case next
+    case previous
+    case volumeUp = "vol_up"
+    case volumeDown = "vol_down"
+    /// Absolute volume. Requires `value`.
+    case volumeAbsolute = "vol_abs"
+}
+
+/// The `POST /control` body.
+public struct ControlRequest: Codable, Sendable {
+    public var zoneID: String
+    public var action: ControlAction
+    /// Only meaningful for `.volumeAbsolute`; the server ignores it otherwise.
+    public var value: Double?
+
+    public init(zoneID: String, action: ControlAction, value: Double? = nil) {
+        self.zoneID = zoneID
+        self.action = action
+        self.value = value
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case zoneID = "zone_id"
+        case action, value
+    }
+}

--- a/companion/uhckit/Sources/UHCKit/PhoneRelayTransport.swift
+++ b/companion/uhckit/Sources/UHCKit/PhoneRelayTransport.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// The fallback transport: the Watch asks the paired iPhone to make the request
+/// and send the bytes back over WatchConnectivity.
+///
+/// **Deliberately unimplemented in this PR** (#619). It exists as a compiling
+/// conformance so that the day `DirectHTTPTransport` is proven unusable on real
+/// Watch hardware, the fix is one line at the composition root — see
+/// `UHCClient.init(transport:)` — and not a rewrite of the client, the models,
+/// or the views. That property is the actual deliverable here; finishing the
+/// relay before knowing whether it is needed would be work spent ahead of the
+/// evidence.
+///
+/// Every call throws `UHCError.transportUnavailable`, so a caller that wires
+/// this up by mistake fails loudly and immediately rather than hanging.
+///
+/// ## What implementing it requires
+///
+/// 1. **Watch side** — `WCSession.default.sendMessageData(_:replyHandler:)`,
+///    encoding `UHCRequest` and decoding `UHCResponse`. Both are `Codable`-able
+///    value types with no reference members, which is why they are shaped that
+///    way. `sendMessageData` needs the counterpart reachable; the
+///    `transferUserInfo` queue is the offline path but is far too slow for
+///    transport controls and should not be used for them.
+/// 2. **Phone side** — a `WCSessionDelegate` implementing
+///    `session(_:didReceiveMessageData:replyHandler:)` that hands the decoded
+///    request to a `DirectHTTPTransport` and replies with the encoded response.
+///    The phone app already holds local-network permission, so its own LAN
+///    access is not in question.
+/// 3. **Payload limit** — a WatchConnectivity message is capped (on the order
+///    of 64 KB). Album art at 240×240 JPEG measured ~27 KB against the live
+///    server, so it fits today, but a relay must either request a bounded size
+///    via the `width`/`height` parameters or fall back to
+///    `transferFile(_:metadata:)` for anything larger.
+/// 4. **Reachability** — `WCSession.isReachable` is false when the phone is
+///    away or locked, which is precisely when a Watch-only user wants the
+///    controller most. A production relay should race both transports rather
+///    than replace one with the other.
+public final class PhoneRelayTransport: UHCTransport, @unchecked Sendable {
+    private static let notImplemented = """
+        Relaying UHC requests through the paired iPhone is not implemented yet. \
+        Use DirectHTTPTransport, or implement PhoneRelayTransport per its \
+        documentation.
+        """
+
+    public init() {}
+
+    public var describedEndpoint: String { "iPhone relay (not implemented)" }
+
+    public func perform(_ request: UHCRequest) async throws -> UHCResponse {
+        throw UHCError.transportUnavailable(Self.notImplemented)
+    }
+}

--- a/companion/uhckit/Sources/UHCKit/UHCClient.swift
+++ b/companion/uhckit/Sources/UHCKit/UHCClient.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// The UHC control client: zones, now-playing, transport, volume, artwork.
+///
+/// Holds a `UHCTransport` and nothing else about how bytes travel, so the same
+/// client serves the Watch over WiFi today and over a phone relay later without
+/// changing a line here or in any view.
+public final class UHCClient: @unchecked Sendable {
+    public let transport: UHCTransport
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    public init(transport: UHCTransport) {
+        self.transport = transport
+    }
+
+    /// Convenience for the common case: direct LAN HTTP to `baseURL`.
+    public convenience init(baseURL: URL, timeout: TimeInterval = 8) {
+        self.init(transport: DirectHTTPTransport(baseURL: baseURL, timeout: timeout))
+    }
+
+    public var describedEndpoint: String { transport.describedEndpoint }
+
+    // MARK: - Reads
+
+    /// `GET /zones`
+    public func zones() async throws -> [Zone] {
+        let response = try await transport.perform(UHCRequest(path: "/zones"))
+        return try decodeJSON(ZoneListResponse.self, from: response).zones
+    }
+
+    /// `GET /now_playing?zone_id=…`
+    ///
+    /// The response also carries the full zone list, so a polling controller can
+    /// refresh both the picker and the current track in one round trip — which
+    /// on a watch is the difference between one radio wake and two.
+    public func nowPlaying(zoneID: String) async throws -> NowPlaying {
+        let response = try await transport.perform(
+            UHCRequest(path: "/now_playing", query: ["zone_id": zoneID])
+        )
+        return try decodeJSON(NowPlaying.self, from: response)
+    }
+
+    /// `GET /status` — a cheap liveness probe that touches no backend.
+    /// Used by the Watch's connection check because it cannot be confused with
+    /// a zone-level failure.
+    @discardableResult
+    public func status() async throws -> ServerStatus {
+        let response = try await transport.perform(UHCRequest(path: "/status", timeout: 5))
+        return try decodeJSON(ServerStatus.self, from: response)
+    }
+
+    // MARK: - Artwork
+
+    /// Fetch album art for a zone.
+    ///
+    /// The server never 404s here: when it has no art it returns an
+    /// `image/svg+xml` placeholder with a 200. `UIImage`/`WKInterfaceImage`
+    /// cannot decode SVG, so a caller that trusted the status code alone would
+    /// render an empty box and have no idea why. This method reports that case
+    /// as `nil` and lets the UI draw its own placeholder.
+    ///
+    /// `width`/`height` are the real parameter names — there is no `size`.
+    public func artwork(zoneID: String, width: Int = 240, height: Int = 240) async throws -> ArtworkData? {
+        let response = try await transport.perform(
+            UHCRequest(
+                path: "/now_playing/image",
+                query: [
+                    "zone_id": zoneID,
+                    "width": String(width),
+                    "height": String(height),
+                ],
+                timeout: 15
+            )
+        )
+
+        guard response.isSuccess else {
+            throw serverError(from: response)
+        }
+
+        let type = response.contentType?.lowercased() ?? ""
+        if type.contains("svg") {
+            return nil  // placeholder, not real art
+        }
+        guard !response.body.isEmpty else { return nil }
+        return ArtworkData(data: response.body, contentType: response.contentType)
+    }
+
+    // MARK: - Writes
+
+    /// `POST /control`
+    ///
+    /// Read-modify-write is not used anywhere here: every action is a discrete
+    /// command against a zone id, which is what makes the Watch safe to use
+    /// while another surface is driving the same zone.
+    public func control(zoneID: String, action: ControlAction, value: Double? = nil) async throws {
+        let body = try encoder.encode(ControlRequest(zoneID: zoneID, action: action, value: value))
+        let response = try await transport.perform(
+            UHCRequest(method: .post, path: "/control", body: body)
+        )
+        guard response.isSuccess else { throw serverError(from: response) }
+    }
+
+    public func play(zoneID: String) async throws { try await control(zoneID: zoneID, action: .play) }
+    public func pause(zoneID: String) async throws { try await control(zoneID: zoneID, action: .pause) }
+    public func playPause(zoneID: String) async throws { try await control(zoneID: zoneID, action: .playPause) }
+    public func next(zoneID: String) async throws { try await control(zoneID: zoneID, action: .next) }
+    public func previous(zoneID: String) async throws { try await control(zoneID: zoneID, action: .previous) }
+
+    /// Set absolute volume, clamped and step-snapped to the zone's own range.
+    ///
+    /// The crown produces a continuous value; zones publish steps of 0.5 and 1
+    /// and ceilings of 42, 98 and 100 side by side on the live server. Snapping
+    /// here means no caller has to remember to.
+    public func setVolume(zoneID: String, to raw: Double, within control: VolumeControl?) async throws {
+        let value = control?.normalized(raw) ?? raw
+        try await self.control(zoneID: zoneID, action: .volumeAbsolute, value: value)
+    }
+
+    public func volumeUp(zoneID: String) async throws { try await control(zoneID: zoneID, action: .volumeUp) }
+    public func volumeDown(zoneID: String) async throws { try await control(zoneID: zoneID, action: .volumeDown) }
+
+    // MARK: - Plumbing
+
+    private func decodeJSON<T: Decodable>(_ type: T.Type, from response: UHCResponse) throws -> T {
+        guard response.isSuccess else { throw serverError(from: response) }
+        do {
+            return try decoder.decode(T.self, from: response.body)
+        } catch {
+            throw UHCError.decoding("\(T.self): \(error)")
+        }
+    }
+
+    private func serverError(from response: UHCResponse) -> UHCError {
+        let body = try? decoder.decode(UHCErrorBody.self, from: response.body)
+        return .server(status: response.statusCode, message: body?.error, code: body?.errorCode)
+    }
+}
+
+/// `GET /status`.
+public struct ServerStatus: Codable, Sendable {
+    public var service: String
+    public var version: String
+    public var roonConnected: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case service, version
+        case roonConnected = "roon_connected"
+    }
+}
+
+/// Raw artwork bytes plus the type the server labelled them with, so the
+/// platform layer decides how to turn them into an image.
+public struct ArtworkData: Sendable, Hashable {
+    public var data: Data
+    public var contentType: String?
+
+    public init(data: Data, contentType: String? = nil) {
+        self.data = data
+        self.contentType = contentType
+    }
+}

--- a/companion/uhckit/Sources/UHCKit/UHCDiscovery.swift
+++ b/companion/uhckit/Sources/UHCKit/UHCDiscovery.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Finds UHC servers advertising `_uhc._tcp.` on the local network.
+///
+/// Moved here from the iOS feature package (#619) because the Watch needs the
+/// identical behaviour and a second copy is exactly the duplication this issue
+/// exists to prevent. The iOS app now reaches it through this package; its
+/// observable behaviour is unchanged.
+///
+/// The resolved service hostname is preferred over the TXT record's `base`: a
+/// server may advertise a loopback or container hostname in its base URL, while
+/// Bonjour has already resolved a name that is reachable from *this* device.
+/// TXT is the fallback for proxies and tunnels whose service hostname is not
+/// usable as an HTTP host.
+///
+/// On watchOS this is subject to the same unresolved local-network question as
+/// `DirectHTTPTransport` — and more sharply, since Bonjour browsing is gated
+/// separately from plain LAN sockets. A Watch build must therefore also accept
+/// a manually typed address, which is why `UHCClient` takes a `URL` and never
+/// requires discovery to have succeeded. See `Transport.md`.
+/// `@unchecked Sendable`: every mutating entry point (`start`, `stop`, the
+/// Bonjour delegate callbacks and the timeout) runs on the main queue, and the
+/// async wrapper below hops to it explicitly. The compiler cannot see that from
+/// an `NSObject` subclass, hence the manual conformance.
+public final class UHCDiscovery: NSObject, NetServiceBrowserDelegate, NetServiceDelegate, @unchecked Sendable {
+    /// Called on the main queue with the first usable server found.
+    public var onBaseURL: ((URL) -> Void)?
+    /// Called on the main queue when the search times out or cannot start.
+    public var onFailure: ((String) -> Void)?
+
+    private let browser = NetServiceBrowser()
+    private let serviceType: String
+    private let domain: String
+    private let timeoutInterval: TimeInterval
+    private var services: [NetService] = []
+    private var finished = false
+    private var timeoutWork: DispatchWorkItem?
+
+    public init(
+        serviceType: String = "_uhc._tcp.",
+        domain: String = "local.",
+        timeout: TimeInterval = 8
+    ) {
+        self.serviceType = serviceType
+        self.domain = domain
+        self.timeoutInterval = timeout
+        super.init()
+    }
+
+    public func start() {
+        finished = false
+        services.removeAll()
+        browser.delegate = self
+        browser.searchForServices(ofType: serviceType, inDomain: domain)
+        let timeout = DispatchWorkItem { [weak self] in
+            guard let self, !self.finished else { return }
+            self.finished = true
+            self.stop()
+            self.onFailure?("No UHC server was found on the local network.")
+        }
+        timeoutWork = timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeoutInterval, execute: timeout)
+    }
+
+    public func stop() {
+        timeoutWork?.cancel()
+        timeoutWork = nil
+        browser.stop()
+        services.forEach { $0.stop() }
+        services.removeAll()
+    }
+
+    /// One-shot async wrapper, for call sites that would rather await than wire
+    /// up two callbacks. Cancels the browse if the surrounding task is
+    /// cancelled.
+    public static func firstServer(
+        serviceType: String = "_uhc._tcp.",
+        domain: String = "local.",
+        timeout: TimeInterval = 8
+    ) async throws -> URL {
+        let discovery = UHCDiscovery(serviceType: serviceType, domain: domain, timeout: timeout)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                // Bonjour can fire a resolve and the timeout in quick
+                // succession; a continuation resumed twice is a crash, so guard
+                // it rather than trusting the ordering.
+                let resumed = ResumeGuard()
+                discovery.onBaseURL = { url in
+                    if resumed.claim() { continuation.resume(returning: url) }
+                }
+                discovery.onFailure = { message in
+                    if resumed.claim() {
+                        continuation.resume(throwing: UHCError.unreachable(underlying: message))
+                    }
+                }
+                DispatchQueue.main.async { discovery.start() }
+            }
+        } onCancel: {
+            DispatchQueue.main.async { discovery.stop() }
+        }
+    }
+
+    // MARK: - NetServiceBrowserDelegate
+
+    public func netServiceBrowser(
+        _ browser: NetServiceBrowser,
+        didFind service: NetService,
+        moreComing: Bool
+    ) {
+        guard !finished else { return }
+        services.append(service)
+        service.delegate = self
+        service.resolve(withTimeout: 5)
+    }
+
+    public func netServiceBrowser(
+        _ browser: NetServiceBrowser,
+        didNotSearch errorDict: [String: NSNumber]
+    ) {
+        onFailure?("Could not search for UHC on the local network.")
+    }
+
+    // MARK: - NetServiceDelegate
+
+    public func netServiceDidResolveAddress(_ sender: NetService) {
+        guard !finished else { return }
+        if let host = sender.hostName?.trimmingCharacters(in: CharacterSet(charactersIn: ".")),
+           !host.isEmpty, sender.port > 0,
+           let url = URL(string: "http://\(host):\(sender.port)") {
+            finish(url)
+            return
+        }
+
+        let txt = sender.txtRecordData().map(NetService.dictionary(fromTXTRecord:)) ?? [:]
+        if let raw = txt["base"].flatMap({ String(data: $0, encoding: .utf8) }),
+           let url = URL(string: raw), url.host != nil {
+            finish(url)
+        }
+    }
+
+    public func netService(_ sender: NetService, didNotResolve errorDict: [String: NSNumber]) {
+        guard !finished, services.allSatisfy({ $0 === sender || $0.port > 0 }) else { return }
+        onFailure?("Could not resolve UHC on the local network.")
+    }
+
+    private func finish(_ url: URL) {
+        finished = true
+        stop()
+        onBaseURL?(url)
+    }
+}
+
+/// Single-claim latch, so a continuation is resumed exactly once.
+private final class ResumeGuard: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if claimed { return false }
+        claimed = true
+        return true
+    }
+}

--- a/companion/uhckit/Sources/UHCKit/UHCDiscovery.swift
+++ b/companion/uhckit/Sources/UHCKit/UHCDiscovery.swift
@@ -1,40 +1,53 @@
 import Foundation
 
+#if os(watchOS)
+import Network
+#endif
+
 /// Finds UHC servers advertising `_uhc._tcp.` on the local network.
 ///
 /// Moved here from the iOS feature package (#619) because the Watch needs the
-/// identical behaviour and a second copy is exactly the duplication this issue
-/// exists to prevent. The iOS app now reaches it through this package; its
-/// observable behaviour is unchanged.
+/// same capability and a second copy is exactly the duplication this issue
+/// exists to prevent.
 ///
-/// The resolved service hostname is preferred over the TXT record's `base`: a
-/// server may advertise a loopback or container hostname in its base URL, while
-/// Bonjour has already resolved a name that is reachable from *this* device.
-/// TXT is the fallback for proxies and tunnels whose service hostname is not
-/// usable as an HTTP host.
+/// ## Why there are two implementations
 ///
-/// On watchOS this is subject to the same unresolved local-network question as
-/// `DirectHTTPTransport` — and more sharply, since Bonjour browsing is gated
-/// separately from plain LAN sockets. A Watch build must therefore also accept
-/// a manually typed address, which is why `UHCClient` takes a `URL` and never
-/// requires discovery to have succeeded. See `Transport.md`.
-/// `@unchecked Sendable`: every mutating entry point (`start`, `stop`, the
-/// Bonjour delegate callbacks and the timeout) runs on the main queue, and the
-/// async wrapper below hops to it explicitly. The compiler cannot see that from
-/// an `NSObject` subclass, hence the manual conformance.
-public final class UHCDiscovery: NSObject, NetServiceBrowserDelegate, NetServiceDelegate, @unchecked Sendable {
+/// **`NetService` and `NetServiceBrowser` do not exist on watchOS.** They are
+/// marked unavailable, so this is a compile error rather than a runtime
+/// failure — one of the few hard facts available about watchOS networking
+/// without a device in hand (see `Transport.md`). The iOS path therefore keeps
+/// the exact `NetService` code that ships today, byte for byte, and watchOS
+/// gets an `NWBrowser` implementation.
+///
+/// The two differ in how they arrive at a URL, and it is worth knowing which
+/// you are relying on:
+///
+/// - **iOS/macOS** resolves the service and prefers the *resolved hostname*,
+///   falling back to the TXT record's `base` key.
+/// - **watchOS** can only read the TXT record: `NWBrowser` reports services and
+///   their metadata but resolving one to a host requires opening an
+///   `NWConnection`, and the TXT `base` key the server already publishes
+///   (`base=http://NAS2:8088`) makes that round trip unnecessary. A server that
+///   advertises no `base` key is therefore undiscoverable from the Watch, which
+///   is why the Watch UI always offers manual address entry too.
+public final class UHCDiscovery: NSObject, @unchecked Sendable {
     /// Called on the main queue with the first usable server found.
     public var onBaseURL: ((URL) -> Void)?
     /// Called on the main queue when the search times out or cannot start.
     public var onFailure: ((String) -> Void)?
 
-    private let browser = NetServiceBrowser()
     private let serviceType: String
     private let domain: String
     private let timeoutInterval: TimeInterval
-    private var services: [NetService] = []
     private var finished = false
     private var timeoutWork: DispatchWorkItem?
+
+    #if os(watchOS)
+    private var browser: NWBrowser?
+    #else
+    private let browser = NetServiceBrowser()
+    private var services: [NetService] = []
+    #endif
 
     public init(
         serviceType: String = "_uhc._tcp.",
@@ -49,9 +62,6 @@ public final class UHCDiscovery: NSObject, NetServiceBrowserDelegate, NetService
 
     public func start() {
         finished = false
-        services.removeAll()
-        browser.delegate = self
-        browser.searchForServices(ofType: serviceType, inDomain: domain)
         let timeout = DispatchWorkItem { [weak self] in
             guard let self, !self.finished else { return }
             self.finished = true
@@ -60,14 +70,20 @@ public final class UHCDiscovery: NSObject, NetServiceBrowserDelegate, NetService
         }
         timeoutWork = timeout
         DispatchQueue.main.asyncAfter(deadline: .now() + timeoutInterval, execute: timeout)
+        startBrowsing()
     }
 
     public func stop() {
         timeoutWork?.cancel()
         timeoutWork = nil
-        browser.stop()
-        services.forEach { $0.stop() }
-        services.removeAll()
+        stopBrowsing()
+    }
+
+    private func finish(_ url: URL) {
+        guard !finished else { return }
+        finished = true
+        stop()
+        onBaseURL?(url)
     }
 
     /// One-shot async wrapper, for call sites that would rather await than wire
@@ -100,7 +116,84 @@ public final class UHCDiscovery: NSObject, NetServiceBrowserDelegate, NetService
         }
     }
 
-    // MARK: - NetServiceBrowserDelegate
+    /// Reads a usable base URL out of a Bonjour TXT record. Shared by both
+    /// implementations so the fallback rule cannot drift between platforms.
+    static func baseURL(fromTXT txt: [String: String]) -> URL? {
+        guard let raw = txt["base"], let url = URL(string: raw), url.host != nil else {
+            return nil
+        }
+        return url
+    }
+}
+
+// MARK: - watchOS: NWBrowser
+
+#if os(watchOS)
+extension UHCDiscovery {
+    private func startBrowsing() {
+        let parameters = NWParameters()
+        parameters.includePeerToPeer = false
+
+        // NWBrowser wants the type without the trailing dot NetService uses.
+        let type = serviceType.hasSuffix(".") ? String(serviceType.dropLast()) : serviceType
+        let trimmedDomain = domain.hasSuffix(".") ? String(domain.dropLast()) : domain
+
+        let browser = NWBrowser(
+            for: .bonjourWithTXTRecord(type: type, domain: trimmedDomain),
+            using: parameters
+        )
+        self.browser = browser
+
+        browser.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            if case .failed(let error) = state {
+                DispatchQueue.main.async {
+                    guard !self.finished else { return }
+                    // On watchOS this is the signal that matters: a denial here
+                    // means local-network access is refused, not that the
+                    // server is absent.
+                    self.onFailure?("Bonjour browsing failed: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        browser.browseResultsChangedHandler = { [weak self] results, _ in
+            guard let self else { return }
+            for result in results {
+                guard case .bonjour(let record) = result.metadata else { continue }
+                guard let url = UHCDiscovery.baseURL(fromTXT: record.dictionary) else { continue }
+                DispatchQueue.main.async { self.finish(url) }
+                return
+            }
+        }
+
+        browser.start(queue: .main)
+    }
+
+    private func stopBrowsing() {
+        browser?.cancel()
+        browser = nil
+    }
+}
+#endif
+
+// MARK: - iOS/macOS: NetService
+//
+// Unchanged from the implementation that ships in the iOS companion today.
+
+#if !os(watchOS)
+extension UHCDiscovery: NetServiceBrowserDelegate, NetServiceDelegate {
+    private func startBrowsing() {
+        services.removeAll()
+        browser.delegate = self
+        browser.searchForServices(ofType: serviceType, inDomain: domain)
+    }
+
+    private func stopBrowsing() {
+        browser.stop()
+        services.forEach { $0.stop() }
+        services.removeAll()
+    }
 
     public func netServiceBrowser(
         _ browser: NetServiceBrowser,
@@ -120,10 +213,11 @@ public final class UHCDiscovery: NSObject, NetServiceBrowserDelegate, NetService
         onFailure?("Could not search for UHC on the local network.")
     }
 
-    // MARK: - NetServiceDelegate
-
     public func netServiceDidResolveAddress(_ sender: NetService) {
         guard !finished else { return }
+        // Prefer the resolved hostname: a server may advertise a loopback or
+        // container hostname in its TXT base URL, while Bonjour has already
+        // resolved a name reachable from *this* device.
         if let host = sender.hostName?.trimmingCharacters(in: CharacterSet(charactersIn: ".")),
            !host.isEmpty, sender.port > 0,
            let url = URL(string: "http://\(host):\(sender.port)") {
@@ -131,24 +225,24 @@ public final class UHCDiscovery: NSObject, NetServiceBrowserDelegate, NetService
             return
         }
 
-        let txt = sender.txtRecordData().map(NetService.dictionary(fromTXTRecord:)) ?? [:]
-        if let raw = txt["base"].flatMap({ String(data: $0, encoding: .utf8) }),
-           let url = URL(string: raw), url.host != nil {
+        // Fall back to the explicit base URL for proxies/tunnels whose service
+        // hostname is not usable as an HTTP host.
+        let raw = sender.txtRecordData().map(NetService.dictionary(fromTXTRecord:)) ?? [:]
+        let txt = raw.compactMapValues { String(data: $0, encoding: .utf8) }
+        if let url = UHCDiscovery.baseURL(fromTXT: txt) {
             finish(url)
         }
     }
 
     public func netService(_ sender: NetService, didNotResolve errorDict: [String: NSNumber]) {
+        // Only give up once every other candidate has also failed: the live
+        // network advertises a stale second instance that never resolves, and
+        // failing on it would abandon a browse that is about to succeed.
         guard !finished, services.allSatisfy({ $0 === sender || $0.port > 0 }) else { return }
         onFailure?("Could not resolve UHC on the local network.")
     }
-
-    private func finish(_ url: URL) {
-        finished = true
-        stop()
-        onBaseURL?(url)
-    }
 }
+#endif
 
 /// Single-claim latch, so a continuation is resumed exactly once.
 private final class ResumeGuard: @unchecked Sendable {

--- a/companion/uhckit/Sources/UHCKit/UHCTransport.swift
+++ b/companion/uhckit/Sources/UHCKit/UHCTransport.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// The one seam between "what the controller wants" and "how the bytes get
+/// there" (#619).
+///
+/// The Watch may reach UHC two ways — straight over WiFi, or relayed through
+/// the paired iPhone via WatchConnectivity — and which of those actually works
+/// on real hardware is *unsettled* (see `Transport.md`). So the abstraction is
+/// placed where swapping costs nothing: a transport moves one request and
+/// returns one response, and knows nothing about zones, artwork or transport
+/// controls. `UHCClient` holds all of that and is transport-agnostic.
+///
+/// The unit is deliberately raw bytes rather than a decoded model. Artwork is a
+/// UHC request like any other, so a relay carries images through the same pipe
+/// as JSON instead of needing a second, image-shaped hole punched through it.
+public protocol UHCTransport: Sendable {
+    /// Perform one request. Throws `UHCError` for transport-level failures;
+    /// a non-2xx *server* response is returned normally, not thrown, so the
+    /// caller can read structured error bodies.
+    func perform(_ request: UHCRequest) async throws -> UHCResponse
+
+    /// Human-readable description of where this transport points, for
+    /// diagnostics on a screen too small for anything longer.
+    var describedEndpoint: String { get }
+}
+
+/// A UHC request, expressed independently of any transport.
+public struct UHCRequest: Sendable, Hashable {
+    public enum Method: String, Sendable, Hashable {
+        case get = "GET"
+        case post = "POST"
+    }
+
+    public var method: Method
+    /// Server-absolute, leading slash, no host: "/zones", "/now_playing".
+    public var path: String
+    public var query: [String: String]
+    public var body: Data?
+    /// Per-request override; nil means the transport's own default.
+    public var timeout: TimeInterval?
+
+    public init(
+        method: Method = .get,
+        path: String,
+        query: [String: String] = [:],
+        body: Data? = nil,
+        timeout: TimeInterval? = nil
+    ) {
+        self.method = method
+        self.path = path
+        self.query = query
+        self.body = body
+        self.timeout = timeout
+    }
+}
+
+/// What a transport hands back.
+public struct UHCResponse: Sendable, Hashable {
+    public var statusCode: Int
+    public var body: Data
+    public var contentType: String?
+
+    public init(statusCode: Int, body: Data, contentType: String? = nil) {
+        self.statusCode = statusCode
+        self.body = body
+        self.contentType = contentType
+    }
+
+    public var isSuccess: Bool { (200..<300).contains(statusCode) }
+}
+
+/// Failures a UHCKit call can produce.
+public enum UHCError: Error, LocalizedError, Sendable {
+    /// The request never reached a server. On watchOS this is the case that
+    /// matters most: it is what a blocked LAN connection looks like.
+    case unreachable(underlying: String)
+    case timedOut
+    /// The server answered with a non-2xx status.
+    case server(status: Int, message: String?, code: String?)
+    case decoding(String)
+    /// A transport that exists but has not been implemented yet.
+    case transportUnavailable(String)
+    case invalidBaseURL
+
+    public var errorDescription: String? {
+        switch self {
+        case .unreachable(let underlying):
+            return "Cannot reach UHC: \(underlying)"
+        case .timedOut:
+            return "UHC did not respond in time."
+        case .server(let status, let message, _):
+            return message.map { "UHC error \(status): \($0)" } ?? "UHC error \(status)."
+        case .decoding(let detail):
+            return "Unexpected response from UHC: \(detail)"
+        case .transportUnavailable(let detail):
+            return detail
+        case .invalidBaseURL:
+            return "The UHC address is not a valid URL."
+        }
+    }
+}
+
+/// The structured error body UHC returns for 4xx on the controller endpoints,
+/// e.g. `{"error":"zone not found","error_code":"ZONE_NOT_FOUND","zones":[…]}`.
+struct UHCErrorBody: Decodable {
+    var error: String?
+    var errorCode: String?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case errorCode = "error_code"
+    }
+}

--- a/companion/uhckit/Tests/UHCKitTests/ContractTests.swift
+++ b/companion/uhckit/Tests/UHCKitTests/ContractTests.swift
@@ -1,0 +1,222 @@
+import XCTest
+@testable import UHCKit
+
+/// The Swift half of the UHCKit wire contract (#619).
+///
+/// Reads the *same* file as `tests/uhckit_contract.rs` — not a copy of it.
+/// That is the whole mechanism: the Rust test proves the fixture still matches
+/// what the server emits, and this test proves the Swift models still decode
+/// the fixture. Neither side can drift without one of the two going red.
+///
+/// If this test cannot find the fixture, that is a real failure and not a
+/// reason to skip: it means the file moved and the Rust test is now guarding
+/// something this client never sees.
+final class ContractTests: XCTestCase {
+    // MARK: - Fixture plumbing
+
+    /// Walks up from this source file to the repository root.
+    ///
+    /// `Bundle.module` would be the idiomatic route, but that needs the fixture
+    /// copied into the package — and a copy is exactly what this design is
+    /// avoiding. The path is resolved from `#filePath` so it breaks loudly if
+    /// the layout changes.
+    static func fixtureURL() throws -> URL {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        // …/companion/uhckit/Tests/UHCKitTests/ContractTests.swift
+        let repoRoot = thisFile
+            .deletingLastPathComponent()  // UHCKitTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // uhckit
+            .deletingLastPathComponent()  // companion
+            .deletingLastPathComponent()  // <repo root>
+        let url = repoRoot
+            .appendingPathComponent("tests/fixtures/uhckit_contract.json")
+
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw XCTSkip(
+                """
+                Contract fixture not found at \(url.path).
+                It is shared with tests/uhckit_contract.rs; if it moved, update both.
+                """
+            )
+        }
+        return url
+    }
+
+    private func fixture() throws -> [String: Any] {
+        let data = try Data(contentsOf: try Self.fixtureURL())
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ContractError.malformed("top level is not an object")
+        }
+        return object
+    }
+
+    /// Re-encodes a fixture subtree so it can be fed to `JSONDecoder`.
+    private func data(at path: [String], in fixture: [String: Any]) throws -> Data {
+        var current: Any = fixture
+        for key in path {
+            guard let dict = current as? [String: Any], let next = dict[key] else {
+                throw ContractError.malformed("missing key path \(path.joined(separator: "."))")
+            }
+            current = next
+        }
+        return try JSONSerialization.data(withJSONObject: current)
+    }
+
+    private func strings(at path: [String], in fixture: [String: Any]) throws -> [String] {
+        var current: Any = fixture
+        for key in path {
+            guard let dict = current as? [String: Any], let next = dict[key] else {
+                throw ContractError.malformed("missing key path \(path.joined(separator: "."))")
+            }
+            current = next
+        }
+        guard let array = current as? [String] else {
+            throw ContractError.malformed("\(path.joined(separator: ".")) is not an array of strings")
+        }
+        return array
+    }
+
+    enum ContractError: Error { case malformed(String) }
+
+    // MARK: - Zones
+
+    func testFullZoneDecodes() throws {
+        let zone = try JSONDecoder().decode(Zone.self, from: try data(at: ["zone", "full"], in: try fixture()))
+
+        XCTAssertEqual(zone.id, "roon:1601deadbeef")
+        XCTAssertEqual(zone.name, "Front Family Room")
+        XCTAssertEqual(zone.source, "roon")
+        XCTAssertEqual(zone.state, .playing)
+        XCTAssertTrue(zone.browseSupported)
+        XCTAssertEqual(zone.libraryTabs, ["browse", "playlists"])
+
+        let volume = try XCTUnwrap(zone.volumeControl)
+        XCTAssertEqual(volume.value, 47.5)
+        XCTAssertEqual(volume.min, 0)
+        XCTAssertEqual(volume.max, 98)
+        XCTAssertEqual(volume.step, 0.5)
+        XCTAssertFalse(volume.isMuted)
+        XCTAssertEqual(volume.scale, "percentage")
+        XCTAssertEqual(volume.outputID, "roon:1701deadbeef")
+
+        XCTAssertEqual(zone.dsp?.type, "hqplayer")
+        XCTAssertEqual(zone.dsp?.instance, "embedded")
+    }
+
+    /// The case that would break a naive model: the live server publishes a
+    /// zone with no `volume_control` key at all.
+    func testZoneWithoutVolumeControlDecodes() throws {
+        let zone = try JSONDecoder().decode(Zone.self, from: try data(at: ["zone", "minimal"], in: try fixture()))
+
+        XCTAssertEqual(zone.name, "HQPlayer Embedded")
+        XCTAssertNil(zone.volumeControl, "a zone with no volume must decode, not throw")
+        XCTAssertNil(zone.dsp)
+        XCTAssertEqual(zone.state, .stopped)
+    }
+
+    /// Every state string the server can emit must map to a case, and an
+    /// unrecognised one must degrade rather than throw — a new adapter should
+    /// not be able to take down the zone list on an already-installed Watch.
+    func testEveryServerStateDecodes() throws {
+        let states = try strings(at: ["zone", "states", "values"], in: try fixture())
+        XCTAssertFalse(states.isEmpty)
+
+        for raw in states {
+            let state = PlaybackState(rawValue: raw)
+            XCTAssertEqual(state.rawValue, raw, "state `\(raw)` did not round-trip")
+            if case .other = state {
+                XCTFail("state `\(raw)` is published by the server but unknown to UHCKit")
+            }
+        }
+
+        let future = PlaybackState(rawValue: "teleporting")
+        XCTAssertEqual(future, .other("teleporting"))
+        XCTAssertFalse(future.isPlaying)
+    }
+
+    // MARK: - Now playing
+
+    func testNowPlayingDecodes() throws {
+        let np = try JSONDecoder().decode(NowPlaying.self, from: try data(at: ["now_playing"], in: try fixture()))
+
+        XCTAssertEqual(np.zoneID, "roon:1601deadbeef")
+        XCTAssertEqual(np.title, "Summer (B-Sides)")
+        XCTAssertEqual(np.artist, "Moby")
+        XCTAssertEqual(np.album, "Play & Play: The B Sides")
+        XCTAssertTrue(np.isPlaying)
+        XCTAssertEqual(np.volume, 47.5)
+        XCTAssertEqual(np.volumeType, "number")
+        XCTAssertEqual(np.imageKey, "b7df27c8dd25dd65084d8f2d94f616d0")
+        XCTAssertEqual(np.seekPosition, 104)
+        XCTAssertEqual(np.length, 358)
+        XCTAssertEqual(np.zonesSHA, "4bb54fbe")
+        XCTAssertNil(np.configSHA, "config_sha is null for non-knob clients")
+
+        // Capability flags gate the UI's buttons; a mis-mapped pair would show
+        // a control that is guaranteed to fail.
+        XCTAssertFalse(np.isPlayAllowed)
+        XCTAssertTrue(np.isPauseAllowed)
+        XCTAssertTrue(np.isNextAllowed)
+        XCTAssertTrue(np.isPreviousAllowed)
+    }
+
+    /// `/now_playing` carries enough to drive the crown without a second
+    /// request to `/zones`.
+    func testNowPlayingProjectsAVolumeControl() throws {
+        let np = try JSONDecoder().decode(NowPlaying.self, from: try data(at: ["now_playing"], in: try fixture()))
+        let volume = try XCTUnwrap(np.volumeControl)
+
+        XCTAssertEqual(volume.value, 47.5)
+        XCTAssertEqual(volume.min, 0)
+        XCTAssertEqual(volume.max, 98)
+        XCTAssertEqual(volume.step, 0.5)
+    }
+
+    func testErrorBodyDecodes() throws {
+        let body = try JSONDecoder().decode(
+            UHCErrorBody.self,
+            from: try data(at: ["now_playing_error"], in: try fixture())
+        )
+        XCTAssertEqual(body.error, "zone not found")
+        XCTAssertEqual(body.errorCode, "ZONE_NOT_FOUND")
+    }
+
+    // MARK: - Control
+
+    /// Every action the Swift enum can emit must be one the fixture blesses,
+    /// and the fixture is in turn checked against the server's match arms by
+    /// `tests/uhckit_contract.rs`.
+    func testControlActionsAreAllServerSupported() throws {
+        let allowed = Set(try strings(at: ["control", "actions"], in: try fixture()))
+        let emitted: [ControlAction] = [
+            .play, .pause, .playPause, .stop, .next, .previous,
+            .volumeUp, .volumeDown, .volumeAbsolute,
+        ]
+
+        for action in emitted {
+            XCTAssertTrue(
+                allowed.contains(action.rawValue),
+                "UHCKit can send `\(action.rawValue)`, which the server contract does not list"
+            )
+        }
+    }
+
+    func testControlRequestEncodesToTheServerShape() throws {
+        let request = ControlRequest(zoneID: "roon:1601deadbeef", action: .volumeAbsolute, value: 31.5)
+        let encoded = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+
+        let expected = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: try data(at: ["control", "request"], in: try fixture()))
+                as? [String: Any]
+        )
+
+        XCTAssertEqual(Set(object.keys), Set(expected.keys))
+        XCTAssertEqual(object["zone_id"] as? String, expected["zone_id"] as? String)
+        XCTAssertEqual(object["action"] as? String, expected["action"] as? String)
+        XCTAssertEqual(object["value"] as? Double, expected["value"] as? Double)
+    }
+}

--- a/companion/uhckit/Tests/UHCKitTests/UHCClientTests.swift
+++ b/companion/uhckit/Tests/UHCKitTests/UHCClientTests.swift
@@ -1,0 +1,190 @@
+import XCTest
+@testable import UHCKit
+
+/// Client behaviour, exercised through a stub transport.
+///
+/// The transport seam exists so the Watch can swap direct-WiFi for a phone
+/// relay without touching the client; the same seam makes the client testable
+/// without a server, which is a good sign the seam is in the right place.
+final class UHCClientTests: XCTestCase {
+    /// Records what the client asked for and replays canned responses.
+    final class StubTransport: UHCTransport, @unchecked Sendable {
+        var requests: [UHCRequest] = []
+        var responses: [UHCResponse]
+        var error: UHCError?
+
+        init(responses: [UHCResponse] = [], error: UHCError? = nil) {
+            self.responses = responses
+            self.error = error
+        }
+
+        var describedEndpoint: String { "stub" }
+
+        func perform(_ request: UHCRequest) async throws -> UHCResponse {
+            requests.append(request)
+            if let error { throw error }
+            guard !responses.isEmpty else {
+                return UHCResponse(statusCode: 200, body: Data("{}".utf8), contentType: "application/json")
+            }
+            return responses.removeFirst()
+        }
+    }
+
+    private func json(_ raw: String, status: Int = 200) -> UHCResponse {
+        UHCResponse(statusCode: status, body: Data(raw.utf8), contentType: "application/json")
+    }
+
+    // MARK: - Requests
+
+    func testNowPlayingSendsZoneIDAsAQueryParameter() async throws {
+        let transport = StubTransport(responses: [json(#"{"zone_id":"roon:1","zones":[]}"#)])
+        let client = UHCClient(transport: transport)
+
+        _ = try await client.nowPlaying(zoneID: "roon:1601abc")
+
+        let request = try XCTUnwrap(transport.requests.first)
+        XCTAssertEqual(request.method, .get)
+        XCTAssertEqual(request.path, "/now_playing")
+        XCTAssertEqual(request.query["zone_id"], "roon:1601abc")
+    }
+
+    /// `width`/`height` — not `size`. Getting this wrong yields a correctly
+    /// sized-looking request that the server silently ignores.
+    func testArtworkRequestsWidthAndHeight() async throws {
+        let transport = StubTransport(responses: [
+            UHCResponse(statusCode: 200, body: Data([0xFF, 0xD8, 0xFF]), contentType: "image/jpeg")
+        ])
+        let client = UHCClient(transport: transport)
+
+        let art = try await client.artwork(zoneID: "roon:1", width: 200, height: 120)
+
+        let request = try XCTUnwrap(transport.requests.first)
+        XCTAssertEqual(request.path, "/now_playing/image")
+        XCTAssertEqual(request.query["width"], "200")
+        XCTAssertEqual(request.query["height"], "120")
+        XCTAssertNil(request.query["size"], "the server has no `size` parameter")
+        XCTAssertEqual(art?.data.count, 3)
+    }
+
+    /// The server answers 200 with an SVG placeholder when it has no art.
+    /// `UIImage` cannot decode SVG, so the client must report "no artwork"
+    /// rather than handing the UI bytes it will fail to render.
+    func testSVGPlaceholderIsReportedAsNoArtwork() async throws {
+        let transport = StubTransport(responses: [
+            UHCResponse(
+                statusCode: 200,
+                body: Data("<svg xmlns=\"http://www.w3.org/2000/svg\"/>".utf8),
+                contentType: "image/svg+xml"
+            )
+        ])
+        let client = UHCClient(transport: transport)
+
+        let art = try await client.artwork(zoneID: "roon:1")
+        XCTAssertNil(art, "an SVG placeholder is not artwork the platform can draw")
+    }
+
+    func testControlPostsTheCanonicalBody() async throws {
+        let transport = StubTransport(responses: [json(#"{"ok":true}"#)])
+        let client = UHCClient(transport: transport)
+
+        try await client.control(zoneID: "roon:1601abc", action: .volumeAbsolute, value: 31.5)
+
+        let request = try XCTUnwrap(transport.requests.first)
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.path, "/control")
+
+        let body = try XCTUnwrap(request.body)
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object["zone_id"] as? String, "roon:1601abc")
+        XCTAssertEqual(object["action"] as? String, "vol_abs")
+        XCTAssertEqual(object["value"] as? Double, 31.5)
+    }
+
+    // MARK: - Errors
+
+    func testStructuredServerErrorsSurfaceTheirCode() async throws {
+        let transport = StubTransport(responses: [
+            json(#"{"error":"zone not found","error_code":"ZONE_NOT_FOUND"}"#, status: 404)
+        ])
+        let client = UHCClient(transport: transport)
+
+        do {
+            _ = try await client.nowPlaying(zoneID: "roon:nope")
+            XCTFail("expected a server error")
+        } catch let error as UHCError {
+            guard case .server(let status, let message, let code) = error else {
+                return XCTFail("expected .server, got \(error)")
+            }
+            XCTAssertEqual(status, 404)
+            XCTAssertEqual(message, "zone not found")
+            XCTAssertEqual(code, "ZONE_NOT_FOUND")
+        }
+    }
+
+    /// A non-2xx must not be reported as a decoding failure — on a watch the
+    /// difference decides whether the user is told "can't reach UHC" or
+    /// "that zone is gone".
+    func testTransportFailuresPropagate() async throws {
+        let transport = StubTransport(error: .unreachable(underlying: "-1004 could not connect"))
+        let client = UHCClient(transport: transport)
+
+        do {
+            _ = try await client.zones()
+            XCTFail("expected a transport error")
+        } catch let error as UHCError {
+            guard case .unreachable(let underlying) = error else {
+                return XCTFail("expected .unreachable, got \(error)")
+            }
+            XCTAssertTrue(underlying.contains("-1004"))
+        }
+    }
+
+    // MARK: - Volume
+
+    /// Zones publish genuinely different ranges and steps (0…98 by 0.5 and
+    /// 0…42 by 1 live side by side), so the crown's raw value must be snapped
+    /// to the zone it is driving.
+    func testVolumeIsClampedAndSnappedToTheZoneRange() {
+        let control = VolumeControl(value: 40, min: 0, max: 98, step: 0.5)
+
+        XCTAssertEqual(control.normalized(47.4), 47.5)
+        XCTAssertEqual(control.normalized(47.6), 47.5)
+        XCTAssertEqual(control.normalized(-10), 0, "below range clamps to min")
+        XCTAssertEqual(control.normalized(1000), 98, "above range clamps to max")
+
+        let coarse = VolumeControl(value: 5, min: 0, max: 42, step: 1)
+        XCTAssertEqual(coarse.normalized(5.4), 5)
+        XCTAssertEqual(coarse.normalized(5.6), 6)
+        XCTAssertEqual(coarse.normalized(41.9), 42)
+    }
+
+    func testSetVolumeSendsTheSnappedValue() async throws {
+        let transport = StubTransport(responses: [json(#"{"ok":true}"#)])
+        let client = UHCClient(transport: transport)
+        let control = VolumeControl(value: 40, min: 0, max: 98, step: 0.5)
+
+        try await client.setVolume(zoneID: "roon:1", to: 47.42, within: control)
+
+        let body = try XCTUnwrap(transport.requests.first?.body)
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(object["value"] as? Double, 47.5)
+    }
+
+    // MARK: - Transports
+
+    /// The relay is a documented placeholder. It must fail loudly and
+    /// immediately rather than hang, so wiring it up by mistake is obvious.
+    func testPhoneRelayTransportFailsLoudly() async {
+        let relay = PhoneRelayTransport()
+        do {
+            _ = try await relay.perform(UHCRequest(path: "/zones"))
+            XCTFail("the relay is not implemented and must not appear to work")
+        } catch let error as UHCError {
+            guard case .transportUnavailable = error else {
+                return XCTFail("expected .transportUnavailable, got \(error)")
+            }
+        } catch {
+            XCTFail("expected UHCError, got \(error)")
+        }
+    }
+}

--- a/companion/uhckit/Transport.md
+++ b/companion/uhckit/Transport.md
@@ -1,0 +1,116 @@
+# Reaching UHC from a Watch
+
+Status: **unsettled**. This document records what is known, what was measured,
+and exactly what still needs a physical Apple Watch to decide (#619).
+
+## The question
+
+Can a watchOS app open an HTTP connection to a device on the local network —
+UHC on `192.168.1.209:8088`, or `NAS2.local:8088` — or must the request be
+relayed through the paired iPhone?
+
+The evidence in the issue conflicts:
+
+- Apple DTS states a plain `URLSession` call to a LAN IP **fails** on watchOS
+  ([forum thread 785846](https://developer.apple.com/forums/thread/785846)).
+- rooWatch ships as a standalone Watch Roon controller that connects **directly
+  over WiFi**, which the first claim would forbid.
+- A third thread suggests the deciding factor is **an iOS app in the same bundle
+  holding local-network permission**
+  ([thread 759321](https://developer.apple.com/forums/thread/759321)).
+
+This project satisfies that third condition: the iOS companion already declares
+`NSLocalNetworkUsageDescription` and `NSBonjourServices` for `_uhc._tcp`, and
+`UHCWatchApp` is embedded in the iOS app bundle via an *Embed Watch Content*
+build phase. So if the third explanation is the correct one, this build should
+work.
+
+## What is actually settled
+
+**`NetService` and `NetServiceBrowser` are unavailable on watchOS.** This is not
+a runtime guess — it is a compile error:
+
+```
+error: 'NetServiceBrowser' is unavailable in watchOS
+```
+
+That is the one hard fact obtainable without a device. It means classic Bonjour
+discovery cannot be shared with iOS, and `UHCDiscovery` therefore carries an
+`NWBrowser` implementation for watchOS. The watchOS path reads the service's TXT
+record and uses its `base` key (`base=http://NAS2:8088`), because resolving a
+`NWBrowser` result to a host otherwise requires opening an `NWConnection`.
+
+A consequence worth noting: Bonjour browsing is gated *separately* from plain
+LAN sockets. Discovery could fail while direct HTTP to a typed-in address still
+works, or vice versa. The Watch UI therefore always offers manual address entry
+and never requires discovery to have succeeded.
+
+## What the simulator proves — and does not
+
+The watchOS simulator runs on macOS and uses the Mac's networking stack. It will
+reach the LAN happily whatever the real OS policy is. **A green simulator run is
+not evidence about real hardware.**
+
+What the simulator run did legitimately establish (watchOS 26.5, Apple Watch
+Series 11 46mm) is that the client and UI are correct: the app discovered the
+live server over Bonjour, listed all 10 real zones, rendered now-playing with
+decoded JPEG artwork, and honoured the server's per-command capability flags.
+Those would be equally true on a device *if* the transport works.
+
+## How to settle it
+
+Build and install `UHCWatchApp` on a real Apple Watch, on the same WiFi network
+as UHC, then:
+
+1. **Launch the app.** It browses for `_uhc._tcp`.
+   - Zones appear → direct LAN access works, including Bonjour. Done.
+   - "No UHC server found" → continue.
+2. **Open `Server` → `Manual address`** and enter the server's IP and port
+   (`192.168.1.209:8088`). Tap **Connect**. This separates the two gates: if
+   this works, plain LAN sockets are allowed and only Bonjour browsing is
+   blocked.
+3. **If it still fails, read the `Diagnostics` section** on that same screen. It
+   shows the raw underlying error rather than a friendly paraphrase, which is
+   the detail that distinguishes the cases:
+   - `-1004` (`cannotConnectToHost`) — nothing listening, or the request was
+     refused. Check the address first.
+   - `-1009` (`notConnectedToInternet`) — the OS considers the app offline; on a
+     Watch that is the signature of a *policy* block rather than a routing
+     failure.
+   - `-1001` (`timedOut`) — silently dropped, the classic look of a firewall or
+     entitlement block.
+4. **Also try with the iPhone switched off or out of range.** If it works only
+   while the phone is nearby, the traffic is being proxied through the phone by
+   the OS and is not true direct access — which changes the answer even though
+   both look identical from the app.
+
+Please report the exact diagnostics string. That is what turns this from a
+guess into a fact.
+
+## If direct access turns out to be blocked
+
+Nothing above the transport changes. `UHCClient` is constructed with a
+`UHCTransport`, and the Watch builds one in exactly one place —
+`WatchController.connect(to:)`:
+
+```swift
+let client = UHCClient(transport: DirectHTTPTransport(baseURL: url))
+```
+
+Swapping that for `PhoneRelayTransport()` is the entire migration. The models,
+the client, and every view are untouched, because a transport moves one
+`UHCRequest` and returns one `UHCResponse` and knows nothing about zones,
+artwork, or transport controls.
+
+`PhoneRelayTransport` is a deliberate, documented placeholder in this PR: it
+compiles, conforms, and throws `UHCError.transportUnavailable` on every call so
+that wiring it up by mistake fails loudly instead of hanging. Its source
+documents what implementing it requires — `sendMessageData` on the Watch side, a
+`WCSessionDelegate` on the phone side, the ~64 KB message cap (measured artwork
+is ~15–27 KB at 200–240 px, so it fits today), and the fact that
+`WCSession.isReachable` is false exactly when a Watch-only user wants the
+controller most.
+
+It was left unimplemented on purpose. Building a relay before knowing whether it
+is needed is work spent ahead of the evidence, and the evidence costs one
+install.

--- a/tests/fixtures/uhckit_contract.json
+++ b/tests/fixtures/uhckit_contract.json
@@ -1,0 +1,163 @@
+{
+  "_comment": [
+    "Single source of truth for the wire shape shared by UHC's controller",
+    "endpoints and UHCKit, the Swift client for the iOS companion and the",
+    "watchOS controller (#619).",
+    "",
+    "Two tests read this file:",
+    "  - tests/uhckit_contract.rs         (Rust: serializes the real response",
+    "                                      types and compares key sets)",
+    "  - companion/uhckit/Tests/UHCKitTests/ContractTests.swift",
+    "                                     (Swift: decodes these payloads into",
+    "                                      the client's models)",
+    "",
+    "Change a field on either side and one of those two fails. Update this",
+    "file plus both models together, and label the PR api-change-approved.",
+    "",
+    "Values are illustrative. The key sets, JSON types and optionality are the",
+    "contract. Shapes below were captured from the live server at",
+    "192.168.1.209:8088 running UHC 3.7.0-alpha.9."
+  ],
+
+  "zone": {
+    "_comment": "One entry of GET /zones -> {\"zones\": [...]}. Serialized from ZoneInfo.",
+    "full": {
+      "zone_id": "roon:1601deadbeef",
+      "zone_name": "Front Family Room",
+      "source": "roon",
+      "state": "playing",
+      "volume_control": {
+        "value": 47.5,
+        "min": 0.0,
+        "max": 98.0,
+        "step": 0.5,
+        "is_muted": false,
+        "scale": "percentage",
+        "output_id": "roon:1701deadbeef"
+      },
+      "dsp": {
+        "type": "hqplayer",
+        "instance": "embedded",
+        "pipeline": "poly-sinc-gauss-long",
+        "profiles": "default"
+      },
+      "browse_supported": true,
+      "library_tabs": ["browse", "playlists"]
+    },
+    "always_present": [
+      "zone_id",
+      "zone_name",
+      "source",
+      "state",
+      "browse_supported",
+      "library_tabs"
+    ],
+    "omitted_when_absent": {
+      "_comment": [
+        "These carry #[serde(skip_serializing_if = \"Option::is_none\")], so the",
+        "key vanishes rather than serializing as null. The live server really",
+        "does publish a zone with no volume_control (\"HQPlayer Embedded\"), so a",
+        "non-optional Swift property here fails to decode the real zone list."
+      ],
+      "keys": ["volume_control", "dsp"]
+    },
+    "minimal": {
+      "zone_id": "roon:16015f6dcafe",
+      "zone_name": "HQPlayer Embedded",
+      "source": "roon",
+      "state": "stopped",
+      "browse_supported": true,
+      "library_tabs": ["browse", "playlists"]
+    },
+    "states": {
+      "_comment": "PlaybackState::to_string() values. Unknown values must decode, not throw.",
+      "values": ["playing", "paused", "stopped", "loading", "buffering", "unknown"]
+    }
+  },
+
+  "now_playing": {
+    "_comment": [
+      "GET /now_playing?zone_id=... -> NowPlayingResponse.",
+      "No field carries skip_serializing_if, so every key is always present,",
+      "null when empty. line1/line2 are never null (line1 falls back to",
+      "\"Idle\", line2 to \"\"); line3 and the rest may be null."
+    ],
+    "zone_id": "roon:1601deadbeef",
+    "line1": "Summer (B-Sides)",
+    "line2": "Moby",
+    "line3": "Play & Play: The B Sides",
+    "is_playing": true,
+    "volume": 47.5,
+    "volume_type": "number",
+    "volume_min": 0.0,
+    "volume_max": 98.0,
+    "volume_step": 0.5,
+    "image_url": "/knob/now_playing/image?zone_id=roon%3A1601deadbeef",
+    "image_key": "b7df27c8dd25dd65084d8f2d94f616d0",
+    "seek_position": 104,
+    "length": 358,
+    "is_play_allowed": false,
+    "is_pause_allowed": true,
+    "is_next_allowed": true,
+    "is_previous_allowed": true,
+    "zones": [],
+    "config_sha": null,
+    "zones_sha": "4bb54fbe"
+  },
+
+  "now_playing_volume_types": {
+    "_comment": [
+      "volume_type uses a DIFFERENT vocabulary from zones[].volume_control.scale.",
+      "Do not conflate them: scale is decibel/percentage/linear/unknown."
+    ],
+    "values": ["db", "number", "fixed"]
+  },
+
+  "now_playing_error": {
+    "_comment": "4xx bodies on the controller endpoints. UHCKit decodes error/error_code.",
+    "error": "zone not found",
+    "error_code": "ZONE_NOT_FOUND"
+  },
+
+  "control": {
+    "_comment": [
+      "POST /control. `value` is only meaningful for vol_abs.",
+      "",
+      "A note the hard way: the server verifies each command by waiting for the",
+      "backend to publish a readback. Setting a volume to the value it already",
+      "holds produces no state change, so no readback ever arrives and the",
+      "request hangs ~15s then 500s with \"Roon accepted the command but did not",
+      "publish a verified readback in time\". Clients must not treat an absolute",
+      "volume write as idempotent."
+    ],
+    "request": {
+      "zone_id": "roon:1601deadbeef",
+      "action": "vol_abs",
+      "value": 31.5
+    },
+    "actions": [
+      "play",
+      "pause",
+      "play_pause",
+      "stop",
+      "next",
+      "previous",
+      "vol_up",
+      "vol_down",
+      "vol_abs"
+    ],
+    "success": { "ok": true }
+  },
+
+  "artwork": {
+    "_comment": [
+      "GET /now_playing/image. Parameters are width/height -- there is no",
+      "`size`. The endpoint never 404s: with no art it returns an SVG",
+      "placeholder with HTTP 200, and UIImage cannot decode SVG, so clients",
+      "must branch on Content-Type rather than on the status code."
+    ],
+    "query": ["zone_id", "width", "height", "format"],
+    "placeholder_content_type": "image/svg+xml",
+    "image_content_type": "image/jpeg"
+  }
+}

--- a/tests/uhckit_contract.rs
+++ b/tests/uhckit_contract.rs
@@ -1,0 +1,288 @@
+//! Wire-shape contract between the Rust controller endpoints and UHCKit, the
+//! Swift client used by the iOS companion and the watchOS controller (#619).
+//!
+//! `tests/api_contract.rs` already guards which *routes* exist. It says nothing
+//! about the *shape* of what they return, so renaming `zone_name` to `name`
+//! would sail past it and silently break every Swift surface at runtime — the
+//! #611 failure mode, one layer down.
+//!
+//! This test closes that gap by serializing the real Rust response types and
+//! comparing the resulting JSON key sets against
+//! `tests/fixtures/uhckit_contract.json`. That same fixture file is decoded by
+//! `UHCKitTests.ContractTests` on the Swift side, so one file is the single
+//! source of truth for both languages:
+//!
+//! - Change a Rust field  -> this test fails.
+//! - Update the fixture to match, but not the Swift models -> the Swift test fails.
+//! - Update both -> the change is deliberate, reviewable, and gets the
+//!   `api-change-approved` label like any other API change.
+//!
+//! Values in the fixture are illustrative; only the key sets and JSON types are
+//! contractual. Optionality is contractual too, and is recorded per field in
+//! the fixture's `optional` lists, because `#[serde(skip_serializing_if)]` on
+//! `ZoneInfo::volume_control` is the difference between a Swift model that
+//! decodes the live zone list and one that throws on it.
+
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+use unified_hifi_control::bus::events::{VolumeControl, VolumeScale};
+use unified_hifi_control::knobs::routes::{DspInfo, NowPlayingResponse, ZoneInfo};
+
+fn fixture() -> Value {
+    serde_json::from_str(include_str!("fixtures/uhckit_contract.json"))
+        .expect("UHCKit contract fixture must be valid JSON")
+}
+
+/// Keys of a JSON object, ignoring `_`-prefixed documentation entries so the
+/// fixture can explain itself without polluting the contract.
+fn object_keys(value: &Value) -> BTreeSet<String> {
+    value
+        .as_object()
+        .expect("expected a JSON object")
+        .keys()
+        .filter(|key| !key.starts_with('_'))
+        .cloned()
+        .collect()
+}
+
+fn string_set(value: &Value) -> BTreeSet<String> {
+    value
+        .as_array()
+        .expect("expected a JSON array of strings")
+        .iter()
+        .map(|item| item.as_str().expect("expected a string").to_string())
+        .collect()
+}
+
+/// A `ZoneInfo` with every optional field populated, so serialization emits the
+/// maximal key set.
+///
+/// Built as a struct literal rather than deserialized: `ZoneInfo` derives only
+/// `Serialize`, and its `library_tabs: Vec<&'static str>` could not be
+/// deserialized anyway. That is a feature here — adding a field to the Rust
+/// type makes this file stop compiling, which is an even louder signal than a
+/// failing assertion.
+fn sample_zone_full() -> ZoneInfo {
+    ZoneInfo {
+        zone_id: "roon:1601deadbeef".to_string(),
+        zone_name: "Front Family Room".to_string(),
+        source: "roon".to_string(),
+        state: "playing".to_string(),
+        volume_control: Some(VolumeControl {
+            value: 47.5,
+            min: 0.0,
+            max: 98.0,
+            step: 0.5,
+            is_muted: false,
+            scale: VolumeScale::Percentage,
+            output_id: Some("roon:1701deadbeef".to_string()),
+        }),
+        dsp: Some(DspInfo {
+            r#type: "hqplayer".to_string(),
+            instance: Some("embedded".to_string()),
+            pipeline: Some("poly-sinc-gauss-long".to_string()),
+            profiles: Some("default".to_string()),
+        }),
+        browse_supported: true,
+        library_tabs: vec!["browse", "playlists"],
+    }
+}
+
+/// The same type with its optional fields absent, which is what the live server
+/// publishes for a zone with no volume control (e.g. "HQPlayer Embedded").
+fn sample_zone_minimal() -> ZoneInfo {
+    ZoneInfo {
+        zone_id: "roon:16015f6dcafe".to_string(),
+        zone_name: "HQPlayer Embedded".to_string(),
+        source: "roon".to_string(),
+        state: "stopped".to_string(),
+        volume_control: None,
+        dsp: None,
+        browse_supported: true,
+        library_tabs: vec!["browse", "playlists"],
+    }
+}
+
+fn sample_now_playing() -> NowPlayingResponse {
+    NowPlayingResponse {
+        zone_id: "roon:1601deadbeef".to_string(),
+        line1: "Summer (B-Sides)".to_string(),
+        line2: "Moby".to_string(),
+        line3: Some("Play & Play: The B Sides".to_string()),
+        is_playing: true,
+        volume: Some(47.5),
+        volume_type: Some("number".to_string()),
+        volume_min: Some(0.0),
+        volume_max: Some(98.0),
+        volume_step: Some(0.5),
+        image_url: Some("/knob/now_playing/image?zone_id=roon%3A1601deadbeef".to_string()),
+        image_key: Some("b7df27c8dd25dd65084d8f2d94f616d0".to_string()),
+        seek_position: Some(104),
+        length: Some(358),
+        is_play_allowed: false,
+        is_pause_allowed: true,
+        is_next_allowed: true,
+        is_previous_allowed: true,
+        zones: vec![],
+        config_sha: None,
+        zones_sha: Some("4bb54fbe".to_string()),
+    }
+}
+
+fn serialize(value: &impl serde::Serialize) -> Value {
+    serde_json::to_value(value).expect("type must serialize")
+}
+
+/// Assert that `actual` carries exactly the keys the fixture declares, and that
+/// each shared key has the same JSON type.
+fn assert_shape(actual: &Value, expected: &Value, what: &str) {
+    let actual_keys = object_keys(actual);
+    let expected_keys = object_keys(expected);
+
+    let missing: Vec<_> = expected_keys.difference(&actual_keys).cloned().collect();
+    let extra: Vec<_> = actual_keys.difference(&expected_keys).cloned().collect();
+
+    assert!(
+        missing.is_empty(),
+        "{what}: the Rust type no longer emits {missing:?}, which UHCKit decodes. \
+         If this is intentional, update tests/fixtures/uhckit_contract.json AND the \
+         matching Swift model in companion/uhckit/Sources/UHCKit/Models.swift, then \
+         label the PR api-change-approved."
+    );
+    assert!(
+        extra.is_empty(),
+        "{what}: the Rust type now emits {extra:?}, which UHCKit does not know about. \
+         Add it to tests/fixtures/uhckit_contract.json and to the Swift model so the \
+         Watch and iOS clients can see it, then label the PR api-change-approved."
+    );
+
+    let actual_object: &Map<String, Value> = actual.as_object().unwrap();
+    let expected_object: &Map<String, Value> = expected.as_object().unwrap();
+    for (key, expected_value) in expected_object {
+        if key.starts_with('_') {
+            continue;
+        }
+        let actual_value = &actual_object[key];
+        // `null` in the fixture documents "nullable"; it constrains presence,
+        // not the type carried when the value is present.
+        if expected_value.is_null() || actual_value.is_null() {
+            continue;
+        }
+        let expected_kind = json_kind(expected_value);
+        let actual_kind = json_kind(actual_value);
+        assert_eq!(
+            actual_kind, expected_kind,
+            "{what}: field `{key}` changed JSON type from {expected_kind} to {actual_kind}; \
+             UHCKit decodes it as {expected_kind}."
+        );
+    }
+}
+
+fn json_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[test]
+fn zone_shape_matches_uhckit() {
+    let fixture = fixture();
+    assert_shape(
+        &serialize(&sample_zone_full()),
+        &fixture["zone"]["full"],
+        "GET /zones zone entry",
+    );
+}
+
+#[test]
+fn zone_volume_control_is_omitted_when_absent() {
+    // Load-bearing: `volume_control` and `dsp` carry
+    // `#[serde(skip_serializing_if = "Option::is_none")]`. If that ever becomes
+    // a plain `Option`, the key starts appearing as `null` — harmless — but if
+    // the `Option` itself is removed, UHCKit's optional stops matching reality
+    // and the live zone list (which really does contain a zone with no volume)
+    // fails to decode.
+    let minimal = serialize(&sample_zone_minimal());
+    let keys = object_keys(&minimal);
+
+    for omitted in ["volume_control", "dsp"] {
+        assert!(
+            !keys.contains(omitted),
+            "a zone without `{omitted}` must omit the key entirely, but got {minimal}"
+        );
+    }
+
+    let required = string_set(&fixture()["zone"]["always_present"]);
+    for key in &required {
+        assert!(
+            keys.contains(key),
+            "zone entry must always carry `{key}`, but got {keys:?}"
+        );
+    }
+}
+
+#[test]
+fn now_playing_shape_matches_uhckit() {
+    let fixture = fixture();
+    assert_shape(
+        &serialize(&sample_now_playing()),
+        &fixture["now_playing"],
+        "GET /now_playing",
+    );
+}
+
+#[test]
+fn now_playing_always_emits_every_key() {
+    // `NowPlayingResponse` carries no `skip_serializing_if`, so every optional
+    // field is emitted as `null` rather than omitted. UHCKit relies on that
+    // only for forward compatibility (it uses decodeIfPresent throughout), but
+    // the knob firmware does not, so the property is worth pinning.
+    let value = serialize(&sample_now_playing());
+    let keys = object_keys(&value);
+    let expected = object_keys(&fixture()["now_playing"]);
+    assert_eq!(
+        keys, expected,
+        "every /now_playing key must be present even when null"
+    );
+}
+
+#[test]
+fn control_actions_are_all_accepted_by_the_server() {
+    // The action strings UHCKit's `ControlAction` can emit. Each must appear in
+    // the match arms of the knob control handler; otherwise the Swift enum can
+    // produce a command the server rejects at runtime.
+    let source = include_str!("../src/knobs/routes.rs");
+    let actions = string_set(&fixture()["control"]["actions"]);
+
+    for action in &actions {
+        let needle = format!("\"{action}\"");
+        assert!(
+            source.contains(&needle),
+            "UHCKit can send action `{action}`, but src/knobs/routes.rs never matches it. \
+             Either the server dropped support or the Swift `ControlAction` enum drifted."
+        );
+    }
+}
+
+#[test]
+fn control_request_shape_matches_uhckit() {
+    // `KnobControlRequest` is what UHCKit's `ControlRequest` encodes into.
+    // Deserializing the Swift-shaped body proves the field names line up.
+    let body = &fixture()["control"]["request"];
+    let parsed: unified_hifi_control::knobs::routes::KnobControlRequest =
+        serde_json::from_value(body.clone())
+            .expect("the body UHCKit encodes must deserialize into KnobControlRequest");
+
+    assert_eq!(parsed.zone_id, "roon:1601deadbeef");
+    assert_eq!(parsed.action, "vol_abs");
+    assert_eq!(
+        parsed.value.as_ref().and_then(Value::as_f64),
+        Some(31.5),
+        "`value` must survive as a number: it carries absolute volume"
+    );
+}


### PR DESCRIPTION
Closes #619.

Extracts `UHCKit` — a platform-neutral Swift control client — and adds a small watchOS controller built on it. Base branch is `integration/streaming-ha-alpha`.

## Endpoint shapes, verified against the live server

Everything below was read off the running production server (`192.168.1.209:8088`, UHC **3.7.0-alpha.9**, `git_sha b66742c`), then cross-checked against the Rust types to find which fields are *omitted* rather than null — a distinction one live sample cannot show. Nothing here was invented.

The controller surface is the one the knob firmware already speaks — `/zones`, `/now_playing`, `/now_playing/image`, `/control` — which is source-agnostic and already designed for embedded clients. No new routes were added, so `tests/api_contract.rs` and its golden file are untouched.

**`GET /zones` → `{"zones":[ZoneInfo]}`**
`zone_id` (prefixed: `roon:…`, `lms:…`), `zone_name`, `source`, `state`, `browse_supported`, `library_tabs` always present. `volume_control` and `dsp` carry `skip_serializing_if` and are **omitted entirely** when absent — the live server publishes a zone with no volume at all ("HQPlayer Embedded"), so a non-optional Swift property here fails to decode the real zone list. Volume ranges genuinely vary per zone: `0…98 step 0.5`, `1…100 step 1`, and `0…42 step 1` all appear side by side, so the crown is bound to the zone's own range, never a hardcoded 0–100.

**`GET /now_playing?zone_id=…`**
`line1`/`line2`/`line3` (title/artist/album), `is_playing`, `volume{,_type,_min,_max,_step}`, `image_url`, `image_key`, `seek_position`, `length`, the four `is_*_allowed` capability flags, an echoed `zones` array, `config_sha`, `zones_sha`. No field carries `skip_serializing_if`, so every key is always present, `null` when empty. Two gotchas the models encode: `volume_type` is `db|number|fixed`, a **different vocabulary** from `zones[].volume_control.scale` (`decibel|percentage|linear|unknown`); and the echoed `zones` array means a polling client refreshes the picker and the track in one round trip — one radio wake instead of two.

**`GET /now_playing/image`**
Parameters are **`width`/`height`, not `size`**. The endpoint never 404s: with no art it returns an `image/svg+xml` placeholder with HTTP 200, and `UIImage` cannot decode SVG — so a client trusting the status code renders an empty box with no clue why. `UHCClient.artwork` branches on `Content-Type` and reports `nil`. Real art measured 13–27 KB as `image/jpeg` at 200–240 px.

**`POST /control`** — `{zone_id, action, value?}`, actions `play|pause|play_pause|stop|next|previous|vol_up|vol_down|vol_abs`.

One finding worth recording, hit the hard way: the server verifies each command by waiting for the backend to publish a readback. **Setting a volume to the value it already holds produces no state change, so no readback ever arrives** — the request hangs ~15 s and then 500s with `"Roon accepted the command but did not publish a verified readback in time"`. An absolute volume write is *not* idempotent. This is documented in the fixture; it may be worth its own issue.

## What the simulator proved

On the owner's booted Apple Watch Series 11 (46mm), watchOS 26.5, against the live server:

- Discovered UHC over Bonjour with no manual configuration (resolved `NAS2.local:8088`).
- Listed all **10 real zones**, playing zones sorted to the top.
- Now-playing rendered with real decoded JPEG artwork, title/artist/album.
- Transport buttons enabled/disabled from the server's own capability flags (`play` correctly disabled while playing), volume reading `47.5` — matching the live zone exactly.

The client's **write** path was proven separately, end to end, through the same `UHCClient`: a one-step volume nudge on the *stopped* Bedroom zone and straight back — `31.0 → 31.5 → 31.0`, each step confirmed by re-reading `/zones`. Inaudible and net zero. A bad zone id returned HTTP 404 `ZONE_NOT_FOUND`, decoded into a structured `UHCError.server`.

I deliberately did **not** press play/pause on a live zone: that would have interrupted music actually playing in the house. That one tap is left for the owner.

## What remains unproven — the LAN question

**The simulator cannot answer it and this PR does not claim otherwise.** The watchOS simulator runs on macOS and uses the Mac's networking stack; it reaches the LAN whatever the real device policy is. The green run above proves the client and UI are correct, nothing more.

One thing *is* now settled, and it is a compile error rather than a guess:

```
error: 'NetServiceBrowser' is unavailable in watchOS
```

`NetService`/`NetServiceBrowser` do not exist on watchOS at all. So `UHCDiscovery` keeps the shipping `NetService` code on iOS (moved, not rewritten) and uses `NWBrowser` on watchOS, reading the TXT `base` key the server already publishes. Note this also means Bonjour browsing is gated *separately* from plain LAN sockets — discovery could fail while a typed-in address works, which is why the Watch always offers manual entry.

### To settle it, on a real Watch on the same WiFi

1. **Launch the app.** Zones appear → direct LAN access works, including Bonjour. Done. Otherwise:
2. **`Server` → `Manual address`**, enter `192.168.1.209:8088`, **Connect**. This separates the two gates: success here means plain sockets are allowed and only Bonjour is blocked.
3. **Read the `Diagnostics` section** on that screen — it shows the raw underlying error, not a paraphrase, because that is the detail that discriminates:
   - `-1004` cannotConnectToHost → nothing listening / refused; check the address.
   - `-1009` notConnectedToInternet → the OS thinks the app is offline: on a Watch that is the signature of a **policy block**.
   - `-1001` timedOut → silently dropped, the classic look of a firewall or entitlement block.
4. **Also try with the iPhone off or out of range.** If it only works with the phone nearby, the OS is proxying through the phone and it is not true direct access — same appearance, different answer.

Please report the exact diagnostics string.

The build is arranged to give the "iOS app in the bundle holds local-network permission" hypothesis its best shot: `UHCWatchApp` is embedded in the iOS app bundle via an *Embed Watch Content* phase, and both bundles declare `NSLocalNetworkUsageDescription` and `NSBonjourServices` for `_uhc._tcp`. Full reasoning in `companion/uhckit/Transport.md`.

## Transport abstraction

`UHCTransport` moves one `UHCRequest` and returns one `UHCResponse` — raw bytes, so artwork travels the same pipe as JSON and a relay needs no second, image-shaped hole. `UHCClient` holds everything else and is transport-agnostic. The Watch constructs a transport in exactly one place, `WatchController.connect(to:)`:

```swift
let client = UHCClient(transport: DirectHTTPTransport(baseURL: url))
```

Swapping that line is the entire migration to a phone relay. `PhoneRelayTransport` is a deliberate documented placeholder: it compiles, conforms, and throws `transportUnavailable` on every call so mis-wiring fails loudly instead of hanging. Its source records what implementing it needs — `sendMessageData`, the phone-side `WCSessionDelegate`, the ~64 KB message cap (measured artwork fits today), and that `isReachable` is false exactly when a Watch-only user wants the controller most. Left unimplemented on purpose: building it before knowing whether it is needed is work ahead of the evidence, and the evidence costs one install.

## Contract test

Wired into the existing Rust suite rather than inventing a parallel mechanism. `tests/api_contract.rs` guards which *routes* exist but says nothing about their *shape* — renaming `zone_name` would sail past it and break every Swift surface at runtime, the #611 failure mode one layer down.

`tests/uhckit_contract.rs` serializes the **real** Rust response types (`ZoneInfo`, `NowPlayingResponse`, `KnobControlRequest`) and compares key sets and JSON types against `tests/fixtures/uhckit_contract.json`. `UHCKitTests/ContractTests.swift` decodes **that same file** — not a copy, resolved from `#filePath` — so one file is the single source of truth for both languages. Change a Rust field and the Rust test fails; update the fixture but not the Swift models and the Swift test fails.

The samples are built as struct literals, so adding a field to a Rust type also makes the test file stop compiling — louder than an assertion.

Verified by mutation, not just asserted green: renaming `zone_name` → `name` in the fixture fails `zone_shape_matches_uhckit` with an actionable message naming both files to update and the `api-change-approved` label.

## Pre-existing break, fixed in its own commit

`integration/streaming-ha-alpha` **does not compile for iOS** before any of my changes — confirmed by stashing everything and building the base:

```
ContentView.swift:213: error: value of type 'AppleMusicCompanionHost' has no member 'forgetAuthorization'
```

`ContentView` has always called it; the iOS host never declared it (the macOS bridge has it). The existing Swift tests could not build, let alone pass, so I could not meet that gate without addressing it. `b623714` adds the method, mirroring the macOS implementation exactly, **as its own commit so it can be dropped** if it collides with the in-flight `Companion.swift` work on `feat/issue-462-streaming-adapters`.

## Gates

| Gate | Result |
|---|---|
| `cargo test` (never `--all-features`) | **pass** — no failures; `uhckit_contract` 6/6 |
| `cargo clippy -- -D warnings` | **pass** |
| `cargo clippy --test uhckit_contract -- -D warnings` | **pass** |
| `cargo fmt --check` | **pass** |
| `swift test` (UHCKit) | **pass** — 17/17 |
| `xcodebuild -scheme UHCKit -destination 'generic/platform=iOS'` | **pass** |
| `xcodebuild -scheme UHCKit -destination 'generic/platform=watchOS'` | **pass** |
| `xcodebuild -scheme UHCWatchApp` (watchOS simulator) | **pass** |
| iOS app build + `AppleMusicIOSCompanionHostFeatureTests` | **pass** — 5/5 |
| Watch app on live UHC (simulator) | zones, now-playing, artwork, capability flags |

`cargo clippy --all-targets` reports 835 pre-existing errors in unrelated test files on this base; the brief's gate is plain `cargo clippy`, which passes, and my own test file is clean under `--all-targets` rules.

No CI runs on PRs based on non-default branches, so green checks here would prove nothing — the table above is local.

## Notes for review

- No Rust UI code touched. No directory renamed or restructured — out of scope per the brief.
- Only one Roon-connecting server was ever involved: production. Nothing was started locally.
- The one live mutation was the volume nudge described above, restored to `31.0`.
