### PR TITLE
fix: hifispeaker.slash is not a real SF Symbol

### DIFF
--- a/companion/apple_music/XcodeMac/AppleMusicCompanionMacPackage/Sources/AppleMusicCompanionMacFeature/ContentView.swift
+++ b/companion/apple_music/XcodeMac/AppleMusicCompanionMacPackage/Sources/AppleMusicCompanionMacFeature/ContentView.swift
@@ -451,7 +451,7 @@ private struct ConnectedHeroView: View {
             }
             Label(
                 outputs.isEmpty ? "No AirPlay outputs detected" : "AirPlay outputs available: \(outputs.count)",
-                systemImage: outputs.isEmpty ? "hifispeaker.slash" : "hifispeaker"
+                systemImage: outputs.isEmpty ? "speaker.slash" : "hifispeaker"
             )
             .foregroundStyle(outputs.isEmpty ? .secondary : .primary)
             if let lastConnectedAt {
@@ -557,7 +557,7 @@ public struct MenuBarContentView: View {
             if model.stage.isConnected {
                 Label(
                     model.outputs.isEmpty ? "AirPlay: no outputs found" : "AirPlay: route managed by macOS",
-                    systemImage: model.outputs.isEmpty ? "hifispeaker.slash" : "hifispeaker"
+                    systemImage: model.outputs.isEmpty ? "speaker.slash" : "hifispeaker"
                 )
                     .font(.caption2)
                     .foregroundStyle(.secondary)

--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/ContentView.swift
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/ContentView.swift
@@ -326,7 +326,7 @@ public struct ContentView: View {
                         if let outputLabel = model.outputLabel {
                             Label("Output: \(outputLabel)", systemImage: "hifispeaker.fill")
                         } else {
-                            Label("Output: unavailable", systemImage: "hifispeaker.slash")
+                            Label("Output: unavailable", systemImage: "speaker.slash")
                                 .foregroundStyle(.secondary)
                         }
                     }


### PR DESCRIPTION
Surfaced by the owner's device log while testing the companion on his iPhone:

```
No symbol named 'hifispeaker.slash' found in system symbol set
```

Three call sites used it — one iOS, two macOS — for the "no output available" state, so that state rendered a blank icon and logged on every pass.

Checked against the actual system symbol set rather than guessing a replacement:

| symbol | exists |
|---|---|
| `hifispeaker` | yes |
| `hifispeaker.fill` | yes |
| `hifispeaker.slash` | **no** |
| `speaker.slash` | yes |

All three now use `speaker.slash`. Swept every `systemImage:` literal in `companion/` against the system symbol set afterwards — all resolve.