### PR TITLE
fix(companion): the iPhone can reset its own pairing

### DIFF
--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/ContentView.swift
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/ContentView.swift
@@ -241,6 +241,29 @@ private final class CompanionModel: ObservableObject {
         isLive = false
         outputLabel = nil
     }
+    /// Clear this device's pairing without contacting UHC. Deliberately does
+    /// not run automatically when `revoke()` fails: a reachable server that
+    /// merely timed out would still list this companion, and silently
+    /// dropping our side would leave that stale entry with nothing pointing
+    /// at it. The user is told, and chooses.
+    func resetThisDevice() {
+        stopPolling()
+        Task { @MainActor in
+            // Best-effort: the store write is what matters, and it must happen
+            // even if the host is in a bad state.
+            try? await host.forgetAuthorization()
+            let fresh = newAppleMusicCompanionInstallation()
+            try? installationStore.save(fresh)
+            host = AppleMusicCompanionHost(installation: fresh, store: installationStore)
+            isPaired = false
+            isLive = false
+            outputLabel = nil
+            pairingCode = ""
+            stage = .findUHC
+            message = "This iPhone was reset. If UHC still lists it, remove it there too."
+        }
+    }
+
     func revoke() {
         Task { @MainActor in
             do {
@@ -251,7 +274,7 @@ private final class CompanionModel: ObservableObject {
                 stage = .findUHC
                 message = "Pairing was removed. Find UHC to connect again."
             } catch {
-                message = "Pairing could not be removed. Try again."
+                message = "Couldn't reach UHC to remove the pairing. You can reset this iPhone instead."
             }
         }
     }
@@ -338,6 +361,13 @@ public struct ContentView: View {
                     }
                     Section {
                         Button("Disconnect from UHC", role: .destructive, action: model.revoke)
+                    } footer: {
+                        Text("Tells UHC to forget this iPhone.")
+                    }
+                    Section {
+                        Button("Reset this iPhone", role: .destructive, action: model.resetThisDevice)
+                    } footer: {
+                        Text("Clears pairing on this iPhone only, without contacting UHC. Use this if UHC is unreachable or has already forgotten this device.")
                     }
                 }
             }


### PR DESCRIPTION
Found on the owner's phone: the app showed **Paired · waiting for UHC** and **Pairing could not be removed. Try again.**, while the server reported:

```json
{"paired":false,"live":false,"companions":[],"pending_pairings":[]}
```

**The bug.** `revoke()` clears local state only after a successful server call:

```swift
try await host.revoke()   // network
isPaired = false          // never runs if the above throws
```

So whenever UHC is unreachable — or has already dropped the pairing, as here — the phone is stuck permanently. "Try again" was advice that could never succeed, and the only real recovery was deleting the app.

**The fix.** `AppleMusicCompanionHost.forgetAuthorization()` already clears the store without any network call; it simply had no path from the UI. Now:

- **Reset this iPhone** — always available, clears local pairing offline, mints a fresh installation identity so the next pairing is clean.
- The revoke failure message points at it rather than at retrying.

Deliberately **not** automatic on revoke failure: a server that merely timed out would still list this companion, and silently dropping our side would strand that entry. The user is told and chooses. The message says so: "If UHC still lists it, remove it there too."

**Verified:** builds clean for iOS; app installs and launches in the iPhone 17 Pro simulator. **Not verified:** the button in situ — it lives in the connected stage, and reaching it means creating a real pairing on the owner's production server, which I didn't do unasked.

**Pre-existing, not from this change:** `testAirPlayRoutePickerIsAvailable` fails identically on the base branch (confirmed by stashing). Worth its own look.