### PR TITLE
feat(companion): UHC controls in the iPhone app via a web view

### DIFF
--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/ContentView.swift
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/ContentView.swift
@@ -47,6 +47,12 @@ private final class CompanionModel: ObservableObject {
     @Published private(set) var isPaired = false
     @Published private(set) var isLive = false
     @Published private(set) var outputLabel: String?
+    /// The UHC web UI's address, once we know one. Nil until discovery or a
+    /// pairing has given us a real server -- the fresh-install placeholder is
+    /// a loopback address that would only render an error page.
+    @Published private(set) var serverURL: URL?
+    @Published private(set) var isFindingServer = false
+    private var controlsDiscovery: UHCBonjourDiscovery?
     private let installationStore: KeychainAppleMusicCompanionInstallationStore
     private let companionID: String
     private var host: AppleMusicCompanionHost
@@ -72,11 +78,54 @@ private final class CompanionModel: ObservableObject {
         companionID = installation.companionID
         host = AppleMusicCompanionHost(installation: installation, store: store)
         bridgeID = installation.bridgeID ?? companionID
+        serverURL = Self.usableServerURL(installation.baseURL)
         let alreadyPaired = installation.accessToken != nil
         isPaired = alreadyPaired
         stage = alreadyPaired ? .connected : .authorize
         message = alreadyPaired ? "Paired. Open this companion to connect to UHC." : nil
         if alreadyPaired { reconnect() }
+    }
+
+    /// The placeholder a fresh install carries is loopback on a port nothing
+    /// serves; treating it as a real address would show the user a failed page
+    /// instead of "find your server".
+    private static func usableServerURL(_ url: URL) -> URL? {
+        guard let host = url.host else { return nil }
+        if host == "127.0.0.1" || host == "localhost" || host == "::1" { return nil }
+        return url
+    }
+
+    /// Find UHC for the Controls tab without starting the Apple Music pairing
+    /// flow -- viewing the web UI needs an address, not a bridge credential.
+    func findServerForControls() {
+        guard !isFindingServer else { return }
+        isFindingServer = true
+        let browser = UHCBonjourDiscovery()
+        controlsDiscovery = browser
+        browser.onBaseURL = { [weak self] baseURL in
+            Task { @MainActor in
+                guard let self else { return }
+                self.isFindingServer = false
+                self.serverURL = Self.usableServerURL(baseURL)
+                // Persist it, or every launch starts at "No UHC server yet"
+                // even though we already know where the server is. Only the
+                // address is stored; this path never touches credentials.
+                if var installation = self.installationStore.load() {
+                    installation.baseURL = baseURL
+                    try? self.installationStore.save(installation)
+                }
+                self.controlsDiscovery = nil
+            }
+        }
+        browser.onFailure = { [weak self] text in
+            Task { @MainActor in
+                guard let self else { return }
+                self.isFindingServer = false
+                self.message = text
+                self.controlsDiscovery = nil
+            }
+        }
+        browser.start()
     }
 
     func authorize() {
@@ -140,6 +189,7 @@ private final class CompanionModel: ObservableObject {
         discovery?.stop(); discovery = nil
         guard var installation = installationStore.load(), installation.accessToken != nil else { return }
         installation.baseURL = baseURL
+        serverURL = Self.usableServerURL(baseURL)
         try? installationStore.save(installation)
         host = AppleMusicCompanionHost(installation: installation, store: installationStore)
         startPolling()
@@ -260,8 +310,19 @@ private final class CompanionModel: ObservableObject {
 public struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
     @StateObject private var model = CompanionModel()
+    @State private var reloadToken = 0
     public init() {}
+
     public var body: some View {
+        TabView {
+            ControlsTab(model: model, reloadToken: $reloadToken)
+                .tabItem { Label("Controls", systemImage: "hifispeaker.2") }
+            appleMusicTab
+                .tabItem { Label("Apple Music", systemImage: "music.note") }
+        }
+    }
+
+    private var appleMusicTab: some View {
         NavigationStack {
             Form {
                 Section {
@@ -351,6 +412,53 @@ public struct ContentView: View {
             }
         }
         .task { model.startPolling() }
+    }
+}
+
+/// UHC's controls, which are the web UI. This tab needs only the server's
+/// address; it deliberately does not require the Apple Music pairing, because
+/// controlling your system and lending this phone's Apple Music account are
+/// unrelated things a user may want independently.
+private struct ControlsTab: View {
+    @ObservedObject var model: CompanionModel
+    @Binding var reloadToken: Int
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let url = model.serverURL {
+                    // No ignoresSafeArea here: UHC's own zones strip is
+                    // pinned to the bottom of its viewport, and letting the
+                    // web view run under the tab bar buries exactly the
+                    // control the user reaches for most.
+                    UHCWebView(url: url, reloadToken: $reloadToken)
+                } else {
+                    ContentUnavailableView {
+                        Label("No UHC server yet", systemImage: "antenna.radiowaves.left.and.right.slash")
+                    } description: {
+                        Text("Find your Unified Hi-Fi Control server on this network to control your zones from here.")
+                    } actions: {
+                        Button(model.isFindingServer ? "Searching…" : "Find UHC") {
+                            model.findServerForControls()
+                        }
+                        .disabled(model.isFindingServer)
+                    }
+                }
+            }
+            .navigationTitle("Controls")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if model.serverURL != nil {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            reloadToken += 1
+                        } label: {
+                            Label("Reload", systemImage: "arrow.clockwise")
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/UHCWebView.swift
+++ b/companion/apple_music_ios/Xcode/AppleMusicIOSCompanionHostPackage/Sources/AppleMusicIOSCompanionHostFeature/UHCWebView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import WebKit
+
+/// UHC's own web UI, embedded. The phone deliberately does not reimplement
+/// zone control natively: the web UI is already responsive, already the admin
+/// surface, and already the thing that gets fixed when a control bug is
+/// found. A second hand-written iOS surface would be a second place for those
+/// fixes to be forgotten.
+struct UHCWebView: UIViewRepresentable {
+    let url: URL
+    @Binding var reloadToken: Int
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        // The UI drives playback controls, not media playback itself.
+        config.allowsInlineMediaPlayback = true
+        let view = WKWebView(frame: .zero, configuration: config)
+        view.accessibilityIdentifier = "uhcWebView"
+        view.allowsBackForwardNavigationGestures = true
+        // The server is on the LAN over plain HTTP; pull-to-refresh is the
+        // cheapest recovery when the phone changes networks.
+        let refresh = UIRefreshControl()
+        refresh.addTarget(
+            context.coordinator,
+            action: #selector(Coordinator.refresh(_:)),
+            for: .valueChanged
+        )
+        view.scrollView.refreshControl = refresh
+        context.coordinator.webView = view
+        view.load(URLRequest(url: url))
+        context.coordinator.loadedURL = url
+        return view
+    }
+
+    func updateUIView(_ view: WKWebView, context: Context) {
+        // Reload when the server address changes, or when the token is bumped.
+        if context.coordinator.loadedURL != url || context.coordinator.token != reloadToken {
+            context.coordinator.loadedURL = url
+            context.coordinator.token = reloadToken
+            view.load(URLRequest(url: url))
+        }
+    }
+
+    final class Coordinator: NSObject {
+        weak var webView: WKWebView?
+        var loadedURL: URL?
+        var token = 0
+
+        @objc func refresh(_ sender: UIRefreshControl) {
+            webView?.reload()
+            sender.endRefreshing()
+        }
+    }
+}


### PR DESCRIPTION
The iPhone companion could pair Apple Music and nothing else — no zones, no transport, no browse. This adds them.

**Approach:** a **Controls** tab hosting UHC's own web UI, rather than a native reimplementation. The web UI is already responsive, already the admin surface, and already where control bugs get fixed. A second hand-written iOS surface would be another place for those fixes to be forgotten — the exact cost paid in #611, when album art broke on four surfaces independently.

**Details**
- Controls is the first tab; Apple Music pairing moves to the second.
- The tab needs only the server's address, **not** the Apple Music pairing — controlling your system and lending this phone's Apple Music account are unrelated things.
- Bonjour discovery for the address (no pairing side effects), and the result is **persisted**, so later launches open straight into the controls.
- Empty state offers "Find UHC" instead of rendering a failed page; a fresh install's loopback placeholder is explicitly treated as "no server".
- Reload button and pull-to-refresh, since a phone changing networks is the common failure.

**Verified in the simulator against the live server** (192.168.1.2), not just compiled:
1. Empty state → tapped Find UHC → discovery resolved and the full UI loaded, listing Roon, Local Library, My Live Radio, Genres, TIDAL, Qobuz, with the zones strip showing Bedroom playing.
2. Relaunched → opened directly into the controls, confirming persistence.

**Caught and fixed during that check:** the first build used `.ignoresSafeArea(edges: .bottom)`, which ran the web view under the tab bar and buried UHC's zones strip — the control you reach for most. Removed; the strip is now fully visible with transport and volume clear of the tab bar.