### PR TITLE
chore(companion): rename bundle ID and display name before the App Store record exists

### DIFF
--- a/companion/apple_music_ios/Host/README.md
+++ b/companion/apple_music_ios/Host/README.md
@@ -9,7 +9,7 @@ be stable across relaunches (store it in Keychain).
 The host flow is:
 
 1. Register the single explicit bundle ID
-   `com.openhorizonlabs.uhc.applemusiccompanion` under the signing team in
+   `com.openhorizonlabs.uhc.companion` under the signing team in
    Certificates, Identifiers & Profiles, enable the **MusicKit** App Service,
    and include `Info.plist` here. MusicKit manages both token lifecycles inside
    the signed app; no custom MusicKit entitlement is required. A subscription

--- a/companion/apple_music_ios/Xcode/Config/Shared.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Shared.xcconfig
@@ -7,8 +7,8 @@
 // Project Identity
 // ==========================================
 PRODUCT_NAME = AppleMusicIOSCompanionHost
-PRODUCT_DISPLAY_NAME = Apple Music Companion
-PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.applemusiccompanion
+PRODUCT_DISPLAY_NAME = Hi-Fi Control
+PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.companion
 DEVELOPMENT_TEAM = B69HKNTV5Q
 MARKETING_VERSION = 0.1.0
 CURRENT_PROJECT_VERSION = 1

--- a/companion/apple_music_ios/Xcode/Config/Tests.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Tests.xcconfig
@@ -7,7 +7,7 @@
 // ==========================================
 // Test Target Settings (Customizable by scaffold tool)
 // ==========================================
-PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.applemusiccompanion
+PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.companion
 TEST_TARGET_NAME = AppleMusicIOSCompanionHost
 
 // Fix duplicate module name issue

--- a/companion/apple_music_ios/Xcode/Config/UHCWatchApp-Info.plist
+++ b/companion/apple_music_ios/Xcode/Config/UHCWatchApp-Info.plist
@@ -28,7 +28,7 @@
 	<key>WKApplication</key>
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>com.openhorizonlabs.uhc.applemusiccompanion</string>
+	<string>com.openhorizonlabs.uhc.companion</string>
 	<key>WKRunsIndependentlyOfCompanionApp</key>
 	<true/>
 	<!--

--- a/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
@@ -9,7 +9,7 @@ PRODUCT_NAME = UHCWatchApp
 PRODUCT_DISPLAY_NAME = UHC
 // Must be the iOS app's identifier plus a suffix for the two to ship as one
 // bundle; the Watch app is embedded in the iOS app's Watch container.
-PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.applemusiccompanion.watchkitapp
+PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.companion.watchkitapp
 DEVELOPMENT_TEAM = B69HKNTV5Q
 MARKETING_VERSION = 0.1.0
 CURRENT_PROJECT_VERSION = 1


### PR DESCRIPTION
Timed deliberately: **a bundle ID is permanent once an App Store Connect app record exists**, and the owner is creating that record now.

The app was `com.openhorizonlabs.uhc.applemusiccompanion`, showing **Apple Music Companion** on the home screen. Accurate when it only bridged Apple Music; wrong now that it opens on a Controls tab with the whole system and Apple Music is the second tab.

| | before | after |
|---|---|---|
| Bundle ID | `…uhc.applemusiccompanion` | `…uhc.companion` |
| Watch bundle ID | `….applemusiccompanion.watchkitapp` | `…companion.watchkitapp` |
| Home screen | Apple Music Companion | **Hi-Fi Control** |

`Hi-Fi Control` rather than the full `Unified Hi-Fi Control` because home-screen labels truncate; the Watch keeps `UHC`.

**The one that would have bitten silently:** `WKCompanionAppBundleIdentifier` in `UHCWatchApp-Info.plist`. It is how the Watch app finds its phone app — leave it pointing at the old ID and the targets build fine and pairing just fails.

**Verified in the built product**, not only in config: `plutil` on the built app reports `com.openhorizonlabs.uhc.companion` / `Hi-Fi Control`, the embedded Watch app reports `…companion.watchkitapp`, and its companion key matches the phone app. Both iOS and watchOS targets build.