### PR TITLE
chore(companion): declare export compliance

### DIFF
--- a/companion/apple_music_ios/Xcode/Config/AppleMusicIOSCompanionHost-Info.plist
+++ b/companion/apple_music_ios/Xcode/Config/AppleMusicIOSCompanionHost-Info.plist
@@ -4,14 +4,16 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>$(PRODUCT_DISPLAY_NAME)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSAppleMusicUsageDescription</key>
 	<string>UHC uses Apple Music to control the session you choose on this iPhone.</string>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>UHC uses your local network to find your paired UHC server.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_uhc._tcp</string>
 	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>UHC uses your local network to find your paired UHC server.</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/companion/apple_music_ios/Xcode/Config/UHCWatchApp-Info.plist
+++ b/companion/apple_music_ios/Xcode/Config/UHCWatchApp-Info.plist
@@ -2,47 +2,35 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!--
-	  Spelled out rather than left to Xcode: with GENERATE_INFOPLIST_FILE = NO
-	  the watchOS build does not synthesise these the way the iOS build does,
-	  and a bundle without CFBundleIdentifier fails to install with only
-	  "Missing bundle ID" to go on.
-	-->
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleDisplayName</key>
+	<string>UHC</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>CFBundleDisplayName</key>
-	<string>UHC</string>
-	<!-- Modern single-target watchOS app (no legacy WatchKit extension). -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_uhc._tcp</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>UHC uses your local network to reach your music server.</string>
 	<key>WKApplication</key>
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>
 	<string>com.openhorizonlabs.uhc.companion</string>
 	<key>WKRunsIndependentlyOfCompanionApp</key>
 	<true/>
-	<!--
-	  #619: the open question is whether watchOS honours these at all. The
-	  iOS companion in the same bundle already declares the identical pair,
-	  which is the configuration the Apple forum thread claims is what makes
-	  a Watch app's LAN access work. Declaring them here too costs nothing
-	  and removes one variable from the on-device test.
-	-->
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>UHC uses your local network to reach your music server.</string>
-	<key>NSBonjourServices</key>
-	<array>
-		<string>_uhc._tcp</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
`ITSAppUsesNonExemptEncryption = false` on both the iOS and watchOS Info.plists.

Without it, App Store Connect interrogates you about export compliance on **every** upload. The app uses only HTTPS and the system keychain — standard, exempt cryptography — so the answer is always the same.

Verified the key survives into the built product (`plutil` on the built `.app` and its embedded Watch app both report `false`), not just in the source plist.