### PR TITLE
fix(companion): Watch app made the archive undistributable

### DIFF
--- a/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
@@ -33,3 +33,10 @@ ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO
 
 // TestFlight/App Store require an app icon on every submitted target.
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
+
+// The Watch app is embedded inside the iOS app, not shipped beside it.
+// Without this it is ALSO copied to the archive root, leaving two .app
+// bundles there; Xcode then cannot identify the primary app, writes no
+// ApplicationProperties, and Organizer offers "Distribute Content"
+// instead of "Distribute App" -- i.e. no TestFlight upload.
+SKIP_INSTALL = YES


### PR DESCRIPTION
Hit while archiving for TestFlight: Organizer offered **Distribute Content** rather than **Distribute App**, which cannot upload to TestFlight.

**Cause.** The Watch target had no `SKIP_INSTALL`, so it was copied to the archive root *in addition to* being embedded in the host app. Two `.app` bundles at `Products/Applications/` leaves Xcode unable to identify the primary app, so it writes no `ApplicationProperties` — and without that key Organizer treats the archive as generic content.

```
before: Applications/{AppleMusicIOSCompanionHost.app, UHCWatchApp.app}   ApplicationProperties: absent
after:  Applications/{AppleMusicIOSCompanionHost.app}                    ApplicationProperties: present
```

**Verified by archiving**, not by reasoning: the fixed archive has one app at the root, `ApplicationProperties` naming `com.openhorizonlabs.uhc.companion`, and the Watch app still embedded at `AppleMusicIOSCompanionHost.app/Watch/UHCWatchApp.app` — the embedding is what makes it install alongside the phone app, so losing it would have traded one bug for a worse one.