### PR TITLE
fix(companion): use the address Bonjour already resolved

### DIFF
--- a/companion/uhckit/Sources/UHCKit/UHCDiscovery.swift
+++ b/companion/uhckit/Sources/UHCKit/UHCDiscovery.swift
@@ -116,6 +116,34 @@ public final class UHCDiscovery: NSObject, @unchecked Sendable {
         }
     }
 
+    /// The first usable numeric host in a Bonjour address list, IPv4 first.
+    /// Link-local IPv6 is skipped: it needs a scope id that does not survive
+    /// being written into a URL string.
+    static func numericHost(from addresses: [Data]) -> String? {
+        var fallbackV6: String?
+        for data in addresses {
+            let host: String? = data.withUnsafeBytes { raw -> String? in
+                guard let base = raw.baseAddress, raw.count >= MemoryLayout<sockaddr>.size else {
+                    return nil
+                }
+                let sa = base.assumingMemoryBound(to: sockaddr.self)
+                var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                guard getnameinfo(sa, socklen_t(raw.count), &buffer, socklen_t(buffer.count),
+                                  nil, 0, NI_NUMERICHOST) == 0 else { return nil }
+                let text = String(cString: buffer)
+                if sa.pointee.sa_family == sa_family_t(AF_INET) { return text }
+                if sa.pointee.sa_family == sa_family_t(AF_INET6) {
+                    if text.hasPrefix("fe80") || text.contains("%") { return nil }
+                    return "[\(text)]"
+                }
+                return nil
+            }
+            guard let host else { continue }
+            if host.hasPrefix("[") { fallbackV6 = fallbackV6 ?? host } else { return host }
+        }
+        return fallbackV6
+    }
+
     /// Reads a usable base URL out of a Bonjour TXT record. Shared by both
     /// implementations so the fallback rule cannot drift between platforms.
     static func baseURL(fromTXT txt: [String: String]) -> URL? {
@@ -215,9 +243,25 @@ extension UHCDiscovery: NetServiceBrowserDelegate, NetServiceDelegate {
 
     public func netServiceDidResolveAddress(_ sender: NetService) {
         guard !finished else { return }
-        // Prefer the resolved hostname: a server may advertise a loopback or
-        // container hostname in its TXT base URL, while Bonjour has already
-        // resolved a name reachable from *this* device.
+        // Prefer the numeric address Bonjour has ALREADY resolved. Using the
+        // `.local` hostname instead makes every subsequent request re-run an
+        // mDNS lookup, and those lose the race often enough to matter -- on
+        // the owner's network that surfaced as sporadic `-1001` timeouts and
+        // a `did not receive all answers in time for nas2.local:8088` in the
+        // device log, on a server that was up the whole time.
+        //
+        // Trade-off, deliberate: an address can go stale if DHCP moves the
+        // server, where a hostname would have followed it. Re-running
+        // discovery fixes that, and a lookup that intermittently fails is
+        // worse than one that fails predictably and can be retried.
+        if let address = UHCDiscovery.numericHost(from: sender.addresses ?? []),
+           sender.port > 0,
+           let url = URL(string: "http://\(address):\(sender.port)") {
+            finish(url)
+            return
+        }
+
+        // No usable address: fall back to the resolved hostname.
         if let host = sender.hostName?.trimmingCharacters(in: CharacterSet(charactersIn: ".")),
            !host.isEmpty, sender.port > 0,
            let url = URL(string: "http://\(host):\(sender.port)") {

--- a/companion/uhckit/Tests/UHCKitTests/DiscoveryAddressTests.swift
+++ b/companion/uhckit/Tests/UHCKitTests/DiscoveryAddressTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import UHCKit
+
+/// Bonjour hands back resolved addresses as packed `sockaddr` blobs. Reading
+/// them is where the mDNS fix lives, so it is pinned here rather than trusted.
+private func ipv4(_ a: UInt8, _ b: UInt8, _ c: UInt8, _ d: UInt8, port: UInt16) -> Data {
+    var sa = sockaddr_in()
+    sa.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    sa.sin_family = sa_family_t(AF_INET)
+    sa.sin_port = port.bigEndian
+    sa.sin_addr.s_addr = UInt32(d) << 24 | UInt32(c) << 16 | UInt32(b) << 8 | UInt32(a)
+    return withUnsafeBytes(of: &sa) { Data($0) }
+}
+
+private func ipv6(_ text: String, port: UInt16) -> Data {
+    var sa = sockaddr_in6()
+    sa.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
+    sa.sin6_family = sa_family_t(AF_INET6)
+    sa.sin6_port = port.bigEndian
+    _ = text.withCString { inet_pton(AF_INET6, $0, &sa.sin6_addr) }
+    return withUnsafeBytes(of: &sa) { Data($0) }
+}
+
+@Test func readsAnIPv4Address() {
+    #expect(UHCDiscovery.numericHost(from: [ipv4(192, 168, 1, 2, port: 8088)]) == "192.168.1.2")
+}
+
+@Test func prefersIPv4OverIPv6() {
+    let addresses = [ipv6("2001:db8::1", port: 8088), ipv4(192, 168, 1, 2, port: 8088)]
+    #expect(UHCDiscovery.numericHost(from: addresses) == "192.168.1.2")
+}
+
+@Test func bracketsIPv6WhenThatIsAllThereIs() {
+    #expect(UHCDiscovery.numericHost(from: [ipv6("2001:db8::1", port: 8088)]) == "[2001:db8::1]")
+}
+
+/// A link-local address needs a scope id that cannot survive a URL string, so
+/// taking one would produce a base URL that never connects.
+@Test func skipsLinkLocalIPv6() {
+    #expect(UHCDiscovery.numericHost(from: [ipv6("fe80::1", port: 8088)]) == nil)
+}
+
+@Test func toleratesGarbage() {
+    #expect(UHCDiscovery.numericHost(from: [Data([0x01, 0x02])]) == nil)
+    #expect(UHCDiscovery.numericHost(from: []) == nil)
+}


### PR DESCRIPTION
The intermittent `-1001`s the owner has been hitting since this session began. From his device log, on a server that was up the entire time:

```
nw_resolver_start_query_timer_block_invoke [C4.1] Query fired:
  did not receive all answers in time for nas2.local:8088
```

**Cause.** `netServiceDidResolveAddress` kept `sender.hostName` — `NAS2.local.` — and threw away `sender.addresses`, which Bonjour had *already resolved*. Every subsequent HTTP request therefore re-ran an mDNS lookup, and enough of those lose the race to produce sporadic timeouts that look exactly like a dead server.

**Fix.** Prefer the numeric address (IPv4 first; link-local IPv6 skipped, since its scope id cannot survive a URL string). Hostname and the TXT `base` key remain fallbacks.

**Proven against the live network**, not just unit tests:

```
service: Unified Hi-Fi Control UHC
  hostName (old behaviour): NAS2.local.:8088
  numeric  (new behaviour): 192.168.1.2:8088
```

Plus 5 new tests over real packed `sockaddr` blobs: IPv4 read, IPv4 preferred over IPv6, IPv6 bracketed when alone, link-local skipped, malformed input tolerated.

**Deliberate trade-off, stated because it is a real cost:** an address goes stale if DHCP moves the server, where a hostname would have followed it. Re-running discovery fixes that, and an intermittent failure is worse than a predictable one. If this bites, the follow-up is storing both and falling back at the transport.