### PR TITLE
feat(watch): make Digital Crown volume trustworthy

### DIFF
--- a/companion/apple_music_ios/Xcode/UHCWatchApp/NowPlayingView.swift
+++ b/companion/apple_music_ios/Xcode/UHCWatchApp/NowPlayingView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WatchKit
 import UHCKit
 
 /// Artwork, three lines of text, transport, and the Digital Crown bound to
@@ -12,6 +13,7 @@ struct NowPlayingView: View {
     @State private var crownVolume: Double = 0
     @State private var crownPrimed = false
     @State private var volumeCommit: Task<Void, Never>?
+    @State private var wasAtLimit = false
 
     var body: some View {
         ScrollView {
@@ -40,6 +42,7 @@ struct NowPlayingView: View {
             // zone's real volume is known, and acting on it would yank the
             // volume to zero the moment the screen appears.
             guard crownPrimed else { return }
+            reportLimit(newValue)
             scheduleVolumeCommit(newValue)
         }
         .onChange(of: controller.nowPlaying?.volume) { _, newValue in
@@ -137,15 +140,30 @@ struct NowPlayingView: View {
     @ViewBuilder
     private var volumeReadout: some View {
         if let control = controller.volumeControl {
+            // While the crown is moving, show where it points -- not what the
+            // server last said. The server's answer lags the turn, and
+            // rendering it mid-gesture is what made the number walk backwards
+            // under the user's finger.
+            let pending = controller.pendingVolume
+            let shown = pending ?? control.value
             HStack(spacing: 4) {
                 Image(systemName: "speaker.wave.2.fill")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-                Text(formatted(control.value))
+                Text(formatted(shown))
                     .font(.caption2)
                     .monospacedDigit()
+                    // Dimmed until the zone confirms it: the number is a
+                    // request, and it says so, rather than claiming a change
+                    // that has not happened.
+                    .foregroundStyle(pending == nil ? .primary : .secondary)
+                    .animation(.easeOut(duration: 0.18), value: pending == nil)
             }
-            .accessibilityLabel("Volume \(formatted(control.value))")
+            .accessibilityLabel(
+                pending == nil
+                    ? "Volume \(formatted(shown))"
+                    : "Volume \(formatted(shown)), setting"
+            )
         }
         if let message = controller.errorMessage {
             Text(message)
@@ -163,12 +181,31 @@ struct NowPlayingView: View {
 
     /// Coalesce crown motion into one request per quiet period. Without this a
     /// single flick of the crown becomes dozens of `vol_abs` commands.
+    /// Commit once the crown has been still for a beat. 250ms fired partway
+    /// through an ordinary turn, so a single adjustment became several writes
+    /// racing each other; a hand comes to rest well inside 600ms.
+    private static let crownQuietPeriod = Duration.milliseconds(600)
+
     private func scheduleVolumeCommit(_ value: Double) {
         volumeCommit?.cancel()
         volumeCommit = Task {
-            try? await Task.sleep(for: .milliseconds(250))
+            try? await Task.sleep(for: Self.crownQuietPeriod)
             guard !Task.isCancelled else { return }
-            await controller.setVolume(value)
+            let landed = await controller.commitVolume(value)
+            guard !Task.isCancelled else { return }
+            // Confirm on the wrist. The crown already ticks while turning;
+            // this is the distinct beat that says the zone actually took it,
+            // which is the whole difference between guessing and knowing.
+            WKInterfaceDevice.current().play(landed ? .click : .failure)
         }
+    }
+
+    /// The ends of the range deserve to be felt, not discovered by watching a
+    /// number stop moving.
+    private func reportLimit(_ value: Double) {
+        guard let control = controller.volumeControl else { return }
+        let atLimit = value <= control.min || value >= control.max
+        if atLimit, !wasAtLimit { WKInterfaceDevice.current().play(.retry) }
+        wasAtLimit = atLimit
     }
 }

--- a/companion/apple_music_ios/Xcode/UHCWatchApp/WatchController.swift
+++ b/companion/apple_music_ios/Xcode/UHCWatchApp/WatchController.swift
@@ -130,6 +130,7 @@ final class WatchController {
     func refreshNowPlaying() async {
         guard let client, let zoneID = selectedZoneID else { return }
         guard Date() >= suppressPollUntil else { return }
+        defer { confirmedVolume = nowPlaying?.volume }
         do {
             let np = try await client.nowPlaying(zoneID: zoneID)
             nowPlaying = np
@@ -209,16 +210,61 @@ final class WatchController {
         await send { try await $0.previous(zoneID: zoneID) }
     }
 
+    /// Where the crown is pointing right now, before the server has agreed.
+    /// While the user is turning, THIS is the truth the readout shows: asking
+    /// the server mid-turn returns a value from before the write landed, and
+    /// rendering that is what made the number jump backwards.
+    private(set) var pendingVolume: Double?
+    /// The last value the server confirmed, used to skip writes that would ask
+    /// a zone for the volume it already has.
+    private var confirmedVolume: Double?
+
     /// Absolute volume from the Digital Crown, snapped to the zone's own step.
-    func setVolume(_ value: Double) async {
-        guard let zoneID = selectedZoneID else { return }
+    ///
+    /// The crown is a continuous input, so the server is told the destination,
+    /// not the journey: the caller debounces, this commits once, and no read
+    /// is issued afterwards. The poller reconciles in its own time.
+    ///
+    /// Returns whether the value actually reached the server, so the view can
+    /// confirm it to the wrist.
+    @discardableResult
+    func commitVolume(_ value: Double) async -> Bool {
+        guard let zoneID = selectedZoneID, let client else { return false }
         let control = nowPlaying?.volumeControl
             ?? zones.first(where: { $0.id == zoneID })?.volumeControl
+        let target = control?.normalized(value) ?? value
+
+        // Writing the value a zone already holds produces no readback, so the
+        // server waits for a change event that never comes and eventually
+        // 500s (#621). At the crown that is not an edge case -- a hand that
+        // stops on the current value is ordinary -- so never send it.
+        if let confirmed = confirmedVolume, confirmed == target {
+            pendingVolume = nil
+            return true
+        }
+
+        pendingVolume = target
         if var np = nowPlaying {
-            np.volume = control?.normalized(value) ?? value
+            np.volume = target
             nowPlaying = np
         }
-        await send { try await $0.setVolume(zoneID: zoneID, to: value, within: control) }
+        // Long enough for the write and its readback, which the poller must
+        // not overwrite in the meantime.
+        suppressPollUntil = Date().addingTimeInterval(1.5)
+        do {
+            try await client.setVolume(zoneID: zoneID, to: target, within: control)
+            confirmedVolume = target
+            pendingVolume = nil
+            errorMessage = nil
+            return true
+        } catch {
+            pendingVolume = nil
+            recordFailure(error)
+            // Only now is a read worth making: the local value is wrong and
+            // the user needs to see where the zone actually sits.
+            await refreshNowPlaying()
+            return false
+        }
     }
 
     private func send(_ body: @escaping (UHCClient) async throws -> Void) async {


### PR DESCRIPTION
Owner, using it on the wrist: *"this happens with the crown which also goes up and down, so it's weird/not reliable, it sometimes get a server error: when I reduce vol multiple times I get a server can't be reached. On other devices I use a quiet period to send the vol I want."*

All three are the same mistake: **a continuous input pointed at a control designed for discrete presses.** `/impeccable adapt` names it exactly — the trap is treating adaptation as scaling. The crown needed a different contract: *tell the server the destination, not the journey.*

| Symptom | Cause | Fix |
|---|---|---|
| Number walks backwards | `send()` awaited the write then immediately read; the readback had not published, so the UI rendered a pre-write value | Success path issues no read; the poller reconciles |
| "Server can't be reached" | A hand resting on the current value re-sent it; a no-op write hangs ~15s (#621) past the client's 8s timeout | Never send a value the zone already holds |
| Unreliable feel | 250ms fired mid-turn, so one adjustment became several racing writes | 600ms quiet period, commit once |

**Delight, in the register Operate mode earns — certainty, not whimsy:**
- A **distinct haptic when the zone actually takes the value**, separate from the crown's own rotation ticks. That is the difference between guessing and knowing, on a device you cannot always look at.
- A **different haptic at the ends of the range**, so a limit is felt rather than inferred from a number that stopped moving.
- The readout shows **where the crown points** while turning, **dimmed** until confirmed — the number admits it is still a request. VoiceOver says "setting" in that state.

**Verified** against the live server in the watch simulator: real zones (Deck/Bedroom/Cen.Grand), now-playing with artwork, and the readout showing Deck's actual volume of 27.

**Not verified:** crown rotation itself and the haptics — the simulator has no crown hardware or Taptic Engine. The debounce, no-op guard, and read-removal are verifiable by inspection; the feel needs the owner's wrist.

Server-side #621 remains worth fixing on its own: this stops the Watch from triggering it, but any client can still hang a zone by writing its current volume.