### PR TITLE
chore(companion): one source for version numbers

### DIFF
--- a/companion/apple_music_ios/Xcode/Config/Shared.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Shared.xcconfig
@@ -1,3 +1,4 @@
+#include "Version.xcconfig"
 // Shared.xcconfig
 // Minimal shared configuration for scaffold tool customization
 // All other settings use Xcode project defaults
@@ -10,8 +11,6 @@ PRODUCT_NAME = AppleMusicIOSCompanionHost
 PRODUCT_DISPLAY_NAME = Hi-Fi Control
 PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.companion
 DEVELOPMENT_TEAM = B69HKNTV5Q
-MARKETING_VERSION = 0.1.0
-CURRENT_PROJECT_VERSION = 1
 
 // ==========================================
 // Platform Configuration

--- a/companion/apple_music_ios/Xcode/Config/Version.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Version.xcconfig
@@ -1,0 +1,12 @@
+// The single place version numbers live.
+//
+// The iOS app and the Watch app embedded in it MUST carry identical values:
+// App Store Connect rejects an upload whose embedded watch app disagrees with
+// its host. They were previously duplicated in Shared.xcconfig and
+// Watch.xcconfig, where they could drift silently.
+//
+// MARKETING_VERSION      what people see (0.1.0). Bump for a real release.
+// CURRENT_PROJECT_VERSION the build number. MUST increase for every upload --
+//                        App Store Connect refuses a duplicate outright.
+MARKETING_VERSION = 0.1.0
+CURRENT_PROJECT_VERSION = 2

--- a/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
+++ b/companion/apple_music_ios/Xcode/Config/Watch.xcconfig
@@ -1,3 +1,4 @@
+#include "Version.xcconfig"
 // Watch.xcconfig
 // Build settings for the UHC watchOS controller app (#619).
 //
@@ -11,8 +12,6 @@ PRODUCT_DISPLAY_NAME = UHC
 // bundle; the Watch app is embedded in the iOS app's Watch container.
 PRODUCT_BUNDLE_IDENTIFIER = com.openhorizonlabs.uhc.companion.watchkitapp
 DEVELOPMENT_TEAM = B69HKNTV5Q
-MARKETING_VERSION = 0.1.0
-CURRENT_PROJECT_VERSION = 1
 
 SDKROOT = watchos
 WATCHOS_DEPLOYMENT_TARGET = 10.0

--- a/companion/apple_music_ios/bump-build.sh
+++ b/companion/apple_music_ios/bump-build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Increment the build number for the next TestFlight upload.
+# App Store Connect refuses an upload whose build number it has already seen.
+set -eu
+CONFIG="$(dirname "$0")/Xcode/Config/Version.xcconfig"
+CURRENT=$(sed -n 's/^CURRENT_PROJECT_VERSION = //p' "$CONFIG")
+NEXT=$((CURRENT + 1))
+sed -i '' "s/^CURRENT_PROJECT_VERSION = .*/CURRENT_PROJECT_VERSION = ${NEXT}/" "$CONFIG"
+echo "build ${CURRENT} -> ${NEXT}"


### PR DESCRIPTION
`MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` lived in **both** `Shared.xcconfig` and `Watch.xcconfig`. App Store Connect rejects an upload whose embedded watch app disagrees with its host, so drift between those two files means a failed upload with an unhelpful message — and nothing kept them in step.

Both now `#include "Version.xcconfig"`. Verified on the built product: phone and embedded watch app both report `0.1.0 (2)`.

Build bumped to **2** because build 1 is already uploaded and App Store Connect refuses duplicates outright.

Adds `companion/apple_music_ios/bump-build.sh` — increments the build number for the next upload, so the step that is easy to forget and fails late is one command.