### PR TITLE
Frame: cache and serve native packed e-ink artwork

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -302,6 +302,8 @@ pub struct AppState {
     /// provider-native image handle behind it. Deliberately a separate table
     /// from `mcp_refs` -- see `crate::mcp::refs::ImageRef`'s docs for why.
     pub image_refs: crate::mcp::refs::ImageRefTable,
+    /// Bounded cache of fully composed, dithered, and packed Frame artwork.
+    pub eink_artwork_cache: crate::knobs::image::EinkArtworkCache,
     /// UHC-owned requested listening sequences, separate from provider queue
     /// observations (#483).
     pub listening_plans: crate::mcp::listening_plan::ListeningPlanStore,
@@ -375,6 +377,7 @@ impl AppState {
             sse_connections: Arc::new(AtomicUsize::new(0)),
             mcp_refs: crate::mcp::refs::RefTable::new(),
             image_refs: crate::mcp::refs::ImageRefTable::new(),
+            eink_artwork_cache: crate::knobs::image::EinkArtworkCache::default(),
             listening_plans: crate::mcp::listening_plan::ListeningPlanStore::from_config(),
             apple_feedback: crate::mcp::feedback::FeedbackStore::from_config(),
             reliable_commands: None,
@@ -412,13 +415,54 @@ impl AppState {
         width: Option<u32>,
         height: Option<u32>,
         format: Option<&str>,
+        resize_policy: Option<crate::knobs::image::Rgb565ResizePolicy>,
     ) -> anyhow::Result<crate::bus::ImageData> {
         use crate::bus::ImageData;
-        use crate::knobs::image::jpeg_to_rgb565;
+        use crate::knobs::image::{
+            image_to_eink_acep6_with_policy, jpeg_to_rgb565_with_policy, EinkCacheKey,
+            Rgb565ResizePolicy,
+        };
+
+        let dimensions = match (width, height) {
+            (Some(w), Some(h)) => (w, h),
+            (Some(w), None) => (w, w),
+            (None, Some(h)) => (h, h),
+            (None, None) if format == Some("eink_acep6") => (800, 450),
+            (None, None) => (240, 240),
+        };
+        let resize_policy = resize_policy.unwrap_or(Rgb565ResizePolicy::Exact);
+        let eink_cache_key = (format == Some("eink_acep6")).then(|| EinkCacheKey {
+            zone_id: zone_id.to_string(),
+            image_key: image_key.to_string(),
+            width: dimensions.0,
+            height: dimensions.1,
+            resize_policy,
+            converter_version: 1,
+        });
+        if let Some(key) = eink_cache_key.as_ref() {
+            if let Some(data) = self.eink_artwork_cache.get(key) {
+                return Ok(ImageData {
+                    content_type: "application/octet-stream".to_string(),
+                    data: data.as_ref().clone(),
+                });
+            }
+        }
+
+        // Smart composition needs the source aspect ratio. Asking a provider
+        // for the final rectangle first can irreversibly stretch or crop it
+        // before UHC gets a chance to apply the crop budget/gallery mat.
+        let provider_dimensions = if resize_policy == Rgb565ResizePolicy::Exact {
+            (width, height)
+        } else {
+            (None, None)
+        };
 
         // Fetch raw image from appropriate adapter
         let raw_image = if zone_id.starts_with("lms:") {
-            let (content_type, data) = self.lms.get_artwork(image_key, width, height).await?;
+            let (content_type, data) = self
+                .lms
+                .get_artwork(image_key, provider_dimensions.0, provider_dimensions.1)
+                .await?;
             ImageData { content_type, data }
         } else if zone_id.starts_with("openhome:") {
             let img = self.openhome.get_image(image_key).await?;
@@ -447,7 +491,10 @@ impl AppState {
         } else if let Some(instance) = zone_id.strip_prefix("hqplayer:") {
             self.hqp_images.get_current_cover(instance).await?
         } else if zone_id.starts_with("roon:") || !zone_id.contains(':') {
-            let img = self.roon.get_image(image_key, width, height).await?;
+            let img = self
+                .roon
+                .get_image(image_key, provider_dimensions.0, provider_dimensions.1)
+                .await?;
             ImageData {
                 content_type: img.content_type,
                 data: img.data,
@@ -456,23 +503,45 @@ impl AppState {
             anyhow::bail!("Unknown zone type for image: {}", zone_id)
         };
 
-        // Convert to RGB565 if requested (for ESP32 LCD displays)
-        if format == Some("rgb565") {
+        // Convert to RGB565 if requested (for ESP32 LCD/e-ink displays).
+        // The smart variant is a capability handshake: older servers return
+        // the source image, allowing firmware to detect and use its fallback.
+        if matches!(format, Some("rgb565" | "rgb565-smart")) {
             // Use square dimensions when only one side specified (matches adapter behavior)
-            let (target_w, target_h) = match (width, height) {
-                (Some(w), Some(h)) => (w, h),
-                (Some(w), None) => (w, w),
-                (None, Some(h)) => (h, h),
-                (None, None) => (240, 240),
-            };
+            let (target_w, target_h) = dimensions;
 
-            match jpeg_to_rgb565(&raw_image.data, target_w, target_h) {
+            match jpeg_to_rgb565_with_policy(&raw_image.data, target_w, target_h, resize_policy) {
                 Ok(rgb565) => Ok(ImageData {
                     content_type: "application/octet-stream".to_string(),
                     data: rgb565.data,
                 }),
                 Err(_) => {
                     // Fall back to original on conversion error
+                    Ok(raw_image)
+                }
+            }
+        } else if format == Some("eink_acep6") {
+            let (target_w, target_h) = dimensions;
+            match image_to_eink_acep6_with_policy(
+                &raw_image.data,
+                target_w,
+                target_h,
+                resize_policy,
+            ) {
+                Ok(eink) => {
+                    let Some(cache_key) = eink_cache_key else {
+                        return Ok(raw_image);
+                    };
+                    let data = self.eink_artwork_cache.insert(cache_key, eink.data);
+                    Ok(ImageData {
+                        content_type: "application/octet-stream".to_string(),
+                        data: data.as_ref().clone(),
+                    })
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        "Frame artwork conversion failed for {zone_id} at {target_w}x{target_h}: {error}"
+                    );
                     Ok(raw_image)
                 }
             }
@@ -1067,6 +1136,7 @@ pub async fn collections_image_handler(
             params.width,
             params.height,
             params.format.as_deref(),
+            None,
         )
         .await
     {

--- a/src/knobs/image.rs
+++ b/src/knobs/image.rs
@@ -7,14 +7,249 @@
 //! - Image resizing (bilinear)
 //! - RGB565 conversion (little-endian for ESP32)
 
-use image::{codecs::jpeg::JpegEncoder, imageops::FilterType, DynamicImage, ImageFormat};
+use image::{
+    codecs::jpeg::JpegEncoder,
+    imageops::{self, FilterType},
+    DynamicImage, ImageFormat, Rgba, RgbaImage,
+};
+use std::collections::VecDeque;
 use std::io::Cursor;
+use std::sync::{Arc, Mutex};
 
 /// RGB565 image data for LCD display
 pub struct Rgb565Image {
     pub data: Vec<u8>,
     pub width: u32,
     pub height: u32,
+}
+
+/// Native framebuffer data for Waveshare's six-color ACeP/Spectra panel.
+/// Two pixels are packed per byte, with the left pixel in the high nibble.
+pub struct EinkAcep6Image {
+    pub data: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+}
+
+const EINK_CACHE_CAPACITY: usize = 8;
+type EinkCacheEntries = VecDeque<(EinkCacheKey, Arc<Vec<u8>>)>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EinkCacheKey {
+    pub zone_id: String,
+    pub image_key: String,
+    pub width: u32,
+    pub height: u32,
+    pub resize_policy: Rgb565ResizePolicy,
+    pub converter_version: u8,
+}
+
+/// Small process-local LRU for already packed Frame artwork. Eight 800x450
+/// entries consume about 1.4 MiB while covering ordinary back/forward skips.
+#[derive(Clone, Default)]
+pub struct EinkArtworkCache {
+    entries: Arc<Mutex<EinkCacheEntries>>,
+}
+
+impl EinkArtworkCache {
+    pub fn get(&self, key: &EinkCacheKey) -> Option<Arc<Vec<u8>>> {
+        let mut entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let index = entries.iter().position(|(candidate, _)| candidate == key)?;
+        let entry = entries.remove(index)?;
+        let data = Arc::clone(&entry.1);
+        entries.push_front(entry);
+        Some(data)
+    }
+
+    pub fn insert(&self, key: EinkCacheKey, data: Vec<u8>) -> Arc<Vec<u8>> {
+        let mut entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(index) = entries.iter().position(|(candidate, _)| candidate == &key) {
+            entries.remove(index);
+        }
+        let data = Arc::new(data);
+        entries.push_front((key, Arc::clone(&data)));
+        entries.truncate(EINK_CACHE_CAPACITY);
+        data
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Rgb565ResizePolicy {
+    /// Legacy behavior for clients that explicitly need every output pixel filled.
+    Exact,
+    /// Preserve the complete source and compose unused space as a gallery mat.
+    Fit,
+    /// Fill only when the center crop stays within the stated source-area budget.
+    SmartCover { max_crop_percent: u8 },
+}
+
+const ACEP6_PALETTE: [[u8; 3]; 6] = [
+    [0, 0, 0],
+    [255, 255, 255],
+    [255, 255, 0],
+    [255, 0, 0],
+    [0, 0, 255],
+    [0, 255, 0],
+];
+const ACEP6_PANEL_INDEX: [u8; 6] = [0, 1, 2, 3, 5, 6];
+
+fn nearest_acep6_color(r: u8, g: u8, b: u8) -> usize {
+    ACEP6_PALETTE
+        .iter()
+        .enumerate()
+        .min_by_key(|(_, color)| {
+            let dr = i32::from(r) - i32::from(color[0]);
+            let dg = i32::from(g) - i32::from(color[1]);
+            let db = i32::from(b) - i32::from(color[2]);
+            dr * dr + dg * dg + db * db
+        })
+        .map(|(index, _)| index)
+        .unwrap_or(0)
+}
+
+fn diffuse_channel(channel: &mut u8, error: i32, numerator: i32) {
+    *channel = (i32::from(*channel) + error * numerator / 16).clamp(0, 255) as u8;
+}
+
+/// Reproduce the accepted Frame firmware conversion on the server: ideal
+/// six-color palette, RGB-distance matching, and raster Floyd-Steinberg error
+/// diffusion with each propagated update clamped to a byte.
+fn floyd_steinberg_acep6(rgb: &mut [u8], width: usize, height: usize) -> Vec<u8> {
+    let bytes_per_row = width.div_ceil(2);
+    let mut packed = vec![0u8; bytes_per_row * height];
+
+    for y in 0..height {
+        for x in 0..width {
+            let offset = (y * width + x) * 3;
+            let r = rgb[offset];
+            let g = rgb[offset + 1];
+            let b = rgb[offset + 2];
+            let palette_index = nearest_acep6_color(r, g, b);
+            let chosen = ACEP6_PALETTE[palette_index];
+            let panel_index = ACEP6_PANEL_INDEX[palette_index];
+            let packed_offset = y * bytes_per_row + x / 2;
+            if x % 2 == 0 {
+                packed[packed_offset] = panel_index << 4;
+            } else {
+                packed[packed_offset] |= panel_index;
+            }
+
+            let errors = [
+                i32::from(r) - i32::from(chosen[0]),
+                i32::from(g) - i32::from(chosen[1]),
+                i32::from(b) - i32::from(chosen[2]),
+            ];
+            let mut add_error = |neighbor: usize, weight: i32| {
+                diffuse_channel(&mut rgb[neighbor], errors[0], weight);
+                diffuse_channel(&mut rgb[neighbor + 1], errors[1], weight);
+                diffuse_channel(&mut rgb[neighbor + 2], errors[2], weight);
+            };
+
+            if x + 1 < width {
+                add_error(offset + 3, 7);
+            }
+            if y + 1 < height {
+                let next_row = (y + 1) * width * 3;
+                if x > 0 {
+                    add_error(next_row + (x - 1) * 3, 3);
+                }
+                add_error(next_row + x * 3, 5);
+                if x + 1 < width {
+                    add_error(next_row + (x + 1) * 3, 1);
+                }
+            }
+        }
+    }
+    packed
+}
+
+const GALLERY_MAT: Rgba<u8> = Rgba([248, 250, 251, 255]);
+const GALLERY_KEYLINE: Rgba<u8> = Rgba([23, 37, 54, 255]);
+
+fn cover_crop_percent(source_w: u32, source_h: u32, target_w: u32, target_h: u32) -> f64 {
+    let source_ratio = source_w as f64 / source_h as f64;
+    let target_ratio = target_w as f64 / target_h as f64;
+    let visible_fraction = if source_ratio < target_ratio {
+        source_ratio / target_ratio
+    } else {
+        target_ratio / source_ratio
+    };
+    (1.0 - visible_fraction) * 100.0
+}
+
+fn fit_on_gallery_mat(img: &DynamicImage, target_w: u32, target_h: u32) -> DynamicImage {
+    let fitted = img
+        .resize(target_w, target_h, FilterType::Triangle)
+        .to_rgba8();
+    let offset_x = (target_w - fitted.width()) / 2;
+    let offset_y = (target_h - fitted.height()) / 2;
+    let mut canvas = RgbaImage::from_pixel(target_w, target_h, GALLERY_MAT);
+
+    // A one-pixel keyline makes the complete sleeve feel deliberately mounted,
+    // especially when pale artwork meets the near-white mat on e-ink.
+    if offset_x > 0 || offset_y > 0 {
+        let left = offset_x.saturating_sub(1);
+        let top = offset_y.saturating_sub(1);
+        let right = (offset_x + fitted.width()).min(target_w - 1);
+        let bottom = (offset_y + fitted.height()).min(target_h - 1);
+        for x in left..=right {
+            canvas.put_pixel(x, top, GALLERY_KEYLINE);
+            canvas.put_pixel(x, bottom, GALLERY_KEYLINE);
+        }
+        for y in top..=bottom {
+            canvas.put_pixel(left, y, GALLERY_KEYLINE);
+            canvas.put_pixel(right, y, GALLERY_KEYLINE);
+        }
+    }
+
+    imageops::overlay(&mut canvas, &fitted, offset_x.into(), offset_y.into());
+    DynamicImage::ImageRgba8(canvas)
+}
+
+fn resize_with_policy(
+    img: &DynamicImage,
+    target_w: u32,
+    target_h: u32,
+    policy: Rgb565ResizePolicy,
+) -> DynamicImage {
+    if img.width() == target_w && img.height() == target_h {
+        return img.clone();
+    }
+
+    match policy {
+        Rgb565ResizePolicy::Exact => img.resize_exact(target_w, target_h, FilterType::Triangle),
+        Rgb565ResizePolicy::Fit => fit_on_gallery_mat(img, target_w, target_h),
+        Rgb565ResizePolicy::SmartCover { max_crop_percent }
+            if cover_crop_percent(img.width(), img.height(), target_w, target_h)
+                <= f64::from(max_crop_percent) =>
+        {
+            img.resize_to_fill(target_w, target_h, FilterType::Triangle)
+        }
+        Rgb565ResizePolicy::SmartCover { .. } => fit_on_gallery_mat(img, target_w, target_h),
+    }
+}
+
+pub fn image_to_eink_acep6_with_policy(
+    image_data: &[u8],
+    target_width: u32,
+    target_height: u32,
+    policy: Rgb565ResizePolicy,
+) -> Result<EinkAcep6Image, image::ImageError> {
+    let image = image::load_from_memory(image_data)?;
+    let resized = resize_with_policy(&image, target_width, target_height, policy);
+    let mut rgb = resized.to_rgb8().into_raw();
+    let data = floyd_steinberg_acep6(&mut rgb, target_width as usize, target_height as usize);
+    Ok(EinkAcep6Image {
+        data,
+        width: target_width,
+        height: target_height,
+    })
 }
 
 /// Convert any image buffer (JPEG, PNG, SVG, etc.) to RGB565 format for ESP32 LCD
@@ -25,6 +260,20 @@ pub fn jpeg_to_rgb565(
     image_data: &[u8],
     target_width: u32,
     target_height: u32,
+) -> Result<Rgb565Image, image::ImageError> {
+    jpeg_to_rgb565_with_policy(
+        image_data,
+        target_width,
+        target_height,
+        Rgb565ResizePolicy::Exact,
+    )
+}
+
+pub fn jpeg_to_rgb565_with_policy(
+    image_data: &[u8],
+    target_width: u32,
+    target_height: u32,
+    policy: Rgb565ResizePolicy,
 ) -> Result<Rgb565Image, image::ImageError> {
     // Check if it's SVG (starts with '<' after optional whitespace/BOM)
     let trimmed = image_data
@@ -43,11 +292,7 @@ pub fn jpeg_to_rgb565(
     let img = image::load_from_memory(image_data)?;
 
     // Resize if needed
-    let img = if img.width() != target_width || img.height() != target_height {
-        img.resize_exact(target_width, target_height, FilterType::Triangle)
-    } else {
-        img
-    };
+    let img = resize_with_policy(&img, target_width, target_height, policy);
 
     // Convert to RGB565
     let rgb565_data = rgba_to_rgb565(&img);
@@ -212,6 +457,129 @@ pub fn placeholder_svg(width: u32, height: u32) -> String {
 mod tests {
     use super::*;
     use image::ImageEncoder;
+
+    fn encode_solid_png(width: u32, height: u32, color: image::Rgba<u8>) -> Vec<u8> {
+        let img = image::RgbaImage::from_pixel(width, height, color);
+        let mut png_data = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut png_data)
+            .write_image(&img, width, height, image::ExtendedColorType::Rgba8)
+            .expect("encode test PNG");
+        png_data
+    }
+
+    fn rgb565_at(image: &Rgb565Image, x: u32, y: u32) -> u16 {
+        let offset = ((y * image.width + x) * 2) as usize;
+        u16::from_le_bytes([image.data[offset], image.data[offset + 1]])
+    }
+
+    #[test]
+    fn smart_resize_mats_square_art_instead_of_cropping_it_to_widescreen() {
+        let png = encode_solid_png(100, 100, image::Rgba([255, 0, 0, 255]));
+        let result = jpeg_to_rgb565_with_policy(
+            &png,
+            160,
+            90,
+            Rgb565ResizePolicy::SmartCover {
+                max_crop_percent: 10,
+            },
+        )
+        .expect("smart conversion");
+
+        assert_eq!(rgb565_at(&result, 0, 45), 0xFFDF, "left gallery mat");
+        assert_eq!(rgb565_at(&result, 80, 45), 0xF800, "complete centered art");
+        assert_eq!(rgb565_at(&result, 159, 45), 0xFFDF, "right gallery mat");
+    }
+
+    #[test]
+    fn smart_resize_allows_a_small_center_crop_without_distortion() {
+        // 5:3 into 16:9 loses 6.25% of source height: under the 10% budget.
+        let png = encode_solid_png(100, 60, image::Rgba([255, 0, 0, 255]));
+        let result = jpeg_to_rgb565_with_policy(
+            &png,
+            160,
+            90,
+            Rgb565ResizePolicy::SmartCover {
+                max_crop_percent: 10,
+            },
+        )
+        .expect("smart conversion");
+
+        assert_eq!(rgb565_at(&result, 0, 0), 0xF800);
+        assert_eq!(rgb565_at(&result, 159, 89), 0xF800);
+    }
+
+    #[test]
+    fn fit_resize_never_changes_aspect_ratio_or_discards_square_art() {
+        let png = encode_solid_png(100, 100, image::Rgba([0, 255, 0, 255]));
+        let result = jpeg_to_rgb565_with_policy(&png, 160, 90, Rgb565ResizePolicy::Fit)
+            .expect("fit conversion");
+
+        assert_eq!(rgb565_at(&result, 0, 45), 0xFFDF);
+        assert_eq!(rgb565_at(&result, 80, 45), 0x07E0);
+    }
+
+    #[test]
+    fn acep6_packs_left_pixel_into_high_nibble_using_panel_indices() {
+        let mut image = image::RgbImage::new(6, 1);
+        for (pixel, color) in image.pixels_mut().zip(ACEP6_PALETTE) {
+            *pixel = image::Rgb(color);
+        }
+        let mut png = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut png)
+            .write_image(&image, 6, 1, image::ExtendedColorType::Rgb8)
+            .expect("encode palette PNG");
+
+        let result = image_to_eink_acep6_with_policy(&png, 6, 1, Rgb565ResizePolicy::Exact)
+            .expect("convert palette");
+
+        assert_eq!(result.data, vec![0x01, 0x23, 0x56]);
+    }
+
+    #[test]
+    fn acep6_smart_fit_is_native_4bpp_and_preserves_gallery_mat() {
+        let png = encode_solid_png(100, 100, image::Rgba([255, 0, 0, 255]));
+        let result = image_to_eink_acep6_with_policy(
+            &png,
+            160,
+            90,
+            Rgb565ResizePolicy::SmartCover {
+                max_crop_percent: 10,
+            },
+        )
+        .expect("smart e-ink conversion");
+
+        assert_eq!(result.data.len(), 160 * 90 / 2);
+        assert_eq!(result.data[45 * 80], 0x11, "left edge remains white mat");
+        assert_eq!(result.data[45 * 80 + 40], 0x33, "center remains red art");
+        assert_eq!(
+            result.data[45 * 80 + 79],
+            0x11,
+            "right edge remains white mat"
+        );
+    }
+
+    #[test]
+    fn eink_cache_key_prevents_stale_dimensions_and_evicts_lru() {
+        let cache = EinkArtworkCache::default();
+        let key = |index: usize, width: u32| EinkCacheKey {
+            zone_id: "roon:zone".to_string(),
+            image_key: format!("art-{index}"),
+            width,
+            height: 450,
+            resize_policy: Rgb565ResizePolicy::SmartCover {
+                max_crop_percent: 10,
+            },
+            converter_version: 1,
+        };
+
+        cache.insert(key(0, 800), vec![0]);
+        assert!(cache.get(&key(0, 799)).is_none());
+        for index in 1..=EINK_CACHE_CAPACITY {
+            cache.insert(key(index, 800), vec![index as u8]);
+        }
+        assert!(cache.get(&key(0, 800)).is_none(), "oldest entry is evicted");
+        assert_eq!(&*cache.get(&key(8, 800)).expect("newest entry"), &[8]);
+    }
 
     #[test]
     fn test_rgb565_conversion() {

--- a/src/knobs/routes.rs
+++ b/src/knobs/routes.rs
@@ -438,6 +438,8 @@ pub struct ImageQuery {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub format: Option<String>,
+    pub scale: Option<String>,
+    pub crop_limit: Option<u8>,
 }
 
 // Image conversion is now handled by state.get_image()
@@ -453,11 +455,45 @@ pub async fn knob_image_handler(
     let target_width = params.width.unwrap_or(240);
     let target_height = params.height.unwrap_or(240);
     let format = params.format.as_deref();
+    let rgb565_requested = matches!(format, Some("rgb565" | "rgb565-smart"));
+    let eink_requested = format == Some("eink_acep6");
+    if eink_requested
+        && (target_width == 0
+            || target_height == 0
+            || u64::from(target_width) * u64::from(target_height) > 1_536_000)
+    {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from("invalid e-ink artwork dimensions"))
+            .unwrap();
+    }
+    let resize_policy = match (format, params.scale.as_deref()) {
+        (Some("rgb565-smart" | "eink_acep6"), _) | (_, Some("smart")) => {
+            Some(crate::knobs::image::Rgb565ResizePolicy::SmartCover {
+                max_crop_percent: params.crop_limit.unwrap_or(10).min(25),
+            })
+        }
+        (_, Some("fit")) => Some(crate::knobs::image::Rgb565ResizePolicy::Fit),
+        _ => None,
+    };
 
     // Helper to return placeholder image in appropriate format
     let placeholder_response = || -> Response {
         let svg = placeholder_svg(target_width, target_height);
-        if format == Some("rgb565") {
+        if eink_requested {
+            let bytes_per_row = target_width.div_ceil(2) as usize;
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, "application/octet-stream")
+                .header("X-Image-Format", "eink_acep6")
+                .header("X-Image-Width", target_width.to_string())
+                .header("X-Image-Height", target_height.to_string())
+                .body(Body::from(vec![
+                    0x11;
+                    bytes_per_row * target_height as usize
+                ]))
+                .unwrap()
+        } else if rgb565_requested {
             // Convert SVG placeholder to RGB565
             match svg_to_rgb565(svg.as_bytes(), target_width, target_height) {
                 Ok(rgb565) => Response::builder()
@@ -510,13 +546,16 @@ pub async fn knob_image_handler(
             Some(target_width),
             Some(target_height),
             format,
+            resize_policy,
         )
         .await
     {
         Ok(image_data) => {
             // If RGB565 was requested but conversion failed (content_type != octet-stream),
             // return the placeholder instead of misleading headers
-            if format == Some("rgb565") && image_data.content_type != "application/octet-stream" {
+            if (rgb565_requested || eink_requested)
+                && image_data.content_type != "application/octet-stream"
+            {
                 return placeholder_response();
             }
 
@@ -525,7 +564,12 @@ pub async fn knob_image_handler(
                 .header(header::CONTENT_TYPE, &image_data.content_type);
 
             // Add RGB565 metadata headers for ESP32 clients
-            if format == Some("rgb565") {
+            if eink_requested {
+                response = response
+                    .header("X-Image-Format", "eink_acep6")
+                    .header("X-Image-Width", target_width.to_string())
+                    .header("X-Image-Height", target_height.to_string());
+            } else if rgb565_requested {
                 response = response
                     .header("X-Image-Format", "rgb565")
                     .header("X-Image-Width", target_width.to_string())

--- a/tests/hqplayer_direct_zone.rs
+++ b/tests/hqplayer_direct_zone.rs
@@ -21,6 +21,7 @@
 mod mock_servers;
 
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Once};
 use std::time::{Duration, Instant};
 
@@ -29,6 +30,7 @@ use axum::http::{Request, StatusCode};
 use axum::response::Redirect;
 use axum::routing::{get, post};
 use axum::Router;
+use image::ImageEncoder;
 use serde_json::{json, Value};
 use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
@@ -51,6 +53,7 @@ use unified_hifi_control::api::{self, AppState};
 use unified_hifi_control::bus::runtime::build_runtime;
 use unified_hifi_control::bus::{create_bus, BusEvent, PlaybackState, SharedBus, Zone};
 use unified_hifi_control::coordinator::AdapterCoordinator;
+use unified_hifi_control::knobs::image::Rgb565ResizePolicy;
 use unified_hifi_control::knobs::{self, KnobStore};
 
 // =============================================================================
@@ -103,15 +106,16 @@ fn fast_recovery() -> HqpRecoveryConfig {
 
 /// The two client-facing routes under test, wired exactly as `main.rs` wires them.
 ///
-/// `/control` and `/knob/now_playing` are the knob's whole world; `/zones` is what both clients read
-/// to populate their picker. Nothing else is mounted, so a test cannot accidentally pass through a
-/// route the client does not use.
+/// `/control`, `/knob/now_playing`, and `/now_playing/image` are the knob's media surface;
+/// `/zones` is what both clients read to populate their picker. Nothing else is mounted, so a test
+/// cannot accidentally pass through a route the client does not use.
 fn client_router(state: AppState) -> Router {
     Router::new()
         .route("/hqplayer/configure", post(api::hqp_configure_handler))
         .route("/control", post(knobs::knob_control_handler))
         .route("/knob/control", post(knobs::knob_control_handler))
         .route("/knob/now_playing", get(knobs::knob_now_playing_handler))
+        .route("/now_playing/image", get(knobs::knob_image_handler))
         .route("/zones", get(knobs::knob_zones_handler))
         .with_state(state)
 }
@@ -645,7 +649,14 @@ async fn hqplayer_current_cover_reaches_the_unified_image_interface() {
 
     let image = rig
         .state
-        .get_image("hqplayer:cover", "hqplayer:test-track", None, None, None)
+        .get_image(
+            "hqplayer:cover",
+            "hqplayer:test-track",
+            None,
+            None,
+            None,
+            None,
+        )
         .await
         .expect("fetch the current HQPlayer cover through the unified image interface");
     assert_eq!(image.content_type, "image/jpeg");
@@ -653,6 +664,113 @@ async fn hqplayer_current_cover_reaches_the_unified_image_interface() {
 
     rig.shutdown().await;
     cover_server.abort();
+}
+
+/// Frame requests for the same artwork identity must not refetch or redither
+/// the provider image. A dimension or composition change remains a cache miss.
+#[tokio::test]
+async fn packed_frame_cover_is_cached_by_artwork_identity_and_policy() {
+    let image = image::RgbaImage::from_pixel(20, 20, image::Rgba([255, 0, 0, 255]));
+    let mut png = Vec::new();
+    image::codecs::png::PngEncoder::new(&mut png)
+        .write_image(&image, 20, 20, image::ExtendedColorType::Rgba8)
+        .expect("encode cover PNG");
+    let requests = Arc::new(AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind cover server");
+    let web_port = listener.local_addr().expect("cover address").port();
+    let cover_server = {
+        let requests = Arc::clone(&requests);
+        tokio::spawn(async move {
+            let app = Router::new().route(
+                "/cover/current",
+                get(move || {
+                    let png = png.clone();
+                    let requests = Arc::clone(&requests);
+                    async move {
+                        requests.fetch_add(1, Ordering::SeqCst);
+                        ([("content-type", "image/png")], png)
+                    }
+                }),
+            );
+            axum::serve(listener, app).await.expect("serve cover");
+        })
+    };
+
+    let rig = Rig::new().await;
+    rig.manager
+        .add_instance(
+            "packed".to_string(),
+            "127.0.0.1".to_string(),
+            Some(9),
+            Some(web_port),
+            None,
+            None,
+        )
+        .await;
+    let policy = Some(Rgb565ResizePolicy::SmartCover {
+        max_crop_percent: 10,
+    });
+
+    for _ in 0..2 {
+        let packed = rig
+            .state
+            .get_image(
+                "hqplayer:packed",
+                "same-track-art",
+                Some(800),
+                Some(450),
+                Some("eink_acep6"),
+                policy,
+            )
+            .await
+            .expect("packed cover");
+        assert_eq!(packed.content_type, "application/octet-stream");
+        assert_eq!(packed.data.len(), 180_000);
+    }
+    assert_eq!(
+        requests.load(Ordering::SeqCst),
+        1,
+        "second request is cached"
+    );
+
+    let resized = rig
+        .state
+        .get_image(
+            "hqplayer:packed",
+            "same-track-art",
+            Some(798),
+            Some(450),
+            Some("eink_acep6"),
+            policy,
+        )
+        .await
+        .expect("different geometry");
+    assert_eq!(resized.data.len(), 798 * 450 / 2);
+    assert_eq!(requests.load(Ordering::SeqCst), 2, "geometry is isolated");
+
+    rig.shutdown().await;
+    cover_server.abort();
+}
+
+#[tokio::test]
+async fn packed_frame_cover_rejects_unbounded_allocations_before_provider_lookup() {
+    let rig = Rig::new().await;
+    let request = Request::builder()
+        .uri(
+            "/now_playing/image?zone_id=hqplayer:none&format=eink_acep6&width=100000&height=100000",
+        )
+        .body(Body::empty())
+        .expect("build oversized image request");
+    let response = rig
+        .app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("oversized image response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    rig.shutdown().await;
 }
 
 /// **Client expectation.** A seek on a zone the server told the client was not seekable is refused


### PR DESCRIPTION
## Outcome

UHC now composes Frame artwork at the requested viewport, applies the existing accepted six-color Floyd–Steinberg conversion, caches the packed result by artwork identity and policy, and returns native 4bpp panel bytes.

Closes #633. Follow-up to #263 on the streaming/HA Alpha line.

## Changes

- `format=eink_acep6` returns high-nibble-first ACeP/Spectra 6 panel bytes
- smart cover allows at most the requested crop budget, then uses the gallery-mat fit
- smart requests preserve source aspect by fetching unconstrained provider artwork
- eight-entry bounded LRU keys by zone, image key, geometry, resize policy, and converter version
- dimensions are bounded before provider lookup/allocation
- existing RGB565 behavior remains available to other clients

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --workspace`
- `tests/qnap_package_contract.sh`
- byte-order, smart-fit, packed-size, cache-hit, cache-isolation, LRU eviction, and oversized-allocation tests

## Review / dissent

**Issue:** #633  
**Phase:** execute/review  
**Commit:** `96ad32588d39d4b3fca04979cddebbf1d0351904`  
**Decision:** ready for Alpha integration. Provider pre-resizing was removed so smart composition sees the source aspect ratio; unbounded dimensions are rejected.  
**Accepted tradeoff:** Frame firmware will require this Alpha UHC format. The maintainer confirmed no other Frame users require backward compatibility. Alternative dither experiments are intentionally out of scope.