### PR TITLE
Make UHCKit consumable as a remote Swift package

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,43 @@
+name: Swift packages
+
+on:
+  pull_request:
+    branches:
+      - v3
+      - integration/streaming-ha-alpha
+    paths:
+      - Package.swift
+      - companion/uhckit/**
+      - tests/fixtures/uhckit_contract.json
+      - .github/workflows/swift.yml
+
+permissions:
+  contents: read
+
+jobs:
+  uhckit:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and test repository-root package
+        run: |
+          swift package dump-package
+          swift build
+          swift test
+
+      - name: Build and test nested development package
+        run: |
+          swift package --package-path companion/uhckit dump-package
+          swift build --package-path companion/uhckit
+          swift test --package-path companion/uhckit
+
+      - name: Verify a fresh Git checkout resolves the root product
+        run: |
+          git clone --no-local "$GITHUB_WORKSPACE" "$RUNNER_TEMP/uhc-remote"
+          git -C "$RUNNER_TEMP/uhc-remote" checkout --detach "$GITHUB_SHA"
+          swift package --package-path "$RUNNER_TEMP/uhc-remote" describe --type json \
+            | grep '"name" : "UHCKit"'
+          swift build --package-path "$RUNNER_TEMP/uhc-remote"

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ __pycache__/
 .ruff_cache/
 
 # Swift package build products (companion/*)
+/.build/
 companion/**/.build/
 companion/**/.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.9
+//
+// Root package entry point for consumers that resolve UHCKit directly from the
+// Unified Hi-Fi Control Git repository. The package source remains under
+// companion/uhckit so the Apple workspace and local development package share
+// one implementation.
+import PackageDescription
+
+let package = Package(
+    name: "UnifiedHiFiControl",
+    platforms: [
+        .iOS(.v17),
+        .watchOS(.v10),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "UHCKit", targets: ["UHCKit"]),
+    ],
+    targets: [
+        .target(
+            name: "UHCKit",
+            path: "companion/uhckit/Sources/UHCKit"
+        ),
+        .testTarget(
+            name: "UHCKitTests",
+            dependencies: ["UHCKit"],
+            path: "companion/uhckit/Tests/UHCKitTests"
+        ),
+    ]
+)

--- a/companion/uhckit/README.md
+++ b/companion/uhckit/README.md
@@ -1,0 +1,41 @@
+# UHCKit
+
+UHCKit is UHC's public, platform-neutral Apple control client. It contains the
+wire models, client behavior, and transport boundary shared by iPhone, iPad,
+and Apple Watch. It deliberately contains no MusicKit or account-specific code.
+
+## Remote Swift package
+
+Consumers should pin an audited UHC commit and depend on the repository root:
+
+```swift
+.package(
+    url: "https://github.com/open-horizon-labs/unified-hifi-control.git",
+    revision: "<pinned-commit-sha>"
+)
+```
+
+Then add the `UHCKit` product to the client target. Pinning a revision keeps the
+wire contract and client implementation explicit; production clients must not
+track a development branch. Once a release tag contains the root manifest,
+consumers may use SwiftPM's `exact` version requirement instead.
+
+The root manifest and this directory's manifest point at the same sources and
+tests. No source is copied between the public UHC client and downstream product
+shells.
+
+## Local development
+
+Run either package entry point:
+
+```sh
+swift test
+swift test --package-path companion/uhckit
+```
+
+Both commands exercise the same contract tests against
+`tests/fixtures/uhckit_contract.json`, which the Rust server contract suite also
+guards.
+
+Transport evidence and the unresolved direct-Watch-versus-phone-relay question
+are documented in [Transport.md](Transport.md).


### PR DESCRIPTION
Fixes #644

## What changed

- Adds a repository-root SwiftPM manifest that exposes the existing public UHCKit product.
- Maps the root and nested manifests to the same source and test directories, with no copied Swift code.
- Documents pinned-revision consumption for the private HiPhi product shell.
- Ignores root Swift build products.

## Verification

- swift package dump-package at repository root: pass
- swift build at repository root: pass
- swift package dump-package and swift build under companion/uhckit: pass
- A throwaway external Swift package cloned this Git repository at commit a4b71828, resolved the UHCKit product, compiled, and ran: pass
- git diff --check: pass

swift test reaches test compilation through both manifests, but this host has Command Line Tools only and no XCTest module. The pre-existing nested package fails identically, so this is an environment limitation rather than a regression. Full Xcode and physical Apple validation remain tracked in #465 and #619.

No UHC HTTP endpoint or payload contract changed.