### PR TITLE
Fix Spotify tunnel callback-only exposure

### DIFF
--- a/docs/controller-auth.md
+++ b/docs/controller-auth.md
@@ -34,14 +34,15 @@ or a local-only setup surface; it is never placed in a tunnel URL.
 
 The local install flow is:
 
-1. Start UHC and expose its configured port through a temporary HTTPS tunnel.
-2. Open the tunnel URL and enter the one-time bootstrap secret.
-3. UHC invalidates the secret and issues the browser controller session plus
-   CSRF token.
-4. The authenticated Settings UI configures Spotify and starts OAuth. The
-   exact HTTPS callback URI remains registered with Spotify.
-5. The UI creates a scoped controller/MCP token only when requested.
-6. Stop the tunnel after setup unless the operator has deliberately configured
+1. Start UHC locally and bootstrap the browser controller session on its LAN
+   address; never put that session or bootstrap secret in a tunnel URL.
+2. The authenticated Settings UI configures Spotify, then opens a temporary
+   HTTPS tunnel only to UHC's callback-only loopback listener.
+3. The exact HTTPS callback URI remains registered with Spotify. The public
+   listener accepts only that callback plus its bounded liveness probe; it
+   does not expose the UHC UI, bootstrap, MCP, provider settings, or LAN API.
+4. The UI creates a scoped controller/MCP token only when requested.
+5. Stop the tunnel after OAuth unless the operator has deliberately configured
    a persistent authenticated reverse proxy.
 
 Recovery uses a new one-time bootstrap secret from the local console/package,

--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -147,8 +147,9 @@ If the browser is not on the UHC host, Spotify accepts plain HTTP only for
 explicit loopback callbacks (`127.0.0.1` or `::1`); anything else — a remote
 QNAP, a different machine on the LAN — needs HTTPS. The "Using UHC from
 another device or a NAS?" panel below the callback URL has a **Get an HTTPS
-address** button for this: it asks UHC's server to open a temporary tunnel to
-itself and shows the resulting `https://…` callback URL with a copy button,
+address** button for this: it asks UHC to open a temporary tunnel to a
+separate loopback-only callback listener and shows the resulting `https://…`
+callback URL with a copy button,
 so a first-time user never has to install or run anything. After allocation
 UHC probes its own public URL once and shows the result (reachable or not)
 before the user registers it with Spotify. The Redirect URI field is
@@ -161,17 +162,20 @@ authorize request always uses the saved Redirect URI verbatim. Paste the
 shown URL into the Spotify dashboard's Redirect URIs, save client settings,
 then Connect. The tunnel closes itself shortly after authorization
 completes (success or failure; teardown is deferred a minute so the
-callback response and settings redirect still travel through it), after 55
+bounded callback response still travels through it), after 55
 minutes (under pinggy's own 60-minute anonymous-tunnel limit, and long
 enough for a first-time dashboard round trip), or via its own "Stop
 tunnel" button — while it
-is open, this UHC server is briefly reachable from the public internet at
-that address, though the callback endpoint behind it only ever accepts the
-single in-flight OAuth `state` token, so no extra trust is extended to
+is open, the public address terminates at that callback-only listener, not at
+the UHC LAN listener. It permits exactly `GET
+/api/providers/spotify/oauth/callback` and a non-sensitive `GET /healthz`
+probe; every other method and path is denied. The callback still accepts only
+the single in-flight OAuth `state` token, so no extra trust is extended to
 traffic that arrives through it (see `oauth_callback_json` in
 `src/api/provider_auth.rs`).
 
-Under the hood this is a plain `ssh -R` reverse tunnel to
+Under the hood this is a plain `ssh -R` reverse tunnel to that separate
+loopback listener, via
 [pinggy.io](https://pinggy.io)'s free tier — no account and no bundled binary
 beyond the `ssh` client already present on essentially every Linux, macOS, or
 NAS install — falling back automatically to
@@ -185,16 +189,17 @@ tunnel's stdout, though, since a first live-smoke pass found the original
 `pinggy.link`-only pattern never matched pinggy's real anonymous-tier hosts —
 `pinggy-free.link` and `free.pinggy.net`). Pinggy's free tier also caps an
 anonymous tunnel at 60 minutes before it expires on its own; UHC's own
-15-minute cap closes it well before that regardless. If `ssh` is missing,
+55-minute cap closes it first. If `ssh` is missing,
 both providers are unreachable, or outbound `ssh` traffic is blocked, the
 panel reports why in the same beginner-readable style as the rest of
 Settings, and the collapsed **Advanced: bring your own HTTPS** note
-underneath still covers running your own tunnel by hand (for example
-`cloudflared tunnel --url http://127.0.0.1:8088` or Tailscale Funnel) and
-pasting its callback URL into the Redirect URI field yourself. Reauthorizing
-later always needs a new tunnel (built-in or your own) and a newly registered
-callback URL either way. This is the first-run onboarding path tracked in
-#469, #534, and #538.
+underneath covers an operator-managed HTTPS proxy only when it independently
+default-denies every route except the exact Spotify callback. Do **not** point
+a manual tunnel, Funnel, or reverse proxy at UHC's main port; that listener
+has intentional LAN-readable and control surfaces. Reauthorizing later always
+needs a new tunnel (built-in or carefully filtered operator-managed route) and
+a newly registered callback URL either way. This is the first-run onboarding
+path tracked in #469, #534, and #538.
 
 New endpoints backing the built-in tunnel — `POST
 /api/providers/spotify/tunnel/start`, `GET

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,6 +48,7 @@ pub mod ingress;
 pub mod mqtt_bootstrap;
 pub mod mqtt_settings;
 pub mod provider_auth;
+pub mod spotify_callback_listener;
 pub mod spotify_tunnel;
 
 const MAX_REMOTE_ARTWORK_BYTES: usize = 10 * 1024 * 1024;

--- a/src/api/provider_auth.rs
+++ b/src/api/provider_auth.rs
@@ -17,7 +17,7 @@ use crate::api::credentials::{
 use crate::api::spotify_tunnel::{SpotifyTunnelManager, TunnelStatus, TunnelStatusResponse};
 use axum::{
     extract::{Path, Query, State},
-    http::{header::HOST, HeaderMap, StatusCode},
+    http::StatusCode,
     response::{IntoResponse, Redirect, Response},
     Json,
 };
@@ -52,11 +52,9 @@ pub struct ProviderAuthState {
     musicassistant_credentials: Option<Arc<MusicAssistantCredentialStore>>,
     /// Temporary HTTPS tunnel for the Spotify OAuth callback (#538).
     pub spotify_tunnel: Arc<SpotifyTunnelManager>,
-    /// The port this server actually bound at boot (see `bind_local_port`).
-    /// The tunnel's `ssh -R` child targets this server directly over
-    /// loopback, so this -- not the request's `Host` header, which proxies
-    /// and ingress layers rewrite -- is the authoritative forward target.
-    local_port: Arc<std::sync::OnceLock<u16>>,
+    /// The separate, loopback-only listener published by the built-in SSH
+    /// tunnel.  This is intentionally never the main UHC listener's port.
+    callback_port: Arc<std::sync::OnceLock<u16>>,
 }
 
 #[derive(Clone)]
@@ -90,7 +88,7 @@ impl Default for ProviderAuthState {
             musicassistant: Arc::new(RwLock::new(None)),
             musicassistant_credentials,
             spotify_tunnel: Arc::new(SpotifyTunnelManager::default()),
-            local_port: Arc::new(std::sync::OnceLock::new()),
+            callback_port: Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -113,7 +111,7 @@ impl ProviderAuthState {
                 .ok()
                 .map(Arc::new),
             spotify_tunnel: Arc::new(SpotifyTunnelManager::default()),
-            local_port: Arc::new(std::sync::OnceLock::new()),
+            callback_port: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -124,19 +122,17 @@ impl ProviderAuthState {
         self.spotify_tunnel.bind_shutdown(token);
     }
 
-    /// Records the port this server bound its HTTP listener to, once, at
-    /// boot. The tunnel start handler prefers this over anything derived
-    /// from request headers: behind a reverse proxy or Home Assistant
-    /// ingress the `Host` header names the proxy's port, and a tunnel
-    /// forwarding there dies as a connection reset on every public request
-    /// (#592). Later calls are ignored (`OnceLock::set` semantics).
-    pub fn bind_local_port(&self, port: u16) {
-        let _ = self.local_port.set(port);
+    /// Records the dedicated callback listener's ephemeral loopback port at
+    /// boot.  There is deliberately no Host, environment, or main-listener
+    /// fallback: losing this binding must fail closed rather than publishing
+    /// UHC's complete LAN router.
+    pub fn bind_callback_port(&self, port: u16) {
+        let _ = self.callback_port.set(port);
     }
 
-    /// The authoritative local forward target port, when known.
-    pub fn local_port(&self) -> Option<u16> {
-        self.local_port.get().copied()
+    /// The only port the built-in tunnel may forward to.
+    pub fn callback_port(&self) -> Option<u16> {
+        self.callback_port.get().copied()
     }
 
     /// Construct provider auth with an explicit Music Assistant credential
@@ -748,16 +744,7 @@ pub async fn oauth_callback(
     //    not be able to kill the tunnel while the user is still working
     //    through Spotify's dashboard.
     if is_spotify {
-        let concluded = match &result {
-            Ok(_) => true,
-            Err((_, Json(body))) => body.code != "invalid_state",
-        };
-        if concluded {
-            state
-                .provider_auth
-                .spotify_tunnel
-                .stop_after(crate::api::spotify_tunnel::TUNNEL_CALLBACK_GRACE);
-        }
+        stop_tunnel_after_concluded_callback(&state, &result);
     }
     match result {
         Ok(Json(response)) if machine => Json(response).into_response(),
@@ -768,6 +755,52 @@ pub async fn oauth_callback(
             urlencoding::encode(error.code)
         ))
         .into_response(),
+    }
+}
+
+/// The handler mounted only on the callback-only loopback listener used by
+/// the built-in SSH tunnel.  It deliberately does not redirect to `/settings`:
+/// that page belongs to the main LAN listener and must remain unreachable from
+/// the internet-facing tunnel.  The page is bounded and contains no OAuth
+/// values, credential data, provider response, or request parameters.
+pub(crate) async fn spotify_tunnel_callback(
+    State(state): State<AppState>,
+    Query(query): Query<OAuthCallbackQuery>,
+) -> Response {
+    let result = oauth_callback_json(
+        State(state.clone()),
+        Path("spotify".to_string()),
+        Query(query),
+    )
+    .await;
+    stop_tunnel_after_concluded_callback(&state, &result);
+    match result {
+        Ok(_) => (
+            StatusCode::OK,
+            "Spotify authorization completed. Return to UHC.",
+        )
+            .into_response(),
+        Err((status, _)) => (
+            status,
+            "Spotify authorization could not be completed. Return to UHC and try again.",
+        )
+            .into_response(),
+    }
+}
+
+fn stop_tunnel_after_concluded_callback(
+    state: &AppState,
+    result: &Result<Json<ProviderAuthResponse>, (StatusCode, Json<ErrorBody>)>,
+) {
+    let concluded = match result {
+        Ok(_) => true,
+        Err((_, Json(body))) => body.code != "invalid_state",
+    };
+    if concluded {
+        state
+            .provider_auth
+            .spotify_tunnel
+            .stop_after(crate::api::spotify_tunnel::TUNNEL_CALLBACK_GRACE);
     }
 }
 
@@ -966,47 +999,19 @@ pub async fn oauth_revoke(
     }))
 }
 
-/// The port a temporary HTTPS tunnel should forward to: this server's own
-/// listening port. The `ssh -R` child runs on the same host as this server
-/// and targets it over loopback, so the port the server actually bound
-/// (recorded at boot via `bind_local_port`) is authoritative. The request's
-/// `Host` header is only a fallback for test/embedded setups that never
-/// call `bind_local_port`: behind a reverse proxy or Home Assistant
-/// ingress the `Host` header names the *proxy's* port, and a tunnel
-/// forwarding there answers every public request with a connection reset
-/// (#592). Final fallbacks are the `PORT` environment variable UHC starts
-/// from, then the documented default.
-fn local_tunnel_port(state: &ProviderAuthState, headers: &HeaderMap) -> u16 {
-    state
-        .local_port()
-        .or_else(|| {
-            headers
-                .get(HOST)
-                .and_then(|value| value.to_str().ok())
-                .and_then(|host| {
-                    // `Host` is `host` or `host:port`; an IPv6 literal host
-                    // looks like `[::1]:8088`, so split from the right on
-                    // the last colon.
-                    host.rsplit_once(':')
-                        .and_then(|(_, port)| port.parse().ok())
-                })
-        })
-        .or_else(|| {
-            std::env::var("PORT")
-                .ok()
-                .and_then(|value| value.parse().ok())
-        })
-        .unwrap_or(8088)
-}
-
 /// POST /api/providers/spotify/tunnel/start - Start (or report the existing)
-/// temporary HTTPS tunnel to this server's Spotify OAuth callback.
-pub async fn spotify_tunnel_start(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-) -> Json<TunnelStatusResponse> {
-    let port = local_tunnel_port(&state.provider_auth, &headers);
-    let status = state.provider_auth.spotify_tunnel.start(port).await;
+/// temporary HTTPS tunnel to the separate callback-only listener.
+pub async fn spotify_tunnel_start(State(state): State<AppState>) -> Json<TunnelStatusResponse> {
+    let status = match state.provider_auth.callback_port() {
+        Some(port) => state.provider_auth.spotify_tunnel.start(port).await,
+        None => state
+            .provider_auth
+            .spotify_tunnel
+            .fail_closed(
+                "Spotify callback listener is unavailable; restart UHC before opening a tunnel.",
+            )
+            .await,
+    };
     Json(status.into())
 }
 
@@ -1435,6 +1440,8 @@ mod tests {
     use crate::api::spotify_tunnel::{
         TunnelLaunchError, TunnelLauncher, TunnelProcess, TunnelProcessEvent, TunnelProviderKind,
     };
+    use axum::http::Method;
+    use tower::ServiceExt;
 
     /// A tunnel process that "prints" one URL line and then idles until
     /// killed, like a healthy long-lived `ssh -R` child.
@@ -1471,6 +1478,29 @@ mod tests {
         ) -> Result<Box<dyn TunnelProcess>, TunnelLaunchError> {
             Ok(Box::new(StaticUrlProcess {
                 line: Some(self.0.clone()),
+                idle: Arc::new(tokio::sync::Notify::new()),
+            }))
+        }
+    }
+
+    /// Captures the actual loopback target passed to `ssh -R`; a correct
+    /// callback router is not enough if startup can still point SSH at UHC's
+    /// broad main listener.
+    struct RecordingTunnelLauncher {
+        url: String,
+        ports: Arc<Mutex<Vec<u16>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl TunnelLauncher for RecordingTunnelLauncher {
+        async fn launch(
+            &self,
+            _provider: TunnelProviderKind,
+            port: u16,
+        ) -> Result<Box<dyn TunnelProcess>, TunnelLaunchError> {
+            self.ports.lock().unwrap().push(port);
+            Ok(Box::new(StaticUrlProcess {
+                line: Some(self.url.clone()),
                 idle: Arc::new(tokio::sync::Notify::new()),
             }))
         }
@@ -1557,6 +1587,149 @@ mod tests {
 
     fn callback_of(tunnel: &str) -> String {
         format!("{tunnel}/api/providers/spotify/oauth/callback")
+    }
+
+    /// #641: the public SSH reverse tunnel must terminate at a different,
+    /// default-deny listener.  This list intentionally spans reads, writes,
+    /// controller/bootstrap routes, provider authority, MCP, and legacy
+    /// routes: controller auth may be disabled on a LAN install, so it cannot
+    /// be the thing preventing these from becoming internet reachable.
+    #[tokio::test]
+    async fn callback_only_listener_rejects_every_non_callback_uhc_route() {
+        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
+        let app = crate::api::spotify_callback_listener::router(state);
+
+        let liveness = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(liveness.status(), StatusCode::NO_CONTENT);
+
+        let callback = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/api/providers/spotify/oauth/callback?state=unknown")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), StatusCode::BAD_REQUEST);
+
+        for (method, path) in [
+            (Method::GET, "/zones"),
+            (Method::GET, "/now_playing"),
+            (Method::POST, "/control"),
+            (Method::POST, "/mcp"),
+            (Method::POST, "/api/controller/bootstrap"),
+            (Method::GET, "/api/controller/status"),
+            (Method::POST, "/api/providers/spotify/configure"),
+            (Method::POST, "/api/providers/spotify/oauth/revoke"),
+            (Method::GET, "/api/providers/spotify/tunnel/status"),
+            (Method::GET, "/api/bridges/applemusic/status"),
+            (Method::GET, "/roon/status"),
+            (Method::GET, "/knob/now_playing"),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(path)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "{path} must be absent from the callback listener"
+            );
+        }
+
+        let wrong_method = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/providers/spotify/oauth/callback")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(wrong_method.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    /// Exercise the socket which `ssh -R` actually targets, rather than only
+    /// the in-process router.  The listener is bound to an ephemeral IPv4
+    /// loopback port and must expose exactly the same default-deny surface.
+    #[tokio::test]
+    async fn callback_only_listener_denies_main_routes_over_its_bound_socket() {
+        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
+        let shutdown = CancellationToken::new();
+        let port = crate::api::spotify_callback_listener::spawn(state, shutdown.clone())
+            .await
+            .expect("callback listener starts");
+        let client = reqwest::Client::new();
+        let origin = format!("http://127.0.0.1:{port}");
+
+        let liveness = client
+            .get(format!("{origin}/healthz"))
+            .send()
+            .await
+            .expect("loopback liveness response");
+        assert_eq!(liveness.status(), StatusCode::NO_CONTENT);
+
+        for path in [
+            "/status",
+            "/zones",
+            "/api/providers/spotify/tunnel/status",
+            "/api/bridges/applemusic/status",
+            "/mcp",
+        ] {
+            let response = client
+                .get(format!("{origin}{path}"))
+                .send()
+                .await
+                .expect("loopback denial response");
+            assert_eq!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "{path} must not be served on the tunnel socket"
+            );
+        }
+        shutdown.cancel();
+    }
+
+    #[tokio::test]
+    async fn tunnel_start_uses_only_the_callback_listener_port() {
+        let (mut state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
+        let ports = Arc::new(Mutex::new(Vec::new()));
+        // Preserve the configured state from the fixture and replace only its
+        // process launcher, avoiding every real-network path.
+        let mut auth = (*state.provider_auth).clone();
+        auth.spotify_tunnel = Arc::new(SpotifyTunnelManager::with_launcher(Arc::new(
+            RecordingTunnelLauncher {
+                url: TUNNEL_A.to_string(),
+                ports: ports.clone(),
+            },
+        )));
+        auth.bind_callback_port(19_417);
+        state.provider_auth = Arc::new(auth);
+
+        let _ = spotify_tunnel_start(State(state.clone())).await;
+        start_tunnel_and_wait_active(&state).await;
+        assert_eq!(*ports.lock().unwrap(), vec![19_417]);
     }
 
     /// #592 pin: the authorize URL always carries the SAVED redirect URI

--- a/src/api/spotify_callback_listener.rs
+++ b/src/api/spotify_callback_listener.rs
@@ -1,0 +1,55 @@
+//! The loopback-only HTTP surface published by the temporary Spotify tunnel.
+//!
+//! This is deliberately a separate listener, not middleware on UHC's main
+//! router.  An SSH reverse forward publishes its target socket wholesale, so
+//! filtering after a request enters the main listener would leave every future
+//! route one wiring mistake away from public exposure (#641).
+
+use axum::{http::StatusCode, routing::get, Router};
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+use super::{provider_auth, AppState};
+
+pub const CALLBACK_PATH: &str = "/api/providers/spotify/oauth/callback";
+pub const LIVENESS_PATH: &str = "/healthz";
+
+/// The whole public surface of a built-in Spotify tunnel.  The callback must
+/// stay exact (rather than using UHC's generic `{provider}` route), and every
+/// other path is absent.  Axum supplies 405 for the wrong method on either
+/// allowed path; the fallback supplies 404 for everything else.
+pub(crate) fn router(state: AppState) -> Router {
+    Router::new()
+        .route(CALLBACK_PATH, get(provider_auth::spotify_tunnel_callback))
+        .route(LIVENESS_PATH, get(liveness))
+        .fallback(denied)
+        .with_state(state)
+}
+
+/// A bounded, non-sensitive round-trip check for a newly allocated tunnel.
+async fn liveness() -> StatusCode {
+    StatusCode::NO_CONTENT
+}
+
+/// Do not disclose whether a main-UHC path happens to exist.
+async fn denied() -> StatusCode {
+    StatusCode::NOT_FOUND
+}
+
+/// Start the callback listener on loopback with an OS-chosen port.  Its port,
+/// rather than the main UHC listener's port or an inbound Host header, is the
+/// only target ever given to `ssh -R`.
+pub async fn spawn(state: AppState, shutdown: CancellationToken) -> anyhow::Result<u16> {
+    let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).await?;
+    let port = listener.local_addr()?.port();
+    let app = router(state);
+    tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await
+        {
+            tracing::error!(%error, "Spotify callback-only listener stopped unexpectedly");
+        }
+    });
+    Ok(port)
+}

--- a/src/api/spotify_tunnel.rs
+++ b/src/api/spotify_tunnel.rs
@@ -11,11 +11,10 @@
 //! "Get an HTTPS address", and is torn down when authorization completes
 //! (success or failure), when the user stops it, on a 55-minute safety
 //! timeout, or when the server shuts down. While it is active this UHC
-//! server is briefly reachable from the public internet at the tunnel's
-//! URL; the callback endpoint behind it only ever accepts the single-use,
-//! in-flight OAuth `state` token (see `oauth_callback_json` in
-//! `provider_auth.rs`), so no additional trust is extended to tunnel
-//! traffic.
+//! callback-only listener is briefly reachable from the public internet at
+//! the tunnel's URL. It accepts only the exact callback and a bounded
+//! liveness probe; the callback itself accepts only the single-use, in-flight
+//! OAuth `state` token (see `oauth_callback_json` in `provider_auth.rs`).
 //!
 //! The state machine (`SpotifyTunnelManager`) is decoupled from the actual
 //! `ssh` process through the `TunnelLauncher`/`TunnelProcess` traits so unit
@@ -36,8 +35,8 @@ use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 /// Hard cap on tunnel lifetime, regardless of activity. A beginner should
-/// never end up with a forgotten tunnel silently keeping this server
-/// internet-reachable.
+/// never end up with a forgotten tunnel silently keeping its callback
+/// listener internet-reachable.
 ///
 /// The cap must comfortably outlast a first-time Spotify enrollment: the
 /// user copies the URL, creates an app in Spotify's developer dashboard,
@@ -295,15 +294,18 @@ pub(crate) trait TunnelProbe: Send + Sync {
     async fn probe(&self, url: &str) -> Option<bool>;
 }
 
-/// Probes by fetching this server's own tunnel-status endpoint through the
-/// public URL. Any well-formed HTTP response proves the round trip; the
-/// endpoint itself is a harmless read.
+/// Probes the callback listener's dedicated liveness path through the public
+/// URL. Any successful response proves the round trip without making a
+/// main-UHC route internet reachable.
 pub(crate) struct RealTunnelProbe;
 
 #[async_trait::async_trait]
 impl TunnelProbe for RealTunnelProbe {
     async fn probe(&self, url: &str) -> Option<bool> {
-        let target = format!("{url}/api/providers/spotify/tunnel/status");
+        let target = format!(
+            "{url}{}",
+            crate::api::spotify_callback_listener::LIVENESS_PATH
+        );
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
             .build()
@@ -470,6 +472,18 @@ impl SpotifyTunnelManager {
 
     pub async fn status(&self) -> TunnelStatus {
         self.status.read().await.clone()
+    }
+
+    /// Report a startup precondition failure without ever choosing a fallback
+    /// forward target.  In particular, a missing callback-only listener must
+    /// not cause the tunnel to fall back to UHC's main LAN port.
+    pub async fn fail_closed(&self, message: impl Into<String>) -> TunnelStatus {
+        self.stop_locked().await;
+        let status = TunnelStatus::Error {
+            message: message.into(),
+        };
+        *self.status.write().await = status.clone();
+        status
     }
 
     /// Starts a tunnel to `port` on this host, unless one is already

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,10 +503,15 @@ mod server {
             shutdown_token.clone(),
         )
         .with_reliable_commands(reliable_commands);
-        // The Spotify tunnel forwards to this server over loopback; record
-        // the port the listener actually bound so the tunnel never trusts a
-        // proxy-rewritten Host header for its forward target (#592).
-        state.provider_auth.bind_local_port(config.port);
+        // The SSH reverse tunnel receives a separate, loopback-only callback
+        // listener.  It must never forward to this main UHC listener: the
+        // latter intentionally serves many LAN routes that are not safe to
+        // publish merely because Spotify needs one callback (#641).
+        let spotify_callback_port =
+            api::spotify_callback_listener::spawn(state.clone(), shutdown_token.clone()).await?;
+        state
+            .provider_auth
+            .bind_callback_port(spotify_callback_port);
         if let Some(bootstrap_token) = state.controller_auth.take_bootstrap_secret().await {
             tracing::info!(
                 "UHC controller bootstrap token (display once; do not put it in a tunnel URL): {}. \


### PR DESCRIPTION
Closes #641

## Summary
- bind an ephemeral loopback callback-only listener and forward the built-in SSH tunnel exclusively to it
- allow only the exact Spotify callback plus a bounded `/healthz` probe; deny all main-UHC routes and methods
- preserve OAuth single-use/state handling while returning a non-sensitive callback response, and correct tunnel documentation

## Validation
- `cargo test --lib api::provider_auth::tests`
- `cargo test --lib api::spotify_tunnel::tests`
- `cargo test --test api_contract`
- `cargo test --test spotify_auth_persistence`
- `cargo test --test spotify_adapter`
- `cargo check --tests`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`

The negative integration coverage exercises the actual bound callback socket and proves zones, controls, MCP, provider/configuration routes, bridge routes, controller routes, and legacy paths are absent.