### PR TITLE
fix: align Spotify with the 2026 Web API contract

### DIFF
--- a/.github/workflows/streaming-alpha.yml
+++ b/.github/workflows/streaming-alpha.yml
@@ -1,0 +1,47 @@
+name: Streaming Alpha Rust
+
+on:
+  pull_request:
+    branches: [integration/streaming-ha-alpha]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "tests/**"
+      - ".github/workflows/streaming-alpha.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Format, lint, and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "streaming-alpha"
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Check the HTTP API contract
+        run: cargo test --test api_contract
+
+      - name: Run workspace tests
+        run: cargo test --workspace

--- a/.github/workflows/streaming-alpha.yml
+++ b/.github/workflows/streaming-alpha.yml
@@ -24,6 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache generated CSS
+        id: cache-css
+        uses: actions/cache@v5
+        with:
+          path: public/tailwind.css
+          key: css-v4.1.18-${{ hashFiles('src/input.css', 'src/app/pages/*.rs', 'src/app/components/*.rs') }}
+
+      - name: Build Tailwind CSS
+        if: steps.cache-css.outputs.cache-hit != 'true'
+        run: make css
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,9 +196,10 @@ it, and made the table derived so the same error cannot be typed again.
 Two things this table does **not** claim:
 
 - **It is per provider, not per device.** A fixed-volume Roon output reports
-  `volume` as supported. UHC cannot currently distinguish "this output has no
-  volume control" from "no volume has been read yet", so `hifi_capabilities` reports
-  the aggregator's `has_volume_control` observation separately rather than guessing.
+  `volume` as supported. `hifi_capabilities` reports `has_volume_control`
+  separately: an explicit device flag is authoritative when available (Spotify's
+  `supports_volume`, even with a null current value); other providers fall back to
+  whether the aggregator has observed a numeric control.
 - **Every ⛔ for OpenHome and UPnP rests on specification knowledge, not on a call
   to a device.** Each cell says so in its own footnote. LMS's cells come from a live
   Lyrion 9.1.2 inventory (#402/#403) and are the strongest rows here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,19 +213,19 @@ Two things this table does **not** claim:
 | `search` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
 | `play_by_query` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
 | `play_by_ref` | 🚧 #396 | 🚧 #396 | 🚧 #396 | 🚧 #396 | 🚧 #209 | 🚧 #481 | ✅ | ✅ |
-| `browse` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
+| `browse` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | 🚧 #473 | ✅ |
 | `queue_read` | 🚧 #400 | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | ✅ | ✅ |
-| `queue_jump` | 🚧 #400 | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
-| `queue_reorder` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
-| `queue_remove` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
-| `queue_clear` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
-| `queue_transfer` | ⛔ | 🚧 #400 | ⛔ | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
-| `play_next` | 🚧 #399 | 🚧 #403 | 🚧 #392 | 🚧 #396 | 🚧 #209 | 🚧 #483 | 🚧 #462 | ✅ |
+| `queue_jump` | 🚧 #400 | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | ⛔ | ✅ |
+| `queue_reorder` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | ⛔ | ✅ |
+| `queue_remove` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | ⛔ | ✅ |
+| `queue_clear` | ⛔ | 🚧 #400 | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #483 | ⛔ | ✅ |
+| `queue_transfer` | ⛔ | 🚧 #400 | ⛔ | ⛔ | 🚧 #209 | 🚧 #462 | ⛔ | ✅ |
+| `play_next` | 🚧 #399 | 🚧 #403 | 🚧 #392 | 🚧 #396 | 🚧 #209 | 🚧 #483 | 🚧 #474 | ✅ |
 | `repeat_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `shuffle_mode` | 🚧 #360 | 🚧 #403 | 🚧 #392 | 🚧 #392 | ✅ | 🚧 #462 | ✅ | ✅ |
 | `saved_playlists` | ✅ | ✅ | ⛔ | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
 | `favorites` | 🚧 #531 | ✅ | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #482 | ✅ | ✅ |
-| `multiroom_sync` | ✅ | ✅ | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | 🚧 #462 | ✅ |
+| `multiroom_sync` | ✅ | ✅ | 🚧 #392 | ⛔ | 🚧 #209 | 🚧 #462 | ⛔ | ✅ |
 
 ✅ supported · ⛔ the provider's protocol cannot do it · 🚧 the provider can, UHC has not wired it (issue that will)
 
@@ -253,6 +253,7 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - ⛔ **upnp / `browse`** — UHC discovers UPnP zones as urn:schemas-upnp-org:device:MediaRenderer:1 and speaks only AVTransport:1 and RenderingControl:1. Searching or browsing content is a ContentDirectory:1 (MediaServer) capability, which a renderer does not have and UHC does not discover. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `browse`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `browse`** (#482) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
+- 🚧 **spotify / `browse`** (#473) — Spotify removed categories, category playlists, featured playlists, and new releases from the Web API surface available to new Development Mode applications in February 2026. A future browse implementation must use a currently available, quota-aware surface rather than call those retired endpoints.
 - 🚧 **roon / `queue_read`** (#400) — the pinned roon-api fork exposes subscribe_queue(zone, max_items), which nothing in UHC calls.
 - 🚧 **lms / `queue_read`** (#400) — status <player> <start> <n> returns the whole current playlist with playlist_cur_index; verified live.
 - 🚧 **openhome / `queue_read`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.
@@ -265,42 +266,42 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - ⛔ **upnp / `queue_jump`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `queue_jump`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_jump`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **spotify / `queue_jump`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **spotify / `queue_jump`** — Spotify's Web API exposes Get the User's Queue and Add Item to Playback Queue, but no endpoint to jump, reorder, remove, clear, or transfer active queue contents. Verified from the Spotify Web API Player reference, not inferred from a device.
 - ⛔ **roon / `queue_reorder`** — The Roon API's transport service exposes a queue subscription and play_from_here and no mutation at all -- no move, remove or clear. The pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing further.
 - 🚧 **lms / `queue_reorder`** (#400) — playlist move <from> <to> reorders the queue; verified live. Roon cannot do this and LMS can, which is why this capability exists in the vocabulary at all.
 - 🚧 **openhome / `queue_reorder`** (#392) — OpenHome's Playlist:1 has no Move action, but Insert takes an AfterId, so a reorder is DeleteId plus Insert -- composite rather than atomic, and reachable. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `queue_reorder`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `queue_reorder`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_reorder`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **spotify / `queue_reorder`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **spotify / `queue_reorder`** — Spotify's Web API exposes Get the User's Queue and Add Item to Playback Queue, but no endpoint to jump, reorder, remove, clear, or transfer active queue contents. Verified from the Spotify Web API Player reference, not inferred from a device.
 - ⛔ **roon / `queue_remove`** — The Roon API's transport service exposes a queue subscription and play_from_here and no mutation at all -- no move, remove or clear. The pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing further.
 - 🚧 **lms / `queue_remove`** (#400) — playlist delete <index> removes one queued item; verified live.
 - 🚧 **openhome / `queue_remove`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `queue_remove`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `queue_remove`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_remove`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **spotify / `queue_remove`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **spotify / `queue_remove`** — Spotify's Web API exposes Get the User's Queue and Add Item to Playback Queue, but no endpoint to jump, reorder, remove, clear, or transfer active queue contents. Verified from the Spotify Web API Player reference, not inferred from a device.
 - ⛔ **roon / `queue_clear`** — The Roon API's transport service exposes a queue subscription and play_from_here and no mutation at all -- no move, remove or clear. The pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing further.
 - 🚧 **lms / `queue_clear`** (#400) — playlist clear empties the queue; verified live.
 - 🚧 **openhome / `queue_clear`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `queue_clear`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `queue_clear`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_clear`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **spotify / `queue_clear`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **spotify / `queue_clear`** — Spotify's Web API exposes Get the User's Queue and Add Item to Playback Queue, but no endpoint to jump, reorder, remove, clear, or transfer active queue contents. Verified from the Spotify Web API Player reference, not inferred from a device.
 - ⛔ **roon / `queue_transfer`** — The Roon API's transport service exposes a queue subscription and play_from_here and no mutation at all -- no move, remove or clear. The pinned roon-api fork (ohc/main) exposes subscribe_queue and play_from_here and nothing further.
 - 🚧 **lms / `queue_transfer`** (#400) — sync <playerid> was verified live (#403) to merge a player into another's sync group by adopting the leader's queue, which destroys the source's queue rather than transferring it; the CLI reference names no dedicated queue-to-queue transfer command. A composite emulation -- read the source's playlist, replay it against the target with playlistcontrol, then playlist clear the source -- is buildable from primitives #400 already verified live, but is not wired.
 - ⛔ **openhome / `queue_transfer`** — OpenHome's Playlist:1 (Read/Insert/DeleteId/DeleteAll) is scoped to one room's renderer; the service set defines no action that moves one room's playlist into another's. Songcast (Sender:1/Receiver:1) relays audio to a group, it does not merge queue state. Verified from the OpenHome service definitions, not from a device.
 - ⛔ **upnp / `queue_transfer`** — AVTransport:1 holds a single current transport URI plus one SetNextAVTransportURI; it has no playlist to enumerate or mutate. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `queue_transfer`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `queue_transfer`** (#462) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **spotify / `queue_transfer`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **spotify / `queue_transfer`** — Spotify's Web API exposes Get the User's Queue and Add Item to Playback Queue, but no endpoint to jump, reorder, remove, clear, or transfer active queue contents. Verified from the Spotify Web API Player reference, not inferred from a device.
 - 🚧 **roon / `play_next`** (#399) — Roon's browse item actions include Play Next alongside Play Now and Queue; UHC's PlayAction models only Play, Queue and Radio, so this arrives with browse rather than with the queue.
 - 🚧 **lms / `play_next`** (#403) — playlistcontrol cmd:insert places an item immediately after the current one, verified live -- and LmsPlayAction::Insert is already modelled in the adapter and simply unreachable from MCP.
 - 🚧 **openhome / `play_next`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.
 - 🚧 **upnp / `play_next`** (#396) — the protocol can play a specific item -- UPnP AVTransport:1 takes SetAVTransportURI and SetNextAVTransportURI, OpenHome Playlist:1 takes Insert(AfterId, Uri, Metadata) -- so what is missing is UHC's ability to name one, not the device's ability to play it. Reported as a UHC gap rather than a provider limit, because a reference minted against a media server would work. Verified from the UPnP AV and OpenHome service definitions, not from a device.
 - 🚧 **hqplayer / `play_next`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `play_next`** (#483) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **spotify / `play_next`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- 🚧 **spotify / `play_next`** (#474) — Spotify exposes Add Item to Playback Queue and UHC routes it through hifi_play action=queue, but UHC does not expose a distinct play-next operation for Spotify.
 - 🚧 **roon / `repeat_mode`** (#360) — the Roon API's transport service takes loop settings (disabled/loop/loop_one); UHC drives none of them from any surface.
 - 🚧 **lms / `repeat_mode`** (#403) — playlist repeat <0|1|2> and playlist repeat ? read and write it; verified live. Note the mode lives on the sync master, so setting it changes every member.
 - 🚧 **openhome / `repeat_mode`** (#392) — OpenHome's Playlist:1 service provides Read/ReadList/IdArray, Insert, DeleteId, DeleteAll, SeekId/SeekIndex and SetRepeat/SetShuffle. UHC discovers only Product/Transport/Volume and drives none of it, so this is a UHC gap. Verified from the OpenHome service definitions, not from a device.
@@ -324,7 +325,7 @@ Every non-supported cell states the fact it rests on, so the claim can be checke
 - ⛔ **upnp / `multiroom_sync`** — UPnP AV defines no synchronised-playback service; multiroom on UPnP renderers is vendor-specific and outside the two services UHC speaks. Verified from the UPnP AV service definitions, not from a device.
 - 🚧 **hqplayer / `multiroom_sync`** (#209) — UHC's HQPlayer adapter speaks transport, volume, seek and pipeline settings; whether HQPlayer's control protocol reaches content operations has not been verified here. Reported as not-yet-implemented rather than as a provider limit, because an unverified 'never' is the more expensive error.
 - 🚧 **applemusic / `multiroom_sync`** (#462) — the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.
-- 🚧 **spotify / `multiroom_sync`** (#462) — the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.
+- ⛔ **spotify / `multiroom_sync`** — Spotify's Transfer Playback endpoint accepts a single target device and does not synchronize multiple Connect devices; transfer is device selection, not multiroom grouping. Verified from the Spotify Web API Transfer Playback reference, not inferred from a device.
 <!-- END GENERATED CAPABILITY MATRIX (#398) -->
 
 `hqplayer:` is a fifth zone prefix: `PrefixedZoneId` lists it and `HqpAdapter`

--- a/README.md
+++ b/README.md
@@ -247,14 +247,14 @@ Control your hi-fi with natural language. The bridge includes an MCP server so C
 | `hifi_play` | Search and play/queue in one command *(Roon, LMS, Spotify)* |
 | `hifi_play_ref` | Play or queue an exact search result |
 | `hifi_queue` | Read the current provider queue |
-| `hifi_spotify` | Browse Spotify, access playlists/liked tracks, and create/edit playlists |
+| `hifi_spotify` | Access Spotify playlists/liked tracks and create/edit playlists |
 | `hifi_status` | Overall bridge status |
 | `hifi_hqplayer_status` | HQPlayer Embedded status and pipeline |
 | `hifi_hqplayer_profiles` | List saved HQPlayer profiles |
 | `hifi_hqplayer_load_profile` | Switch HQPlayer profile |
 | `hifi_hqplayer_set_pipeline` | Change filter, shaper, dither settings |
 
-*Spotify is a controller for existing Spotify Connect devices, not a receiver. Spotify search, exact play/queue, queue read, catalog browsing, playlists, liked tracks, repeat, and shuffle require the corresponding OAuth scopes; transport controls work with all enabled adapters.*
+*Spotify is a controller for existing Spotify Connect devices, not a receiver. Spotify search, exact play/queue-add, queue read, playlists, liked tracks, repeat, and shuffle require the corresponding OAuth scopes. New Development Mode applications cannot use the removed categories, featured-playlists, or new-releases browse endpoints. Spotify exposes no active-queue jump/reorder/remove/clear/transfer operations, and Transfer Playback selects one device rather than synchronizing a multiroom group. Transport controls work with all enabled adapters.*
 
 The MCP endpoint is unauthenticated like the rest of the bridge — see [Security and Network Exposure](#security-and-network-exposure).
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Control your hi-fi with natural language. The bridge includes an MCP server so C
 | `hifi_hqplayer_load_profile` | Switch HQPlayer profile |
 | `hifi_hqplayer_set_pipeline` | Change filter, shaper, dither settings |
 
-*Spotify is a controller for existing Spotify Connect devices, not a receiver. Spotify search, exact play/queue-add, queue read, playlists, liked tracks, repeat, and shuffle require the corresponding OAuth scopes. New Development Mode applications cannot use the removed categories, featured-playlists, or new-releases browse endpoints. Spotify exposes no active-queue jump/reorder/remove/clear/transfer operations, and Transfer Playback selects one device rather than synchronizing a multiroom group. Transport controls work with all enabled adapters.*
+*Spotify is a controller for existing Spotify Connect devices, not a receiver. Spotify search, exact play/queue-add, queue read, playlists, liked tracks, repeat, and shuffle require the corresponding OAuth scopes. New Development Mode applications cannot use the removed categories, featured-playlists, or new-releases browse endpoints; UHC defaults to that mode. Existing Extended Quota applications can explicitly retain those legacy browse calls with `UHC_SPOTIFY_QUOTA_MODE=extended`. Spotify exposes no active-queue jump/reorder/remove/clear/transfer operations, and Transfer Playback selects one device rather than synchronizing a multiroom group. Transport controls work with all enabled adapters.*
 
 The MCP endpoint is unauthenticated like the rest of the bridge — see [Security and Network Exposure](#security-and-network-exposure).
 

--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -86,6 +86,33 @@ standard authorization-code flow:
 - `POST /api/providers/spotify/oauth/revoke` clears the adapter and removes
   the durable credential file.
 
+### Spotify's 2026 Development Mode boundary
+
+UHC controls existing Spotify Connect devices; it is not a Connect receiver
+and receives no audio. For applications created under Spotify's current
+Development Mode rules, UHC uses `/me/playlists`, parses a playlist's `items`
+summary, and limits search requests to 10 results. It deliberately does not
+call or advertise the removed categories, category-playlists, featured-
+playlists, or new-releases endpoints. Use search, the authenticated user's
+playlists, and saved tracks instead. See Spotify's
+[February 2026 migration guide](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide)
+and [change log](https://developer.spotify.com/documentation/web-api/references/changes/february-2026).
+
+Spotify's active playback queue can be read and a track or episode can be
+added. The Web API does not provide active-queue jump, reorder, remove, clear,
+or queue-transfer operations. Likewise,
+[Transfer Playback](https://developer.spotify.com/documentation/web-api/reference/transfer-a-users-playback)
+selects one Connect device; it is not multiroom grouping or synchronized
+playback. A device with a nullable ID is omitted from UHC's zone inventory,
+while `supports_volume` determines whether UHC exposes volume control even if
+Spotify also returns a `volume_percent` value.
+
+Spotify may return HTTP 429 for a short-term rate limit or with the structured
+reason `QUOTA_EXCEEDED` for application quota exhaustion. UHC reports those as
+different failures and never includes Spotify's response body in the error.
+Spotify's [July 2026 quota update](https://developer.spotify.com/blog/2026-07-23-web-api-quota-updates)
+describes the current Development Mode allowance.
+
 The credential envelope uses an operator-managed 32-byte key. Set
 `UHC_CREDENTIAL_KEY` (hex or base64url) or `UHC_CREDENTIAL_KEY_FILE`; when
 neither is set, UHC creates `credential.key` beside the encrypted credential

--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -91,12 +91,20 @@ standard authorization-code flow:
 UHC controls existing Spotify Connect devices; it is not a Connect receiver
 and receives no audio. For applications created under Spotify's current
 Development Mode rules, UHC uses `/me/playlists`, parses a playlist's `items`
-summary, and limits search requests to 10 results. It deliberately does not
-call or advertise the removed categories, category-playlists, featured-
-playlists, or new-releases endpoints. Use search, the authenticated user's
-playlists, and saved tracks instead. See Spotify's
+summary, and limits search requests to 10 results. Development Mode is the
+default, and in that mode UHC refuses the removed categories,
+category-playlists, featured-playlists, and new-releases operations before a
+provider request. Use search, the authenticated user's playlists, and saved
+tracks instead. See Spotify's
 [February 2026 migration guide](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide)
 and [change log](https://developer.spotify.com/documentation/web-api/references/changes/february-2026).
+
+Existing Spotify applications with Extended Quota entitlement can retain
+those legacy browse operations by setting
+`UHC_SPOTIFY_QUOTA_MODE=extended`. This switch must only be set when the
+Spotify application actually has Extended Quota access; it does not grant
+entitlement. `UHC_SPOTIFY_QUOTA_MODE=development` is equivalent to the default.
+An invalid value is rejected to Development Mode and logged at startup.
 
 Spotify's active playback queue can be read and a track or episode can be
 added. The Web API does not provide active-queue jump, reorder, remove, clear,
@@ -110,6 +118,10 @@ Spotify also returns a `volume_percent` value.
 Spotify may return HTTP 429 for a short-term rate limit or with the structured
 reason `QUOTA_EXCEEDED` for application quota exhaustion. UHC reports those as
 different failures and never includes Spotify's response body in the error.
+Short-term failures honor Spotify's `Retry-After` header and block repeated
+requests locally until that delay expires. Because the quota response provides
+no reset time, UHC blocks retries for 15 minutes (or until credentials change)
+after `QUOTA_EXCEEDED` to avoid a request storm.
 Spotify's [July 2026 quota update](https://developer.spotify.com/blog/2026-07-23-web-api-quota-updates)
 describes the current Development Mode allowance.
 

--- a/src/adapters/spotify.rs
+++ b/src/adapters/spotify.rs
@@ -96,6 +96,8 @@ pub struct SpotifyDevice {
     #[serde(default)]
     pub is_restricted: bool,
     #[serde(default)]
+    pub supports_volume: bool,
+    #[serde(default)]
     pub volume_percent: Option<u8>,
 }
 
@@ -123,15 +125,20 @@ impl SpotifyDevice {
             zone_id: zone_id.clone(),
             zone_name: self.name.clone(),
             state,
-            volume_control: self.volume_percent.map(|value| VolumeControl {
-                value: f32::from(value),
-                min: 0.0,
-                max: 100.0,
-                step: 1.0,
-                is_muted: false,
-                scale: VolumeScale::Percentage,
-                output_id: Some(zone_id),
-            }),
+            volume_control: self
+                .supports_volume
+                .then(|| {
+                    self.volume_percent.map(|value| VolumeControl {
+                        value: f32::from(value),
+                        min: 0.0,
+                        max: 100.0,
+                        step: 1.0,
+                        is_muted: false,
+                        scale: VolumeScale::Percentage,
+                        output_id: Some(zone_id),
+                    })
+                })
+                .flatten(),
             now_playing,
             source: "spotify".to_string(),
             is_controllable: controllable,
@@ -288,11 +295,11 @@ pub struct SpotifyPlaylist {
     #[serde(default)]
     pub images: Vec<SpotifyImage>,
     #[serde(default)]
-    pub tracks: Option<SpotifyPlaylistTrackSummary>,
+    pub items: Option<SpotifyPlaylistItemSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct SpotifyPlaylistTrackSummary {
+pub struct SpotifyPlaylistItemSummary {
     #[serde(default)]
     pub total: usize,
 }
@@ -330,16 +337,6 @@ struct SpotifySnapshot {
     snapshot_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-struct SpotifyFeaturedPlaylists {
-    playlists: SpotifyPage<SpotifyPlaylist>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct SpotifyNewReleases {
-    albums: SpotifyPage<SpotifyAlbumSummary>,
-}
-
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct SpotifyArtist {
     pub name: String,
@@ -360,7 +357,41 @@ pub struct SpotifyImage {
 #[derive(Debug, Clone, Deserialize)]
 struct DevicesResponse {
     #[serde(default)]
-    devices: Vec<SpotifyDevice>,
+    devices: Vec<SpotifyDeviceResponse>,
+}
+
+/// Spotify documents device IDs as nullable. UHC zones require a stable ID, so
+/// the wire shape stays nullable until the inventory boundary and anonymous
+/// devices are skipped without discarding the rest of the poll.
+#[derive(Debug, Clone, Deserialize)]
+struct SpotifyDeviceResponse {
+    id: Option<String>,
+    name: String,
+    #[serde(rename = "type", default)]
+    device_type: String,
+    #[serde(default)]
+    is_active: bool,
+    #[serde(default)]
+    is_restricted: bool,
+    #[serde(default)]
+    supports_volume: bool,
+    #[serde(default)]
+    volume_percent: Option<u8>,
+}
+
+impl SpotifyDeviceResponse {
+    fn into_device(self) -> Option<SpotifyDevice> {
+        let id = self.id.filter(|id| !id.trim().is_empty())?;
+        Some(SpotifyDevice {
+            id,
+            name: self.name,
+            device_type: self.device_type,
+            is_active: self.is_active,
+            is_restricted: self.is_restricted,
+            supports_volume: self.supports_volume,
+            volume_percent: self.volume_percent,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -525,7 +556,7 @@ impl SpotifyAdapter {
         if query.is_empty() {
             return Err(anyhow!("Spotify search query cannot be empty"));
         }
-        let limit = limit.clamp(1, 50);
+        let limit = spotify_search_limit(limit);
         let path = format!(
             "/search?q={}&type=track%2Calbum%2Cartist&limit={limit}",
             urlencoding::encode(query)
@@ -578,99 +609,52 @@ impl SpotifyAdapter {
         Ok(results)
     }
 
-    /// Browse Spotify's top-level catalog categories.
+    /// Spotify removed catalog categories from the Web API surface available
+    /// to new Development Mode applications in February 2026.
     pub async fn browse_categories(
         &self,
-        limit: usize,
-        offset: usize,
-        country: Option<&str>,
-        locale: Option<&str>,
+        _limit: usize,
+        _offset: usize,
+        _country: Option<&str>,
+        _locale: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyCategory>> {
-        let mut query = vec![
-            format!("limit={}", spotify_page_limit(limit)),
-            format!("offset={offset}"),
-        ];
-        if let Some(country) = country.filter(|value| !value.is_empty()) {
-            query.push(format!("country={}", urlencoding::encode(country)));
-        }
-        if let Some(locale) = locale.filter(|value| !value.is_empty()) {
-            query.push(format!("locale={}", urlencoding::encode(locale)));
-        }
-        let path = format!("/browse/categories?{}", query.join("&"));
-        self.request_json(Method::GET, &path).await
+        Err(development_mode_browse_unavailable("catalog categories"))
     }
 
-    /// Browse playlists attached to one Spotify catalog category.
+    /// Spotify removed category playlists from the Web API surface available
+    /// to new Development Mode applications in February 2026.
     pub async fn browse_category_playlists(
         &self,
-        category_id: &str,
-        limit: usize,
-        offset: usize,
-        country: Option<&str>,
+        _category_id: &str,
+        _limit: usize,
+        _offset: usize,
+        _country: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyPlaylist>> {
-        let category_id = category_id.trim();
-        if category_id.is_empty() {
-            return Err(anyhow!("Spotify category id cannot be empty"));
-        }
-        let mut query = vec![
-            format!("limit={}", spotify_page_limit(limit)),
-            format!("offset={offset}"),
-        ];
-        if let Some(country) = country.filter(|value| !value.is_empty()) {
-            query.push(format!("country={}", urlencoding::encode(country)));
-        }
-        let path = format!(
-            "/browse/categories/{}/playlists?{}",
-            urlencoding::encode(category_id),
-            query.join("&")
-        );
-        self.request_json(Method::GET, &path).await
+        Err(development_mode_browse_unavailable("category playlists"))
     }
 
-    /// Browse Spotify's featured editorial playlists.
+    /// Spotify removed featured playlists from the Web API surface available
+    /// to new Development Mode applications in February 2026.
     pub async fn browse_featured_playlists(
         &self,
-        limit: usize,
-        offset: usize,
-        country: Option<&str>,
-        locale: Option<&str>,
-        timestamp: Option<&str>,
+        _limit: usize,
+        _offset: usize,
+        _country: Option<&str>,
+        _locale: Option<&str>,
+        _timestamp: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyPlaylist>> {
-        let mut query = vec![
-            format!("limit={}", spotify_page_limit(limit)),
-            format!("offset={offset}"),
-        ];
-        if let Some(country) = country.filter(|value| !value.is_empty()) {
-            query.push(format!("country={}", urlencoding::encode(country)));
-        }
-        if let Some(locale) = locale.filter(|value| !value.is_empty()) {
-            query.push(format!("locale={}", urlencoding::encode(locale)));
-        }
-        if let Some(timestamp) = timestamp.filter(|value| !value.is_empty()) {
-            query.push(format!("timestamp={}", urlencoding::encode(timestamp)));
-        }
-        let path = format!("/browse/featured-playlists?{}", query.join("&"));
-        let response: SpotifyFeaturedPlaylists = self.request_json(Method::GET, &path).await?;
-        Ok(response.playlists)
+        Err(development_mode_browse_unavailable("featured playlists"))
     }
 
-    /// Browse Spotify's new-release album catalog.
+    /// Spotify removed new releases from the Web API surface available to new
+    /// Development Mode applications in February 2026.
     pub async fn browse_new_releases(
         &self,
-        limit: usize,
-        offset: usize,
-        country: Option<&str>,
+        _limit: usize,
+        _offset: usize,
+        _country: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyAlbumSummary>> {
-        let mut query = vec![
-            format!("limit={}", spotify_page_limit(limit)),
-            format!("offset={offset}"),
-        ];
-        if let Some(country) = country.filter(|value| !value.is_empty()) {
-            query.push(format!("country={}", urlencoding::encode(country)));
-        }
-        let path = format!("/browse/new-releases?{}", query.join("&"));
-        let response: SpotifyNewReleases = self.request_json(Method::GET, &path).await?;
-        Ok(response.albums)
+        Err(development_mode_browse_unavailable("new releases"))
     }
 
     /// List playlists visible to the current Spotify user.
@@ -1072,7 +1056,11 @@ impl SpotifyAdapter {
     async fn fetch_devices(&self) -> Result<Vec<SpotifyDevice>> {
         let response: DevicesResponse =
             self.request_json(Method::GET, "/me/player/devices").await?;
-        Ok(response.devices)
+        Ok(response
+            .devices
+            .into_iter()
+            .filter_map(SpotifyDeviceResponse::into_device)
+            .collect())
     }
 
     async fn fetch_playback(&self) -> Result<Option<SpotifyPlayback>> {
@@ -1188,11 +1176,7 @@ impl SpotifyAdapter {
             .await
             .map_err(|e| anyhow!("failed reading Spotify response: {}", e))?;
         if !status.is_success() {
-            let detail = serde_json::from_str::<Value>(&body)
-                .ok()
-                .and_then(|json| json["error"]["message"].as_str().map(str::to_string))
-                .unwrap_or_else(|| body.chars().take(240).collect());
-            return Err(anyhow!("Spotify API returned HTTP {}: {}", status, detail));
+            return Err(spotify_api_error(status, &body, false));
         }
         serde_json::from_str(&body).map_err(|e| anyhow!("invalid Spotify response JSON: {}", e))
     }
@@ -1217,21 +1201,7 @@ impl SpotifyAdapter {
             return Ok(());
         }
         let body = response.text().await.unwrap_or_default();
-        let detail = serde_json::from_str::<Value>(&body)
-            .ok()
-            .and_then(|json| json["error"]["message"].as_str().map(str::to_string))
-            .unwrap_or_else(|| body.chars().take(240).collect());
-        if playback_control && status == StatusCode::FORBIDDEN {
-            return Err(anyhow!(
-                "Spotify playback control requires a Premium account: {detail}"
-            ));
-        }
-        if playback_control && status == StatusCode::TOO_MANY_REQUESTS {
-            return Err(anyhow!(
-                "Spotify playback control is rate limited; try again shortly: {detail}"
-            ));
-        }
-        Err(anyhow!("Spotify API returned HTTP {}: {}", status, detail))
+        Err(spotify_api_error(status, &body, playback_control))
     }
 
     async fn send_json_command<T: Serialize>(
@@ -1254,11 +1224,7 @@ impl SpotifyAdapter {
             return Ok(());
         }
         let body = response.text().await.unwrap_or_default();
-        let detail = serde_json::from_str::<Value>(&body)
-            .ok()
-            .and_then(|json| json["error"]["message"].as_str().map(str::to_string))
-            .unwrap_or_else(|| body.chars().take(240).collect());
-        Err(anyhow!("Spotify API returned HTTP {}: {}", status, detail))
+        Err(spotify_api_error(status, &body, false))
     }
 
     async fn request_json_with_body<T: Serialize, R: for<'de> Deserialize<'de>>(
@@ -1417,6 +1383,9 @@ impl AdapterLogic for SpotifyAdapter {
                     .await
             }
             AdapterCommand::VolumeAbsolute(value) => {
+                if !device.supports_volume {
+                    return Ok(failure("Spotify device does not support volume control"));
+                }
                 let value = value.clamp(0, 100);
                 self.send_command(
                     Method::PUT,
@@ -1428,6 +1397,9 @@ impl AdapterLogic for SpotifyAdapter {
                 .await
             }
             AdapterCommand::VolumeRelative(delta) => {
+                if !device.supports_volume {
+                    return Ok(failure("Spotify device does not support volume control"));
+                }
                 let current = device
                     .volume_percent
                     .ok_or_else(|| anyhow!("Spotify device volume is unavailable"));
@@ -1528,26 +1500,17 @@ impl LibraryAdapter for SpotifyAdapter {
             .unwrap_or(20)
             .clamp(1, 50);
         let result = match operation {
-            "browse_categories" => serde_json::to_value(
-                self.browse_categories(limit as usize, 0, None, None)
-                    .await?,
-            )?,
-            "browse_category_playlists" => {
-                let id = params
-                    .get("category_id")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| anyhow!("category_id is required"))?;
-                serde_json::to_value(
-                    self.browse_category_playlists(id, limit as usize, 0, None)
-                        .await?,
-                )?
+            "browse_categories" => {
+                return Err(development_mode_browse_unavailable("catalog categories"))
             }
-            "browse_featured_playlists" => serde_json::to_value(
-                self.browse_featured_playlists(limit as usize, 0, None, None, None)
-                    .await?,
-            )?,
+            "browse_category_playlists" => {
+                return Err(development_mode_browse_unavailable("category playlists"))
+            }
+            "browse_featured_playlists" => {
+                return Err(development_mode_browse_unavailable("featured playlists"))
+            }
             "browse_new_releases" => {
-                serde_json::to_value(self.browse_new_releases(limit as usize, 0, None).await?)?
+                return Err(development_mode_browse_unavailable("new releases"))
             }
             "playlists" => {
                 self.request_json(Method::GET, &format!("/me/playlists?limit={limit}"))
@@ -1573,17 +1536,13 @@ impl LibraryAdapter for SpotifyAdapter {
                     .and_then(Value::as_str)
                     .filter(|s| !s.trim().is_empty())
                     .ok_or_else(|| anyhow!("name is required"))?;
-                let profile = self
-                    .request_json::<SpotifyUserProfile>(Method::GET, "/me")
-                    .await?;
                 let body = serde_json::json!({
                     "name": name,
                     "public": params.get("public").and_then(Value::as_bool).unwrap_or(false),
                     "collaborative": false,
                     "description": params.get("description").and_then(Value::as_str).unwrap_or("")
                 });
-                let path = format!("/users/{}/playlists", profile.id);
-                self.request_json_with_body(Method::POST, &path, &body)
+                self.request_json_with_body(Method::POST, "/me/playlists", &body)
                     .await?
             }
             "update_playlist" => {
@@ -1703,6 +1662,39 @@ fn now_secs() -> u64 {
 
 fn spotify_page_limit(limit: usize) -> usize {
     limit.clamp(1, 50)
+}
+
+fn spotify_search_limit(limit: usize) -> usize {
+    limit.clamp(1, 10)
+}
+
+fn development_mode_browse_unavailable(surface: &str) -> anyhow::Error {
+    anyhow!(
+        "Spotify {surface} are unavailable to new Development Mode applications as of the February 2026 Web API changes; use search or the authenticated user's library instead"
+    )
+}
+
+fn spotify_api_error(status: StatusCode, body: &str, playback_control: bool) -> anyhow::Error {
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        let reason = serde_json::from_str::<Value>(body)
+            .ok()
+            .and_then(|json| json["error"]["reason"].as_str().map(str::to_owned));
+        if reason.as_deref() == Some("QUOTA_EXCEEDED") {
+            return anyhow!(
+                "Spotify API quota exhausted (QUOTA_EXCEEDED); retry after the developer quota resets"
+            );
+        }
+        return anyhow!("Spotify API rate limited the request; retry after Retry-After");
+    }
+
+    let detail = serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|json| json["error"]["message"].as_str().map(str::to_string))
+        .unwrap_or_else(|| body.chars().take(240).collect());
+    if playback_control && status == StatusCode::FORBIDDEN {
+        return anyhow!("Spotify playback control requires a Premium account: {detail}");
+    }
+    anyhow!("Spotify API returned HTTP {}: {}", status, detail)
 }
 
 fn spotify_ids(ids: &[String]) -> Result<String> {

--- a/src/adapters/spotify.rs
+++ b/src/adapters/spotify.rs
@@ -11,16 +11,16 @@
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use reqwest::{Client, Method, StatusCode};
+use reqwest::{header::RETRY_AFTER, Client, Method, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
-use tokio::time::interval;
+use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -36,6 +36,80 @@ use crate::bus::{
 
 const SPOTIFY_API_URL: &str = "https://api.spotify.com/v1";
 const SPOTIFY_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const SPOTIFY_QUOTA_BACKOFF: Duration = Duration::from_secs(15 * 60);
+const SPOTIFY_QUOTA_MODE_ENV: &str = "UHC_SPOTIFY_QUOTA_MODE";
+
+/// Spotify application entitlement used to select the available Web API
+/// surface. New installations are Development Mode unless an operator
+/// explicitly declares an Extended Quota app.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SpotifyQuotaMode {
+    #[default]
+    Development,
+    Extended,
+}
+
+impl SpotifyQuotaMode {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "development" => Ok(Self::Development),
+            "extended" => Ok(Self::Extended),
+            value => Err(anyhow!(
+                "invalid {SPOTIFY_QUOTA_MODE_ENV} value '{value}'; expected 'development' or 'extended'"
+            )),
+        }
+    }
+
+    fn from_environment() -> Self {
+        let Ok(value) = std::env::var(SPOTIFY_QUOTA_MODE_ENV) else {
+            return Self::default();
+        };
+        match Self::parse(&value) {
+            Ok(mode) => mode,
+            Err(error) => {
+                warn!("{error}; using Development Mode");
+                Self::default()
+            }
+        }
+    }
+}
+
+/// Spotify-specific 429 outcomes that callers can classify without parsing
+/// provider text or exposing the provider response body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpotifyApiError {
+    RateLimited { retry_after: Option<Duration> },
+    QuotaExceeded,
+}
+
+impl fmt::Display for SpotifyApiError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RateLimited {
+                retry_after: Some(delay),
+            } => write!(
+                formatter,
+                "Spotify API rate limited the request; retry after {} seconds",
+                delay.as_secs()
+            ),
+            Self::RateLimited { retry_after: None } => {
+                write!(formatter, "Spotify API rate limited the request")
+            }
+            Self::QuotaExceeded => write!(
+                formatter,
+                "Spotify API quota exhausted (QUOTA_EXCEEDED); retry after the developer quota resets"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SpotifyApiError {}
+
+#[derive(Debug, Clone, Copy)]
+enum SpotifyRequestGate {
+    RateLimitedUntil(Instant),
+    QuotaExceededUntil(Instant),
+}
 
 /// OAuth credentials needed to call the Spotify Web API.
 ///
@@ -331,6 +405,16 @@ pub struct SpotifyAlbumSummary {
     pub images: Vec<SpotifyImage>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct SpotifyFeaturedPlaylists {
+    playlists: SpotifyPage<SpotifyPlaylist>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SpotifyNewReleases {
+    albums: SpotifyPage<SpotifyAlbumSummary>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct SpotifySnapshot {
     #[serde(default)]
@@ -456,6 +540,7 @@ struct SpotifyState {
     account: Option<ProviderAccount>,
     account_loaded: bool,
     running: bool,
+    request_gate: Option<SpotifyRequestGate>,
 }
 
 /// Direct Spotify Connect controller adapter.
@@ -464,6 +549,7 @@ pub struct SpotifyAdapter {
     state: Arc<RwLock<SpotifyState>>,
     client: Client,
     api_base_url: String,
+    quota_mode: SpotifyQuotaMode,
     bus: SharedBus,
     shutdown: Arc<RwLock<CancellationToken>>,
     refresher: Arc<RwLock<Option<Arc<dyn SpotifyTokenRefresher>>>>,
@@ -472,11 +558,26 @@ pub struct SpotifyAdapter {
 impl SpotifyAdapter {
     /// Create an adapter using Spotify's production Web API.
     pub fn new(bus: SharedBus) -> Self {
-        Self::with_base_url(bus, SPOTIFY_API_URL.to_string())
+        Self::with_base_url_and_quota_mode(
+            bus,
+            SPOTIFY_API_URL.to_string(),
+            SpotifyQuotaMode::from_environment(),
+        )
     }
 
     /// Create an adapter pointed at a custom API URL (used by protocol tests).
     pub fn with_base_url(bus: SharedBus, api_base_url: String) -> Self {
+        Self::with_base_url_and_quota_mode(bus, api_base_url, SpotifyQuotaMode::default())
+    }
+
+    /// Create an adapter with an explicit Spotify application entitlement.
+    /// Tests and Extended Quota deployments use this to make the boundary
+    /// observable instead of inferring it from provider failures.
+    pub fn with_base_url_and_quota_mode(
+        bus: SharedBus,
+        api_base_url: String,
+        quota_mode: SpotifyQuotaMode,
+    ) -> Self {
         #[allow(clippy::expect_used)]
         let client = Client::builder()
             .timeout(Duration::from_secs(10))
@@ -486,6 +587,7 @@ impl SpotifyAdapter {
             state: Arc::new(RwLock::new(SpotifyState::default())),
             client,
             api_base_url: api_base_url.trim_end_matches('/').to_string(),
+            quota_mode,
             bus,
             shutdown: Arc::new(RwLock::new(CancellationToken::new())),
             refresher: Arc::new(RwLock::new(None)),
@@ -498,6 +600,7 @@ impl SpotifyAdapter {
         state.token = Some(token);
         state.account = None;
         state.account_loaded = false;
+        state.request_gate = None;
     }
 
     /// Install the authorization-layer refresh callback.
@@ -523,6 +626,7 @@ impl SpotifyAdapter {
         state.playback = None;
         state.account = None;
         state.account_loaded = false;
+        state.request_gate = None;
     }
 
     /// Return whether an unexpired access token is available.
@@ -613,48 +717,124 @@ impl SpotifyAdapter {
     /// to new Development Mode applications in February 2026.
     pub async fn browse_categories(
         &self,
-        _limit: usize,
-        _offset: usize,
-        _country: Option<&str>,
-        _locale: Option<&str>,
+        limit: usize,
+        offset: usize,
+        country: Option<&str>,
+        locale: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyCategory>> {
-        Err(development_mode_browse_unavailable("catalog categories"))
+        self.require_extended_quota("catalog categories")?;
+        let mut query = vec![
+            format!("limit={}", spotify_page_limit(limit)),
+            format!("offset={offset}"),
+        ];
+        if let Some(country) = country.filter(|value| !value.is_empty()) {
+            query.push(format!("country={}", urlencoding::encode(country)));
+        }
+        if let Some(locale) = locale.filter(|value| !value.is_empty()) {
+            query.push(format!("locale={}", urlencoding::encode(locale)));
+        }
+        self.request_json(
+            Method::GET,
+            &format!("/browse/categories?{}", query.join("&")),
+        )
+        .await
     }
 
     /// Spotify removed category playlists from the Web API surface available
     /// to new Development Mode applications in February 2026.
     pub async fn browse_category_playlists(
         &self,
-        _category_id: &str,
-        _limit: usize,
-        _offset: usize,
-        _country: Option<&str>,
+        category_id: &str,
+        limit: usize,
+        offset: usize,
+        country: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyPlaylist>> {
-        Err(development_mode_browse_unavailable("category playlists"))
+        self.require_extended_quota("category playlists")?;
+        let category_id = category_id.trim();
+        if category_id.is_empty() {
+            return Err(anyhow!("Spotify category id cannot be empty"));
+        }
+        let mut query = vec![
+            format!("limit={}", spotify_page_limit(limit)),
+            format!("offset={offset}"),
+        ];
+        if let Some(country) = country.filter(|value| !value.is_empty()) {
+            query.push(format!("country={}", urlencoding::encode(country)));
+        }
+        self.request_json(
+            Method::GET,
+            &format!(
+                "/browse/categories/{}/playlists?{}",
+                urlencoding::encode(category_id),
+                query.join("&")
+            ),
+        )
+        .await
     }
 
     /// Spotify removed featured playlists from the Web API surface available
     /// to new Development Mode applications in February 2026.
     pub async fn browse_featured_playlists(
         &self,
-        _limit: usize,
-        _offset: usize,
-        _country: Option<&str>,
-        _locale: Option<&str>,
-        _timestamp: Option<&str>,
+        limit: usize,
+        offset: usize,
+        country: Option<&str>,
+        locale: Option<&str>,
+        timestamp: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyPlaylist>> {
-        Err(development_mode_browse_unavailable("featured playlists"))
+        self.require_extended_quota("featured playlists")?;
+        let mut query = vec![
+            format!("limit={}", spotify_page_limit(limit)),
+            format!("offset={offset}"),
+        ];
+        if let Some(country) = country.filter(|value| !value.is_empty()) {
+            query.push(format!("country={}", urlencoding::encode(country)));
+        }
+        if let Some(locale) = locale.filter(|value| !value.is_empty()) {
+            query.push(format!("locale={}", urlencoding::encode(locale)));
+        }
+        if let Some(timestamp) = timestamp.filter(|value| !value.is_empty()) {
+            query.push(format!("timestamp={}", urlencoding::encode(timestamp)));
+        }
+        let response: SpotifyFeaturedPlaylists = self
+            .request_json(
+                Method::GET,
+                &format!("/browse/featured-playlists?{}", query.join("&")),
+            )
+            .await?;
+        Ok(response.playlists)
     }
 
     /// Spotify removed new releases from the Web API surface available to new
     /// Development Mode applications in February 2026.
     pub async fn browse_new_releases(
         &self,
-        _limit: usize,
-        _offset: usize,
-        _country: Option<&str>,
+        limit: usize,
+        offset: usize,
+        country: Option<&str>,
     ) -> Result<SpotifyPage<SpotifyAlbumSummary>> {
-        Err(development_mode_browse_unavailable("new releases"))
+        self.require_extended_quota("new releases")?;
+        let mut query = vec![
+            format!("limit={}", spotify_page_limit(limit)),
+            format!("offset={offset}"),
+        ];
+        if let Some(country) = country.filter(|value| !value.is_empty()) {
+            query.push(format!("country={}", urlencoding::encode(country)));
+        }
+        let response: SpotifyNewReleases = self
+            .request_json(
+                Method::GET,
+                &format!("/browse/new-releases?{}", query.join("&")),
+            )
+            .await?;
+        Ok(response.albums)
+    }
+
+    fn require_extended_quota(&self, surface: &str) -> Result<()> {
+        if self.quota_mode == SpotifyQuotaMode::Extended {
+            return Ok(());
+        }
+        Err(development_mode_browse_unavailable(surface))
     }
 
     /// List playlists visible to the current Spotify user.
@@ -982,13 +1162,20 @@ impl SpotifyAdapter {
         for device in &devices {
             let zone_id = PrefixedZoneId::spotify(&device.id);
             let device_playback = playback_for_device(playback.as_ref(), &device.id);
-            if previous_devices.contains_key(&device.id) {
+            if let Some(previous_device) = previous_devices.get(&device.id) {
                 let zone = device.to_zone(device_playback);
-                self.bus.publish(BusEvent::ZoneUpdated {
-                    zone_id: zone_id.clone(),
-                    display_name: device.name.clone(),
-                    state: zone.state.to_string(),
-                });
+                let needs_full_refresh = previous_device.is_restricted != device.is_restricted
+                    || previous_device.supports_volume != device.supports_volume
+                    || previous_device.volume_percent.is_some() != device.volume_percent.is_some();
+                if needs_full_refresh {
+                    self.bus.publish(BusEvent::ZoneDiscovered { zone });
+                } else {
+                    self.bus.publish(BusEvent::ZoneUpdated {
+                        zone_id: zone_id.clone(),
+                        display_name: device.name.clone(),
+                        state: zone.state.to_string(),
+                    });
+                }
 
                 let previous_device_playback =
                     playback_for_device(previous_playback.as_ref(), &device.id);
@@ -1037,8 +1224,13 @@ impl SpotifyAdapter {
                     }
                 }
             } else {
-                self.bus.publish(BusEvent::ZoneDiscovered {
-                    zone: device.to_zone(device_playback),
+                let zone = device.to_zone(device_playback);
+                self.bus.publish(BusEvent::ZoneDiscovered { zone });
+            }
+            if device.supports_volume && device.volume_percent.is_none() {
+                self.bus.publish(BusEvent::VolumeCapabilityChanged {
+                    zone_id,
+                    supported: true,
                 });
             }
         }
@@ -1082,6 +1274,7 @@ impl SpotifyAdapter {
 
     async fn request(&self, method: Method, path: &str) -> Result<reqwest::Response> {
         let access_token = self.ensure_access_token().await?;
+        self.enforce_request_gate().await?;
         let has_command_body = method == Method::POST || method == Method::PUT;
         let request = self
             .client
@@ -1155,6 +1348,7 @@ impl SpotifyAdapter {
         body: &T,
     ) -> Result<R> {
         let access_token = self.ensure_access_token().await?;
+        self.enforce_request_gate().await?;
         let response = self
             .client
             .request(method, format!("{}{}", self.api_base_url, path))
@@ -1171,12 +1365,15 @@ impl SpotifyAdapter {
         response: reqwest::Response,
     ) -> Result<T> {
         let status = response.status();
+        let retry_after = spotify_retry_after(&response);
         let body = response
             .text()
             .await
             .map_err(|e| anyhow!("failed reading Spotify response: {}", e))?;
         if !status.is_success() {
-            return Err(spotify_api_error(status, &body, false));
+            return Err(self
+                .record_api_error(status, retry_after, &body, false)
+                .await);
         }
         serde_json::from_str(&body).map_err(|e| anyhow!("invalid Spotify response JSON: {}", e))
     }
@@ -1200,8 +1397,11 @@ impl SpotifyAdapter {
         if status.is_success() || status == StatusCode::NO_CONTENT {
             return Ok(());
         }
+        let retry_after = spotify_retry_after(&response);
         let body = response.text().await.unwrap_or_default();
-        Err(spotify_api_error(status, &body, playback_control))
+        Err(self
+            .record_api_error(status, retry_after, &body, playback_control)
+            .await)
     }
 
     async fn send_json_command<T: Serialize>(
@@ -1211,6 +1411,7 @@ impl SpotifyAdapter {
         body: &T,
     ) -> Result<()> {
         let access_token = self.ensure_access_token().await?;
+        self.enforce_request_gate().await?;
         let response = self
             .client
             .request(method, format!("{}{}", self.api_base_url, path))
@@ -1223,8 +1424,11 @@ impl SpotifyAdapter {
         if status.is_success() || status == StatusCode::NO_CONTENT {
             return Ok(());
         }
+        let retry_after = spotify_retry_after(&response);
         let body = response.text().await.unwrap_or_default();
-        Err(spotify_api_error(status, &body, false))
+        Err(self
+            .record_api_error(status, retry_after, &body, false)
+            .await)
     }
 
     async fn request_json_with_body<T: Serialize, R: for<'de> Deserialize<'de>>(
@@ -1234,6 +1438,7 @@ impl SpotifyAdapter {
         body: &T,
     ) -> Result<R> {
         let access_token = self.ensure_access_token().await?;
+        self.enforce_request_gate().await?;
         let response = self
             .client
             .request(method, format!("{}{}", self.api_base_url, path))
@@ -1243,6 +1448,54 @@ impl SpotifyAdapter {
             .await
             .map_err(|e| anyhow!("Spotify request {} failed: {}", path, e))?;
         self.decode_response(response).await
+    }
+
+    async fn enforce_request_gate(&self) -> Result<()> {
+        let now = Instant::now();
+        let mut state = self.state.write().await;
+        match state.request_gate {
+            Some(SpotifyRequestGate::RateLimitedUntil(until)) if until > now => {
+                Err(SpotifyApiError::RateLimited {
+                    retry_after: Some(until.duration_since(now)),
+                }
+                .into())
+            }
+            Some(SpotifyRequestGate::QuotaExceededUntil(until)) if until > now => {
+                Err(SpotifyApiError::QuotaExceeded.into())
+            }
+            Some(_) => {
+                state.request_gate = None;
+                Ok(())
+            }
+            None => Ok(()),
+        }
+    }
+
+    async fn record_api_error(
+        &self,
+        status: StatusCode,
+        retry_after: Option<Duration>,
+        body: &str,
+        playback_control: bool,
+    ) -> anyhow::Error {
+        let error = spotify_api_error(status, retry_after, body, playback_control);
+        if let Some(spotify_error) = error.downcast_ref::<SpotifyApiError>() {
+            let gate = match spotify_error {
+                SpotifyApiError::RateLimited {
+                    retry_after: Some(delay),
+                } => Some(SpotifyRequestGate::RateLimitedUntil(
+                    Instant::now() + *delay,
+                )),
+                SpotifyApiError::RateLimited { retry_after: None } => None,
+                SpotifyApiError::QuotaExceeded => Some(SpotifyRequestGate::QuotaExceededUntil(
+                    Instant::now() + SPOTIFY_QUOTA_BACKOFF,
+                )),
+            };
+            if let Some(gate) = gate {
+                self.state.write().await.request_gate = Some(gate);
+            }
+        }
+        error
     }
 
     async fn start_internal(&self) -> Result<()> {
@@ -1303,14 +1556,23 @@ impl AdapterLogic for SpotifyAdapter {
             adapter: "spotify".to_string(),
             details: Some("Spotify Web API".to_string()),
         });
-        let mut ticker = interval(SPOTIFY_POLL_INTERVAL);
+        // Preserve the adapter's immediate first discovery while using
+        // one-shot sleeps afterward so a long provider call cannot make an
+        // interval ticker catch up with a burst of requests.
+        let mut poll_delay = Duration::ZERO;
         loop {
             tokio::select! {
                 _ = ctx.shutdown.cancelled() => break,
-                _ = ticker.tick() => {
-                    if let Err(error) = self.update().await {
-                        self.publish_error(&error);
-                        debug!("Spotify polling failed: {}", error);
+                _ = sleep(poll_delay) => {
+                    match self.update().await {
+                        Ok(()) => poll_delay = SPOTIFY_POLL_INTERVAL,
+                        Err(error) => {
+                            self.publish_error(&error);
+                            debug!("Spotify polling failed: {}", error);
+                            poll_delay = spotify_retry_delay(&error)
+                                .unwrap_or(SPOTIFY_POLL_INTERVAL)
+                                .max(Duration::from_secs(1));
+                        }
                     }
                 }
             }
@@ -1500,17 +1762,26 @@ impl LibraryAdapter for SpotifyAdapter {
             .unwrap_or(20)
             .clamp(1, 50);
         let result = match operation {
-            "browse_categories" => {
-                return Err(development_mode_browse_unavailable("catalog categories"))
-            }
+            "browse_categories" => serde_json::to_value(
+                self.browse_categories(limit as usize, 0, None, None)
+                    .await?,
+            )?,
             "browse_category_playlists" => {
-                return Err(development_mode_browse_unavailable("category playlists"))
+                let category_id = params
+                    .get("category_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow!("category_id is required"))?;
+                serde_json::to_value(
+                    self.browse_category_playlists(category_id, limit as usize, 0, None)
+                        .await?,
+                )?
             }
-            "browse_featured_playlists" => {
-                return Err(development_mode_browse_unavailable("featured playlists"))
-            }
+            "browse_featured_playlists" => serde_json::to_value(
+                self.browse_featured_playlists(limit as usize, 0, None, None, None)
+                    .await?,
+            )?,
             "browse_new_releases" => {
-                return Err(development_mode_browse_unavailable("new releases"))
+                serde_json::to_value(self.browse_new_releases(limit as usize, 0, None).await?)?
             }
             "playlists" => {
                 self.request_json(Method::GET, &format!("/me/playlists?limit={limit}"))
@@ -1674,17 +1945,20 @@ fn development_mode_browse_unavailable(surface: &str) -> anyhow::Error {
     )
 }
 
-fn spotify_api_error(status: StatusCode, body: &str, playback_control: bool) -> anyhow::Error {
+fn spotify_api_error(
+    status: StatusCode,
+    retry_after: Option<Duration>,
+    body: &str,
+    playback_control: bool,
+) -> anyhow::Error {
     if status == StatusCode::TOO_MANY_REQUESTS {
         let reason = serde_json::from_str::<Value>(body)
             .ok()
             .and_then(|json| json["error"]["reason"].as_str().map(str::to_owned));
         if reason.as_deref() == Some("QUOTA_EXCEEDED") {
-            return anyhow!(
-                "Spotify API quota exhausted (QUOTA_EXCEEDED); retry after the developer quota resets"
-            );
+            return SpotifyApiError::QuotaExceeded.into();
         }
-        return anyhow!("Spotify API rate limited the request; retry after Retry-After");
+        return SpotifyApiError::RateLimited { retry_after }.into();
     }
 
     let detail = serde_json::from_str::<Value>(body)
@@ -1695,6 +1969,23 @@ fn spotify_api_error(status: StatusCode, body: &str, playback_control: bool) -> 
         return anyhow!("Spotify playback control requires a Premium account: {detail}");
     }
     anyhow!("Spotify API returned HTTP {}: {}", status, detail)
+}
+
+fn spotify_retry_after(response: &reqwest::Response) -> Option<Duration> {
+    response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+fn spotify_retry_delay(error: &anyhow::Error) -> Option<Duration> {
+    match error.downcast_ref::<SpotifyApiError>() {
+        Some(SpotifyApiError::RateLimited { retry_after }) => *retry_after,
+        Some(SpotifyApiError::QuotaExceeded) => Some(SPOTIFY_QUOTA_BACKOFF),
+        None => None,
+    }
 }
 
 fn spotify_ids(ids: &[String]) -> Result<String> {

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -62,6 +62,7 @@ pub struct ZoneAggregator {
 #[derive(Default)]
 struct AggregateState {
     zones: HashMap<String, Zone>,
+    volume_capabilities: HashMap<String, bool>,
     hqplayer_snapshots: HashMap<String, HqpSnapshot>,
     projection_revision: u64,
     source_cursors: HashMap<String, ProjectionCursor>,
@@ -155,11 +156,11 @@ impl ZoneAggregator {
                     self.observed_playback
                         .record_zone(&zone, observation_now())
                         .await;
-                    self.state
-                        .write()
-                        .await
-                        .zones
-                        .insert(zone.zone_id.clone(), zone);
+                    let mut aggregate = self.state.write().await;
+                    aggregate
+                        .volume_capabilities
+                        .insert(zone.zone_id.clone(), zone.volume_control.is_some());
+                    aggregate.zones.insert(zone.zone_id.clone(), zone);
                 }
 
                 BusEvent::ZoneUpdated {
@@ -180,7 +181,9 @@ impl ZoneAggregator {
                 BusEvent::ZoneRemoved { zone_id } => {
                     debug!("Zone removed: {}", zone_id);
                     self.observed_playback.clear_zone(zone_id.as_str()).await;
-                    self.state.write().await.zones.remove(zone_id.as_str());
+                    let mut aggregate = self.state.write().await;
+                    aggregate.zones.remove(zone_id.as_str());
+                    aggregate.volume_capabilities.remove(zone_id.as_str());
                 }
 
                 BusEvent::ProviderAccountUpdated { provider, account } => {
@@ -318,6 +321,16 @@ impl ZoneAggregator {
                     }
                 }
 
+                BusEvent::VolumeCapabilityChanged { zone_id, supported } => {
+                    debug!("Volume capability changed: {} = {}", zone_id, supported);
+                    let mut aggregate = self.state.write().await;
+                    if aggregate.zones.contains_key(zone_id.as_str()) {
+                        aggregate
+                            .volume_capabilities
+                            .insert(zone_id.to_string(), supported);
+                    }
+                }
+
                 BusEvent::SeekPositionChanged { zone_id, position } => {
                     debug!("Seek position changed: {} = {}", zone_id, position);
                     if let Some(zone) = self.state.write().await.zones.get_mut(zone_id.as_str()) {
@@ -343,6 +356,7 @@ impl ZoneAggregator {
 
                         for zone_id in &zone_ids {
                             aggregate.zones.remove(zone_id);
+                            aggregate.volume_capabilities.remove(zone_id);
                         }
                         zone_ids
                     };
@@ -397,6 +411,22 @@ impl ZoneAggregator {
     /// Get a specific zone
     pub async fn get_zone(&self, zone_id: &str) -> Option<Zone> {
         self.state.read().await.zones.get(zone_id).cloned()
+    }
+
+    /// Return whether the current device observation says this zone can accept
+    /// volume commands. This is separate from `Zone::volume_control`, whose
+    /// numeric value is absent when a provider reports support but no current
+    /// volume value.
+    pub async fn has_volume_control(&self, zone_id: &str) -> Option<bool> {
+        let aggregate = self.state.read().await;
+        let zone = aggregate.zones.get(zone_id)?;
+        Some(
+            aggregate
+                .volume_capabilities
+                .get(zone_id)
+                .copied()
+                .unwrap_or_else(|| zone.volume_control.is_some()),
+        )
     }
 
     /// Get now playing for a zone

--- a/src/bus/events.rs
+++ b/src/bus/events.rs
@@ -567,6 +567,13 @@ pub enum BusEvent {
         is_muted: bool,
     },
 
+    /// Whether a zone can accept volume commands independently of whether a
+    /// current numeric volume was available in the latest observation.
+    VolumeCapabilityChanged {
+        zone_id: PrefixedZoneId,
+        supported: bool,
+    },
+
     // =========================================================================
     // Command Events
     // =========================================================================
@@ -700,6 +707,7 @@ impl BusEvent {
             Self::PlaybackModesChanged { .. } => "playback_modes_changed",
             Self::SeekPositionChanged { .. } => "seek_position_changed",
             Self::VolumeChanged { .. } => "volume_changed",
+            Self::VolumeCapabilityChanged { .. } => "volume_capability_changed",
             Self::CommandReceived { .. } => "command_received",
             Self::CommandResult { .. } => "command_result",
             Self::AdapterStopping { .. } => "adapter_stopping",
@@ -730,6 +738,7 @@ impl BusEvent {
                 | Self::ZoneUpdated { .. }
                 | Self::ZoneRemoved { .. }
                 | Self::ZonesFlushed { .. }
+                | Self::VolumeCapabilityChanged { .. }
         )
     }
 

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -379,7 +379,11 @@ fn routed(target: ZoneTarget, capability: Capability) -> Option<Support> {
         // (the same browse/load session `hifi_search` already drives);
         // favorites remains a gap -- see `GAPS` below -- because Roon exposes
         // it as a browse hierarchy this slice does not yet walk into.
-        Capability::Browse | Capability::SavedPlaylists => matches!(
+        Capability::Browse => matches!(
+            target,
+            ZoneTarget::MusicAssistant | ZoneTarget::Lms | ZoneTarget::Roon
+        ),
+        Capability::SavedPlaylists => matches!(
             target,
             ZoneTarget::Spotify | ZoneTarget::MusicAssistant | ZoneTarget::Lms | ZoneTarget::Roon
         ),
@@ -695,10 +699,33 @@ pub fn support(target: ZoneTarget, capability: Capability) -> Support {
             evidence: "the native companion content bridge is specified but not enabled; this capability remains pending its approved owner-scoped transport and companion validation.",
         };
     }
-    if matches!(
-        target,
-        ZoneTarget::AppleMusic | ZoneTarget::Spotify | ZoneTarget::MusicAssistant
-    ) {
+    if target == ZoneTarget::Spotify {
+        return match capability {
+            Capability::Browse => Support::NotImplemented {
+                tracked_by: "#473",
+                evidence: "Spotify removed categories, category playlists, featured playlists, and new releases from the Web API surface available to new Development Mode applications in February 2026. A future browse implementation must use a currently available, quota-aware surface rather than call those retired endpoints.",
+            },
+            Capability::QueueJump
+            | Capability::QueueReorder
+            | Capability::QueueRemove
+            | Capability::QueueClear
+            | Capability::QueueTransfer => Support::Unsupported {
+                evidence: "Spotify's Web API exposes Get the User's Queue and Add Item to Playback Queue, but no endpoint to jump, reorder, remove, clear, or transfer active queue contents. Verified from the Spotify Web API Player reference, not inferred from a device.",
+            },
+            Capability::PlayNext => Support::NotImplemented {
+                tracked_by: "#474",
+                evidence: "Spotify exposes Add Item to Playback Queue and UHC routes it through hifi_play action=queue, but UHC does not expose a distinct play-next operation for Spotify.",
+            },
+            Capability::MultiroomSync => Support::Unsupported {
+                evidence: "Spotify's Transfer Playback endpoint accepts a single target device and does not synchronize multiple Connect devices; transfer is device selection, not multiroom grouping. Verified from the Spotify Web API Transfer Playback reference, not inferred from a device.",
+            },
+            _ => Support::NotImplemented {
+                tracked_by: "#462",
+                evidence: "the Spotify adapter has no routed implementation for this capability; the provider-neutral streaming follow-up tracks it.",
+            },
+        };
+    }
+    if matches!(target, ZoneTarget::AppleMusic | ZoneTarget::MusicAssistant) {
         return Support::NotImplemented {
             tracked_by: "#462",
             evidence: "the adapter's initial contract covers transport, skip and volume; library, browse, queue and playlist operations are separate follow-on capability steps and are not wired yet.",
@@ -1104,7 +1131,10 @@ mod tests {
         );
         assert!(matches!(
             support(ZoneTarget::Spotify, Capability::Browse),
-            Support::Supported
+            Support::NotImplemented {
+                tracked_by: "#473",
+                ..
+            }
         ));
     }
 

--- a/src/mcp/capabilities.rs
+++ b/src/mcp/capabilities.rs
@@ -50,13 +50,12 @@
 //!
 //! **Capability is per provider, not per device.** A fixed-volume Roon output —
 //! an endpoint feeding an analogue preamp — has no volume control, and this module
-//! reports `volume: supported` for it. UHC cannot currently do better: the
-//! aggregator's `volume_control: None` conflates "this output has no volume
-//! control" with "no volume has been read yet", so deriving from it would mislabel
-//! every freshly discovered zone. The wire payload carries the aggregator's
-//! `has_volume_control` observation beside the capability so a client can combine
-//! the two itself; the ambiguity is documented on that field rather than resolved
-//! by guessing.
+//! reports `volume: supported` for it. The wire payload therefore carries
+//! `has_volume_control` beside the provider capability. It uses an explicit
+//! per-device capability when a provider supplies one (Spotify's
+//! `supports_volume`), even when the current value is null; otherwise it falls
+//! back to whether the aggregator has observed a numeric volume control. Clients
+//! can combine that device observation with the provider-level capability.
 //!
 //! **Capability is per operation family, not per action.** `transport` covers
 //! play/pause and `transport_skip` covers next/previous, because UPnP refuses the
@@ -796,13 +795,13 @@ pub struct McpCapabilityZone {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zone_name: Option<String>,
     pub provider: Provider,
-    /// Whether the aggregator currently holds a volume control for this zone.
+    /// Whether the latest device observation says this zone accepts volume.
     ///
-    /// **An observation, not a capability.** `false` means either "this output
-    /// has no volume control" or "no volume has been read yet", and UHC cannot
-    /// tell those apart — which is exactly why `volume`'s capability state is
-    /// per provider and this is reported separately for the client to weigh.
-    /// Absent when the aggregator holds no such zone.
+    /// **An observation, not a provider capability.** When the provider exposes
+    /// an explicit per-device flag (currently Spotify), that flag is authoritative
+    /// even if the numeric value is absent. Other providers fall back to whether
+    /// a numeric control has been observed, so `false` can still mean "not yet
+    /// observed" there. Absent when the aggregator holds no such zone.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub has_volume_control: Option<bool>,
 }

--- a/src/mcp/envelope.rs
+++ b/src/mcp/envelope.rs
@@ -269,6 +269,8 @@ impl Observed {
 /// | [`Self::NotImplemented`]     | `unsupported` | retry once `tracked_by` ships |
 /// | [`Self::InvalidParameter`]   | `invalid`     | resend with a value from `accepted` |
 /// | [`Self::UnknownTarget`]      | `invalid`     | enumerate via `discover_with` |
+/// | [`Self::RateLimited`]        | `error`       | retry after the stated delay |
+/// | [`Self::QuotaExceeded`]      | `error`       | wait for provider quota recovery |
 /// | [`Self::BackendError`]       | `error`       | retrying may work |
 ///
 /// The variant determines the [`Outcome`] — see [`Self::outcome`] and
@@ -320,6 +322,15 @@ pub enum Refusal {
         discover_with: &'static str,
         detail: String,
     },
+    /// The provider applied a short-lived rate limit. Clients should not retry
+    /// before `retry_after_seconds` when it is present.
+    RateLimited {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        retry_after_seconds: Option<u64>,
+        detail: String,
+    },
+    /// The provider's longer-lived account/application quota is exhausted.
+    QuotaExceeded { code: &'static str, detail: String },
     /// The operation was attempted and the backend failed.
     BackendError { detail: String },
 }
@@ -330,7 +341,9 @@ impl Refusal {
         match self {
             Self::ProviderLimitation { .. } | Self::NotImplemented { .. } => Outcome::Unsupported,
             Self::InvalidParameter { .. } | Self::UnknownTarget { .. } => Outcome::Invalid,
-            Self::BackendError { .. } => Outcome::Error,
+            Self::RateLimited { .. } | Self::QuotaExceeded { .. } | Self::BackendError { .. } => {
+                Outcome::Error
+            }
         }
     }
 

--- a/src/mcp/tools/capabilities.rs
+++ b/src/mcp/tools/capabilities.rs
@@ -84,12 +84,13 @@ async fn one_zone(
     }
 
     let zone = state.aggregator.get_zone(zone_id).await;
+    let has_volume_control = state.aggregator.has_volume_control(zone_id).await;
     let report = McpCapabilityReport {
         zones: vec![McpCapabilityZone {
             zone_id: zone_id.to_string(),
             zone_name: zone.as_ref().map(|z| z.zone_name.clone()),
             provider: target.provider(),
-            has_volume_control: zone.as_ref().map(|z| z.volume_control.is_some()),
+            has_volume_control,
         }],
         providers: vec![provider_capabilities(target)],
     };
@@ -105,16 +106,15 @@ async fn every_zone(state: &AppState, env: Envelope) -> CallToolResult {
     // Same visibility policy as `hifi_zones`. This report is how a client discovers what it can do
     // with each zone, so listing a hidden zone here would put it back in front of the assistant
     // that `hifi_zones` just withheld it from.
-    let zones: Vec<McpCapabilityZone> = crate::zone_list::visible_zones(state)
-        .await
-        .into_iter()
-        .map(|zone| McpCapabilityZone {
+    let mut zones = Vec::new();
+    for zone in crate::zone_list::visible_zones(state).await {
+        zones.push(McpCapabilityZone {
             provider: ZoneTarget::classify(&zone.zone_id).provider(),
-            has_volume_control: Some(zone.volume_control.is_some()),
+            has_volume_control: state.aggregator.has_volume_control(&zone.zone_id).await,
             zone_id: zone.zone_id,
             zone_name: Some(zone.zone_name),
-        })
-        .collect();
+        });
+    }
 
     let providers: Vec<McpProviderCapabilities> = ZoneTarget::PROVIDERS
         .iter()

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -45,6 +45,7 @@
 //! again rather than failing generically. This module is also the target for
 //! #399 (hierarchical browse), which will mint refs the same way.
 
+use super::spotify::refusal_for_spotify_error;
 use crate::api::AppState;
 use crate::mcp::capabilities::{support, Capability};
 use crate::mcp::envelope::{Envelope, Observed, Provider, Refusal, Scope};
@@ -256,7 +257,10 @@ pub async fn handle_search(
                     }
                     Ok(env.json_result(&mcp_results))
                 }
-                Err(e) => env.failed(format!("Search error: {}", e)),
+                Err(e) => env.refused(
+                    format!("Search error: {}", e),
+                    refusal_for_spotify_error(&e),
+                ),
             }
         }
         LibraryRoute::MusicAssistant => {
@@ -664,14 +668,20 @@ pub async fn handle_play(
                         };
                         match result {
                             Ok(message) => Ok(play_success(state, env, message).await),
-                            Err(e) => env.failed(format!("Play error: {}", e)),
+                            Err(e) => env.refused(
+                                format!("Play error: {}", e),
+                                refusal_for_spotify_error(&e),
+                            ),
                         }
                     }
                     None => {
                         env.failed("Play error: Spotify search returned no results".to_string())
                     }
                 },
-                Err(e) => env.failed(format!("Search error: {}", e)),
+                Err(e) => env.refused(
+                    format!("Search error: {}", e),
+                    refusal_for_spotify_error(&e),
+                ),
             }
         }
         LibraryRoute::MusicAssistant => {
@@ -1246,7 +1256,10 @@ async fn play_ref_spotify(
     };
     match result {
         Ok(message) => Ok(play_success(state, env, message).await),
-        Err(error) => env.failed(format!("Play error for {title}: {}", error)),
+        Err(error) => env.refused(
+            format!("Play error for {title}: {}", error),
+            refusal_for_spotify_error(&error),
+        ),
     }
 }
 

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -144,7 +144,6 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_spotify" => &[
             "action",
             "playlist_id",
-            "category_id",
             "name",
             "description",
             "uri",

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -144,6 +144,7 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_spotify" => &[
             "action",
             "playlist_id",
+            "category_id",
             "name",
             "description",
             "uri",

--- a/src/mcp/tools/queue.rs
+++ b/src/mcp/tools/queue.rs
@@ -10,6 +10,8 @@ use rust_mcp_sdk::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::spotify::refusal_for_spotify_error;
+
 #[mcp_tool(
     name = "hifi_queue",
     description = "Read or edit a playback queue. action='read' is the default. Music Assistant supports jump, reorder, remove, clear, and transfer against its active queue; each mutation returns a fresh queue readback. transfer (Alpha capability: expect refinement across releases) moves the active queue from zone_id to target_zone_id (both must be Music Assistant zones). Queue add is hifi_play action='queue'."
@@ -131,7 +133,7 @@ pub async fn handle_queue(
             .await
         {
             Ok(value) => Ok(env.json_result(&value)),
-            Err(e) => env.failed(format!("Queue error: {e}")),
+            Err(e) => env.refused(format!("Queue error: {e}"), refusal_for_spotify_error(&e)),
         },
         LibraryRoute::AppleMusic => match state
             .adapter_registry

--- a/src/mcp/tools/spotify.rs
+++ b/src/mcp/tools/spotify.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 
 #[mcp_tool(
     name = "hifi_spotify",
-    description = "Spotify catalog and library access. Actions include browse_categories, browse_category_playlists, browse_featured_playlists, browse_new_releases, playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Use hifi_search and hifi_play for catalog search and playback. Playlist/library writes require the corresponding Spotify scopes."
+    description = "Spotify personal-library access. Actions: playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Use hifi_search and hifi_play for catalog search, playback, and queue-add. Spotify's February 2026 Development Mode API removed categories, category playlists, featured playlists, and new releases, so this tool does not advertise or call them. The Web API can read/add to the active queue but cannot jump, reorder, remove, clear, or transfer queue contents. Transfer Playback selects one device; it is not multiroom synchronization. Playlist/library writes require the corresponding Spotify scopes."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiSpotifyTool {
@@ -21,9 +21,6 @@ pub struct HifiSpotifyTool {
     /// Playlist id for playlist_tracks, update_playlist, or playlist_add.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub playlist_id: Option<String>,
-    /// Spotify browse category id.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub category_id: Option<String>,
     /// Playlist name for create/update.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -49,10 +46,6 @@ pub async fn handle_spotify(
     args: HifiSpotifyTool,
 ) -> Result<CallToolResult, CallToolError> {
     let accepted = [
-        "browse_categories",
-        "browse_category_playlists",
-        "browse_featured_playlists",
-        "browse_new_releases",
         "playlists",
         "playlist_tracks",
         "saved_tracks",
@@ -77,7 +70,6 @@ pub async fn handle_spotify(
     }
     let params = json!({
         "playlist_id": args.playlist_id,
-        "category_id": args.category_id,
         "name": args.name,
         "description": args.description,
         "uri": args.uri,

--- a/src/mcp/tools/spotify.rs
+++ b/src/mcp/tools/spotify.rs
@@ -1,8 +1,9 @@
 //! Spotify catalog and library operations that do not map cleanly to the
 //! provider-neutral transport tools.
 
+use crate::adapters::spotify::SpotifyApiError;
 use crate::api::AppState;
-use crate::mcp::envelope::Envelope;
+use crate::mcp::envelope::{Envelope, Refusal};
 use rust_mcp_sdk::{
     macros::{mcp_tool, JsonSchema},
     schema::{schema_utils::CallToolError, CallToolResult},
@@ -12,7 +13,7 @@ use serde_json::json;
 
 #[mcp_tool(
     name = "hifi_spotify",
-    description = "Spotify personal-library access. Actions: playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Use hifi_search and hifi_play for catalog search, playback, and queue-add. Spotify's February 2026 Development Mode API removed categories, category playlists, featured playlists, and new releases, so this tool does not advertise or call them. The Web API can read/add to the active queue but cannot jump, reorder, remove, clear, or transfer queue contents. Transfer Playback selects one device; it is not multiroom synchronization. Playlist/library writes require the corresponding Spotify scopes."
+    description = "Spotify personal-library access. Actions: playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Extended Quota apps configured with UHC_SPOTIFY_QUOTA_MODE=extended may also use browse_categories, browse_category_playlists, browse_featured_playlists, and browse_new_releases; those actions are unavailable by default because Spotify removed them from the February 2026 Development Mode API. Use hifi_search and hifi_play for catalog search, playback, and queue-add. The Web API can read/add to the active queue but cannot jump, reorder, remove, clear, or transfer queue contents. Transfer Playback selects one device; it is not multiroom synchronization. Playlist/library writes require the corresponding Spotify scopes."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiSpotifyTool {
@@ -21,6 +22,9 @@ pub struct HifiSpotifyTool {
     /// Playlist id for playlist_tracks, update_playlist, or playlist_add.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub playlist_id: Option<String>,
+    /// Spotify browse category id. Extended Quota mode only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category_id: Option<String>,
     /// Playlist name for create/update.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -46,6 +50,10 @@ pub async fn handle_spotify(
     args: HifiSpotifyTool,
 ) -> Result<CallToolResult, CallToolError> {
     let accepted = [
+        "browse_categories",
+        "browse_category_playlists",
+        "browse_featured_playlists",
+        "browse_new_releases",
         "playlists",
         "playlist_tracks",
         "saved_tracks",
@@ -70,6 +78,7 @@ pub async fn handle_spotify(
     }
     let params = json!({
         "playlist_id": args.playlist_id,
+        "category_id": args.category_id,
         "name": args.name,
         "description": args.description,
         "uri": args.uri,
@@ -84,6 +93,48 @@ pub async fn handle_spotify(
         .await
     {
         Ok(value) => Ok(env.json_result(&value)),
-        Err(e) => env.failed(format!("Spotify {} failed: {}", args.action, e)),
+        Err(error) => env.refused(
+            format!("Spotify {} failed: {}", args.action, error),
+            refusal_for_spotify_error(&error),
+        ),
+    }
+}
+
+pub(super) fn refusal_for_spotify_error(error: &anyhow::Error) -> Refusal {
+    match error.downcast_ref::<SpotifyApiError>() {
+        Some(SpotifyApiError::RateLimited { retry_after }) => Refusal::RateLimited {
+            retry_after_seconds: retry_after.map(|delay| delay.as_secs()),
+            detail: error.to_string(),
+        },
+        Some(SpotifyApiError::QuotaExceeded) => Refusal::QuotaExceeded {
+            code: "QUOTA_EXCEEDED",
+            detail: error.to_string(),
+        },
+        None => Refusal::backend_error(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn spotify_rate_and_quota_failures_have_distinct_structured_reasons() {
+        let rate = anyhow::Error::new(SpotifyApiError::RateLimited {
+            retry_after: Some(Duration::from_secs(17)),
+        });
+        let rate =
+            serde_json::to_value(refusal_for_spotify_error(&rate)).expect("rate refusal JSON");
+        assert_eq!(rate["reason"], "rate_limited");
+        assert_eq!(rate["retry_after_seconds"], 17);
+        assert!(!rate.to_string().contains("provider response body"));
+
+        let quota = anyhow::Error::new(SpotifyApiError::QuotaExceeded);
+        let quota =
+            serde_json::to_value(refusal_for_spotify_error(&quota)).expect("quota refusal JSON");
+        assert_eq!(quota["reason"], "quota_exceeded");
+        assert_eq!(quota["code"], "QUOTA_EXCEEDED");
+        assert!(!quota.to_string().contains("provider response body"));
     }
 }

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -398,11 +398,16 @@
     }
   },
   "hifi_spotify": {
-    "description": "Spotify personal-library access. Actions: playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Use hifi_search and hifi_play for catalog search, playback, and queue-add. Spotify's February 2026 Development Mode API removed categories, category playlists, featured playlists, and new releases, so this tool does not advertise or call them. The Web API can read/add to the active queue but cannot jump, reorder, remove, clear, or transfer queue contents. Transfer Playback selects one device; it is not multiroom synchronization. Playlist/library writes require the corresponding Spotify scopes.",
+    "description": "Spotify personal-library access. Actions: playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Extended Quota apps configured with UHC_SPOTIFY_QUOTA_MODE=extended may also use browse_categories, browse_category_playlists, browse_featured_playlists, and browse_new_releases; those actions are unavailable by default because Spotify removed them from the February 2026 Development Mode API. Use hifi_search and hifi_play for catalog search, playback, and queue-add. The Web API can read/add to the active queue but cannot jump, reorder, remove, clear, or transfer queue contents. Transfer Playback selects one device; it is not multiroom synchronization. Playlist/library writes require the corresponding Spotify scopes.",
     "inputSchema": {
       "properties": {
         "action": {
           "description": "Operation to perform.",
+          "type": "string"
+        },
+        "category_id": {
+          "description": "Spotify browse category id. Extended Quota mode only.",
+          "nullable": true,
           "type": "string"
         },
         "description": {

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -398,16 +398,11 @@
     }
   },
   "hifi_spotify": {
-    "description": "Spotify catalog and library access. Actions include browse_categories, browse_category_playlists, browse_featured_playlists, browse_new_releases, playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Use hifi_search and hifi_play for catalog search and playback. Playlist/library writes require the corresponding Spotify scopes.",
+    "description": "Spotify personal-library access. Actions: playlists, playlist_tracks, saved_tracks, saved_tracks_check, saved_tracks_add/remove, create_playlist, update_playlist, playlist_add/replace/remove. Use hifi_search and hifi_play for catalog search, playback, and queue-add. Spotify's February 2026 Development Mode API removed categories, category playlists, featured playlists, and new releases, so this tool does not advertise or call them. The Web API can read/add to the active queue but cannot jump, reorder, remove, clear, or transfer queue contents. Transfer Playback selects one device; it is not multiroom synchronization. Playlist/library writes require the corresponding Spotify scopes.",
     "inputSchema": {
       "properties": {
         "action": {
           "description": "Operation to perform.",
-          "type": "string"
-        },
-        "category_id": {
-          "description": "Spotify browse category id.",
-          "nullable": true,
           "type": "string"
         },
         "description": {

--- a/tests/fixtures/spotify/devices_2026.json
+++ b/tests/fixtures/spotify/devices_2026.json
@@ -1,0 +1,31 @@
+{
+  "devices": [
+    {
+      "id": null,
+      "name": "Ephemeral device without an addressable id",
+      "type": "Smartphone",
+      "is_active": false,
+      "is_restricted": false,
+      "supports_volume": true,
+      "volume_percent": 12
+    },
+    {
+      "id": "fixed-device",
+      "name": "Fixed output",
+      "type": "Speaker",
+      "is_active": false,
+      "is_restricted": false,
+      "supports_volume": false,
+      "volume_percent": 65
+    },
+    {
+      "id": "controllable-device",
+      "name": "Controllable output",
+      "type": "Speaker",
+      "is_active": true,
+      "is_restricted": false,
+      "supports_volume": true,
+      "volume_percent": 42
+    }
+  ]
+}

--- a/tests/fixtures/spotify/playlist_2026.json
+++ b/tests/fixtures/spotify/playlist_2026.json
@@ -1,0 +1,12 @@
+{
+  "id": "playlist-2",
+  "name": "New Playlist",
+  "uri": "spotify:playlist:playlist-2",
+  "description": "Made by UHC",
+  "public": false,
+  "collaborative": false,
+  "images": [],
+  "items": {
+    "total": 0
+  }
+}

--- a/tests/fixtures/spotify/quota_exceeded_2026.json
+++ b/tests/fixtures/spotify/quota_exceeded_2026.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "status": 429,
+    "message": "provider-internal-account-diagnostic-must-not-leak",
+    "reason": "QUOTA_EXCEEDED"
+  }
+}

--- a/tests/fixtures/spotify/rate_limited_2026.json
+++ b/tests/fixtures/spotify/rate_limited_2026.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "status": 429,
+    "message": "provider-rate-limit-diagnostic-must-not-leak"
+  }
+}

--- a/tests/fixtures/spotify/search_2026.json
+++ b/tests/fixtures/spotify/search_2026.json
@@ -1,0 +1,35 @@
+{
+  "tracks": {
+    "items": [
+      {
+        "id": "track-1",
+        "name": "Song",
+        "uri": "spotify:track:track-1",
+        "artists": [{"name": "Artist"}],
+        "album": {"name": "Album", "images": []},
+        "duration_ms": 180000
+      }
+    ]
+  },
+  "albums": {
+    "items": [
+      {
+        "id": "album-1",
+        "name": "Album",
+        "uri": "spotify:album:album-1",
+        "artists": [{"name": "Artist"}],
+        "images": []
+      }
+    ]
+  },
+  "artists": {
+    "items": [
+      {
+        "id": "artist-1",
+        "name": "Artist",
+        "uri": "spotify:artist:artist-1",
+        "images": []
+      }
+    ]
+  }
+}

--- a/tests/fixtures/spotify/web_api_2026_contract.json
+++ b/tests/fixtures/spotify/web_api_2026_contract.json
@@ -1,0 +1,17 @@
+{
+  "sources": {
+    "february_2026_changes": "https://developer.spotify.com/documentation/web-api/references/changes/february-2026",
+    "february_2026_migration": "https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide",
+    "july_2026_quota_update": "https://developer.spotify.com/blog/2026-07-23-web-api-quota-updates",
+    "transfer_playback": "https://developer.spotify.com/documentation/web-api/reference/transfer-a-users-playback"
+  },
+  "playlist_create_path": "/me/playlists",
+  "playlist_items_field": "items",
+  "search_limit_max": 10,
+  "removed_development_mode_browse_actions": [
+    "browse_categories",
+    "browse_category_playlists",
+    "browse_featured_playlists",
+    "browse_new_releases"
+  ]
+}

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -832,6 +832,7 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
         &[
             ("action", true),
             ("playlist_id", false),
+            ("category_id", false),
             ("name", false),
             ("description", false),
             ("uri", false),

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -832,7 +832,6 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
         &[
             ("action", true),
             ("playlist_id", false),
-            ("category_id", false),
             ("name", false),
             ("description", false),
             ("uri", false),
@@ -6067,8 +6066,8 @@ async fn every_supported_capability_reaches_that_providers_own_adapter() {
     // stopped being reported as supported, which is the direction that hides a
     // capability rather than inventing one.
     assert_eq!(
-        proved, 53,
-        "{proved} supported cells were proved end to end, expected 53. If a capability was deliberately wired or unwired, change this number in the same commit."
+        proved, 52,
+        "{proved} supported cells were proved end to end, expected 52. If a capability was deliberately wired or unwired, change this number in the same commit."
     );
 }
 

--- a/tests/spotify_adapter.rs
+++ b/tests/spotify_adapter.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use axum::{
     body::Bytes,
     extract::State,
-    http::{Method, StatusCode, Uri},
+    http::{header::CONTENT_TYPE, Method, StatusCode, Uri},
     response::{IntoResponse, Response},
     routing::any,
     Json, Router,
@@ -14,9 +14,26 @@ use tokio::net::TcpListener;
 use unified_hifi_control::adapters::spotify::{
     SpotifyAdapter, SpotifyDevice, SpotifyToken, SpotifyTokenRefresher,
 };
-use unified_hifi_control::adapters::{AdapterCommand, AdapterLogic, Startable};
+use unified_hifi_control::adapters::{AdapterCommand, AdapterLogic, LibraryAdapter, Startable};
 use unified_hifi_control::bus::RepeatMode;
 use unified_hifi_control::bus::{create_bus, BusEvent};
+use unified_hifi_control::mcp::capabilities::{support, Capability, Support};
+use unified_hifi_control::mcp::routing::ZoneTarget;
+
+const SPOTIFY_2026_CONTRACT: &str = include_str!("fixtures/spotify/web_api_2026_contract.json");
+const SPOTIFY_2026_DEVICES: &str = include_str!("fixtures/spotify/devices_2026.json");
+const SPOTIFY_2026_PLAYLIST: &str = include_str!("fixtures/spotify/playlist_2026.json");
+const SPOTIFY_2026_SEARCH: &str = include_str!("fixtures/spotify/search_2026.json");
+const SPOTIFY_2026_QUOTA: &str = include_str!("fixtures/spotify/quota_exceeded_2026.json");
+const SPOTIFY_2026_RATE_LIMIT: &str = include_str!("fixtures/spotify/rate_limited_2026.json");
+
+fn spotify_token() -> SpotifyToken {
+    SpotifyToken {
+        access_token: "access".to_string(),
+        refresh_token: None,
+        expires_at: Some(u64::MAX),
+    }
+}
 
 struct RefreshingToken;
 
@@ -35,6 +52,12 @@ impl SpotifyTokenRefresher for RefreshingToken {
 struct MockSpotifyState {
     requests: Arc<Mutex<Vec<String>>>,
     bodies: Arc<Mutex<Vec<String>>>,
+    devices_response: Arc<Mutex<Option<(StatusCode, String)>>>,
+    search_response: Arc<Mutex<Option<(StatusCode, String)>>>,
+}
+
+fn json_response(status: StatusCode, body: String) -> Response {
+    (status, [(CONTENT_TYPE, "application/json")], body).into_response()
 }
 
 async fn spotify_mock(
@@ -56,6 +79,27 @@ async fn spotify_mock(
             .push(String::from_utf8_lossy(&body).into_owned());
     }
 
+    if method == Method::GET && uri.path() == "/me/player/devices" {
+        if let Some((status, body)) = state
+            .devices_response
+            .lock()
+            .expect("devices response lock")
+            .clone()
+        {
+            return json_response(status, body);
+        }
+    }
+    if method == Method::GET && uri.path() == "/search" {
+        if let Some((status, body)) = state
+            .search_response
+            .lock()
+            .expect("search response lock")
+            .clone()
+        {
+            return json_response(status, body);
+        }
+    }
+
     match (method, uri.path()) {
         (Method::GET, "/me/player/devices") => Json(serde_json::json!({
             "devices": [{
@@ -64,6 +108,7 @@ async fn spotify_mock(
                 "type": "Speaker",
                 "is_active": true,
                 "is_restricted": false,
+                "supports_volume": true,
                 "volume_percent": 42
             }]
         }))
@@ -104,107 +149,11 @@ async fn spotify_mock(
             }]
         }))
         .into_response(),
-        (Method::GET, "/search") => Json(serde_json::json!({
-            "tracks": {
-                "items": [{
-                    "id": "track-1",
-                    "name": "Song",
-                    "uri": "spotify:track:track-1",
-                    "artists": [{"name": "Artist"}],
-                    "album": {"name": "Album", "images": []},
-                    "duration_ms": 180000
-                }]
-            },
-            "albums": {
-                "items": [{
-                    "id": "album-1",
-                    "name": "Album",
-                    "uri": "spotify:album:album-1",
-                    "artists": [{"name": "Artist"}],
-                    "images": []
-                }]
-            },
-            "artists": {
-                "items": [{
-                    "id": "artist-1",
-                    "name": "Artist",
-                    "uri": "spotify:artist:artist-1",
-                    "images": []
-                }]
-            }
-        }))
-        .into_response(),
+        (Method::GET, "/search") => json_response(StatusCode::OK, SPOTIFY_2026_SEARCH.to_string()),
         (Method::GET, "/me") => Json(serde_json::json!({
             "id": "account-1",
             "display_name": "Muness Castle",
             "email": "muness@example.test"
-        }))
-        .into_response(),
-        (Method::GET, "/browse/categories") => Json(serde_json::json!({
-            "href": "https://api.spotify.test/browse/categories",
-            "limit": 2,
-            "next": null,
-            "offset": 0,
-            "previous": null,
-            "total": 1,
-            "items": [{"id": "workout", "name": "Workout", "icons": []}]
-        }))
-        .into_response(),
-        (Method::GET, "/browse/categories/workout/playlists") => Json(serde_json::json!({
-            "href": "https://api.spotify.test/browse/categories/workout/playlists",
-            "limit": 2,
-            "next": null,
-            "offset": 0,
-            "previous": null,
-            "total": 1,
-            "items": [{
-                "id": "playlist-1",
-                "name": "Workout",
-                "uri": "spotify:playlist:playlist-1",
-                "description": "Keep moving",
-                "public": true,
-                "collaborative": false,
-                "images": []
-            }]
-        }))
-        .into_response(),
-        (Method::GET, "/browse/featured-playlists") => Json(serde_json::json!({
-            "message": "Featured",
-            "playlists": {
-                "href": "https://api.spotify.test/browse/featured-playlists",
-                "limit": 2,
-                "next": null,
-                "offset": 0,
-                "previous": null,
-                "total": 1,
-                "items": [{
-                    "id": "playlist-1",
-                    "name": "Workout",
-                    "uri": "spotify:playlist:playlist-1",
-                    "description": "Keep moving",
-                    "public": true,
-                    "collaborative": false,
-                    "images": []
-                }]
-            }
-        }))
-        .into_response(),
-        (Method::GET, "/browse/new-releases") => Json(serde_json::json!({
-            "albums": {
-                "href": "https://api.spotify.test/browse/new-releases",
-                "limit": 2,
-                "next": null,
-                "offset": 0,
-                "previous": null,
-                "total": 1,
-                "items": [{
-                    "id": "album-1",
-                    "name": "Album",
-                    "uri": "spotify:album:album-1",
-                    "artists": [{"name": "Artist"}],
-                    "images": []
-                }]
-            }
         }))
         .into_response(),
         (Method::GET, "/me/playlists") => Json(serde_json::json!({
@@ -266,17 +215,9 @@ async fn spotify_mock(
         (Method::GET, "/me/library/contains") => {
             Json(serde_json::json!([true, false])).into_response()
         }
-        (Method::POST, "/me/playlists") => Json(serde_json::json!({
-            "id": "playlist-2",
-            "name": "New Playlist",
-            "uri": "spotify:playlist:playlist-2",
-            "description": "Made by UHC",
-            "public": false,
-            "collaborative": false,
-            "images": [],
-            "tracks": {"total": 0}
-        }))
-        .into_response(),
+        (Method::POST, "/me/playlists") => {
+            json_response(StatusCode::OK, SPOTIFY_2026_PLAYLIST.to_string())
+        }
         (Method::PUT, "/playlists/playlist-1") => StatusCode::NO_CONTENT.into_response(),
         (Method::POST, "/playlists/playlist-1/items") => Json(serde_json::json!({
             "snapshot_id": "snapshot-add"
@@ -325,6 +266,7 @@ fn spotify_device_maps_to_prefixed_zone() {
         device_type: "Speaker".to_string(),
         is_active: true,
         is_restricted: false,
+        supports_volume: true,
         volume_percent: Some(42),
     };
 
@@ -344,6 +286,7 @@ fn restricted_spotify_device_is_not_controllable() {
         device_type: "Speaker".to_string(),
         is_active: false,
         is_restricted: true,
+        supports_volume: false,
         volume_percent: None,
     };
     let zone = device.to_zone(None);
@@ -616,7 +559,251 @@ async fn search_returns_track_album_and_artist_uri_targets() {
 }
 
 #[tokio::test]
-async fn catalog_playlists_saved_tracks_and_playlist_edits_use_spotify_endpoints() {
+async fn official_2026_device_shape_skips_null_ids_and_honors_supports_volume() {
+    let (base_url, mock, server) = mock_server().await;
+    *mock.devices_response.lock().expect("devices response lock") =
+        Some((StatusCode::OK, SPOTIFY_2026_DEVICES.to_string()));
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    adapter
+        .update()
+        .await
+        .expect("the current Spotify device response must be accepted");
+    let devices = adapter.get_devices().await;
+    assert_eq!(devices.len(), 2);
+    let fixed = devices
+        .iter()
+        .find(|device| device.id == "fixed-device")
+        .expect("fixed-volume device");
+    let controllable = devices
+        .iter()
+        .find(|device| device.id == "controllable-device")
+        .expect("volume-capable device");
+    assert!(fixed.to_zone(None).volume_control.is_none());
+    assert_eq!(
+        controllable
+            .to_zone(None)
+            .volume_control
+            .as_ref()
+            .map(|volume| volume.value),
+        Some(42.0)
+    );
+    let response = adapter
+        .handle_command("spotify:fixed-device", AdapterCommand::VolumeAbsolute(20))
+        .await
+        .expect("fixed device refusal");
+    assert!(!response.success);
+    assert!(response.error.expect("error").contains("does not support"));
+    assert!(!mock
+        .requests
+        .lock()
+        .expect("mock lock")
+        .iter()
+        .any(|request| request.contains("device_id=fixed-device")));
+    server.abort();
+}
+
+#[tokio::test]
+async fn search_clamps_every_request_to_the_official_2026_maximum() {
+    let contract: serde_json::Value =
+        serde_json::from_str(SPOTIFY_2026_CONTRACT).expect("Spotify contract fixture");
+    let maximum = contract["search_limit_max"]
+        .as_u64()
+        .expect("search maximum");
+    let (base_url, mock, server) = mock_server().await;
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    adapter
+        .search("Song", 50)
+        .await
+        .expect("Spotify search response");
+    let requests = mock.requests.lock().expect("mock lock").clone();
+    let search_request = requests
+        .iter()
+        .find(|request| request.starts_with("GET /search?"))
+        .expect("search request");
+    assert!(search_request.contains(&format!("limit={maximum}")));
+    assert!(!search_request.contains("limit=50"));
+    server.abort();
+}
+
+#[tokio::test]
+async fn current_playlist_shape_and_content_creation_use_me_endpoint() {
+    let contract: serde_json::Value =
+        serde_json::from_str(SPOTIFY_2026_CONTRACT).expect("Spotify contract fixture");
+    let create_path = contract["playlist_create_path"]
+        .as_str()
+        .expect("playlist create path");
+    let items_field = contract["playlist_items_field"]
+        .as_str()
+        .expect("playlist items field");
+    let (base_url, mock, server) = mock_server().await;
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    let created = LibraryAdapter::content(
+        &adapter,
+        "create_playlist",
+        &serde_json::json!({"name": "Official Current"}),
+    )
+    .await
+    .expect("content playlist creation");
+    assert_eq!(created[items_field]["total"], 0);
+    let requests = mock.requests.lock().expect("mock lock").clone();
+    assert!(requests
+        .iter()
+        .any(|request| request == &format!("POST {create_path}")));
+    assert!(!requests.iter().any(|request| request.contains("/users/")));
+    server.abort();
+}
+
+#[tokio::test]
+async fn removed_development_mode_browse_actions_refuse_without_provider_calls() {
+    let contract: serde_json::Value =
+        serde_json::from_str(SPOTIFY_2026_CONTRACT).expect("Spotify contract fixture");
+    let removed = contract["removed_development_mode_browse_actions"]
+        .as_array()
+        .expect("removed browse actions");
+    let (base_url, mock, server) = mock_server().await;
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    for action in removed {
+        let action = action.as_str().expect("action name");
+        let error = LibraryAdapter::content(
+            &adapter,
+            action,
+            &serde_json::json!({"category_id": "workout"}),
+        )
+        .await
+        .expect_err("removed Development Mode browse action must be refused");
+        let message = error.to_string();
+        assert!(message.contains("Development Mode"), "{action}: {message}");
+    }
+    assert!(adapter
+        .browse_categories(10, 0, None, None)
+        .await
+        .expect_err("removed category browse must be refused")
+        .to_string()
+        .contains("Development Mode"));
+    assert!(adapter
+        .browse_category_playlists("workout", 10, 0, None)
+        .await
+        .expect_err("removed category-playlist browse must be refused")
+        .to_string()
+        .contains("Development Mode"));
+    assert!(adapter
+        .browse_featured_playlists(10, 0, None, None, None)
+        .await
+        .expect_err("removed featured browse must be refused")
+        .to_string()
+        .contains("Development Mode"));
+    assert!(adapter
+        .browse_new_releases(10, 0, None)
+        .await
+        .expect_err("removed new-releases browse must be refused")
+        .to_string()
+        .contains("Development Mode"));
+    let requests = mock.requests.lock().expect("mock lock").clone();
+    assert!(!requests.iter().any(|request| request.contains("/browse/")));
+    server.abort();
+}
+
+#[tokio::test]
+async fn quota_exceeded_is_classified_without_exposing_the_provider_body() {
+    let (base_url, mock, server) = mock_server().await;
+    *mock.search_response.lock().expect("search response lock") = Some((
+        StatusCode::TOO_MANY_REQUESTS,
+        SPOTIFY_2026_QUOTA.to_string(),
+    ));
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    let message = adapter
+        .search("Song", 10)
+        .await
+        .expect_err("quota exhaustion must fail")
+        .to_string();
+    assert!(message.contains("QUOTA_EXCEEDED"), "{message}");
+    assert!(message.to_ascii_lowercase().contains("quota"), "{message}");
+    assert!(
+        !message.contains("provider-secret-diagnostic-marker"),
+        "{message}"
+    );
+    server.abort();
+}
+
+#[tokio::test]
+async fn ordinary_rate_limit_is_distinct_and_does_not_expose_the_provider_body() {
+    let (base_url, mock, server) = mock_server().await;
+    *mock.search_response.lock().expect("search response lock") = Some((
+        StatusCode::TOO_MANY_REQUESTS,
+        SPOTIFY_2026_RATE_LIMIT.to_string(),
+    ));
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    let message = adapter
+        .search("Song", 10)
+        .await
+        .expect_err("rate limiting must fail")
+        .to_string();
+    assert!(
+        message.to_ascii_lowercase().contains("rate limit"),
+        "{message}"
+    );
+    assert!(!message.contains("QUOTA_EXCEEDED"), "{message}");
+    assert!(
+        !message.contains("provider-rate-limit-diagnostic"),
+        "{message}"
+    );
+    server.abort();
+}
+
+#[test]
+fn spotify_capability_truth_distinguishes_removed_and_unsupported_operations() {
+    assert!(matches!(
+        support(ZoneTarget::Spotify, Capability::Browse),
+        Support::NotImplemented { .. }
+    ));
+    for capability in [
+        Capability::QueueJump,
+        Capability::QueueReorder,
+        Capability::QueueRemove,
+        Capability::QueueClear,
+        Capability::QueueTransfer,
+        Capability::MultiroomSync,
+    ] {
+        assert!(
+            matches!(
+                support(ZoneTarget::Spotify, capability),
+                Support::Unsupported { .. }
+            ),
+            "{} must be a provider limitation, not an implementation promise",
+            capability.name()
+        );
+    }
+}
+
+#[test]
+fn spotify_tool_source_does_not_advertise_removed_development_mode_actions() {
+    let contract: serde_json::Value =
+        serde_json::from_str(SPOTIFY_2026_CONTRACT).expect("Spotify contract fixture");
+    let source = include_str!("../src/mcp/tools/spotify.rs");
+    for action in contract["removed_development_mode_browse_actions"]
+        .as_array()
+        .expect("removed browse actions")
+    {
+        let action = action.as_str().expect("action name");
+        assert!(!source.contains(&format!("\"{action}\"")), "{action}");
+    }
+    assert!(source.contains("Development Mode"));
+}
+
+#[tokio::test]
+async fn playlists_saved_tracks_and_playlist_edits_use_current_spotify_endpoints() {
     let (base_url, mock, server) = mock_server().await;
     let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
     adapter
@@ -626,27 +813,6 @@ async fn catalog_playlists_saved_tracks_and_playlist_edits_use_spotify_endpoints
             expires_at: Some(u64::MAX),
         })
         .await;
-
-    let categories = adapter
-        .browse_categories(2, 0, None, None)
-        .await
-        .expect("Spotify categories");
-    assert_eq!(categories.items[0].id, "workout");
-    let category_playlists = adapter
-        .browse_category_playlists("workout", 2, 0, None)
-        .await
-        .expect("Spotify category playlists");
-    assert_eq!(category_playlists.items[0].id, "playlist-1");
-    let featured = adapter
-        .browse_featured_playlists(2, 0, None, None, None)
-        .await
-        .expect("Spotify featured playlists");
-    assert_eq!(featured.items[0].id, "playlist-1");
-    let releases = adapter
-        .browse_new_releases(2, 0, None)
-        .await
-        .expect("Spotify new releases");
-    assert_eq!(releases.items[0].id, "album-1");
 
     let playlists = adapter
         .get_playlists(2, 0)
@@ -679,6 +845,7 @@ async fn catalog_playlists_saved_tracks_and_playlist_edits_use_spotify_endpoints
         .await
         .expect("Spotify create playlist");
     assert_eq!(created.id, "playlist-2");
+    assert_eq!(created.items.as_ref().map(|items| items.total), Some(0));
     adapter
         .update_playlist("playlist-1", Some("Renamed"), Some(false), None, None)
         .await
@@ -708,18 +875,7 @@ async fn catalog_playlists_saved_tracks_and_playlist_edits_use_spotify_endpoints
         .expect("Spotify remove saved track");
 
     let requests = mock.requests.lock().expect("mock lock").clone();
-    assert!(requests
-        .iter()
-        .any(|request| request.starts_with("GET /browse/categories?")));
-    assert!(requests
-        .iter()
-        .any(|request| request.starts_with("GET /browse/categories/workout/playlists?")));
-    assert!(requests
-        .iter()
-        .any(|request| request.starts_with("GET /browse/featured-playlists?")));
-    assert!(requests
-        .iter()
-        .any(|request| request.starts_with("GET /browse/new-releases?")));
+    assert!(!requests.iter().any(|request| request.contains("/browse/")));
     assert!(requests
         .iter()
         .any(|request| request.starts_with("GET /me/playlists?")));

--- a/tests/spotify_adapter.rs
+++ b/tests/spotify_adapter.rs
@@ -5,16 +5,18 @@ use async_trait::async_trait;
 use axum::{
     body::Bytes,
     extract::State,
-    http::{header::CONTENT_TYPE, Method, StatusCode, Uri},
+    http::{header::CONTENT_TYPE, header::RETRY_AFTER, HeaderValue, Method, StatusCode, Uri},
     response::{IntoResponse, Response},
     routing::any,
     Json, Router,
 };
 use tokio::net::TcpListener;
 use unified_hifi_control::adapters::spotify::{
-    SpotifyAdapter, SpotifyDevice, SpotifyToken, SpotifyTokenRefresher,
+    SpotifyAdapter, SpotifyApiError, SpotifyDevice, SpotifyQuotaMode, SpotifyToken,
+    SpotifyTokenRefresher,
 };
 use unified_hifi_control::adapters::{AdapterCommand, AdapterLogic, LibraryAdapter, Startable};
+use unified_hifi_control::aggregator::ZoneAggregator;
 use unified_hifi_control::bus::RepeatMode;
 use unified_hifi_control::bus::{create_bus, BusEvent};
 use unified_hifi_control::mcp::capabilities::{support, Capability, Support};
@@ -54,6 +56,7 @@ struct MockSpotifyState {
     bodies: Arc<Mutex<Vec<String>>>,
     devices_response: Arc<Mutex<Option<(StatusCode, String)>>>,
     search_response: Arc<Mutex<Option<(StatusCode, String)>>>,
+    search_retry_after: Arc<Mutex<Option<String>>>,
 }
 
 fn json_response(status: StatusCode, body: String) -> Response {
@@ -96,7 +99,17 @@ async fn spotify_mock(
             .expect("search response lock")
             .clone()
         {
-            return json_response(status, body);
+            let mut response = json_response(status, body);
+            if let Some(value) = state
+                .search_retry_after
+                .lock()
+                .expect("search Retry-After lock")
+                .as_deref()
+                .and_then(|value| HeaderValue::from_str(value).ok())
+            {
+                response.headers_mut().insert(RETRY_AFTER, value);
+            }
+            return response;
         }
     }
 
@@ -212,6 +225,66 @@ async fn spotify_mock(
             }]
         }))
         .into_response(),
+        (Method::GET, "/browse/categories") => Json(serde_json::json!({
+            "href": "https://api.spotify.test/browse/categories",
+            "limit": 10,
+            "next": null,
+            "offset": 0,
+            "previous": null,
+            "total": 1,
+            "items": [{"id": "workout", "name": "Workout", "icons": []}]
+        }))
+        .into_response(),
+        (Method::GET, "/browse/categories/workout/playlists") => Json(serde_json::json!({
+            "href": "https://api.spotify.test/browse/categories/workout/playlists",
+            "limit": 10,
+            "next": null,
+            "offset": 0,
+            "previous": null,
+            "total": 1,
+            "items": [{
+                "id": "playlist-1",
+                "name": "Workout",
+                "uri": "spotify:playlist:playlist-1",
+                "images": []
+            }]
+        }))
+        .into_response(),
+        (Method::GET, "/browse/featured-playlists") => Json(serde_json::json!({
+            "playlists": {
+                "href": "https://api.spotify.test/browse/featured-playlists",
+                "limit": 10,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total": 1,
+                "items": [{
+                    "id": "featured-1",
+                    "name": "Featured",
+                    "uri": "spotify:playlist:featured-1",
+                    "images": []
+                }]
+            }
+        }))
+        .into_response(),
+        (Method::GET, "/browse/new-releases") => Json(serde_json::json!({
+            "albums": {
+                "href": "https://api.spotify.test/browse/new-releases",
+                "limit": 10,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total": 1,
+                "items": [{
+                    "id": "album-1",
+                    "name": "New Album",
+                    "uri": "spotify:album:album-1",
+                    "artists": [{"name": "Artist"}],
+                    "images": []
+                }]
+            }
+        }))
+        .into_response(),
         (Method::GET, "/me/library/contains") => {
             Json(serde_json::json!([true, false])).into_response()
         }
@@ -256,6 +329,52 @@ async fn mock_server() -> (String, MockSpotifyState, tokio::task::JoinHandle<()>
         axum::serve(listener, router).await.expect("mock serve");
     });
     (format!("http://{}", address), state, handle)
+}
+
+fn device_inventory(
+    id: &str,
+    is_restricted: bool,
+    supports_volume: bool,
+    volume_percent: Option<u8>,
+) -> String {
+    serde_json::json!({
+        "devices": [{
+            "id": id,
+            "name": "Kitchen",
+            "type": "Speaker",
+            "is_active": true,
+            "is_restricted": is_restricted,
+            "supports_volume": supports_volume,
+            "volume_percent": volume_percent
+        }]
+    })
+    .to_string()
+}
+
+async fn wait_for_zone(
+    aggregator: &ZoneAggregator,
+    zone_id: &str,
+    predicate: impl Fn(&unified_hifi_control::bus::Zone) -> bool,
+) -> unified_hifi_control::bus::Zone {
+    for _ in 0..100 {
+        if let Some(zone) = aggregator.get_zone(zone_id).await {
+            if predicate(&zone) {
+                return zone;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("zone {zone_id:?} did not reach the expected state");
+}
+
+async fn wait_for_volume_capability(aggregator: &ZoneAggregator, zone_id: &str, expected: bool) {
+    for _ in 0..100 {
+        if aggregator.has_volume_control(zone_id).await == Some(expected) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("zone {zone_id:?} did not report volume capability {expected}");
 }
 
 #[test]
@@ -605,6 +724,102 @@ async fn official_2026_device_shape_skips_null_ids_and_honors_supports_volume() 
 }
 
 #[tokio::test]
+async fn same_id_device_capability_transitions_replace_aggregator_truth() {
+    let (base_url, mock, server) = mock_server().await;
+    *mock.devices_response.lock().expect("devices response lock") = Some((
+        StatusCode::OK,
+        device_inventory("changing-device", false, true, Some(42)),
+    ));
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run_with_ready(ready_tx).await })
+    };
+    ready_rx.await.expect("aggregator ready");
+    let adapter = SpotifyAdapter::with_base_url(bus, base_url);
+    adapter.set_token(spotify_token()).await;
+
+    adapter.update().await.expect("initial device poll");
+    let initial = wait_for_zone(&aggregator, "spotify:changing-device", |zone| {
+        zone.is_controllable && zone.volume_control.is_some()
+    })
+    .await;
+    assert_eq!(
+        initial.volume_control.as_ref().map(|volume| volume.value),
+        Some(42.0)
+    );
+    wait_for_volume_capability(&aggregator, "spotify:changing-device", true).await;
+
+    *mock.devices_response.lock().expect("devices response lock") = Some((
+        StatusCode::OK,
+        device_inventory("changing-device", true, false, Some(42)),
+    ));
+    adapter.update().await.expect("restricted device poll");
+    let restricted = wait_for_zone(&aggregator, "spotify:changing-device", |zone| {
+        !zone.is_controllable && zone.volume_control.is_none()
+    })
+    .await;
+    assert!(!restricted.is_play_allowed);
+    wait_for_volume_capability(&aggregator, "spotify:changing-device", false).await;
+
+    *mock.devices_response.lock().expect("devices response lock") = Some((
+        StatusCode::OK,
+        device_inventory("changing-device", false, true, Some(55)),
+    ));
+    adapter.update().await.expect("recovered device poll");
+    let recovered = wait_for_zone(&aggregator, "spotify:changing-device", |zone| {
+        zone.is_controllable
+            && zone
+                .volume_control
+                .as_ref()
+                .is_some_and(|volume| volume.value == 55.0)
+    })
+    .await;
+    assert!(recovered.is_play_allowed);
+    wait_for_volume_capability(&aggregator, "spotify:changing-device", true).await;
+
+    aggregator_task.abort();
+    server.abort();
+}
+
+#[tokio::test]
+async fn supports_volume_without_current_value_is_capable_without_inventing_a_value() {
+    let (base_url, mock, server) = mock_server().await;
+    *mock.devices_response.lock().expect("devices response lock") = Some((
+        StatusCode::OK,
+        device_inventory("unknown-volume", false, true, None),
+    ));
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let aggregator_task = {
+        let aggregator = aggregator.clone();
+        tokio::spawn(async move { aggregator.run_with_ready(ready_tx).await })
+    };
+    ready_rx.await.expect("aggregator ready");
+    let adapter = SpotifyAdapter::with_base_url(bus, base_url);
+    adapter.set_token(spotify_token()).await;
+
+    adapter.update().await.expect("device poll");
+    let zone = wait_for_zone(&aggregator, "spotify:unknown-volume", |_| true).await;
+    assert!(
+        zone.volume_control.is_none(),
+        "an unknown current value must not be fabricated"
+    );
+    wait_for_volume_capability(&aggregator, "spotify:unknown-volume", true).await;
+    let result = adapter
+        .handle_command("spotify:unknown-volume", AdapterCommand::VolumeAbsolute(25))
+        .await
+        .expect("absolute volume response");
+    assert!(result.success, "absolute volume failed: {:?}", result.error);
+
+    aggregator_task.abort();
+    server.abort();
+}
+
+#[tokio::test]
 async fn search_clamps_every_request_to_the_official_2026_maximum() {
     let contract: serde_json::Value =
         serde_json::from_str(SPOTIFY_2026_CONTRACT).expect("Spotify contract fixture");
@@ -712,6 +927,71 @@ async fn removed_development_mode_browse_actions_refuse_without_provider_calls()
 }
 
 #[tokio::test]
+async fn explicit_extended_quota_mode_preserves_legacy_browse_calls() {
+    let (base_url, mock, server) = mock_server().await;
+    let adapter = SpotifyAdapter::with_base_url_and_quota_mode(
+        create_bus(),
+        base_url,
+        SpotifyQuotaMode::Extended,
+    );
+    adapter.set_token(spotify_token()).await;
+
+    let categories = adapter
+        .browse_categories(10, 0, None, None)
+        .await
+        .expect("Extended mode categories");
+    assert_eq!(categories.items[0].id, "workout");
+    let category_playlists = adapter
+        .browse_category_playlists("workout", 10, 0, None)
+        .await
+        .expect("Extended mode category playlists");
+    assert_eq!(category_playlists.items[0].id, "playlist-1");
+    let featured = adapter
+        .browse_featured_playlists(10, 0, None, None, None)
+        .await
+        .expect("Extended mode featured playlists");
+    assert_eq!(featured.items[0].id, "featured-1");
+    let releases = adapter
+        .browse_new_releases(10, 0, None)
+        .await
+        .expect("Extended mode new releases");
+    assert_eq!(releases.items[0].id, "album-1");
+
+    let content = LibraryAdapter::content(
+        &adapter,
+        "browse_category_playlists",
+        &serde_json::json!({"category_id": "workout", "limit": 10}),
+    )
+    .await
+    .expect("Extended mode MCP content bridge");
+    assert_eq!(content["items"][0]["id"], "playlist-1");
+
+    let requests = mock.requests.lock().expect("mock lock").clone();
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.contains("/browse/"))
+            .count(),
+        5
+    );
+    server.abort();
+}
+
+#[test]
+fn quota_mode_configuration_defaults_to_development_and_is_explicit() {
+    assert_eq!(SpotifyQuotaMode::default(), SpotifyQuotaMode::Development);
+    assert_eq!(
+        SpotifyQuotaMode::parse("development").expect("Development mode"),
+        SpotifyQuotaMode::Development
+    );
+    assert_eq!(
+        SpotifyQuotaMode::parse("extended").expect("Extended mode"),
+        SpotifyQuotaMode::Extended
+    );
+    assert!(SpotifyQuotaMode::parse("legacy").is_err());
+}
+
+#[tokio::test]
 async fn quota_exceeded_is_classified_without_exposing_the_provider_body() {
     let (base_url, mock, server) = mock_server().await;
     *mock.search_response.lock().expect("search response lock") = Some((
@@ -762,6 +1042,97 @@ async fn ordinary_rate_limit_is_distinct_and_does_not_expose_the_provider_body()
     server.abort();
 }
 
+#[tokio::test]
+async fn rate_limit_carries_retry_after_and_suppresses_requests_during_backoff() {
+    let (base_url, mock, server) = mock_server().await;
+    *mock.search_response.lock().expect("search response lock") = Some((
+        StatusCode::TOO_MANY_REQUESTS,
+        SPOTIFY_2026_RATE_LIMIT.to_string(),
+    ));
+    *mock
+        .search_retry_after
+        .lock()
+        .expect("search Retry-After lock") = Some("120".to_string());
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    let first = adapter
+        .search("Song", 10)
+        .await
+        .expect_err("rate limit must fail");
+    assert!(matches!(
+        first.downcast_ref::<SpotifyApiError>(),
+        Some(SpotifyApiError::RateLimited {
+            retry_after: Some(delay)
+        }) if *delay == Duration::from_secs(120)
+    ));
+    let second = adapter
+        .search("Song", 10)
+        .await
+        .expect_err("backoff must reject locally");
+    assert!(matches!(
+        second.downcast_ref::<SpotifyApiError>(),
+        Some(SpotifyApiError::RateLimited {
+            retry_after: Some(delay)
+        }) if *delay <= Duration::from_secs(120) && !delay.is_zero()
+    ));
+    let search_requests = mock
+        .requests
+        .lock()
+        .expect("mock lock")
+        .iter()
+        .filter(|request| request.starts_with("GET /search?"))
+        .count();
+    assert_eq!(search_requests, 1, "backoff must prevent another API call");
+    assert!(!second
+        .to_string()
+        .contains("provider-rate-limit-diagnostic"));
+    server.abort();
+}
+
+#[tokio::test]
+async fn quota_exhaustion_is_typed_and_suppresses_repeated_requests() {
+    let (base_url, mock, server) = mock_server().await;
+    *mock.search_response.lock().expect("search response lock") = Some((
+        StatusCode::TOO_MANY_REQUESTS,
+        SPOTIFY_2026_QUOTA.to_string(),
+    ));
+    let adapter = SpotifyAdapter::with_base_url(create_bus(), base_url);
+    adapter.set_token(spotify_token()).await;
+
+    let first = adapter
+        .search("Song", 10)
+        .await
+        .expect_err("quota exhaustion must fail");
+    assert!(matches!(
+        first.downcast_ref::<SpotifyApiError>(),
+        Some(SpotifyApiError::QuotaExceeded)
+    ));
+    let second = adapter
+        .search("Song", 10)
+        .await
+        .expect_err("quota gate must reject locally");
+    assert!(matches!(
+        second.downcast_ref::<SpotifyApiError>(),
+        Some(SpotifyApiError::QuotaExceeded)
+    ));
+    let search_requests = mock
+        .requests
+        .lock()
+        .expect("mock lock")
+        .iter()
+        .filter(|request| request.starts_with("GET /search?"))
+        .count();
+    assert_eq!(
+        search_requests, 1,
+        "quota gate must prevent another API call"
+    );
+    assert!(!second
+        .to_string()
+        .contains("provider-secret-diagnostic-marker"));
+    server.abort();
+}
+
 #[test]
 fn spotify_capability_truth_distinguishes_removed_and_unsupported_operations() {
     assert!(matches!(
@@ -788,7 +1159,7 @@ fn spotify_capability_truth_distinguishes_removed_and_unsupported_operations() {
 }
 
 #[test]
-fn spotify_tool_source_does_not_advertise_removed_development_mode_actions() {
+fn spotify_tool_source_marks_legacy_browse_actions_as_extended_only() {
     let contract: serde_json::Value =
         serde_json::from_str(SPOTIFY_2026_CONTRACT).expect("Spotify contract fixture");
     let source = include_str!("../src/mcp/tools/spotify.rs");
@@ -797,9 +1168,11 @@ fn spotify_tool_source_does_not_advertise_removed_development_mode_actions() {
         .expect("removed browse actions")
     {
         let action = action.as_str().expect("action name");
-        assert!(!source.contains(&format!("\"{action}\"")), "{action}");
+        assert!(source.contains(&format!("\"{action}\"")), "{action}");
     }
     assert!(source.contains("Development Mode"));
+    assert!(source.contains("Extended Quota"));
+    assert!(source.contains("UHC_SPOTIFY_QUOTA_MODE=extended"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #642\n\n## Summary\n\n- update Spotify playlist creation and response parsing for the 2026 Web API contract\n- clamp search requests to 10 and retire removed Development Mode browse calls and MCP advertising\n- classify quota exhaustion separately from ordinary rate limits without leaking provider response bodies\n- tolerate nullable device IDs and honor supports_volume for discovery and control\n- make Spotify queue and multiroom capability documentation truthful\n\n## Verification\n\n- failing-first Spotify contract tests: 7 expected failures before implementation, plus an ordinary-rate-limit red test\n- cargo fmt --check\n- cargo clippy -- -D warnings\n- cargo test --workspace\n- cargo test --test spotify_adapter (24 passed)\n- API route contract unchanged\n- encrypted credential persistence suite passed as part of the workspace run\n- manual staged-diff review completed; sg review is not installed in this environment\n\n## External evidence\n\nA real Development Mode Premium smoke covering consent, refresh, discovery, restricted and non-volume devices, transport, and queue behavior remains required before release readiness can be claimed.