### PR TITLE
Run CI for streaming alpha pull requests

### DIFF
--- a/.github/workflows/api-guard.yml
+++ b/.github/workflows/api-guard.yml
@@ -2,7 +2,7 @@ name: API Guard
 
 on:
   pull_request:
-    branches: [master, v3]
+    branches: [master, v3, 'integration/streaming-ha-alpha']
     paths:
       - 'src/main.rs'
       - 'src/api/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   pull_request:
-    branches: [master, v3]
+    branches: [master, v3, 'integration/streaming-ha-alpha']
     types: [opened, synchronize, reopened, labeled]
   push:
     branches: [v3, 'feature/**']

--- a/.github/workflows/ha-integration.yml
+++ b/.github/workflows/ha-integration.yml
@@ -4,20 +4,19 @@ name: Home Assistant integration
 # package. This job is intentionally independent of the Rust crate's
 # build/CI (build.yml) since it has its own toolchain and dependencies.
 #
-# Note: feature-branch PRs in this repo do not currently run CI checks
-# (see AGENTS.md / stacked-PR workflow notes); this workflow becomes
-# active once merged to v3.
+# The streaming/companion alpha branch is also an active integration target;
+# changes there need the same package-level evidence before review.
 
 on:
   push:
-    branches: [v3]
+    branches: [v3, 'integration/streaming-ha-alpha']
     paths:
       - "custom_components/unified_hifi_control/**"
       - "hacs.json"
       - "pyproject.toml"
       - ".github/workflows/ha-integration.yml"
   pull_request:
-    branches: [v3]
+    branches: [v3, 'integration/streaming-ha-alpha']
     paths:
       - "custom_components/unified_hifi_control/**"
       - "hacs.json"

--- a/tests/ci_workflow_contract.rs
+++ b/tests/ci_workflow_contract.rs
@@ -1,0 +1,46 @@
+use std::{fs, path::PathBuf};
+
+const ALPHA: &str = "integration/streaming-ha-alpha";
+
+fn workflow(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".github/workflows")
+        .join(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+#[test]
+fn alpha_pull_requests_run_rust_and_api_contract_checks() {
+    for name in ["build.yml", "api-guard.yml"] {
+        let source = workflow(name);
+        let pull_request = source
+            .split("pull_request:")
+            .nth(1)
+            .unwrap_or_else(|| panic!("{name} has no pull_request trigger"));
+        let trigger = pull_request.split("jobs:").next().unwrap_or(pull_request);
+        assert!(
+            trigger.contains(ALPHA),
+            "{name} must run for pull requests targeting {ALPHA}"
+        );
+    }
+}
+
+#[test]
+fn alpha_home_assistant_changes_run_the_ha_workflow() {
+    let source = workflow("ha-integration.yml");
+    assert_eq!(
+        source.matches(ALPHA).count(),
+        2,
+        "HA integration must cover alpha push and pull-request triggers"
+    );
+}
+
+#[test]
+fn alpha_does_not_enable_edge_image_publication() {
+    let source = workflow("docker.yml");
+    assert!(
+        !source.contains(ALPHA),
+        "alpha work must not enter the Docker edge publication workflow"
+    );
+}


### PR DESCRIPTION
Fixes #648

## What changed

- run the existing Build workflow for pull requests targeting `integration/streaming-ha-alpha`
- apply the existing API Guard contract policy to alpha PRs
- run Home Assistant integration checks for alpha pushes and pull requests when HA paths change
- add a deterministic Rust contract test for the workflow trigger boundary
- keep alpha out of the Docker edge publication workflow and leave optional release/package jobs disabled unless their existing explicit triggers fire

## Test evidence

- failing-first: `cargo test --test ci_workflow_contract` failed because all three alpha trigger assertions were absent
- passing: `cargo test --test ci_workflow_contract`
- `cargo fmt --check`
- `git diff --check`

`actionlint` is not installed on the development host; the GitHub workflow parser is the remote syntax proof. No API route or runtime behavior changed.

No merge requested.
