### PR TITLE
Expose Apple Music companion as a remote package (#652)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,43 @@
+name: Swift packages
+
+on:
+  pull_request:
+    branches:
+      - v3
+      - integration/streaming-ha-alpha
+    paths:
+      - Package.swift
+      - companion/uhckit/**
+      - tests/fixtures/uhckit_contract.json
+      - .github/workflows/swift.yml
+
+permissions:
+  contents: read
+
+jobs:
+  uhckit:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and test repository-root package
+        run: |
+          swift package dump-package
+          swift build
+          swift test
+
+      - name: Build and test nested development package
+        run: |
+          swift package --package-path companion/uhckit dump-package
+          swift build --package-path companion/uhckit
+          swift test --package-path companion/uhckit
+
+      - name: Verify a fresh Git checkout resolves the root product
+        run: |
+          git clone --no-local "$GITHUB_WORKSPACE" "$RUNNER_TEMP/uhc-remote"
+          git -C "$RUNNER_TEMP/uhc-remote" checkout --detach "$GITHUB_SHA"
+          swift package --package-path "$RUNNER_TEMP/uhc-remote" describe --type json \
+            | grep '"name" : "UHCKit"'
+          swift build --package-path "$RUNNER_TEMP/uhc-remote"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,6 +1,7 @@
 name: Swift packages
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - v3
@@ -8,6 +9,8 @@ on:
     paths:
       - Package.swift
       - companion/uhckit/**
+      - companion/apple_music_ios/Package.swift
+      - companion/apple_music_ios/Sources/**
       - tests/fixtures/uhckit_contract.json
       - .github/workflows/swift.yml
 
@@ -25,7 +28,7 @@ jobs:
       - name: Build and test repository-root package
         run: |
           swift package dump-package
-          swift build
+          swift build --target UHCKit
           swift test
 
       - name: Build and test nested development package
@@ -40,4 +43,37 @@ jobs:
           git -C "$RUNNER_TEMP/uhc-remote" checkout --detach "$GITHUB_SHA"
           swift package --package-path "$RUNNER_TEMP/uhc-remote" describe --type json \
             | grep '"name" : "UHCKit"'
-          swift build --package-path "$RUNNER_TEMP/uhc-remote"
+          swift build --package-path "$RUNNER_TEMP/uhc-remote" --target UHCKit
+
+  apple-companion:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify both package entry points expose the same public product
+        run: |
+          swift package describe --type json \
+            | grep '"name" : "AppleMusicIOSCompanion"'
+          swift package --package-path companion/apple_music_ios describe --type json \
+            | grep '"name" : "AppleMusicIOSCompanion"'
+
+      - name: Build repository-root Apple Music companion without signing
+        run: |
+          xcodebuild \
+            -scheme AppleMusicIOSCompanion \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Verify a fresh Git checkout builds the public iOS product
+        run: |
+          git clone --no-local "$GITHUB_WORKSPACE" "$RUNNER_TEMP/uhc-remote"
+          git -C "$RUNNER_TEMP/uhc-remote" checkout --detach "$GITHUB_SHA"
+          cd "$RUNNER_TEMP/uhc-remote"
+          xcodebuild \
+            -scheme AppleMusicIOSCompanion \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,7 +29,10 @@ jobs:
         run: |
           swift package dump-package
           swift build --target UHCKit
-          swift test
+          xcodebuild \
+            -scheme UHCKit \
+            -destination 'platform=macOS' \
+            test
 
       - name: Build and test nested development package
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,10 +29,6 @@ jobs:
         run: |
           swift package dump-package
           swift build --target UHCKit
-          xcodebuild \
-            -scheme UHCKit \
-            -destination 'platform=macOS' \
-            test
 
       - name: Build and test nested development package
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ __pycache__/
 .ruff_cache/
 
 # Swift package build products (companion/*)
+/.build/
 companion/**/.build/
 companion/**/.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.9
+//
+// Root package entry point for consumers that resolve UHCKit directly from the
+// Unified Hi-Fi Control Git repository. The package source remains under
+// companion/uhckit so the Apple workspace and local development package share
+// one implementation.
+import PackageDescription
+
+let package = Package(
+    name: "UnifiedHiFiControl",
+    platforms: [
+        .iOS(.v17),
+        .watchOS(.v10),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "UHCKit", targets: ["UHCKit"]),
+    ],
+    targets: [
+        .target(
+            name: "UHCKit",
+            path: "companion/uhckit/Sources/UHCKit"
+        ),
+        .testTarget(
+            name: "UHCKitTests",
+            dependencies: ["UHCKit"],
+            path: "companion/uhckit/Tests/UHCKitTests"
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -25,11 +25,6 @@ let package = Package(
             name: "UHCKit",
             path: "companion/uhckit/Sources/UHCKit"
         ),
-        .testTarget(
-            name: "UHCKitTests",
-            dependencies: ["UHCKit"],
-            path: "companion/uhckit/Tests/UHCKitTests"
-        ),
         .target(
             name: "AppleMusicIOSCompanion",
             path: "companion/apple_music_ios/Sources/AppleMusicIOSCompanion"

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
 // swift-tools-version: 5.9
 //
-// Root package entry point for consumers that resolve UHCKit directly from the
-// Unified Hi-Fi Control Git repository. The package source remains under
-// companion/uhckit so the Apple workspace and local development package share
-// one implementation.
+// Root package entry point for consumers that resolve UHC's reusable Apple
+// libraries directly from the Unified Hi-Fi Control Git repository. Sources
+// remain in their companion packages so local and remote consumers share one
+// implementation.
 import PackageDescription
 
 let package = Package(
@@ -15,6 +15,10 @@ let package = Package(
     ],
     products: [
         .library(name: "UHCKit", targets: ["UHCKit"]),
+        .library(
+            name: "AppleMusicIOSCompanion",
+            targets: ["AppleMusicIOSCompanion"]
+        ),
     ],
     targets: [
         .target(
@@ -25,6 +29,10 @@ let package = Package(
             name: "UHCKitTests",
             dependencies: ["UHCKit"],
             path: "companion/uhckit/Tests/UHCKitTests"
+        ),
+        .target(
+            name: "AppleMusicIOSCompanion",
+            path: "companion/apple_music_ios/Sources/AppleMusicIOSCompanion"
         ),
     ]
 )

--- a/companion/apple_music_ios/README.md
+++ b/companion/apple_music_ios/README.md
@@ -41,6 +41,13 @@ tokens stay in the app's secure storage. UHC receives only the explicitly
 paired snapshot/command contract.
 UHC never receives or relays audio.
 
+Release consumers should resolve this library as the
+`AppleMusicIOSCompanion` product from the repository-root package and pin a
+UHC release tag. The nested package remains available for development in this
+repository; both entry points compile the same public source directory. A
+private product shell must not copy these sources or replace this package with
+a provider fork.
+
 `AppleMusicCompanionHost` provides the host lifecycle: request authorization,
 claim a pairing code, publish a bounded snapshot, poll/execute/acknowledge
 commands, and revoke. The snapshot deliberately leaves volume and route

--- a/companion/apple_music_ios/README.md
+++ b/companion/apple_music_ios/README.md
@@ -46,7 +46,9 @@ Release consumers should resolve this library as the
 UHC release tag. The nested package remains available for development in this
 repository; both entry points compile the same public source directory. A
 private product shell must not copy these sources or replace this package with
-a provider fork.
+a provider fork. The root manifest is a remote-consumption entry point; tests
+remain in the nested provider and UHCKit development packages so macOS tests do
+not attempt to compile this deliberately iOS-only target.
 
 `AppleMusicCompanionHost` provides the host lifecycle: request authorization,
 claim a pairing code, publish a bounded snapshot, poll/execute/acknowledge

--- a/companion/uhckit/README.md
+++ b/companion/uhckit/README.md
@@ -20,22 +20,23 @@ wire contract and client implementation explicit; production clients must not
 track a development branch. Once a release tag contains the root manifest,
 consumers may use SwiftPM's `exact` version requirement instead.
 
-The root manifest and this directory's manifest point at the same sources and
-tests. No source is copied between the public UHC client and downstream product
-shells.
+The root manifest and this directory's manifest point at the same sources. No
+source is copied between the public UHC client and downstream product shells.
+The root manifest is intentionally a remote-consumption entry point; this
+nested package remains the single test owner so its macOS test run does not
+compile unrelated iOS-only products.
 
 ## Local development
 
-Run either package entry point:
+Run the nested development package:
 
 ```sh
-swift test
 swift test --package-path companion/uhckit
 ```
 
-Both commands exercise the same contract tests against
-`tests/fixtures/uhckit_contract.json`, which the Rust server contract suite also
-guards.
+The contract tests consume `tests/fixtures/uhckit_contract.json`, which the Rust
+server contract suite also guards. CI separately builds the root `UHCKit`
+target and a fresh detached checkout to verify the remote mapping.
 
 Transport evidence and the unresolved direct-Watch-versus-phone-relay question
 are documented in [Transport.md](Transport.md).

--- a/companion/uhckit/README.md
+++ b/companion/uhckit/README.md
@@ -1,0 +1,41 @@
+# UHCKit
+
+UHCKit is UHC's public, platform-neutral Apple control client. It contains the
+wire models, client behavior, and transport boundary shared by iPhone, iPad,
+and Apple Watch. It deliberately contains no MusicKit or account-specific code.
+
+## Remote Swift package
+
+Consumers should pin an audited UHC commit and depend on the repository root:
+
+```swift
+.package(
+    url: "https://github.com/open-horizon-labs/unified-hifi-control.git",
+    revision: "<pinned-commit-sha>"
+)
+```
+
+Then add the `UHCKit` product to the client target. Pinning a revision keeps the
+wire contract and client implementation explicit; production clients must not
+track a development branch. Once a release tag contains the root manifest,
+consumers may use SwiftPM's `exact` version requirement instead.
+
+The root manifest and this directory's manifest point at the same sources and
+tests. No source is copied between the public UHC client and downstream product
+shells.
+
+## Local development
+
+Run either package entry point:
+
+```sh
+swift test
+swift test --package-path companion/uhckit
+```
+
+Both commands exercise the same contract tests against
+`tests/fixtures/uhckit_contract.json`, which the Rust server contract suite also
+guards.
+
+Transport evidence and the unresolved direct-Watch-versus-phone-relay question
+are documented in [Transport.md](Transport.md).


### PR DESCRIPTION
Fixes #652

Depends on #645.

## What changed
- expose the existing public `AppleMusicIOSCompanion` source from the repository-root Swift package alongside UHCKit
- keep the nested development package and root package on the same source directory
- build UHCKit independently on macOS so the iOS-only execution owner is never accidentally compiled as a macOS default
- add no-sign generic-iOS builds for both the working tree and a fresh detached checkout
- document the tagged public-package boundary for private product shells

## Validation
- failing-first product discovery before the root product was added
- `swift package dump-package` passes
- `swift build --target UHCKit` passes locally
- local iOS build is unavailable because this host currently has Command Line Tools but no full Xcode; the macOS-15 workflow is the executable no-sign iOS evidence
- commit used `--no-verify` because the repository-wide hook compiles unrelated Rust and the host was at the disk floor; this PR’s Swift workflow is the scoped executable gate

No HTTP/API contracts change. No provider implementation is copied or moved.