### PR TITLE
fix: separate HiPhi session and command grant authorities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -949,7 +949,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: binary-macos-x64
-          path: target/x86_64-apple-darwin/release/unified-hifi-control
+          path: |
+            target/x86_64-apple-darwin/release/unified-hifi-control
+            target/x86_64-apple-darwin/release/uhc-hiphi-pair
           retention-days: 5
 
   build-macos-arm64:
@@ -1005,7 +1007,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: binary-macos-arm64
-          path: target/aarch64-apple-darwin/release/unified-hifi-control
+          path: |
+            target/aarch64-apple-darwin/release/unified-hifi-control
+            target/aarch64-apple-darwin/release/uhc-hiphi-pair
           retention-days: 5
 
   build-macos-universal:
@@ -1037,7 +1041,12 @@ jobs:
             x64/unified-hifi-control \
             arm64/unified-hifi-control \
             -output dist/bin/unified-hifi-macos-universal
+          lipo -create \
+            x64/uhc-hiphi-pair \
+            arm64/uhc-hiphi-pair \
+            -output dist/bin/uhc-hiphi-pair-macos-universal
           file dist/bin/unified-hifi-macos-universal
+          file dist/bin/uhc-hiphi-pair-macos-universal
 
       - name: Upload binary
         uses: actions/upload-artifact@v7
@@ -1222,6 +1231,7 @@ jobs:
         run: |
           mkdir -p dist/bin
           cp target/release/unified-hifi-control.exe dist/bin/unified-hifi-win64.exe
+          cp target/release/uhc-hiphi-pair.exe dist/bin/uhc-hiphi-pair-win64.exe
 
       # Windows Authenticode signing (issue #561): deferred until Windows
       # matters commercially. Prepared but inactive - gated on
@@ -1231,7 +1241,7 @@ jobs:
       # populate those two secrets for a traditional PFX cert, or swap this
       # step for azure/trusted-signing-action and its AZURE_TRUSTED_SIGNING_*
       # secrets - both are viable, pick whichever the owner buys.
-      - name: Sign Windows binary (Authenticode)
+      - name: Sign Windows binaries (Authenticode)
         if: ${{ env.HAS_WINDOWS_CERT == 'true' }}
         shell: bash
         env:
@@ -1245,7 +1255,9 @@ jobs:
             exit 1
           fi
           "$SIGNTOOL" sign /f cert.pfx /p "$CERT_PASSWORD" /tr http://timestamp.digicert.com /td sha256 /fd sha256 dist/bin/unified-hifi-win64.exe
+          "$SIGNTOOL" sign /f cert.pfx /p "$CERT_PASSWORD" /tr http://timestamp.digicert.com /td sha256 /fd sha256 dist/bin/uhc-hiphi-pair-win64.exe
           "$SIGNTOOL" verify /pa dist/bin/unified-hifi-win64.exe
+          "$SIGNTOOL" verify /pa dist/bin/uhc-hiphi-pair-win64.exe
           rm -f cert.pfx
 
       - name: Note unsigned Windows binary
@@ -1334,26 +1346,35 @@ jobs:
           # All use same name so LMS findBin('unified-hifi-control') works
           if [ -f ../binaries/unified-hifi-linux-x64 ]; then
             cp ../binaries/unified-hifi-linux-x64 Bin/x86_64-linux/unified-hifi-control
+            cp ../binaries/uhc-hiphi-pair-x64 Bin/x86_64-linux/uhc-hiphi-pair
             chmod +x Bin/x86_64-linux/unified-hifi-control
+            chmod +x Bin/x86_64-linux/uhc-hiphi-pair
           fi
 
           if [ -f ../binaries/unified-hifi-linux-arm64 ]; then
             cp ../binaries/unified-hifi-linux-arm64 Bin/aarch64-linux/unified-hifi-control
+            cp ../binaries/uhc-hiphi-pair-arm64 Bin/aarch64-linux/uhc-hiphi-pair
             chmod +x Bin/aarch64-linux/unified-hifi-control
+            chmod +x Bin/aarch64-linux/uhc-hiphi-pair
           fi
 
           if [ -f ../binaries/unified-hifi-linux-armv7 ]; then
             cp ../binaries/unified-hifi-linux-armv7 Bin/arm-linux/unified-hifi-control
+            cp ../binaries/uhc-hiphi-pair-armv7 Bin/arm-linux/uhc-hiphi-pair
             chmod +x Bin/arm-linux/unified-hifi-control
+            chmod +x Bin/arm-linux/uhc-hiphi-pair
           fi
 
           if [ -f ../binaries/unified-hifi-macos-universal ]; then
             cp ../binaries/unified-hifi-macos-universal Bin/darwin/unified-hifi-control
+            cp ../binaries/uhc-hiphi-pair-macos-universal Bin/darwin/uhc-hiphi-pair
             chmod +x Bin/darwin/unified-hifi-control
+            chmod +x Bin/darwin/uhc-hiphi-pair
           fi
 
           if [ -f ../binaries/unified-hifi-win64.exe ]; then
             cp ../binaries/unified-hifi-win64.exe Bin/MSWin32-x64-multi-thread/unified-hifi-control.exe
+            cp ../binaries/uhc-hiphi-pair-win64.exe Bin/MSWin32-x64-multi-thread/uhc-hiphi-pair.exe
           fi
 
           # Note: Web assets are embedded in the binary (ADR 002)
@@ -1410,10 +1431,12 @@ jobs:
             cpu_arch: x86_64
             target: x86_64-unknown-linux-musl
             binary: unified-hifi-linux-x64
+            pairing_helper: uhc-hiphi-pair-x64
           - arch: armv8
             cpu_arch: armv8
             target: aarch64-unknown-linux-musl
             binary: unified-hifi-linux-arm64
+            pairing_helper: uhc-hiphi-pair-arm64
     steps:
       - uses: actions/checkout@v6
 
@@ -1438,6 +1461,7 @@ jobs:
             "${{ needs.plan.outputs.version }}" \
             "${{ matrix.arch }}" \
             "dist/synology-binary/${{ matrix.binary }}" \
+            "dist/synology-binary/${{ matrix.pairing_helper }}" \
             "dist/installers/${SPK_NAME}"
 
       - name: Upload Synology package
@@ -1630,6 +1654,7 @@ jobs:
       - name: Prepare binary
         run: |
           mv binaries/unified-hifi-linux-x64 binaries/unified-hifi-linux-amd64
+          mv binaries/uhc-hiphi-pair-x64 binaries/uhc-hiphi-pair-amd64
           chmod +x binaries/*
           ls -la binaries/
 
@@ -1680,14 +1705,17 @@ jobs:
             target: x86_64-unknown-linux-musl
             binary: unified-hifi-linux-x64
             arch: amd64
+            pairing_helper: uhc-hiphi-pair-x64
           - platform: linux/arm64
             target: aarch64-unknown-linux-musl
             binary: unified-hifi-linux-arm64
             arch: arm64
+            pairing_helper: uhc-hiphi-pair-arm64
           - platform: linux/arm/v7
             target: armv7-unknown-linux-musleabihf
             binary: unified-hifi-linux-armv7
             arch: armv7
+            pairing_helper: uhc-hiphi-pair-armv7
     steps:
       - uses: actions/checkout@v6
 
@@ -1700,7 +1728,8 @@ jobs:
       - name: Prepare binary
         run: |
           mv dist/${{ matrix.binary }} dist/unified-hifi-control
-          chmod +x dist/unified-hifi-control
+          mv dist/${{ matrix.pairing_helper }} dist/uhc-hiphi-pair
+          chmod +x dist/unified-hifi-control dist/uhc-hiphi-pair
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -1847,6 +1876,7 @@ jobs:
             -a amd64 \
             --after-install build/linux/postinst.sh \
             dist/bin/unified-hifi-linux-x64=/usr/bin/unified-hifi-control \
+            dist/bin/uhc-hiphi-pair-x64=/usr/bin/uhc-hiphi-pair \
             build/linux/unified-hifi-control.service=/etc/systemd/system/unified-hifi-control.service
 
       - name: Build rpm package (x64)
@@ -1860,6 +1890,7 @@ jobs:
             -a x86_64 \
             --after-install build/linux/postinst.sh \
             dist/bin/unified-hifi-linux-x64=/usr/bin/unified-hifi-control \
+            dist/bin/uhc-hiphi-pair-x64=/usr/bin/uhc-hiphi-pair \
             build/linux/unified-hifi-control.service=/etc/systemd/system/unified-hifi-control.service
 
       - name: Build deb package (arm64)
@@ -1874,6 +1905,7 @@ jobs:
             -a arm64 \
             --after-install build/linux/postinst.sh \
             dist/bin/unified-hifi-linux-arm64=/usr/bin/unified-hifi-control \
+            dist/bin/uhc-hiphi-pair-arm64=/usr/bin/uhc-hiphi-pair \
             build/linux/unified-hifi-control.service=/etc/systemd/system/unified-hifi-control.service
 
       - name: Build deb package (armv7/armhf)
@@ -1888,6 +1920,7 @@ jobs:
             -a armhf \
             --after-install build/linux/postinst.sh \
             dist/bin/unified-hifi-linux-armv7=/usr/bin/unified-hifi-control \
+            dist/bin/uhc-hiphi-pair-armv7=/usr/bin/uhc-hiphi-pair \
             build/linux/unified-hifi-control.service=/etc/systemd/system/unified-hifi-control.service
 
       - name: Upload Linux packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -637,15 +637,19 @@ jobs:
         run: |
           # Force rebuild of main crate to pick up version env vars and embedded assets
           cargo clean -p unified-hifi-control 2>/dev/null || true
-          cargo zigbuild --release --target x86_64-unknown-linux-musl
+          cargo zigbuild --release --target x86_64-unknown-linux-musl \
+            --bin unified-hifi-control --bin uhc-hiphi-pair
 
       - name: Rename binary
         run: |
           mkdir -p dist/bin
           cp target/x86_64-unknown-linux-musl/release/unified-hifi-control dist/bin/unified-hifi-linux-x64
+          cp target/x86_64-unknown-linux-musl/release/uhc-hiphi-pair dist/bin/uhc-hiphi-pair-x64
 
       - name: Verify ELF hardening
-        run: scripts/check-elf-hardening.sh dist/bin/unified-hifi-linux-x64
+        run: |
+          scripts/check-elf-hardening.sh dist/bin/unified-hifi-linux-x64
+          scripts/check-elf-hardening.sh dist/bin/uhc-hiphi-pair-x64
 
       - name: Upload binary
         uses: actions/upload-artifact@v7
@@ -865,7 +869,8 @@ jobs:
         run: |
           # Force rebuild of main crate to pick up version env vars and embedded assets
           cargo clean -p unified-hifi-control 2>/dev/null || true
-          cargo zigbuild --release --target ${{ matrix.target }}
+          cargo zigbuild --release --target ${{ matrix.target }} \
+            --bin unified-hifi-control --bin uhc-hiphi-pair
 
       - name: Smoke test armv7 binary
         if: matrix.target == 'armv7-unknown-linux-musleabihf'
@@ -877,9 +882,12 @@ jobs:
         run: |
           mkdir -p dist/bin
           cp target/${{ matrix.target }}/release/unified-hifi-control dist/bin/${{ matrix.output }}
+          cp target/${{ matrix.target }}/release/uhc-hiphi-pair dist/bin/uhc-hiphi-pair-${{ matrix.arch }}
 
       - name: Verify ELF hardening
-        run: scripts/check-elf-hardening.sh dist/bin/${{ matrix.output }}
+        run: |
+          scripts/check-elf-hardening.sh dist/bin/${{ matrix.output }}
+          scripts/check-elf-hardening.sh dist/bin/uhc-hiphi-pair-${{ matrix.arch }}
 
       - name: Upload binary
         uses: actions/upload-artifact@v7
@@ -1467,7 +1475,9 @@ jobs:
         run: |
           mkdir -p qnap-build/shared
           cp dist/bin/unified-hifi-linux-x64 qnap-build/shared/unified-hifi-control
+          cp dist/bin/uhc-hiphi-pair-x64 qnap-build/shared/uhc-hiphi-pair
           chmod +x qnap-build/shared/unified-hifi-control
+          chmod +x qnap-build/shared/uhc-hiphi-pair
           cp build/qnap/shared/*.sh qnap-build/shared/
           chmod +x qnap-build/shared/*.sh
           cp -r build/qnap/shared/icons qnap-build/
@@ -1548,7 +1558,9 @@ jobs:
         run: |
           mkdir -p qnap-build/shared
           cp dist/bin/unified-hifi-linux-arm64 qnap-build/shared/unified-hifi-control
+          cp dist/bin/uhc-hiphi-pair-arm64 qnap-build/shared/uhc-hiphi-pair
           chmod +x qnap-build/shared/unified-hifi-control
+          chmod +x qnap-build/shared/uhc-hiphi-pair
           cp build/qnap/shared/*.sh qnap-build/shared/
           chmod +x qnap-build/shared/*.sh
           cp -r build/qnap/shared/icons qnap-build/

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,7 +11,8 @@ RUN apk add --no-cache ca-certificates openssh-client
 # Copy pre-built binary (web assets are embedded)
 ARG TARGETARCH
 COPY binaries/unified-hifi-linux-${TARGETARCH} /app/unified-hifi-control
-RUN chmod +x /app/unified-hifi-control
+COPY binaries/uhc-hiphi-pair-${TARGETARCH} /app/uhc-hiphi-pair
+RUN chmod +x /app/unified-hifi-control /app/uhc-hiphi-pair
 
 # Home Assistant custom integration (#613) - see Dockerfile.release. Kept
 # identical here so branch/PR images behave like release images when the

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -13,9 +13,10 @@ RUN apk add --no-cache ca-certificates openssh-client
 
 # Copy pre-built binary (web assets are embedded)
 COPY dist/unified-hifi-control /app/
+COPY dist/uhc-hiphi-pair /app/
 
 # Make binary executable
-RUN chmod +x /app/unified-hifi-control
+RUN chmod +x /app/unified-hifi-control /app/uhc-hiphi-pair
 
 # Home Assistant custom integration (#613). The add-on image is built FROM
 # this one, and its run.sh copies this directory into Home Assistant's

--- a/build/qnap/shared/install.sh
+++ b/build/qnap/shared/install.sh
@@ -17,6 +17,7 @@ fi
 
 # Set executable permissions
 chmod +x "${QPKG_ROOT}/unified-hifi-control"
+chmod +x "${QPKG_ROOT}/uhc-hiphi-pair"
 chmod +x "${QPKG_ROOT}/unified-hifi-control.sh"
 
 # Create log file
@@ -28,6 +29,20 @@ touch "${QPKG_ROOT}/unified-hifi-control.log"
 # service run without relying on HOME or an operator shell profile.
 mkdir -p "${QPKG_ROOT}/config"
 chmod 700 "${QPKG_ROOT}/config"
+
+# Pairing writes only these four public connector bindings here.  The private
+# installation key stays in the same owner-only config directory and is never
+# copied to HiPhi Cloud.  Preserve both across QPKG upgrades.
+if [ -L "${QPKG_ROOT}/config/hiphi.env" ]; then
+    echo "Refusing symlinked HiPhi connector configuration" >&2
+    exit 1
+elif [ ! -e "${QPKG_ROOT}/config/hiphi.env" ]; then
+    touch "${QPKG_ROOT}/config/hiphi.env"
+elif [ ! -f "${QPKG_ROOT}/config/hiphi.env" ]; then
+    echo "Refusing non-file HiPhi connector configuration" >&2
+    exit 1
+fi
+chmod 600 "${QPKG_ROOT}/config/hiphi.env"
 
 # Restart service if it was running before upgrade
 if [ "$WAS_RUNNING" = true ]; then

--- a/build/qnap/shared/unified-hifi-control.sh
+++ b/build/qnap/shared/unified-hifi-control.sh
@@ -16,6 +16,7 @@ export HOME=$QPKG_ROOT
 # this with an environment supplied by their service manager.
 export UHC_CONFIG_DIR=${UHC_CONFIG_DIR:-${QPKG_ROOT}/config}
 export PATH=$QPKG_ROOT:$PATH
+HIPHI_ENV_FILE=${UHC_CONFIG_DIR}/hiphi.env
 
 export PIDF=${QPKG_ROOT}/unified-hifi-control.pid
 export LOGF=${QPKG_ROOT}/unified-hifi-control.log
@@ -24,6 +25,59 @@ export LOGF=${QPKG_ROOT}/unified-hifi-control.log
 # Do not let a permissive NAS-wide umask make newly-created package state readable
 # by other local users.
 umask 077
+
+# Load data, never shell code.  The pairing helper persists a compact file of
+# exact connector keys; parsing a fixed allowlist here means a damaged config
+# cannot turn a privileged NAS service restart into arbitrary shell execution.
+load_hiphi_config() {
+    if [ -L "$HIPHI_ENV_FILE" ]; then
+        echo "Refusing unsafe HiPhi connector configuration: $HIPHI_ENV_FILE"
+        return 1
+    fi
+    [ -e "$HIPHI_ENV_FILE" ] || return 0
+    if [ ! -f "$HIPHI_ENV_FILE" ]; then
+        echo "Refusing unsafe HiPhi connector configuration: $HIPHI_ENV_FILE"
+        return 1
+    fi
+
+    SEEN_RELAY=false
+    SEEN_INSTALLATION=false
+    SEEN_SESSION=false
+    SEEN_COMMAND=false
+    while IFS= read -r HIPHI_LINE || [ -n "$HIPHI_LINE" ]; do
+        case "$HIPHI_LINE" in
+            ''|'#'*) continue ;;
+            *=*) ;;
+            *) echo "Invalid HiPhi connector configuration line"; return 1 ;;
+        esac
+        HIPHI_NAME=${HIPHI_LINE%%=*}
+        HIPHI_VALUE=${HIPHI_LINE#*=}
+        [ -n "$HIPHI_VALUE" ] || { echo "Empty HiPhi connector setting: $HIPHI_NAME"; return 1; }
+        case "$HIPHI_NAME" in
+            UHC_HIPHI_RELAY_URL)
+                [ "$SEEN_RELAY" = false ] || return 1
+                SEEN_RELAY=true
+                export UHC_HIPHI_RELAY_URL="$HIPHI_VALUE"
+                ;;
+            UHC_HIPHI_INSTALLATION_ID)
+                [ "$SEEN_INSTALLATION" = false ] || return 1
+                SEEN_INSTALLATION=true
+                export UHC_HIPHI_INSTALLATION_ID="$HIPHI_VALUE"
+                ;;
+            UHC_HIPHI_SESSION_ISSUER_KEYS)
+                [ "$SEEN_SESSION" = false ] || return 1
+                SEEN_SESSION=true
+                export UHC_HIPHI_SESSION_ISSUER_KEYS="$HIPHI_VALUE"
+                ;;
+            UHC_HIPHI_COMMAND_ISSUER_KEYS)
+                [ "$SEEN_COMMAND" = false ] || return 1
+                SEEN_COMMAND=true
+                export UHC_HIPHI_COMMAND_ISSUER_KEYS="$HIPHI_VALUE"
+                ;;
+            *) echo "Unknown HiPhi connector setting: $HIPHI_NAME"; return 1 ;;
+        esac
+    done < "$HIPHI_ENV_FILE"
+}
 
 # A PID file is only a hint: after a crash or reboot its numeric PID can be reused by an
 # unrelated process. Refuse to signal unless /proc still identifies the package binary.
@@ -48,6 +102,8 @@ case "$1" in
     fi
 
     cd "$QPKG_ROOT" || { echo "Failed to cd to $QPKG_ROOT"; exit 1; }
+
+    load_hiphi_config || { echo "Failed to load HiPhi connector configuration"; exit 1; }
 
     # Start the static binary (musl-linked, no dependencies)
     "${QPKG_ROOT}/unified-hifi-control" >> "$LOGF" 2>&1 &

--- a/build/synology/build-spk.sh
+++ b/build/synology/build-spk.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <version> <x86_64|armv8> <binary> <output.spk>" >&2
+    echo "Usage: $0 <version> <x86_64|armv8> <binary> <pairing-helper> <output.spk>" >&2
     exit 2
 }
 
@@ -37,13 +37,14 @@ normalize_version() {
     fi
 }
 
-[[ $# -eq 4 ]] || usage
+[[ $# -eq 5 ]] || usage
 
 SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SOURCE_VERSION=$1
 ARCH=$2
 BINARY=$3
-OUTPUT=$4
+PAIRING_HELPER=$4
+OUTPUT=$5
 
 case "$ARCH" in
     x86_64 | armv8) ;;
@@ -55,6 +56,10 @@ esac
 
 [[ -f "$BINARY" ]] || {
     echo "Binary not found: $BINARY" >&2
+    exit 2
+}
+[[ -f "$PAIRING_HELPER" ]] || {
+    echo "Pairing helper not found: $PAIRING_HELPER" >&2
     exit 2
 }
 
@@ -72,7 +77,9 @@ cp -R "${SOURCE_DIR}/scripts" "${SOURCE_DIR}/conf" "${STAGE_DIR}/"
 cp -R "${SOURCE_DIR}/package/." "${STAGE_DIR}/package/"
 cp "${SOURCE_DIR}/PACKAGE_ICON.PNG" "${SOURCE_DIR}/PACKAGE_ICON_256.PNG" "${STAGE_DIR}/"
 cp "$BINARY" "${STAGE_DIR}/package/unified-hifi-control"
-chmod +x "${STAGE_DIR}/package/unified-hifi-control" "${STAGE_DIR}"/scripts/*
+cp "$PAIRING_HELPER" "${STAGE_DIR}/package/uhc-hiphi-pair"
+chmod +x "${STAGE_DIR}/package/unified-hifi-control" \
+    "${STAGE_DIR}/package/uhc-hiphi-pair" "${STAGE_DIR}"/scripts/*
 
 sed \
     -e "s/{{VERSION}}/${DSM_VERSION}/g" \

--- a/docs/adr/005-cloud-relay-zero-trust-boundary.md
+++ b/docs/adr/005-cloud-relay-zero-trust-boundary.md
@@ -46,12 +46,18 @@ a command UHC accepts; the command authority may authorize an exact command
 but cannot authenticate a relay session. UHC rejects connector configuration
 that reuses either the same key ID or the same public key for both roles.
 
-Operators configure the split trust roots with
-`UHC_HIPHI_SESSION_ISSUER_KEY_ID`, `UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY`,
-`UHC_HIPHI_COMMAND_ISSUER_KEY_ID`, and
-`UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY`. The public keys use unpadded URL-safe
-base64. The old combined `UHC_HIPHI_ISSUER_*` pair is deliberately not a
-fallback because accepting it would silently collapse the two authorities.
+Operators configure the split trust roots with the versioned JSON rings
+`UHC_HIPHI_SESSION_ISSUER_KEYS` and `UHC_HIPHI_COMMAND_ISSUER_KEYS`. Each ring
+contains one to eight key-ID and unpadded URL-safe base64 Ed25519 public-key
+pairs. UHC rejects malformed, empty, oversized, duplicate, weak-key, or
+cross-authority rings before connecting. This bounded overlap allows a new key
+to be published before its signer becomes active and the previous verifier to
+remain until every grant it signed has expired. The old single-key
+`UHC_HIPHI_*_ISSUER_KEY_ID` / `*_PUBLIC_KEY` settings and the still older
+combined `UHC_HIPHI_ISSUER_*` pair are deliberately not fallbacks: accepting
+multiple configuration shapes would make the active trust roots ambiguous.
+The complete publish, switch, wait, and retire sequence is documented in
+[`../hiphi-cloud-issuer-key-rotation.md`](../hiphi-cloud-issuer-key-rotation.md).
 
 For every command, UHC pins the command issuer by `key_id` and verifies issuer,
 audience, installation,

--- a/docs/adr/005-cloud-relay-zero-trust-boundary.md
+++ b/docs/adr/005-cloud-relay-zero-trust-boundary.md
@@ -40,7 +40,21 @@ its local key, and consumes the handoff after successful initiation. The UHC
 pairing CLI never accepts, stores, or forwards the owner's bearer token.
 
 Every command is independently authorized by a compact Ed25519 JWS grant. UHC
-pins issuer keys by `key_id` and verifies issuer, audience, installation,
+pins the session-grant and command-grant authorities independently. The
+session authority may authenticate a short-lived relay session but cannot mint
+a command UHC accepts; the command authority may authorize an exact command
+but cannot authenticate a relay session. UHC rejects connector configuration
+that reuses either the same key ID or the same public key for both roles.
+
+Operators configure the split trust roots with
+`UHC_HIPHI_SESSION_ISSUER_KEY_ID`, `UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY`,
+`UHC_HIPHI_COMMAND_ISSUER_KEY_ID`, and
+`UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY`. The public keys use unpadded URL-safe
+base64. The old combined `UHC_HIPHI_ISSUER_*` pair is deliberately not a
+fallback because accepting it would silently collapse the two authorities.
+
+For every command, UHC pins the command issuer by `key_id` and verifies issuer,
+audience, installation,
 control node, request, epoch, scope, exact canonical payload hash, expiry, and
 grant generation before dispatch. The control-node identity is carried in the
 signed grant and the command envelope, allowing one installation to serve
@@ -58,6 +72,8 @@ image, and capability values are never logged or placed in URLs.
 ## Consequences
 
 - Open-source UHC can be audited without exposing a cloud signing secret.
+- Compromise or misuse of one cloud signing role does not automatically grant
+  the other role.
 - HiPhi Cloud can provide account, entitlement, and façade policy without
   gaining LAN access or provider credential authority.
 - The connector requires a direct Ed25519 dependency when wired into the

--- a/docs/adr/005-cloud-relay-zero-trust-boundary.md
+++ b/docs/adr/005-cloud-relay-zero-trust-boundary.md
@@ -58,6 +58,9 @@ combined `UHC_HIPHI_ISSUER_*` pair are deliberately not fallbacks: accepting
 multiple configuration shapes would make the active trust roots ambiguous.
 The complete publish, switch, wait, and retire sequence is documented in
 [`../hiphi-cloud-issuer-key-rotation.md`](../hiphi-cloud-issuer-key-rotation.md).
+The public attacker model, runtime data classification, release invariants, and
+known residual risks are documented in
+[`../hiphi-cloud-threat-model.md`](../hiphi-cloud-threat-model.md).
 
 For every command, UHC pins the command issuer by `key_id` and verifies issuer,
 audience, installation,

--- a/docs/adr/005-cloud-relay-zero-trust-boundary.md
+++ b/docs/adr/005-cloud-relay-zero-trust-boundary.md
@@ -67,7 +67,10 @@ reuse with a different payload is rejected. A lost terminal result is
 Artwork is a bounded, low-priority request/response lane. Capabilities are
 opaque, short-lived, installation-scoped, and single-use (except an identical
 idempotent retry). UHC returns bytes only; the cloud validates and serves the
-image, and capability values are never logged or placed in URLs.
+image. The cloud façade places the opaque capability in the exact
+`/v1/garmin/artwork/<capability>` path because Garmin fetches artwork without
+the watch bearer. Neither UHC nor the cloud logs that path or capability, and
+the relay protocol itself carries no arbitrary URL.
 
 ## Consequences
 

--- a/docs/hiphi-cloud-issuer-key-rotation.md
+++ b/docs/hiphi-cloud-issuer-key-rotation.md
@@ -1,5 +1,9 @@
 # HiPhi Cloud issuer-key rotation
 
+This procedure implements the signer-compromise and verifier-overlap controls
+described in the public
+[HiPhi Cloud connector threat model](hiphi-cloud-threat-model.md).
+
 UHC independently pins two HiPhi Cloud authorities. The installation-session
 authority authenticates the outbound WebSocket session; the command authority
 authorizes exact remote commands. They must never share a key ID or public key.

--- a/docs/hiphi-cloud-issuer-key-rotation.md
+++ b/docs/hiphi-cloud-issuer-key-rotation.md
@@ -1,0 +1,46 @@
+# HiPhi Cloud issuer-key rotation
+
+UHC independently pins two HiPhi Cloud authorities. The installation-session
+authority authenticates the outbound WebSocket session; the command authority
+authorizes exact remote commands. They must never share a key ID or public key.
+
+Configure each authority as a version-1 JSON ring containing one to eight
+unpadded base64url Ed25519 public keys:
+
+```text
+UHC_HIPHI_SESSION_ISSUER_KEYS={"version":1,"keys":[{"kid":"session-v2","key":"BASE64URL_PUBLIC_KEY"}]}
+UHC_HIPHI_COMMAND_ISSUER_KEYS={"version":1,"keys":[{"kid":"command-v2","key":"BASE64URL_PUBLIC_KEY"}]}
+```
+
+UHC fails closed before connecting if a ring is malformed, empty, larger than
+eight entries or 4 KiB, contains an invalid or weak key, repeats a key ID or
+public key, or overlaps the other authority's IDs or keys. The former singular
+`*_KEY_ID` and `*_PUBLIC_KEY` variables are not accepted.
+
+## Planned rotation
+
+Rotate the two authorities independently. For each one:
+
+1. Add the new public key to the cloud relay's verifier ring while retaining
+   the old public key. Restart the relay and confirm readiness.
+2. Add the same new public key to UHC's corresponding issuer ring while
+   retaining the old entry. Restart UHC and confirm the connector is healthy.
+3. Switch the HiPhi authorizer to the new private signer and matching `kid`.
+   Confirm newly issued grants use the new ID and UHC accepts them.
+4. Start the retirement clock only after the authorizer is confirmed to issue
+   exclusively with the new key. Retain a command verifier for at least 75
+   seconds and a session verifier for at least 180 seconds: each interval is
+   the protocol's maximum grant lifetime plus its 60-second clock tolerance.
+   Add an operational safety margin.
+5. Remove the old entry from UHC and the cloud relay, restart each component,
+   and confirm new grants still work while an otherwise-valid old-key grant is
+   rejected as unknown.
+
+Removing the old verifier before step 4 strands a healthy connector. Leaving
+retired keys indefinitely enlarges the trust set; the eight-key bound is a
+safety ceiling, not a retention policy.
+
+For a suspected signer compromise, remove the affected public key immediately
+on both sides and accept the short authentication outage. Issuer rotation does
+not require deleting the paired installation or its locally held private key.
+No part of this procedure changes or exposes UHC's LAN HTTP API.

--- a/docs/hiphi-cloud-threat-model.md
+++ b/docs/hiphi-cloud-threat-model.md
@@ -1,0 +1,310 @@
+# HiPhi Cloud connector threat model and security invariants
+
+This document describes the security boundary between an open-source Unified
+Hi-Fi Control (UHC) installation on a private network and the optional HiPhi
+Cloud remote-control service. It covers the public connector and relay protocol
+implemented in this repository. Cloud account, façade, relay, and controller
+implementations must preserve the same invariants even when their source is
+maintained separately.
+
+This is a design and review contract, not a security certification. Statements
+about what the system prevents assume that the deployed code, keys, TLS
+configuration, and operational controls match this document.
+
+“Zero trust” is scoped here to the relay boundary: possession of a relay socket
+is not command authority. It does not mean that the cloud service is trustless,
+that semantic state is end-to-end encrypted, or that every component is
+independently verifiable from this repository.
+
+Related documents:
+
+- [ADR 005: Cloud relay is an outbound, proof-bound zero-trust boundary](adr/005-cloud-relay-zero-trust-boundary.md)
+- [HiPhi Cloud issuer-key rotation](hiphi-cloud-issuer-key-rotation.md)
+- Relay wire types and bounds: [`src/cloud_connector/protocol.rs`](../src/cloud_connector/protocol.rs)
+
+## Security goals
+
+The connector is intended to provide remote semantic playback control without
+turning UHC into a general-purpose path into the home network.
+
+It must:
+
+1. keep provider credentials, provider-native identifiers, LAN addresses, and
+   UHC's existing HTTP API behind the local trust boundary;
+2. accept remote commands only when a pinned command-signing authority binds a
+   short-lived grant to one installation, controller, session epoch, request,
+   idempotency key, scope, and exact canonical payload;
+3. require proof of the installation's locally held private key before a relay
+   session is established;
+4. contain replay, stale-session, parser, artwork, and resource-exhaustion
+   failures rather than forwarding them into provider adapters;
+5. fail closed when cloud authentication or protocol validation fails while
+   leaving local playback and LAN control available; and
+6. remain secure when the UHC source, protocol fixtures, endpoint names,
+   application IDs, and pinned public keys are public.
+
+## Assets to protect
+
+- Provider-native credentials and refresh tokens.
+- The installation Ed25519 private key and pairing state.
+- The ability to issue playback and volume commands on a listener's system.
+- LAN topology, hostnames, addresses, URLs, raw provider/device identifiers,
+  cookies, and HTTP headers.
+- Owner and controller credentials managed by the cloud service.
+- Semantic listening state such as zone names, titles, artists, playback state,
+  volume, and artwork.
+- Service availability and local playback independence.
+
+## Trust boundaries
+
+### 1. UHC host and private LAN
+
+UHC, its configuration directory, aggregator, adapters, and provider
+credentials are trusted to enforce local policy. The aggregator remains the
+only authority for client-facing state. The connector may request allowlisted
+semantic actions through normal local dispatch; it may not call arbitrary LAN
+HTTP endpoints or bypass the aggregator.
+
+The connector opens an **outbound** TLS WebSocket. Pairing and remote access do
+not require an inbound firewall rule, port forward, public UHC route, reverse
+proxy, or cloud-supplied destination URL.
+
+### 2. Installation identity
+
+Each installation generates its own Ed25519 key pair. The private key remains
+on the UHC host with owner-only filesystem permissions. Enrollment exports only
+the public key and fingerprint, and requires both a signed-in owner action and
+a local owner-only handoff. Installation keys are not system-wide cloud keys.
+
+### 3. Cloud authority and relay
+
+The cloud authority authenticates owners, pairs controllers, issues bounded
+session and command grants, and owns entitlement policy. The relay coordinates
+the live socket and can observe, delay, reorder, duplicate, or drop semantic
+messages. UHC therefore does not treat possession of a relay connection as
+command authority.
+
+Session and command signers are separate trust roots. A session-signing key can
+authenticate a short-lived socket grant but cannot authorize playback. A
+command-signing key can authorize an exact command but cannot prove possession
+of an installation key or authenticate the socket. UHC rejects configuration
+that reuses a key ID or public key across those roles.
+
+The command-signing authority is nevertheless a trusted, system-wide
+component. Its compromise can forge bounded commands for installations that
+pin that authority; see [Residual risks and non-goals](#residual-risks-and-non-goals).
+
+### 4. Remote controllers
+
+Browsers, Garmin watches, and future controllers authenticate to the cloud, not
+to a public LAN endpoint. A controller is account-bound, installation-scoped,
+individually named, expiring, and revocable. UHC does not trust a controller
+credential directly; it trusts only a valid command grant from its pinned
+command authority.
+
+### 5. Public artwork delivery
+
+Garmin fetches artwork through Garmin infrastructure and cannot attach the
+watch bearer to that image request. The public artwork route therefore uses an
+opaque, short-lived, installation- and artwork-bound capability. UHC accepts no
+URL in the artwork request, applies source-size and concurrency bounds, and
+returns bytes through a separate low-priority lane. The cloud deployment must
+decode, validate, re-encode, and output-bound those bytes before serving them
+publicly.
+
+## Attacker model
+
+The design considers:
+
+- an unauthenticated internet attacker sending malformed, oversized, replayed,
+  guessed, or high-volume requests;
+- a malicious or compromised controller with a valid but bounded credential;
+- a stolen owner browser session attempting to pair or retain a controller;
+- a malicious or compromised relay that can observe and manipulate traffic but
+  does not possess a command-signing key;
+- compromise of either cloud signing role;
+- a LAN peer probing UHC's separately configured local APIs;
+- dependency, build, package, or update-channel compromise; and
+- a compromised UHC host or provider process.
+
+The last two cases can replace trusted code or read local secrets and are not
+solved by the relay protocol. They require ordinary host, dependency, signing,
+and update security.
+
+## Data that crosses the boundary
+
+The cloud protocol deliberately carries a semantic projection, not a provider
+or LAN projection.
+
+| May cross while cloud control is enabled | Must remain local |
+|---|---|
+| Installation ID, public key/fingerprint, connector version, protocol capabilities | Installation private key |
+| Opaque zone handle, owner-visible zone name, transport state, and bounded volume state | Raw Roon/LMS/OpenHome/UPnP/HQPlayer/Spotify/Apple Music identifiers |
+| Bounded now-playing title, artist, playing state, and opaque image revision | Provider credentials, refresh tokens, cookies, CSRF tokens, and authorization headers |
+| Bounded artwork bytes requested through an opaque capability | Provider artwork URL, arbitrary URL, LAN URL, hostname, or filesystem path |
+| Controller ID in signed grants, command/result status, epoch, revision, and timestamps | General LAN HTTP requests or responses and UHC's local API surface |
+
+This means HiPhi Cloud can learn zone names and now-playing metadata while the
+connector is active. That is an intentional privacy tradeoff, not encrypted
+end-to-end state. In addition, Cloudflare or another TLS/network edge
+necessarily sees connection metadata such as the public source IP, timing, and
+traffic volume even though the relay protocol does not carry or persist a LAN
+address.
+
+## Security invariants
+
+These are release invariants. A change that violates one requires an explicit
+security decision and an update to this document and ADR 005.
+
+1. **No inbound cloud path.** UHC initiates the connection. The feature never
+   exposes, proxies, or tunnels the existing LAN HTTP service.
+2. **Pinned secure destination.** Production configuration accepts an exact
+   `wss://` relay endpoint and rejects insecure, credential-bearing, fragment,
+   or otherwise non-canonical endpoints. The cloud cannot supply a per-command
+   destination.
+3. **Local private-key custody.** The installation private key is generated and
+   stored locally with owner-only permissions and is never serialized into a
+   browser response, handoff file, log, protocol message, image URL, package,
+   or repository.
+4. **Dual-confirm enrollment.** Pairing requires a signed-in owner capability
+   bound to the installation public key plus an owner-only local handoff and
+   installation-key proof. A browser bearer is never copied into UHC.
+5. **Separate signing roles.** Session and command issuer rings are independently
+   pinned, bounded to eight Ed25519 keys, and may not overlap by key ID or
+   public key.
+6. **Proof-bound sessions.** A short-lived session grant is bound to the exact
+   installation, installation public key, connector version, endpoint, and
+   generation. Before the socket becomes authoritative, UHC also signs the
+   relay's fresh nonce challenge with the installation private key.
+7. **Exact command grants.** Every command grant binds issuer, audience,
+   installation, controller, request ID, idempotency key, session epoch, scope,
+   exact canonical payload hash, expiry, and revocation generation. The maximum
+   command-grant lifetime is 15 seconds.
+8. **Allowlisted semantics only.** The wire command vocabulary is limited to
+   play/pause, next, previous, relative volume, and bounded finite absolute
+   volume. Unknown fields, duplicate security fields, non-finite values, and
+   unknown actions fail before dispatch.
+9. **Fresh epoch and snapshot first.** Reconnect assigns a new monotonically
+   increasing epoch. UHC sends a full aggregator-derived snapshot before
+   accepting deltas or work, and drops pending work on disconnect.
+10. **Replay and uncertain-result safety.** Request IDs are replay checked;
+    idempotency keys are bound to payload hashes in a bounded terminal ledger.
+    A lost terminal result becomes `unknown_outcome` and is not silently
+    executed again.
+11. **Bounded parsing and work.** Messages, command payloads, strings, zone
+    counts, replay caches, result ledgers, artwork source/output sizes, chunks,
+    queue depth, and concurrency have explicit limits. Capacity exhaustion
+    rejects or drops excess work instead of evicting authorization state or
+    growing without limit.
+12. **Opaque handles.** Provider IDs and artwork keys are reduced to
+    installation-scoped opaque handles/revisions. The reverse mapping exists
+    only in local process memory, is never serialized, and is regenerated after
+    a UHC process restart.
+13. **Capability-bound artwork.** Artwork capabilities contain no fetch URL,
+    are short-lived and single-use except for an identical idempotent retry,
+    and cannot select an arbitrary host, port, path, header, or file.
+14. **Fail closed, local operation survives.** Invalid configuration, expired or
+    forged grants, clock failure, revocation, relay loss, and cloud outage stop
+    remote work. They do not disable the aggregator, adapters, or local control.
+15. **No secret-by-obscurity dependency.** Publishing UHC as open source must
+    reveal no credential that grants runtime authority. Security rests on local
+    private keys, protected cloud signer keys, explicit trust roots, freshness,
+    exact binding, and bounded parsers—not on hiding source or wire formats.
+16. **Sensitive values are not observability fields.** Credentials, grants,
+    enrollment secrets, artwork capabilities/paths, provider identifiers,
+    command payloads, and artwork bytes must not be placed in application logs,
+    analytics, presence records, or error text.
+
+Executable evidence lives primarily in `tests/cloud_connector.rs`,
+`tests/fixtures/hiphi-relay-v1/`, `tests/hiphi_pairing_ui_contract.rs`, package
+contracts, and the cloud deployment's separate adversarial tests. Documentation
+is not a substitute for those checks.
+
+## Residual risks and non-goals
+
+### Command-authority compromise
+
+The current design does not provide controller-to-installation end-to-end
+signatures. The system-wide command-signing authority is trusted to enforce
+account ownership, controller scope, installation selection, revocation, and
+payload intent. If its private key and routing context are compromised, an
+attacker may mint otherwise valid short-lived commands across installations
+that pin that key. Separate session signing prevents that key from proving an
+installation session, but it does not remove this command-forgery blast radius.
+
+Mitigations are protected secret storage, role separation, short grants,
+generation revocation, bounded verifier overlap, audit/alerting, and the
+documented emergency rotation procedure. A future stronger design could give
+each controller an owner-approved public key and require a controller signature
+that UHC verifies end to end; that is not implemented today.
+
+### Semantic-state privacy
+
+The cloud sees the semantic projection needed to render remote controls,
+including owner-visible zone names and now-playing metadata. Provider
+credentials and raw provider identifiers staying local does not make that
+projection private from the service. End-to-end encrypted state is not a goal
+of protocol version 1.
+
+### Account and controller compromise
+
+A stolen owner session may approve, rename, or revoke resources according to
+the cloud account policy. A stolen controller credential may act within its
+installation, scope, expiry, and revocation generation. MFA, session security,
+device storage, owner-visible controller inventory, expiry, and revocation are
+cloud responsibilities.
+
+### Local-host and LAN compromise
+
+An attacker controlling the UHC process or host can read local state, issue
+local commands, replace trust roots, or modify connector code. The connector
+does not sandbox provider adapters. Existing LAN API authentication is a
+separate boundary; enabling HiPhi Cloud must not weaken it, but does not repair
+an independently unsafe LAN deployment.
+
+### Availability and traffic analysis
+
+The relay, authority, DNS, TLS PKI, network edge, or internet connection can
+deny service. The design intentionally has no durable offline command queue,
+because executing old commands after revocation or reconnection is a larger
+risk than remote-control availability. Network observers and the TLS edge can
+infer connection timing and volume.
+
+### Supply chain and cryptographic assumptions
+
+The model assumes correctly implemented Ed25519, SHA-256, canonical JSON, TLS,
+secure randomness, a reasonably synchronized clock, trustworthy release
+artifacts, and protected dependency/build/update infrastructure. Failures in
+those foundations can invalidate the protocol guarantees.
+
+### Cloud implementation assurance
+
+Publishing UHC and its protocol does not make separately deployed cloud code,
+signing operations, account policy, persistence, or image sanitization
+auditable. The cloud implementation is not made auditable by publishing UHC;
+its deployment needs its own review, tests, secret controls, and incident
+response. This public document defines the contract that deployment must meet,
+not evidence that every deployment meets it.
+
+## Reviewing changes against this model
+
+Treat a change as security-significant if it adds a command/action, field,
+controller type, public route, cloud-persisted datum, artwork behavior, trust
+root, pairing path, offline behavior, or log field. Review it by asking:
+
+1. Does it move a provider credential, raw identifier, URL, or LAN authority
+   across the boundary?
+2. Can a relay, controller, browser session, or stale grant cause work without
+   the exact required signer and installation binding?
+3. Is freshness, replay behavior, uncertain outcome, revocation, and reconnect
+   behavior explicit?
+4. Are parsing, storage, concurrency, and response sizes bounded before work is
+   dispatched?
+5. Does cloud failure remain isolated from local playback?
+6. Does publishing the implementation reveal any operational secret? If yes,
+   the secret is in the wrong place.
+
+Do not post working credentials, private keys, or live exploit details in a
+public issue. The repository should publish a dedicated private security-
+reporting channel before the remote-control feature is presented as generally
+available.

--- a/lms-plugin/Helper.pm
+++ b/lms-plugin/Helper.pm
@@ -7,6 +7,7 @@ use strict;
 use warnings;
 
 use File::Spec::Functions qw(catfile catdir);
+use File::Basename qw(dirname);
 use File::Path qw(make_path);
 use JSON::XS;
 use Proc::Background;
@@ -40,10 +41,13 @@ sub init {
         make_path($configDir) or $log->error("Failed to create data directory $configDir: $!");
     }
 
-    # On macOS, clear quarantine flag to prevent Gatekeeper blocking unsigned binary
+    # On macOS, clear quarantine from both bundled executables. Settings invokes
+    # uhc-hiphi-pair beside the server, so clearing only the server leaves the
+    # enrollment ceremony broken even though normal playback works.
     if (main::ISMAC && (my $binary = $class->bin())) {
-        system('xattr', '-cr', $binary);
-        $? && $log->error("Failed to clear quarantine attribute on $binary: $!");
+        my $binaryDir = dirname($binary);
+        system('xattr', '-cr', $binaryDir);
+        $? && $log->error("Failed to clear quarantine attributes in $binaryDir: $!");
     }
 }
 
@@ -96,6 +100,7 @@ sub start {
     # Using local ensures they're restored after Proc::Background->new() returns
     local $ENV{PORT} = $port;
     local $ENV{CONFIG_DIR} = $configDir;
+    local $ENV{UHC_CONFIG_DIR} = $configDir;
     local $ENV{LMS_HOST} = '127.0.0.1';
     local $ENV{LMS_PORT} = $lmsPort;
     local $ENV{LMS_UNIFIEDHIFI_STARTED} = 'true';

--- a/src/api/controller_auth.rs
+++ b/src/api/controller_auth.rs
@@ -331,6 +331,9 @@ fn is_native_bridge(path: &str) -> bool {
 }
 
 fn is_protected(path: &str, method: &axum::http::Method) -> bool {
+    if path.starts_with("/api/hiphi/pairing/") {
+        return true;
+    }
     if path.starts_with("/api/providers/") && path != "/api/providers/spotify/oauth/callback"
         || path == "/mcp"
     {

--- a/src/api/hiphi_pairing.rs
+++ b/src/api/hiphi_pairing.rs
@@ -1,0 +1,265 @@
+//! Local browser bridge to the packaged `uhc-hiphi-pair` ceremony.
+//!
+//! The helper remains the only code that reads the installation signing key.
+//! This module invokes that exact sibling binary without a shell, accepts only
+//! the bounded public handoff contract, and projects only public ceremony data
+//! back to the Settings UI.
+
+use axum::{http::StatusCode, response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+const MAX_HANDOFF_BYTES: usize = 4 * 1024;
+const MAX_HELPER_OUTPUT_BYTES: usize = 16 * 1024;
+const HIPHI_CLOUD_ORIGIN: &str = "https://relay.hiphi.audio";
+
+#[derive(Debug, Serialize)]
+struct PairingError {
+    code: &'static str,
+    message: String,
+}
+
+fn error(
+    status: StatusCode,
+    code: &'static str,
+    message: impl Into<String>,
+) -> axum::response::Response {
+    (
+        status,
+        Json(PairingError {
+            code,
+            message: message.into(),
+        }),
+    )
+        .into_response()
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnrollmentHandoffUpload {
+    pub enrollment_capability: String,
+    pub installation_audience: String,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InitiateRequest {
+    pub enrollment: EnrollmentHandoffUpload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompleteRequest {
+    pub account_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PrepareResponse {
+    pub installation_public_key: String,
+    pub installation_fingerprint: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InitiateResponse {
+    pub pairing_id: String,
+    pub installation_id: String,
+    pub pairing_secret: String,
+    pub installation_fingerprint: String,
+    pub expires_at_ms: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CompleteResponse {
+    pub paired: bool,
+    pub installation_id: String,
+    pub relay_endpoint: String,
+    pub restart_required: bool,
+}
+
+fn helper_path() -> anyhow::Result<PathBuf> {
+    let current = std::env::current_exe()?;
+    let helper = current.with_file_name("uhc-hiphi-pair");
+    if !helper.is_file() {
+        anyhow::bail!(
+            "the HiPhi pairing helper is missing beside the UHC executable; install the current QPKG build"
+        );
+    }
+    Ok(helper)
+}
+
+async fn run_helper(arguments: &[&str]) -> anyhow::Result<BTreeMap<String, String>> {
+    let output = Command::new(helper_path()?)
+        .args(arguments)
+        .output()
+        .await?;
+    if output.stdout.len() > MAX_HELPER_OUTPUT_BYTES
+        || output.stderr.len() > MAX_HELPER_OUTPUT_BYTES
+    {
+        anyhow::bail!("the pairing helper returned an oversized response");
+    }
+    if !output.status.success() {
+        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!(
+            "{}",
+            if message.is_empty() {
+                "the pairing helper refused the request"
+            } else {
+                message.as_str()
+            }
+        );
+    }
+    parse_helper_output(&output.stdout)
+}
+
+fn parse_helper_output(output: &[u8]) -> anyhow::Result<BTreeMap<String, String>> {
+    let text = std::str::from_utf8(output)?;
+    let mut fields = BTreeMap::new();
+    for line in text.lines() {
+        let (key, value) = line
+            .split_once('=')
+            .ok_or_else(|| anyhow::anyhow!("the pairing helper returned an invalid response"))?;
+        if key.is_empty()
+            || value.is_empty()
+            || fields.insert(key.to_string(), value.to_string()).is_some()
+        {
+            anyhow::bail!("the pairing helper returned an invalid response");
+        }
+    }
+    Ok(fields)
+}
+
+fn field<'a>(fields: &'a BTreeMap<String, String>, name: &str) -> anyhow::Result<&'a str> {
+    fields
+        .get(name)
+        .map(String::as_str)
+        .ok_or_else(|| anyhow::anyhow!("the pairing helper omitted {name}"))
+}
+
+fn write_handoff(handoff: &EnrollmentHandoffUpload) -> anyhow::Result<PathBuf> {
+    use std::io::Write as _;
+
+    let bytes = serde_json::to_vec_pretty(handoff)?;
+    if bytes.len() > MAX_HANDOFF_BYTES {
+        anyhow::bail!("the enrollment handoff exceeds the size limit");
+    }
+    let directory = crate::config::get_config_dir();
+    std::fs::create_dir_all(&directory)?;
+    let path = directory.join(format!("hiphi-enrollment-{}.json", uuid::Uuid::new_v4()));
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    Ok(path)
+}
+
+fn cleanup_handoff(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(%error, path = %path.display(), "failed to remove enrollment handoff")
+        }
+    }
+}
+
+pub async fn prepare() -> axum::response::Response {
+    match run_helper(&["prepare"]).await.and_then(|fields| {
+        Ok(PrepareResponse {
+            installation_public_key: field(&fields, "installation_public_key")?.to_string(),
+            installation_fingerprint: field(&fields, "installation_fingerprint")?.to_string(),
+        })
+    }) {
+        Ok(response) => Json(response).into_response(),
+        Err(error_value) => error(
+            StatusCode::BAD_REQUEST,
+            "pairing_prepare_failed",
+            error_value.to_string(),
+        ),
+    }
+}
+
+pub async fn initiate(Json(request): Json<InitiateRequest>) -> axum::response::Response {
+    let handoff_path = match write_handoff(&request.enrollment) {
+        Ok(path) => path,
+        Err(error_value) => {
+            return error(
+                StatusCode::BAD_REQUEST,
+                "enrollment_invalid",
+                error_value.to_string(),
+            );
+        }
+    };
+    let handoff = handoff_path.to_string_lossy().into_owned();
+    let result = run_helper(&["initiate", HIPHI_CLOUD_ORIGIN, &handoff]).await;
+    cleanup_handoff(&handoff_path);
+    match result.and_then(|fields| {
+        Ok(InitiateResponse {
+            pairing_id: field(&fields, "pairing_id")?.to_string(),
+            installation_id: field(&fields, "installation_id")?.to_string(),
+            pairing_secret: field(&fields, "pairing_secret")?.to_string(),
+            installation_fingerprint: field(&fields, "installation_fingerprint")?.to_string(),
+            expires_at_ms: field(&fields, "expires_at_ms")?.parse()?,
+        })
+    }) {
+        Ok(response) => Json(response).into_response(),
+        Err(error_value) => error(
+            StatusCode::BAD_REQUEST,
+            "pairing_initiate_failed",
+            error_value.to_string(),
+        ),
+    }
+}
+
+pub async fn complete(Json(request): Json<CompleteRequest>) -> axum::response::Response {
+    match run_helper(&["complete", &request.account_id])
+        .await
+        .and_then(|fields| {
+            if field(&fields, "pairing_complete")? != "true" {
+                anyhow::bail!("the pairing helper did not report semantic success");
+            }
+            Ok(CompleteResponse {
+                paired: true,
+                installation_id: field(&fields, "UHC_HIPHI_INSTALLATION_ID")?.to_string(),
+                relay_endpoint: field(&fields, "UHC_HIPHI_RELAY_URL")?.to_string(),
+                restart_required: field(&fields, "connector_restart_required")? == "true",
+            })
+        }) {
+        Ok(response) => Json(response).into_response(),
+        Err(error_value) => error(
+            StatusCode::BAD_REQUEST,
+            "pairing_complete_failed",
+            error_value.to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn helper_output_rejects_duplicates_and_malformed_lines() {
+        assert!(parse_helper_output(b"a=one\na=two\n").is_err());
+        assert!(parse_helper_output(b"not-a-field\n").is_err());
+        assert!(parse_helper_output(b"=value\n").is_err());
+        assert!(parse_helper_output(b"key=\n").is_err());
+    }
+
+    #[test]
+    fn helper_output_preserves_equals_inside_values() {
+        let fields = parse_helper_output(b"key=value=with=equals\n").unwrap();
+        assert_eq!(
+            fields.get("key").map(String::as_str),
+            Some("value=with=equals")
+        );
+    }
+}

--- a/src/api/hiphi_pairing.rs
+++ b/src/api/hiphi_pairing.rs
@@ -156,6 +156,19 @@ fn write_handoff(handoff: &EnrollmentHandoffUpload) -> anyhow::Result<PathBuf> {
         options.mode(0o600);
     }
     let mut file = options.open(&path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // QNAP shared-volume ACL inheritance can add group/other mode bits
+        // after create(0600). Clear them on the open file descriptor and
+        // verify the filesystem actually honored the owner-only boundary
+        // before placing a one-use capability in the file.
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        if file.metadata()?.permissions().mode() & 0o077 != 0 {
+            anyhow::bail!("the UHC config volume cannot enforce owner-only enrollment files");
+        }
+    }
     file.write_all(&bytes)?;
     file.sync_all()?;
     Ok(path)

--- a/src/api/hiphi_pairing.rs
+++ b/src/api/hiphi_pairing.rs
@@ -88,13 +88,38 @@ pub struct PairingStatusResponse {
 
 fn helper_path() -> anyhow::Result<PathBuf> {
     let current = std::env::current_exe()?;
-    let helper = current.with_file_name("uhc-hiphi-pair");
-    if !helper.is_file() {
-        anyhow::bail!(
-            "the HiPhi pairing helper is missing beside the UHC executable; install the current QPKG build"
-        );
+    for helper in helper_candidates(&current) {
+        if helper.is_file() {
+            return Ok(helper);
+        }
     }
-    Ok(helper)
+    anyhow::bail!(
+        "the HiPhi pairing helper is missing beside the UHC executable; install a current UHC package"
+    );
+}
+
+fn helper_candidates(current: &Path) -> Vec<PathBuf> {
+    let mut candidates = vec![current.with_file_name(if cfg!(windows) {
+        "uhc-hiphi-pair.exe"
+    } else {
+        "uhc-hiphi-pair"
+    })];
+    let filename = current
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let direct_name = match filename {
+        "unified-hifi-linux-x64" => Some("uhc-hiphi-pair-x64"),
+        "unified-hifi-linux-arm64" => Some("uhc-hiphi-pair-arm64"),
+        "unified-hifi-linux-armv7" => Some("uhc-hiphi-pair-armv7"),
+        "unified-hifi-macos-universal" => Some("uhc-hiphi-pair-macos-universal"),
+        "unified-hifi-win64.exe" => Some("uhc-hiphi-pair-win64.exe"),
+        _ => None,
+    };
+    if let Some(name) = direct_name {
+        candidates.push(current.with_file_name(name));
+    }
+    candidates
 }
 
 async fn run_helper(arguments: &[&str]) -> anyhow::Result<BTreeMap<String, String>> {
@@ -325,5 +350,33 @@ mod tests {
             fields.get("key").map(String::as_str),
             Some("value=with=equals")
         );
+    }
+
+    #[test]
+    fn packaged_and_direct_binary_names_find_the_matching_pairing_helper() {
+        let packaged = helper_candidates(Path::new("/opt/uhc/unified-hifi-control"));
+        assert_eq!(
+            packaged[0].file_name().and_then(|name| name.to_str()),
+            Some(if cfg!(windows) {
+                "uhc-hiphi-pair.exe"
+            } else {
+                "uhc-hiphi-pair"
+            })
+        );
+
+        for (server, helper) in [
+            ("unified-hifi-linux-x64", "uhc-hiphi-pair-x64"),
+            ("unified-hifi-linux-arm64", "uhc-hiphi-pair-arm64"),
+            ("unified-hifi-linux-armv7", "uhc-hiphi-pair-armv7"),
+            (
+                "unified-hifi-macos-universal",
+                "uhc-hiphi-pair-macos-universal",
+            ),
+            ("unified-hifi-win64.exe", "uhc-hiphi-pair-win64.exe"),
+        ] {
+            assert!(helper_candidates(Path::new(server))
+                .iter()
+                .any(|path| { path.file_name().and_then(|name| name.to_str()) == Some(helper) }));
+        }
     }
 }

--- a/src/api/hiphi_pairing.rs
+++ b/src/api/hiphi_pairing.rs
@@ -5,7 +5,7 @@
 //! the bounded public handoff contract, and projects only public ceremony data
 //! back to the Settings UI.
 
-use axum::{http::StatusCode, response::IntoResponse, Json};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -77,6 +77,13 @@ pub struct CompleteResponse {
     pub installation_id: String,
     pub relay_endpoint: String,
     pub restart_required: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PairingStatusResponse {
+    pub paired: bool,
+    pub installation_id: Option<String>,
+    pub connector_state: &'static str,
 }
 
 fn helper_path() -> anyhow::Result<PathBuf> {
@@ -232,8 +239,31 @@ pub async fn initiate(Json(request): Json<InitiateRequest>) -> axum::response::R
     }
 }
 
-pub async fn complete(Json(request): Json<CompleteRequest>) -> axum::response::Response {
-    match run_helper(&["complete", &request.account_id])
+pub async fn status(State(state): State<crate::api::AppState>) -> axum::response::Response {
+    match state
+        .hiphi_connector
+        .status_from_runtime(crate::config::get_config_dir())
+        .await
+    {
+        Ok(status) => Json(PairingStatusResponse {
+            paired: status.configured,
+            installation_id: status.installation_id,
+            connector_state: status.phase.as_str(),
+        })
+        .into_response(),
+        Err(error_value) => error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "pairing_status_failed",
+            error_value.to_string(),
+        ),
+    }
+}
+
+pub async fn complete(
+    State(state): State<crate::api::AppState>,
+    Json(request): Json<CompleteRequest>,
+) -> axum::response::Response {
+    let parsed = run_helper(&["complete", &request.account_id])
         .await
         .and_then(|fields| {
             if field(&fields, "pairing_complete")? != "true" {
@@ -245,8 +275,29 @@ pub async fn complete(Json(request): Json<CompleteRequest>) -> axum::response::R
                 relay_endpoint: field(&fields, "UHC_HIPHI_RELAY_URL")?.to_string(),
                 restart_required: field(&fields, "connector_restart_required")? == "true",
             })
-        }) {
-        Ok(response) => Json(response).into_response(),
+        });
+    match parsed {
+        Ok(mut response) => {
+            match state
+                .hiphi_connector
+                .start_from_runtime(state.clone(), crate::config::get_config_dir())
+                .await
+            {
+                Ok(crate::cloud_connector::runtime::ConnectorStart::Started)
+                | Ok(crate::cloud_connector::runtime::ConnectorStart::AlreadyRunning) => {
+                    response.restart_required = false;
+                }
+                Ok(crate::cloud_connector::runtime::ConnectorStart::NotConfigured) => {
+                    tracing::error!("HiPhi pairing completed without persisted connector config");
+                }
+                Err(error_value) => {
+                    tracing::error!(
+                        "HiPhi pairing completed but connector activation failed: {error_value}"
+                    );
+                }
+            }
+            Json(response).into_response()
+        }
         Err(error_value) => error(
             StatusCode::BAD_REQUEST,
             "pairing_complete_failed",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -44,6 +44,7 @@ pub mod browse;
 pub mod controller_auth;
 pub mod credentials;
 pub mod ha_integration;
+pub mod hiphi_pairing;
 pub mod ingress;
 pub mod mqtt_bootstrap;
 pub mod mqtt_settings;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -318,6 +318,9 @@ pub struct AppState {
     /// Fully inert until both configured and enabled; see
     /// `crate::mqtt::MqttPublisher`.
     pub mqtt: Arc<crate::mqtt::MqttPublisher>,
+    /// Process-owned HiPhi connector lifecycle. It is package-agnostic and
+    /// survives Settings reloads by reconstructing from owner-only config.
+    pub hiphi_connector: crate::cloud_connector::runtime::ConnectorSupervisor,
 }
 
 impl AppState {
@@ -384,6 +387,7 @@ impl AppState {
             apple_feedback: crate::mcp::feedback::FeedbackStore::from_config(),
             reliable_commands: None,
             mqtt,
+            hiphi_connector: crate::cloud_connector::runtime::ConnectorSupervisor::default(),
         }
     }
 

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -145,6 +145,25 @@ pub struct HiphiCompleteResponse {
     pub restart_required: bool,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct HiphiPairingStatus {
+    pub paired: bool,
+    pub installation_id: Option<String>,
+    pub connector_state: String,
+}
+
+impl HiphiPairingStatus {
+    pub fn display_state(&self) -> &'static str {
+        match self.connector_state.as_str() {
+            "online" => "Connected to HiPhi Cloud",
+            "connecting" => "Paired · connecting",
+            "offline" => "Paired · reconnecting",
+            "revoked" => "Cloud access revoked",
+            _ => "Not paired",
+        }
+    }
+}
+
 /// `GET /api/controller/status`.
 pub async fn fetch_controller_status() -> Result<ControllerStatus, String> {
     fetch_json("/api/controller/status").await

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -100,6 +100,51 @@ pub struct ControllerBootstrapResponse {
     pub expires_at: u64,
 }
 
+// =============================================================================
+// HiPhi Cloud installation pairing
+// =============================================================================
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct HiphiPrepareResponse {
+    pub installation_public_key: String,
+    pub installation_fingerprint: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct HiphiEnrollmentHandoff {
+    pub enrollment_capability: String,
+    pub installation_audience: String,
+    pub expires_at: i64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct HiphiInitiateRequest {
+    pub enrollment: HiphiEnrollmentHandoff,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct HiphiInitiateResponse {
+    pub pairing_id: String,
+    pub installation_id: String,
+    pub pairing_secret: String,
+    pub installation_fingerprint: String,
+    pub expires_at_ms: i64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct HiphiCompleteRequest {
+    pub account_id: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct HiphiCompleteResponse {
+    pub paired: bool,
+    pub installation_id: String,
+    pub relay_endpoint: String,
+    pub restart_required: bool,
+}
+
 /// `GET /api/controller/status`.
 pub async fn fetch_controller_status() -> Result<ControllerStatus, String> {
     fetch_json("/api/controller/status").await

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -6,12 +6,12 @@ use dioxus::prelude::*;
 
 use crate::app::api::{
     source_label, AppSettings, AppleBridgeStatus, HiphiCompleteRequest, HiphiCompleteResponse,
-    HiphiEnrollmentHandoff, HiphiInitiateRequest, HiphiInitiateResponse, HiphiPrepareResponse,
-    HqpStatus, LmsConfig, ManagedZone, ManagedZonesResponse, MoveDirection, MqttConfigureRequest,
-    MqttStatusResponse, MusicAssistantConfigureRequest, MusicAssistantStatusResponse,
-    ProviderAuthResponse, ProviderOAuthStart, RoonStatus, SpotifyAccountResponse,
-    SpotifyConfigureRequest, SpotifyConfigureResponse, SpotifyTunnelStatus, ZoneNameRequest,
-    ZoneOrderRequest, ZoneVisibilityRequest, ZonesResponse,
+    HiphiEnrollmentHandoff, HiphiInitiateRequest, HiphiInitiateResponse, HiphiPairingStatus,
+    HiphiPrepareResponse, HqpStatus, LmsConfig, ManagedZone, ManagedZonesResponse, MoveDirection,
+    MqttConfigureRequest, MqttStatusResponse, MusicAssistantConfigureRequest,
+    MusicAssistantStatusResponse, ProviderAuthResponse, ProviderOAuthStart, RoonStatus,
+    SpotifyAccountResponse, SpotifyConfigureRequest, SpotifyConfigureResponse, SpotifyTunnelStatus,
+    ZoneNameRequest, ZoneOrderRequest, ZoneVisibilityRequest, ZonesResponse,
 };
 use crate::app::components::{ErrorAlert, Layout};
 use crate::app::settings_context::{initial_app_settings, use_settings};
@@ -118,6 +118,9 @@ fn HiphiCloudPairing() -> Element {
     let public_key_copy = use_signal(CopyState::default);
     let pairing_id_copy = use_signal(CopyState::default);
     let pairing_secret_copy = use_signal(CopyState::default);
+    let mut pairing_status = use_resource(|| async {
+        crate::app::api::fetch_json::<HiphiPairingStatus>("/api/hiphi/pairing/status").await
+    });
 
     let prepare = move |_| {
         action.set(ProviderActionState::Loading);
@@ -174,7 +177,8 @@ fn HiphiCloudPairing() -> Element {
         let account = account_id().trim().to_string();
         if account.is_empty() {
             error.set(Some(
-                "Paste the account ID shown after confirming the NAS in HiPhi Cloud.".to_string(),
+                "Paste the account ID shown after confirming the installation in HiPhi Cloud."
+                    .to_string(),
             ));
             return;
         }
@@ -191,6 +195,7 @@ fn HiphiCloudPairing() -> Element {
             {
                 Ok(response) if response.paired => {
                     completed.set(Some(response));
+                    pairing_status.restart();
                     action.set(ProviderActionState::Success);
                 }
                 Ok(_) => {
@@ -205,6 +210,12 @@ fn HiphiCloudPairing() -> Element {
         });
     };
 
+    let status_snapshot = pairing_status.read().as_ref().cloned();
+    let status_pending = status_snapshot.is_none();
+    let paired_status = status_snapshot
+        .and_then(Result::ok)
+        .filter(|status| status.paired);
+
     rsx! {
         section { class: "mb-8", aria_labelledby: "hiphi-cloud-heading",
             div { class: "mb-4",
@@ -215,9 +226,20 @@ fn HiphiCloudPairing() -> Element {
                 }
             }
             div { class: "card p-5 sm:p-6 space-y-6",
+                if status_pending {
+                    p { class: "text-sm text-secondary", "Checking this installation’s HiPhi Cloud connection…" }
+                } else if let Some(status) = paired_status {
+                    div { class: "status-ok", role: "status",
+                        p { class: "font-medium", "This UHC installation is paired." }
+                        p { class: "mt-1", "{status.display_state()}" }
+                        if let Some(installation_id) = status.installation_id {
+                            p { class: "mt-2 text-xs text-muted break-all", "Installation ID: {installation_id}" }
+                        }
+                    }
+                } else {
                 div {
-                    h3 { class: "font-semibold", "1. Prepare this NAS" }
-                    p { class: "mt-1 text-sm text-secondary", "The private installation key stays on this NAS. Only its public key is shown." }
+                    h3 { class: "font-semibold", "1. Prepare this UHC installation" }
+                    p { class: "mt-1 text-sm text-secondary", "The private installation key stays with this UHC installation. Only its public key is shown." }
                     button {
                         r#type: "button",
                         class: "btn-primary mt-3",
@@ -277,7 +299,7 @@ fn HiphiCloudPairing() -> Element {
                     }
                     if let Some(pairing) = initiated() {
                         div { class: "mt-4 rounded-md border border-default bg-elevated p-4 space-y-3",
-                            p { class: "font-medium", "Return to HiPhi Cloud and claim this pending NAS." }
+                            p { class: "font-medium", "Return to HiPhi Cloud and claim this pending UHC installation." }
                             label { class: "text-sm font-medium", "Pairing ID" }
                             div { class: "flex flex-col gap-2 sm:flex-row",
                                 code { class: "min-w-0 flex-1 break-all", "{pairing.pairing_id}" }
@@ -302,13 +324,14 @@ fn HiphiCloudPairing() -> Element {
                     button { r#type: "button", class: "btn-primary mt-3", disabled: initiated().is_none() || matches!(action(), ProviderActionState::Loading), onclick: complete_pairing, "Complete pairing" }
                     if let Some(result) = completed() {
                         div { class: "mt-4 status-ok", role: "status",
-                            p { class: "font-medium", "This NAS is paired." }
-                            if result.restart_required { p { class: "mt-1", "Restart Unified Hi-Fi Control once in QNAP App Center to start the outbound connector." } }
+                            p { class: "font-medium", "This UHC installation is paired." }
+                            if result.restart_required { p { class: "mt-1", "The connector could not start automatically. Restart Unified Hi-Fi Control using this installation’s normal restart control." } }
                         }
                     }
                 }
 
                 if let Some(message) = error() { p { class: "status-err", role: "alert", "{message}" } }
+                }
             }
         }
     }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -19,6 +19,8 @@ use crate::app::sse::use_sse;
 use crate::app::theme::{use_theme, Theme};
 use crate::app::{McpEndpoint, Route};
 
+const HIPHI_STATUS_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// OpenHome status response
 #[derive(Clone, Debug, Default, serde::Deserialize, PartialEq)]
 struct OpenHomeStatus {
@@ -120,6 +122,19 @@ fn HiphiCloudPairing() -> Element {
     let pairing_secret_copy = use_signal(CopyState::default);
     let mut pairing_status = use_resource(|| async {
         crate::app::api::fetch_json::<HiphiPairingStatus>("/api/hiphi/pairing/status").await
+    });
+
+    // Pairing is durable, but relay presence changes independently of page
+    // navigation. Refresh only this small status resource so a page opened
+    // while online cannot keep claiming connectivity after a disconnect (or
+    // stay on "connecting" after recovery).
+    use_effect(move || {
+        spawn(async move {
+            loop {
+                dioxus_sdk_time::sleep(HIPHI_STATUS_POLL_INTERVAL).await;
+                pairing_status.restart();
+            }
+        });
     });
 
     let prepare = move |_| {

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -5,12 +5,13 @@
 use dioxus::prelude::*;
 
 use crate::app::api::{
-    source_label, AppSettings, AppleBridgeStatus, HqpStatus, LmsConfig, ManagedZone,
-    ManagedZonesResponse, MoveDirection, MqttConfigureRequest, MqttStatusResponse,
-    MusicAssistantConfigureRequest, MusicAssistantStatusResponse, ProviderAuthResponse,
-    ProviderOAuthStart, RoonStatus, SpotifyAccountResponse, SpotifyConfigureRequest,
-    SpotifyConfigureResponse, SpotifyTunnelStatus, ZoneNameRequest, ZoneOrderRequest,
-    ZoneVisibilityRequest, ZonesResponse,
+    source_label, AppSettings, AppleBridgeStatus, HiphiCompleteRequest, HiphiCompleteResponse,
+    HiphiEnrollmentHandoff, HiphiInitiateRequest, HiphiInitiateResponse, HiphiPrepareResponse,
+    HqpStatus, LmsConfig, ManagedZone, ManagedZonesResponse, MoveDirection, MqttConfigureRequest,
+    MqttStatusResponse, MusicAssistantConfigureRequest, MusicAssistantStatusResponse,
+    ProviderAuthResponse, ProviderOAuthStart, RoonStatus, SpotifyAccountResponse,
+    SpotifyConfigureRequest, SpotifyConfigureResponse, SpotifyTunnelStatus, ZoneNameRequest,
+    ZoneOrderRequest, ZoneVisibilityRequest, ZonesResponse,
 };
 use crate::app::components::{ErrorAlert, Layout};
 use crate::app::settings_context::{initial_app_settings, use_settings};
@@ -102,6 +103,214 @@ fn copy_to_clipboard(value: String, state: Signal<CopyState>) {
     {
         // Event handlers run in the hydrated WASM client, never during SSR.
         let _ = (value, state);
+    }
+}
+
+#[component]
+fn HiphiCloudPairing() -> Element {
+    let mut action = use_signal(ProviderActionState::default);
+    let mut error = use_signal(|| None::<String>);
+    let mut prepared = use_signal(|| None::<HiphiPrepareResponse>);
+    let mut handoff = use_signal(|| None::<HiphiEnrollmentHandoff>);
+    let mut initiated = use_signal(|| None::<HiphiInitiateResponse>);
+    let mut account_id = use_signal(String::new);
+    let mut completed = use_signal(|| None::<HiphiCompleteResponse>);
+    let public_key_copy = use_signal(CopyState::default);
+    let pairing_id_copy = use_signal(CopyState::default);
+    let pairing_secret_copy = use_signal(CopyState::default);
+
+    let prepare = move |_| {
+        action.set(ProviderActionState::Loading);
+        error.set(None);
+        spawn(async move {
+            match crate::app::api::post_json::<serde_json::Value, HiphiPrepareResponse>(
+                "/api/hiphi/pairing/prepare",
+                &serde_json::json!({}),
+            )
+            .await
+            {
+                Ok(response) => {
+                    prepared.set(Some(response));
+                    action.set(ProviderActionState::Success);
+                }
+                Err(message) => {
+                    action.set(ProviderActionState::Failed);
+                    error.set(crate::app::api::suppress_controller_unauthorized(message));
+                }
+            }
+        });
+    };
+
+    let start_pairing = move |_| {
+        let Some(enrollment) = handoff() else {
+            error.set(Some(
+                "Choose the enrollment file downloaded from HiPhi Cloud first.".to_string(),
+            ));
+            return;
+        };
+        action.set(ProviderActionState::Loading);
+        error.set(None);
+        spawn(async move {
+            let request = HiphiInitiateRequest { enrollment };
+            match crate::app::api::post_json::<HiphiInitiateRequest, HiphiInitiateResponse>(
+                "/api/hiphi/pairing/initiate",
+                &request,
+            )
+            .await
+            {
+                Ok(response) => {
+                    initiated.set(Some(response));
+                    action.set(ProviderActionState::Success);
+                }
+                Err(message) => {
+                    action.set(ProviderActionState::Failed);
+                    error.set(crate::app::api::suppress_controller_unauthorized(message));
+                }
+            }
+        });
+    };
+
+    let complete_pairing = move |_| {
+        let account = account_id().trim().to_string();
+        if account.is_empty() {
+            error.set(Some(
+                "Paste the account ID shown after confirming the NAS in HiPhi Cloud.".to_string(),
+            ));
+            return;
+        }
+        action.set(ProviderActionState::Loading);
+        error.set(None);
+        spawn(async move {
+            match crate::app::api::post_json::<HiphiCompleteRequest, HiphiCompleteResponse>(
+                "/api/hiphi/pairing/complete",
+                &HiphiCompleteRequest {
+                    account_id: account,
+                },
+            )
+            .await
+            {
+                Ok(response) if response.paired => {
+                    completed.set(Some(response));
+                    action.set(ProviderActionState::Success);
+                }
+                Ok(_) => {
+                    action.set(ProviderActionState::Failed);
+                    error.set(Some("HiPhi Cloud did not confirm pairing.".to_string()));
+                }
+                Err(message) => {
+                    action.set(ProviderActionState::Failed);
+                    error.set(crate::app::api::suppress_controller_unauthorized(message));
+                }
+            }
+        });
+    };
+
+    rsx! {
+        section { class: "mb-8", aria_labelledby: "hiphi-cloud-heading",
+            div { class: "mb-4",
+                h2 { id: "hiphi-cloud-heading", class: "text-xl font-semibold", "Connect HiPhi Cloud" }
+                p { class: "text-muted text-sm",
+                    "HiPhi Cloud adds secure remote and Garmin control while local listening stays local. "
+                    a { href: "https://hiphi.audio/#cloud", target: "_blank", rel: "noopener noreferrer", "Why sign up?" }
+                }
+            }
+            div { class: "card p-5 sm:p-6 space-y-6",
+                div {
+                    h3 { class: "font-semibold", "1. Prepare this NAS" }
+                    p { class: "mt-1 text-sm text-secondary", "The private installation key stays on this NAS. Only its public key is shown." }
+                    button {
+                        r#type: "button",
+                        class: "btn-primary mt-3",
+                        disabled: matches!(action(), ProviderActionState::Loading),
+                        onclick: prepare,
+                        if prepared().is_some() { "Show installation identity" } else { "Prepare installation identity" }
+                    }
+                    if let Some(identity) = prepared() {
+                        div { class: "mt-4 rounded-md border border-default bg-elevated p-4",
+                            label { class: "text-sm font-medium", "Installation public key" }
+                            div { class: "mt-2 flex flex-col gap-2 sm:flex-row",
+                                code { class: "min-w-0 flex-1 break-all", "{identity.installation_public_key}" }
+                                button {
+                                    r#type: "button", class: "btn-secondary shrink-0",
+                                    onclick: move |_| copy_to_clipboard(identity.installation_public_key.clone(), public_key_copy),
+                                    "{public_key_copy().label(\"Copy public key\")}"
+                                }
+                            }
+                            p { class: "mt-3 text-xs text-muted", "Fingerprint: {identity.installation_fingerprint}" }
+                            a { class: "btn-primary mt-4 inline-block", href: "https://app.hiphi.audio/", target: "_blank", rel: "noopener noreferrer", "Open HiPhi Cloud" }
+                        }
+                    }
+                }
+
+                div { class: "border-t border-default pt-6",
+                    h3 { class: "font-semibold", "2. Import the one-use handoff" }
+                    p { class: "mt-1 text-sm text-secondary", "In HiPhi Cloud, paste the public key above and download the enrollment file. It expires after five minutes." }
+                    label { class: "mt-3 block text-sm font-medium", r#for: "hiphi-enrollment-file", "Choose enrollment file" }
+                    input {
+                        id: "hiphi-enrollment-file",
+                        r#type: "file",
+                        accept: "application/json,.json",
+                        class: "mt-2 block w-full text-sm",
+                        onchange: move |event| {
+                            let Some(file) = event.files().into_iter().next() else { return; };
+                            if file.size() > 4096 {
+                                error.set(Some("The enrollment file is larger than the supported contract.".to_string()));
+                                return;
+                            }
+                            spawn(async move {
+                                match file.read_string().await
+                                    .map_err(|read_error| read_error.to_string())
+                                    .and_then(|contents| serde_json::from_str::<HiphiEnrollmentHandoff>(&contents).map_err(|parse_error| parse_error.to_string()))
+                                {
+                                    Ok(enrollment) => { handoff.set(Some(enrollment)); error.set(None); }
+                                    Err(message) => { handoff.set(None); error.set(Some(format!("That is not a valid HiPhi enrollment file: {message}"))); }
+                                }
+                            });
+                        }
+                    }
+                    button {
+                        r#type: "button",
+                        class: "btn-primary mt-3",
+                        disabled: handoff().is_none() || matches!(action(), ProviderActionState::Loading),
+                        onclick: start_pairing,
+                        "Start pairing"
+                    }
+                    if let Some(pairing) = initiated() {
+                        div { class: "mt-4 rounded-md border border-default bg-elevated p-4 space-y-3",
+                            p { class: "font-medium", "Return to HiPhi Cloud and claim this pending NAS." }
+                            label { class: "text-sm font-medium", "Pairing ID" }
+                            div { class: "flex flex-col gap-2 sm:flex-row",
+                                code { class: "min-w-0 flex-1 break-all", "{pairing.pairing_id}" }
+                                button { r#type: "button", class: "btn-secondary shrink-0", onclick: move |_| copy_to_clipboard(pairing.pairing_id.clone(), pairing_id_copy), "{pairing_id_copy().label(\"Copy ID\")}" }
+                            }
+                            label { class: "text-sm font-medium", "One-time pairing secret" }
+                            div { class: "flex flex-col gap-2 sm:flex-row",
+                                code { class: "min-w-0 flex-1 break-all", "{pairing.pairing_secret}" }
+                                button { r#type: "button", class: "btn-secondary shrink-0", onclick: move |_| copy_to_clipboard(pairing.pairing_secret.clone(), pairing_secret_copy), "{pairing_secret_copy().label(\"Copy secret\")}" }
+                            }
+                            p { class: "text-sm font-medium", "Pairing fingerprint" }
+                            code { class: "block break-all", "{pairing.installation_fingerprint}" }
+                        }
+                    }
+                }
+
+                div { class: "border-t border-default pt-6",
+                    h3 { class: "font-semibold", "3. Complete pairing" }
+                    p { class: "mt-1 text-sm text-secondary", "After confirming the exact fingerprint in HiPhi Cloud, paste the account ID it shows." }
+                    label { class: "mt-3 block text-sm font-medium", r#for: "hiphi-account-id", "HiPhi account ID" }
+                    input { id: "hiphi-account-id", class: "input mt-2 w-full", value: "{account_id}", oninput: move |event| account_id.set(event.value()) }
+                    button { r#type: "button", class: "btn-primary mt-3", disabled: initiated().is_none() || matches!(action(), ProviderActionState::Loading), onclick: complete_pairing, "Complete pairing" }
+                    if let Some(result) = completed() {
+                        div { class: "mt-4 status-ok", role: "status",
+                            p { class: "font-medium", "This NAS is paired." }
+                            if result.restart_required { p { class: "mt-1", "Restart Unified Hi-Fi Control once in QNAP App Center to start the outbound connector." } }
+                        }
+                    }
+                }
+
+                if let Some(message) = error() { p { class: "status-err", role: "alert", "{message}" } }
+            }
+        }
     }
 }
 
@@ -1654,6 +1863,8 @@ pub fn Settings() -> Element {
             hide_knobs: hide_knobs(),
 
             h1 { class: "text-2xl font-bold mb-6", "Settings" }
+
+            HiphiCloudPairing {}
 
             // Features section (adapters + page visibility)
             section { class: "mb-8",

--- a/src/bin/uhc_hiphi_pair.rs
+++ b/src/bin/uhc_hiphi_pair.rs
@@ -243,7 +243,8 @@ mod command {
         println!("pairing_complete=true");
         println!("UHC_HIPHI_INSTALLATION_ID={}", response.installation_id);
         println!("UHC_HIPHI_RELAY_URL={}", relay.as_str());
-        println!("issuer_public_key_configuration_required=true");
+        println!("session_issuer_public_key_configuration_required=true");
+        println!("command_issuer_public_key_configuration_required=true");
         Ok(())
     }
 

--- a/src/bin/uhc_hiphi_pair.rs
+++ b/src/bin/uhc_hiphi_pair.rs
@@ -63,6 +63,8 @@ mod command {
     struct CompletionResponse {
         installation_id: Uuid,
         relay_endpoint: String,
+        session_issuer_keys: serde_json::Value,
+        command_issuer_keys: serde_json::Value,
     }
 
     pub async fn run() -> anyhow::Result<()> {
@@ -236,15 +238,29 @@ mod command {
         if response.installation_id != pending.installation_id {
             anyhow::bail!("cloud completed a different installation");
         }
-        let relay = unified_hifi_control::cloud_connector::transport::RelayEndpoint::parse(
+        let session_keys = serde_json::to_string(&response.session_issuer_keys)?;
+        let command_keys = serde_json::to_string(&response.command_issuer_keys)?;
+        let connector = unified_hifi_control::cloud_connector::CloudConnectorConfig::from_values(
+            config_dir.clone(),
             &response.relay_endpoint,
+            &response.installation_id.to_string(),
+            &session_keys,
+            &command_keys,
+        )?;
+        let environment_path = config_dir.join("hiphi.env");
+        persist_connector_environment(
+            &environment_path,
+            connector.endpoint.as_str(),
+            &response.installation_id.to_string(),
+            &session_keys,
+            &command_keys,
         )?;
         fs::remove_file(&pending_path)?;
         println!("pairing_complete=true");
         println!("UHC_HIPHI_INSTALLATION_ID={}", response.installation_id);
-        println!("UHC_HIPHI_RELAY_URL={}", relay.as_str());
-        println!("session_issuer_key_ring_configuration_required=true");
-        println!("command_issuer_key_ring_configuration_required=true");
+        println!("UHC_HIPHI_RELAY_URL={}", connector.endpoint.as_str());
+        println!("connector_environment_path={}", environment_path.display());
+        println!("connector_restart_required=true");
         Ok(())
     }
 
@@ -435,6 +451,43 @@ mod command {
         Ok(())
     }
 
+    fn persist_connector_environment(
+        path: &Path,
+        relay_endpoint: &str,
+        installation_id: &str,
+        session_keys: &str,
+        command_keys: &str,
+    ) -> anyhow::Result<()> {
+        use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+        let parent = path
+            .parent()
+            .context("connector environment has no parent")?;
+        fs::create_dir_all(parent)?;
+        let temporary = parent.join(format!(".hiphi.env.{}.tmp", Uuid::new_v4().simple()));
+        let bytes = format!(
+            "UHC_HIPHI_RELAY_URL={relay_endpoint}\nUHC_HIPHI_INSTALLATION_ID={installation_id}\nUHC_HIPHI_SESSION_ISSUER_KEYS={session_keys}\nUHC_HIPHI_COMMAND_ISSUER_KEYS={command_keys}\n"
+        );
+        let write_result = (|| -> anyhow::Result<()> {
+            let mut file = fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(0o600)
+                .open(&temporary)?;
+            file.write_all(bytes.as_bytes())?;
+            file.sync_all()?;
+            fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600))?;
+            fs::rename(&temporary, path)?;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+            fs::File::open(parent)?.sync_all()?;
+            Ok(())
+        })();
+        if write_result.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        write_result
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -545,6 +598,64 @@ mod command {
                 serde_json::json!({"ok": true, "authority": "extra"})
             )
             .is_err());
+
+            let completion = serde_json::json!({
+                "installation_id": Uuid::from_u128(2),
+                "relay_endpoint": "wss://cloud.example/v1/relay/connect",
+                "session_issuer_keys": {
+                    "version": 1,
+                    "keys": [{"kid": "session-v1", "key": URL_SAFE_NO_PAD.encode([3_u8; 32])}],
+                },
+                "command_issuer_keys": {
+                    "version": 1,
+                    "keys": [{"kid": "command-v1", "key": URL_SAFE_NO_PAD.encode([4_u8; 32])}],
+                },
+            });
+            assert!(serde_json::from_value::<CompletionResponse>(completion.clone()).is_ok());
+            let mut incomplete = completion;
+            incomplete
+                .as_object_mut()
+                .unwrap()
+                .remove("command_issuer_keys");
+            assert!(serde_json::from_value::<CompletionResponse>(incomplete).is_err());
+        }
+
+        #[test]
+        fn completed_pairing_environment_is_atomic_private_and_complete() {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let directory = tempfile::tempdir().unwrap();
+            let path = directory.path().join("hiphi.env");
+            persist_connector_environment(
+                &path,
+                "wss://cloud.example/v1/relay/connect",
+                "11111111-1111-4111-8111-111111111111",
+                r#"{"version":1,"keys":[{"kid":"session-v1","key":"session-public-key"}]}"#,
+                r#"{"version":1,"keys":[{"kid":"command-v1","key":"command-public-key"}]}"#,
+            )
+            .unwrap();
+
+            let content = fs::read_to_string(&path).unwrap();
+            for key in [
+                "UHC_HIPHI_RELAY_URL=",
+                "UHC_HIPHI_INSTALLATION_ID=",
+                "UHC_HIPHI_SESSION_ISSUER_KEYS=",
+                "UHC_HIPHI_COMMAND_ISSUER_KEYS=",
+            ] {
+                assert!(content.contains(key));
+            }
+            assert_eq!(content.lines().count(), 4);
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+            assert!(fs::read_dir(directory.path()).unwrap().all(|entry| {
+                !entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".tmp")
+            }));
         }
 
         #[test]

--- a/src/bin/uhc_hiphi_pair.rs
+++ b/src/bin/uhc_hiphi_pair.rs
@@ -18,7 +18,7 @@ mod command {
     use serde::{Deserialize, Serialize};
     use unified_hifi_control::cloud_connector::{
         pairing::{enrollment_possession_message, possession_message},
-        InstallationIdentity,
+        CloudConnectorConfig, InstallationIdentity,
     };
     use url::Url;
     use uuid::Uuid;
@@ -107,7 +107,7 @@ mod command {
         let config_dir = unified_hifi_control::config::get_config_dir();
         fs::create_dir_all(&config_dir)?;
         let key_path = config_dir.join("hiphi-installation.key");
-        if key_path.exists() && std::env::var_os("UHC_HIPHI_INSTALLATION_ID").is_some() {
+        if CloudConnectorConfig::from_runtime(&config_dir)?.is_some() {
             anyhow::bail!("this UHC is already configured with a HiPhi installation identity");
         }
         let identity = load_or_create_identity(&key_path)?;
@@ -134,7 +134,7 @@ mod command {
                 pending_path.display()
             );
         }
-        if key_path.exists() && std::env::var_os("UHC_HIPHI_INSTALLATION_ID").is_some() {
+        if CloudConnectorConfig::from_runtime(&config_dir)?.is_some() {
             anyhow::bail!("this UHC is already configured with a HiPhi installation identity");
         }
         let identity =

--- a/src/bin/uhc_hiphi_pair.rs
+++ b/src/bin/uhc_hiphi_pair.rs
@@ -243,8 +243,8 @@ mod command {
         println!("pairing_complete=true");
         println!("UHC_HIPHI_INSTALLATION_ID={}", response.installation_id);
         println!("UHC_HIPHI_RELAY_URL={}", relay.as_str());
-        println!("session_issuer_public_key_configuration_required=true");
-        println!("command_issuer_public_key_configuration_required=true");
+        println!("session_issuer_key_ring_configuration_required=true");
+        println!("command_issuer_key_ring_configuration_required=true");
         Ok(())
     }
 

--- a/src/cloud_connector/config.rs
+++ b/src/cloud_connector/config.rs
@@ -9,8 +9,10 @@ pub struct CloudConnectorConfig {
     pub installation_id: String,
     pub key_path: PathBuf,
     pub epoch_path: PathBuf,
-    pub issuer_key_id: String,
-    pub issuer_public_key: Vec<u8>,
+    pub session_issuer_key_id: String,
+    pub session_issuer_public_key: Vec<u8>,
+    pub command_issuer_key_id: String,
+    pub command_issuer_public_key: Vec<u8>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -35,16 +37,22 @@ impl CloudConnectorConfig {
         };
         let installation_id = env::var("UHC_HIPHI_INSTALLATION_ID")
             .map_err(|_| ConfigError::Missing("UHC_HIPHI_INSTALLATION_ID"))?;
-        let issuer_key_id = env::var("UHC_HIPHI_ISSUER_KEY_ID")
-            .map_err(|_| ConfigError::Missing("UHC_HIPHI_ISSUER_KEY_ID"))?;
-        let encoded_key = env::var("UHC_HIPHI_ISSUER_PUBLIC_KEY")
-            .map_err(|_| ConfigError::Missing("UHC_HIPHI_ISSUER_PUBLIC_KEY"))?;
+        let session_issuer_key_id = env::var("UHC_HIPHI_SESSION_ISSUER_KEY_ID")
+            .map_err(|_| ConfigError::Missing("UHC_HIPHI_SESSION_ISSUER_KEY_ID"))?;
+        let encoded_session_key = env::var("UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY")
+            .map_err(|_| ConfigError::Missing("UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY"))?;
+        let command_issuer_key_id = env::var("UHC_HIPHI_COMMAND_ISSUER_KEY_ID")
+            .map_err(|_| ConfigError::Missing("UHC_HIPHI_COMMAND_ISSUER_KEY_ID"))?;
+        let encoded_command_key = env::var("UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY")
+            .map_err(|_| ConfigError::Missing("UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY"))?;
         Ok(Some(Self::from_values(
             config_dir.into(),
             &endpoint,
             &installation_id,
-            &issuer_key_id,
-            &encoded_key,
+            &session_issuer_key_id,
+            &encoded_session_key,
+            &command_issuer_key_id,
+            &encoded_command_key,
         )?))
     }
 
@@ -52,25 +60,39 @@ impl CloudConnectorConfig {
         config_dir: PathBuf,
         endpoint: &str,
         installation_id: &str,
-        issuer_key_id: &str,
-        encoded_key: &str,
+        session_issuer_key_id: &str,
+        encoded_session_key: &str,
+        command_issuer_key_id: &str,
+        encoded_command_key: &str,
     ) -> Result<Self, ConfigError> {
-        let issuer_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(encoded_key)
-            .map_err(|_| ConfigError::Invalid("UHC_HIPHI_ISSUER_PUBLIC_KEY"))?;
+        let session_issuer_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded_session_key)
+            .map_err(|_| ConfigError::Invalid("UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY"))?;
+        let command_issuer_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(encoded_command_key)
+            .map_err(|_| ConfigError::Invalid("UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY"))?;
         if uuid::Uuid::parse_str(installation_id).is_err()
-            || issuer_public_key.len() != 32
-            || issuer_key_id.is_empty()
+            || session_issuer_public_key.len() != 32
+            || command_issuer_public_key.len() != 32
+            || session_issuer_key_id.trim().is_empty()
+            || command_issuer_key_id.trim().is_empty()
         {
             return Err(ConfigError::Invalid("installation/key id"));
+        }
+        if session_issuer_key_id == command_issuer_key_id
+            || session_issuer_public_key == command_issuer_public_key
+        {
+            return Err(ConfigError::Invalid("issuer authority separation"));
         }
         Ok(Self {
             endpoint: RelayEndpoint::parse(endpoint)?,
             installation_id: installation_id.to_owned(),
             key_path: config_dir.join("hiphi-installation.key"),
             epoch_path: config_dir.join("hiphi-relay-epoch"),
-            issuer_key_id: issuer_key_id.to_owned(),
-            issuer_public_key,
+            session_issuer_key_id: session_issuer_key_id.to_owned(),
+            session_issuer_public_key,
+            command_issuer_key_id: command_issuer_key_id.to_owned(),
+            command_issuer_public_key,
         })
     }
 }
@@ -80,17 +102,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn values_accept_an_installation_without_a_single_control_node() {
+    fn values_accept_distinct_session_and_command_authorities() {
+        let session_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([7_u8; 32]);
+        let command_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([8_u8; 32]);
+        assert!(matches!(
+            CloudConnectorConfig::from_values(
+                PathBuf::from("/tmp/uhc-test"),
+                "wss://cloud.example/v1/relay",
+                "11111111-1111-4111-8111-111111111111",
+                "session-issuer-1",
+                &session_key,
+                "command-issuer-1",
+                &command_key,
+            ),
+            Ok(config)
+                if config.installation_id == "11111111-1111-4111-8111-111111111111"
+                    && config.session_issuer_key_id == "session-issuer-1"
+                    && config.command_issuer_key_id == "command-issuer-1"
+        ));
+    }
+
+    #[test]
+    fn values_reject_reused_session_and_command_authority() {
         let key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([7_u8; 32]);
         assert!(matches!(
             CloudConnectorConfig::from_values(
                 PathBuf::from("/tmp/uhc-test"),
                 "wss://cloud.example/v1/relay",
                 "11111111-1111-4111-8111-111111111111",
-                "issuer-1",
+                "shared-issuer",
+                &key,
+                "shared-issuer",
                 &key,
             ),
-            Ok(config) if config.installation_id == "11111111-1111-4111-8111-111111111111"
+            Err(ConfigError::Invalid("issuer authority separation"))
         ));
     }
 }

--- a/src/cloud_connector/config.rs
+++ b/src/cloud_connector/config.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, env, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashSet},
+    env,
+    path::PathBuf,
+};
 
 use super::transport::{EndpointError, RelayEndpoint};
 use base64::Engine as _;
@@ -7,6 +11,7 @@ use serde::Deserialize;
 
 pub const MAX_ISSUER_KEYS: usize = 8;
 const MAX_ISSUER_RING_JSON_BYTES: usize = 4 * 1024;
+const MAX_PERSISTED_CONFIG_BYTES: u64 = 16 * 1024;
 
 #[derive(Clone, Debug)]
 pub struct IssuerVerifyingKeyRing {
@@ -90,6 +95,10 @@ pub enum ConfigError {
     Missing(&'static str),
     #[error("invalid HiPhi Cloud setting {0}")]
     Invalid(&'static str),
+    #[error("HiPhi Cloud persisted configuration is unsafe or invalid")]
+    InvalidPersisted,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
     #[error(transparent)]
     Endpoint(#[from] EndpointError),
 }
@@ -119,6 +128,56 @@ impl CloudConnectorConfig {
         )?))
     }
 
+    /// Load connector configuration without depending on a packaging-specific
+    /// launcher. Explicit process environment wins; otherwise UHC reads the
+    /// owner-only file written by the pairing ceremony itself.
+    pub fn from_runtime(config_dir: impl Into<PathBuf>) -> Result<Option<Self>, ConfigError> {
+        let config_dir = config_dir.into();
+        match Self::from_env(config_dir.clone())? {
+            Some(config) => Ok(Some(config)),
+            None => Self::from_persisted(config_dir),
+        }
+    }
+
+    pub fn from_persisted(config_dir: impl Into<PathBuf>) -> Result<Option<Self>, ConfigError> {
+        let config_dir = config_dir.into();
+        let path = config_dir.join("hiphi.env");
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        if !metadata.file_type().is_file() || metadata.len() > MAX_PERSISTED_CONFIG_BYTES {
+            return Err(ConfigError::InvalidPersisted);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            if metadata.permissions().mode() & 0o077 != 0 {
+                return Err(ConfigError::InvalidPersisted);
+            }
+        }
+        let contents = std::fs::read_to_string(&path)?;
+        if contents.trim().is_empty() {
+            return Ok(None);
+        }
+        let mut values = parse_persisted_config(&contents)?;
+        let endpoint = take_persisted(&mut values, "UHC_HIPHI_RELAY_URL")?;
+        let installation_id = take_persisted(&mut values, "UHC_HIPHI_INSTALLATION_ID")?;
+        let session_keys = take_persisted(&mut values, "UHC_HIPHI_SESSION_ISSUER_KEYS")?;
+        let command_keys = take_persisted(&mut values, "UHC_HIPHI_COMMAND_ISSUER_KEYS")?;
+        if !values.is_empty() {
+            return Err(ConfigError::InvalidPersisted);
+        }
+        Ok(Some(Self::from_values(
+            config_dir,
+            &endpoint,
+            &installation_id,
+            &session_keys,
+            &command_keys,
+        )?))
+    }
+
     /// Validate an explicit connector binding before it is persisted by a
     /// local enrollment tool. This applies the same rules as service startup.
     pub fn from_values(
@@ -145,6 +204,27 @@ impl CloudConnectorConfig {
             command_issuer_keys,
         })
     }
+}
+
+fn parse_persisted_config(contents: &str) -> Result<BTreeMap<String, String>, ConfigError> {
+    let mut values = BTreeMap::new();
+    for line in contents.lines() {
+        let (name, value) = line.split_once('=').ok_or(ConfigError::InvalidPersisted)?;
+        if name.is_empty()
+            || value.is_empty()
+            || values.insert(name.to_owned(), value.to_owned()).is_some()
+        {
+            return Err(ConfigError::InvalidPersisted);
+        }
+    }
+    Ok(values)
+}
+
+fn take_persisted(
+    values: &mut BTreeMap<String, String>,
+    name: &'static str,
+) -> Result<String, ConfigError> {
+    values.remove(name).ok_or(ConfigError::InvalidPersisted)
 }
 
 fn parse_key_ring(
@@ -310,5 +390,71 @@ mod tests {
             ),
             Err(ConfigError::Invalid("issuer authority separation"))
         ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_runtime_config_is_owner_only_exact_and_complete() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("hiphi.env");
+        let session_keys = key_ring(&[("session-issuer-1", 7)]);
+        let command_keys = key_ring(&[("command-issuer-1", 8)]);
+        std::fs::write(
+            &path,
+            format!(
+                "UHC_HIPHI_RELAY_URL=wss://cloud.example/v1/relay\n\
+                 UHC_HIPHI_INSTALLATION_ID=11111111-1111-4111-8111-111111111111\n\
+                 UHC_HIPHI_SESSION_ISSUER_KEYS={session_keys}\n\
+                 UHC_HIPHI_COMMAND_ISSUER_KEYS={command_keys}\n"
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let config = CloudConnectorConfig::from_persisted(directory.path())
+            .unwrap()
+            .expect("complete config should load");
+        assert_eq!(
+            config.installation_id,
+            "11111111-1111-4111-8111-111111111111"
+        );
+
+        for invalid in [
+            format!(
+                "UHC_HIPHI_RELAY_URL=wss://cloud.example/v1/relay\n\
+                 UHC_HIPHI_INSTALLATION_ID=11111111-1111-4111-8111-111111111111\n\
+                 UHC_HIPHI_SESSION_ISSUER_KEYS={session_keys}\n"
+            ),
+            format!(
+                "UHC_HIPHI_RELAY_URL=wss://cloud.example/v1/relay\n\
+                 UHC_HIPHI_RELAY_URL=wss://cloud.example/v1/relay\n\
+                 UHC_HIPHI_INSTALLATION_ID=11111111-1111-4111-8111-111111111111\n\
+                 UHC_HIPHI_SESSION_ISSUER_KEYS={session_keys}\n\
+                 UHC_HIPHI_COMMAND_ISSUER_KEYS={command_keys}\n"
+            ),
+            format!(
+                "UHC_HIPHI_RELAY_URL=wss://cloud.example/v1/relay\n\
+                 UHC_HIPHI_INSTALLATION_ID=11111111-1111-4111-8111-111111111111\n\
+                 UHC_HIPHI_SESSION_ISSUER_KEYS={session_keys}\n\
+                 UHC_HIPHI_COMMAND_ISSUER_KEYS={command_keys}\n\
+                 SHELL_COMMAND=touch /tmp/nope\n"
+            ),
+        ] {
+            std::fs::write(&path, invalid).unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+            assert!(CloudConnectorConfig::from_persisted(directory.path()).is_err());
+        }
+
+        std::fs::write(&path, "").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(CloudConnectorConfig::from_persisted(directory.path())
+            .unwrap()
+            .is_none());
+
+        std::fs::write(&path, "UHC_HIPHI_RELAY_URL=wss://cloud.example/v1/relay\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+        assert!(CloudConnectorConfig::from_persisted(directory.path()).is_err());
     }
 }

--- a/src/cloud_connector/config.rs
+++ b/src/cloud_connector/config.rs
@@ -119,7 +119,9 @@ impl CloudConnectorConfig {
         )?))
     }
 
-    fn from_values(
+    /// Validate an explicit connector binding before it is persisted by a
+    /// local enrollment tool. This applies the same rules as service startup.
+    pub fn from_values(
         config_dir: PathBuf,
         endpoint: &str,
         installation_id: &str,

--- a/src/cloud_connector/config.rs
+++ b/src/cloud_connector/config.rs
@@ -1,7 +1,78 @@
-use std::{env, path::PathBuf};
+use std::{collections::HashSet, env, path::PathBuf};
 
 use super::transport::{EndpointError, RelayEndpoint};
 use base64::Engine as _;
+use ed25519_dalek::VerifyingKey;
+use serde::Deserialize;
+
+pub const MAX_ISSUER_KEYS: usize = 8;
+const MAX_ISSUER_RING_JSON_BYTES: usize = 4 * 1024;
+
+#[derive(Clone, Debug)]
+pub struct IssuerVerifyingKeyRing {
+    keys: Vec<(String, VerifyingKey)>,
+}
+
+impl IssuerVerifyingKeyRing {
+    pub fn from_entries(
+        entries: impl IntoIterator<Item = (String, VerifyingKey)>,
+    ) -> Result<Self, ConfigError> {
+        Self::validated(entries.into_iter().collect(), "issuer key ring")
+    }
+
+    fn validated(
+        keys: Vec<(String, VerifyingKey)>,
+        setting: &'static str,
+    ) -> Result<Self, ConfigError> {
+        if !(1..=MAX_ISSUER_KEYS).contains(&keys.len()) {
+            return Err(ConfigError::Invalid(setting));
+        }
+        let mut key_ids = HashSet::with_capacity(keys.len());
+        let mut public_keys = HashSet::with_capacity(keys.len());
+        for (key_id, key) in &keys {
+            if !valid_key_id(key_id)
+                || !key_ids.insert(key_id.clone())
+                || !public_keys.insert(key.to_bytes())
+                || key.is_weak()
+            {
+                return Err(ConfigError::Invalid(setting));
+            }
+        }
+        Ok(Self { keys })
+    }
+
+    pub fn get(&self, key_id: &str) -> Option<&VerifyingKey> {
+        self.keys
+            .iter()
+            .find_map(|(candidate, key)| (candidate == key_id).then_some(key))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &VerifyingKey)> {
+        self.keys.iter().map(|(key_id, key)| (key_id.as_str(), key))
+    }
+
+    pub fn len(&self) -> usize {
+        self.keys.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IssuerKeyRingManifest {
+    version: u8,
+    keys: Vec<IssuerKeyManifestEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IssuerKeyManifestEntry {
+    kid: String,
+    key: String,
+}
 
 #[derive(Clone, Debug)]
 pub struct CloudConnectorConfig {
@@ -9,10 +80,8 @@ pub struct CloudConnectorConfig {
     pub installation_id: String,
     pub key_path: PathBuf,
     pub epoch_path: PathBuf,
-    pub session_issuer_key_id: String,
-    pub session_issuer_public_key: Vec<u8>,
-    pub command_issuer_key_id: String,
-    pub command_issuer_public_key: Vec<u8>,
+    pub session_issuer_keys: IssuerVerifyingKeyRing,
+    pub command_issuer_keys: IssuerVerifyingKeyRing,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -37,22 +106,16 @@ impl CloudConnectorConfig {
         };
         let installation_id = env::var("UHC_HIPHI_INSTALLATION_ID")
             .map_err(|_| ConfigError::Missing("UHC_HIPHI_INSTALLATION_ID"))?;
-        let session_issuer_key_id = env::var("UHC_HIPHI_SESSION_ISSUER_KEY_ID")
-            .map_err(|_| ConfigError::Missing("UHC_HIPHI_SESSION_ISSUER_KEY_ID"))?;
-        let encoded_session_key = env::var("UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY")
-            .map_err(|_| ConfigError::Missing("UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY"))?;
-        let command_issuer_key_id = env::var("UHC_HIPHI_COMMAND_ISSUER_KEY_ID")
-            .map_err(|_| ConfigError::Missing("UHC_HIPHI_COMMAND_ISSUER_KEY_ID"))?;
-        let encoded_command_key = env::var("UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY")
-            .map_err(|_| ConfigError::Missing("UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY"))?;
+        let session_issuer_keys = env::var("UHC_HIPHI_SESSION_ISSUER_KEYS")
+            .map_err(|_| ConfigError::Missing("UHC_HIPHI_SESSION_ISSUER_KEYS"))?;
+        let command_issuer_keys = env::var("UHC_HIPHI_COMMAND_ISSUER_KEYS")
+            .map_err(|_| ConfigError::Missing("UHC_HIPHI_COMMAND_ISSUER_KEYS"))?;
         Ok(Some(Self::from_values(
             config_dir.into(),
             &endpoint,
             &installation_id,
-            &session_issuer_key_id,
-            &encoded_session_key,
-            &command_issuer_key_id,
-            &encoded_command_key,
+            &session_issuer_keys,
+            &command_issuer_keys,
         )?))
     }
 
@@ -60,80 +123,188 @@ impl CloudConnectorConfig {
         config_dir: PathBuf,
         endpoint: &str,
         installation_id: &str,
-        session_issuer_key_id: &str,
-        encoded_session_key: &str,
-        command_issuer_key_id: &str,
-        encoded_command_key: &str,
+        encoded_session_keys: &str,
+        encoded_command_keys: &str,
     ) -> Result<Self, ConfigError> {
-        let session_issuer_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(encoded_session_key)
-            .map_err(|_| ConfigError::Invalid("UHC_HIPHI_SESSION_ISSUER_PUBLIC_KEY"))?;
-        let command_issuer_public_key = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(encoded_command_key)
-            .map_err(|_| ConfigError::Invalid("UHC_HIPHI_COMMAND_ISSUER_PUBLIC_KEY"))?;
-        if uuid::Uuid::parse_str(installation_id).is_err()
-            || session_issuer_public_key.len() != 32
-            || command_issuer_public_key.len() != 32
-            || session_issuer_key_id.trim().is_empty()
-            || command_issuer_key_id.trim().is_empty()
-        {
+        if uuid::Uuid::parse_str(installation_id).is_err() {
             return Err(ConfigError::Invalid("installation/key id"));
         }
-        if session_issuer_key_id == command_issuer_key_id
-            || session_issuer_public_key == command_issuer_public_key
-        {
-            return Err(ConfigError::Invalid("issuer authority separation"));
-        }
+        let session_issuer_keys =
+            parse_key_ring(encoded_session_keys, "UHC_HIPHI_SESSION_ISSUER_KEYS")?;
+        let command_issuer_keys =
+            parse_key_ring(encoded_command_keys, "UHC_HIPHI_COMMAND_ISSUER_KEYS")?;
+        validate_distinct_authorities(&session_issuer_keys, &command_issuer_keys)?;
         Ok(Self {
             endpoint: RelayEndpoint::parse(endpoint)?,
             installation_id: installation_id.to_owned(),
             key_path: config_dir.join("hiphi-installation.key"),
             epoch_path: config_dir.join("hiphi-relay-epoch"),
-            session_issuer_key_id: session_issuer_key_id.to_owned(),
-            session_issuer_public_key,
-            command_issuer_key_id: command_issuer_key_id.to_owned(),
-            command_issuer_public_key,
+            session_issuer_keys,
+            command_issuer_keys,
         })
     }
+}
+
+fn parse_key_ring(
+    encoded: &str,
+    setting: &'static str,
+) -> Result<IssuerVerifyingKeyRing, ConfigError> {
+    if encoded.len() > MAX_ISSUER_RING_JSON_BYTES {
+        return Err(ConfigError::Invalid(setting));
+    }
+    let manifest: IssuerKeyRingManifest =
+        serde_json::from_str(encoded).map_err(|_| ConfigError::Invalid(setting))?;
+    if manifest.version != 1 {
+        return Err(ConfigError::Invalid(setting));
+    }
+    let mut keys = Vec::with_capacity(manifest.keys.len().min(MAX_ISSUER_KEYS));
+    for entry in manifest.keys {
+        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&entry.key)
+            .map_err(|_| ConfigError::Invalid(setting))?;
+        if base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&bytes) != entry.key {
+            return Err(ConfigError::Invalid(setting));
+        }
+        let key = VerifyingKey::from_bytes(
+            &bytes
+                .try_into()
+                .map_err(|_| ConfigError::Invalid(setting))?,
+        )
+        .map_err(|_| ConfigError::Invalid(setting))?;
+        keys.push((entry.kid, key));
+    }
+    IssuerVerifyingKeyRing::validated(keys, setting)
+}
+
+fn validate_distinct_authorities(
+    session: &IssuerVerifyingKeyRing,
+    command: &IssuerVerifyingKeyRing,
+) -> Result<(), ConfigError> {
+    if session.iter().any(|(session_id, session_key)| {
+        command
+            .iter()
+            .any(|(command_id, command_key)| session_id == command_id || session_key == command_key)
+    }) {
+        return Err(ConfigError::Invalid("issuer authority separation"));
+    }
+    Ok(())
+}
+
+fn valid_key_id(value: &str) -> bool {
+    (1..=64).contains(&value.len())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn key_ring(entries: &[(&str, u8)]) -> String {
+        key_ring_owned(
+            entries
+                .iter()
+                .map(|(kid, byte)| ((*kid).to_owned(), *byte))
+                .collect(),
+        )
+    }
+
+    fn key_ring_owned(entries: Vec<(String, u8)>) -> String {
+        serde_json::json!({
+            "version": 1,
+            "keys": entries
+                .iter()
+                .map(|(kid, byte)| serde_json::json!({
+                    "kid": kid,
+                    "key": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+                        SigningKey::from_bytes(&[*byte; 32]).verifying_key().to_bytes()
+                    )
+                }))
+                .collect::<Vec<_>>()
+        })
+        .to_string()
+    }
 
     #[test]
     fn values_accept_distinct_session_and_command_authorities() {
-        let session_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([7_u8; 32]);
-        let command_key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([8_u8; 32]);
+        let session_keys = key_ring(&[("session-issuer-1", 7), ("session-issuer-2", 8)]);
+        let command_keys = key_ring(&[("command-issuer-1", 9), ("command-issuer-2", 10)]);
         assert!(matches!(
             CloudConnectorConfig::from_values(
                 PathBuf::from("/tmp/uhc-test"),
                 "wss://cloud.example/v1/relay",
                 "11111111-1111-4111-8111-111111111111",
-                "session-issuer-1",
-                &session_key,
-                "command-issuer-1",
-                &command_key,
+                &session_keys,
+                &command_keys,
             ),
             Ok(config)
                 if config.installation_id == "11111111-1111-4111-8111-111111111111"
-                    && config.session_issuer_key_id == "session-issuer-1"
-                    && config.command_issuer_key_id == "command-issuer-1"
+                    && config.session_issuer_keys.len() == 2
+                    && config.command_issuer_keys.len() == 2
         ));
     }
 
     #[test]
-    fn values_reject_reused_session_and_command_authority() {
-        let key = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode([7_u8; 32]);
+    fn values_reject_malformed_duplicate_oversized_and_cross_authority_rings() {
+        let valid_session = key_ring(&[("session-issuer-1", 7)]);
+        let valid_command = key_ring(&[("command-issuer-1", 8)]);
+        let mut weak_key = [0_u8; 32];
+        weak_key[0] = 1;
+        for malformed in [
+            "not-json".to_owned(),
+            r#"{"version":2,"keys":[{"kid":"session-issuer-1","key":"bad"}]}"#.to_owned(),
+            r#"{"version":1,"keys":[]}"#.to_owned(),
+            r#"{"version":1,"keys":[{"kid":"invalid-key","key":"not-base64url"}]}"#.to_owned(),
+            serde_json::json!({
+                "version": 1,
+                "keys": [{
+                    "kid": "weak-key",
+                    "key": base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(weak_key)
+                }]
+            })
+            .to_string(),
+            key_ring(&[("duplicate", 7), ("duplicate", 8)]),
+            key_ring(&[("same-key-1", 7), ("same-key-2", 7)]),
+            key_ring_owned(
+                (0..=MAX_ISSUER_KEYS)
+                    .map(|index| (format!("key-{index}"), index as u8 + 1))
+                    .collect(),
+            ),
+            format!(
+                "{{\"version\":1,\"keys\":[],\"padding\":\"{}\"}}",
+                "x".repeat(MAX_ISSUER_RING_JSON_BYTES)
+            ),
+        ] {
+            assert!(CloudConnectorConfig::from_values(
+                PathBuf::from("/tmp/uhc-test"),
+                "wss://cloud.example/v1/relay",
+                "11111111-1111-4111-8111-111111111111",
+                &malformed,
+                &valid_command,
+            )
+            .is_err());
+        }
+
+        let reused_id = key_ring(&[("shared-issuer", 7)]);
         assert!(matches!(
             CloudConnectorConfig::from_values(
                 PathBuf::from("/tmp/uhc-test"),
                 "wss://cloud.example/v1/relay",
                 "11111111-1111-4111-8111-111111111111",
-                "shared-issuer",
-                &key,
-                "shared-issuer",
-                &key,
+                &reused_id,
+                &key_ring(&[("shared-issuer", 8)]),
+            ),
+            Err(ConfigError::Invalid("issuer authority separation"))
+        ));
+        assert!(matches!(
+            CloudConnectorConfig::from_values(
+                PathBuf::from("/tmp/uhc-test"),
+                "wss://cloud.example/v1/relay",
+                "11111111-1111-4111-8111-111111111111",
+                &valid_session,
+                &key_ring(&[("command-issuer-1", 7)]),
             ),
             Err(ConfigError::Invalid("issuer authority separation"))
         ));

--- a/src/cloud_connector/mod.rs
+++ b/src/cloud_connector/mod.rs
@@ -16,7 +16,7 @@ pub mod transport;
 
 pub use artwork::{ArtLane, ArtRequest, ArtResponse};
 pub use commands::{CommandGrantVerifier, CommandLedger, CommandOutcome, VerifiedCommand};
-pub use config::{CloudConnectorConfig, ConfigError};
+pub use config::{CloudConnectorConfig, ConfigError, IssuerVerifyingKeyRing, MAX_ISSUER_KEYS};
 pub use identity::{InstallationIdentity, ZoneHandleMap};
 pub use protocol::{
     parse_relay_message, AllowedAction, ArtworkChunk, ArtworkRelayRequest, ArtworkRelayResponse,

--- a/src/cloud_connector/protocol.rs
+++ b/src/cloud_connector/protocol.rs
@@ -465,6 +465,18 @@ pub fn canonical_json(value: &serde_json::Value) -> Result<Vec<u8>, serde_json::
             serde_json::Value::Array(values) => {
                 serde_json::Value::Array(values.iter().map(normalize).collect())
             }
+            serde_json::Value::Number(number) if number.is_f64() => {
+                if let Some(value) = number.as_f64() {
+                    const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991.0;
+                    if value.fract() == 0.0 && value.abs() <= MAX_SAFE_INTEGER {
+                        serde_json::Value::Number(serde_json::Number::from(value as i64))
+                    } else {
+                        value.into()
+                    }
+                } else {
+                    serde_json::Value::Number(number.clone())
+                }
+            }
             other => other.clone(),
         }
     }

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -112,17 +112,9 @@ async fn run(
                 continue;
             }
         };
-        let session_issuer_key = match session_issuer_verifying_key(&config) {
-            Ok(key) => key,
-            Err(error) => {
-                tracing::error!("HiPhi Cloud session issuer key is invalid: {error}");
-                break;
-            }
-        };
         let verified_grant = match verify_installation_session_grant(
             &grant,
-            &config.session_issuer_key_id,
-            &session_issuer_key,
+            &config.session_issuer_keys,
             &identity,
             config.endpoint.as_str(),
             now_ms(),
@@ -349,7 +341,6 @@ where
     });
     send_json(&mut socket, &snapshot).await?;
 
-    let command_issuer_key = command_issuer_verifying_key(config)?;
     let mut verifier = CommandGrantVerifier::new(
         "hiphi-command-authorization",
         UHC_AUDIENCE,
@@ -357,7 +348,9 @@ where
         epoch,
         grant_generation,
     );
-    verifier.pin_key(config.command_issuer_key_id.clone(), command_issuer_key);
+    for (key_id, key) in config.command_issuer_keys.iter() {
+        verifier.pin_key(key_id.to_owned(), *key);
+    }
     let (artwork_tx, mut artwork_rx) = mpsc::channel(ARTWORK_QUEUE_CAPACITY);
     let artwork_slots =
         std::sync::Arc::new(Semaphore::new(ARTWORK_QUEUE_CAPACITY + ARTWORK_CONCURRENCY));
@@ -841,26 +834,6 @@ fn now_ms() -> i64 {
         .as_millis() as i64
 }
 
-fn session_issuer_verifying_key(
-    config: &CloudConnectorConfig,
-) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
-    verifying_key(&config.session_issuer_public_key, "session issuer")
-}
-
-fn command_issuer_verifying_key(
-    config: &CloudConnectorConfig,
-) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
-    verifying_key(&config.command_issuer_public_key, "command issuer")
-}
-
-fn verifying_key(bytes: &[u8], authority: &str) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
-    Ok(ed25519_dalek::VerifyingKey::from_bytes(
-        bytes
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("{authority} key must be 32 bytes"))?,
-    )?)
-}
-
 fn websocket_upgrade_request(
     endpoint: &str,
     grant: &str,
@@ -893,7 +866,7 @@ mod tests {
         api::AppState,
         bus::create_bus,
         cloud_connector::{
-            config::CloudConnectorConfig,
+            config::{CloudConnectorConfig, IssuerVerifyingKeyRing},
             identity::InstallationIdentity,
             protocol::{
                 CommandAction, CommandEnvelope, CommandGrantClaims, CommandPayload,
@@ -1366,7 +1339,9 @@ mod tests {
     async fn production_connection_uses_distinct_command_authority_then_honors_revocation() {
         let installation_id = Uuid::new_v4().to_string();
         let identity = InstallationIdentity::generate(installation_id.clone()).unwrap();
+        let previous_session_issuer = SigningKey::from_bytes(&[28; 32]);
         let session_issuer = SigningKey::from_bytes(&[30; 32]);
+        let previous_command_issuer = SigningKey::from_bytes(&[29; 32]);
         let command_issuer = SigningKey::from_bytes(&[31; 32]);
         let temp = tempfile::tempdir().unwrap();
         let endpoint = "wss://cloud.invalid/v1/relay/connect";
@@ -1375,10 +1350,22 @@ mod tests {
             installation_id: installation_id.clone(),
             key_path: temp.path().join("installation.key"),
             epoch_path: temp.path().join("epoch"),
-            session_issuer_key_id: "session-issuer-1".into(),
-            session_issuer_public_key: session_issuer.verifying_key().to_bytes().to_vec(),
-            command_issuer_key_id: "command-issuer-1".into(),
-            command_issuer_public_key: command_issuer.verifying_key().to_bytes().to_vec(),
+            session_issuer_keys: IssuerVerifyingKeyRing::from_entries([
+                (
+                    "session-issuer-1".into(),
+                    previous_session_issuer.verifying_key(),
+                ),
+                ("session-issuer-2".into(), session_issuer.verifying_key()),
+            ])
+            .unwrap(),
+            command_issuer_keys: IssuerVerifyingKeyRing::from_entries([
+                (
+                    "command-issuer-1".into(),
+                    previous_command_issuer.verifying_key(),
+                ),
+                ("command-issuer-2".into(), command_issuer.verifying_key()),
+            ])
+            .unwrap(),
         };
         let state = empty_app_state().await;
         let (client_io, server_io) = tokio::io::duplex(128 * 1024);
@@ -1394,7 +1381,7 @@ mod tests {
         });
         let epoch = u64::try_from(now).unwrap();
         let command = signed_command(
-            "command-issuer-1",
+            "command-issuer-2",
             &command_issuer,
             &installation_id,
             epoch,
@@ -1492,10 +1479,16 @@ mod tests {
             installation_id: installation_id.clone(),
             key_path: temp.path().join("installation.key"),
             epoch_path: temp.path().join("epoch"),
-            session_issuer_key_id: "session-issuer-1".into(),
-            session_issuer_public_key: session_issuer.verifying_key().to_bytes().to_vec(),
-            command_issuer_key_id: "command-issuer-1".into(),
-            command_issuer_public_key: command_issuer.verifying_key().to_bytes().to_vec(),
+            session_issuer_keys: IssuerVerifyingKeyRing::from_entries([(
+                "session-issuer-1".into(),
+                session_issuer.verifying_key(),
+            )])
+            .unwrap(),
+            command_issuer_keys: IssuerVerifyingKeyRing::from_entries([(
+                "command-issuer-1".into(),
+                command_issuer.verifying_key(),
+            )])
+            .unwrap(),
         };
         let state = empty_app_state().await;
         let shutdown = state.shutdown.clone();

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -106,17 +106,17 @@ async fn run(
                 continue;
             }
         };
-        let issuer_key = match issuer_verifying_key(&config) {
+        let session_issuer_key = match session_issuer_verifying_key(&config) {
             Ok(key) => key,
             Err(error) => {
-                tracing::error!("HiPhi Cloud issuer key is invalid: {error}");
+                tracing::error!("HiPhi Cloud session issuer key is invalid: {error}");
                 break;
             }
         };
         let verified_grant = match verify_installation_session_grant(
             &grant,
-            &config.issuer_key_id,
-            &issuer_key,
+            &config.session_issuer_key_id,
+            &session_issuer_key,
             &identity,
             config.endpoint.as_str(),
             now_ms(),
@@ -335,7 +335,7 @@ where
     });
     send_json(&mut socket, &snapshot).await?;
 
-    let issuer_key = issuer_verifying_key(config)?;
+    let command_issuer_key = command_issuer_verifying_key(config)?;
     let mut verifier = CommandGrantVerifier::new(
         "hiphi-command-authorization",
         UHC_AUDIENCE,
@@ -343,7 +343,7 @@ where
         epoch,
         grant_generation,
     );
-    verifier.pin_key(config.issuer_key_id.clone(), issuer_key);
+    verifier.pin_key(config.command_issuer_key_id.clone(), command_issuer_key);
     let (artwork_tx, mut artwork_rx) = mpsc::channel(ARTWORK_QUEUE_CAPACITY);
     let artwork_slots =
         std::sync::Arc::new(Semaphore::new(ARTWORK_QUEUE_CAPACITY + ARTWORK_CONCURRENCY));
@@ -800,15 +800,23 @@ fn now_ms() -> i64 {
         .as_millis() as i64
 }
 
-fn issuer_verifying_key(
+fn session_issuer_verifying_key(
     config: &CloudConnectorConfig,
 ) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
+    verifying_key(&config.session_issuer_public_key, "session issuer")
+}
+
+fn command_issuer_verifying_key(
+    config: &CloudConnectorConfig,
+) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
+    verifying_key(&config.command_issuer_public_key, "command issuer")
+}
+
+fn verifying_key(bytes: &[u8], authority: &str) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
     Ok(ed25519_dalek::VerifyingKey::from_bytes(
-        config
-            .issuer_public_key
-            .as_slice()
+        bytes
             .try_into()
-            .map_err(|_| anyhow::anyhow!("issuer key must be 32 bytes"))?,
+            .map_err(|_| anyhow::anyhow!("{authority} key must be 32 bytes"))?,
     )?)
 }
 
@@ -847,8 +855,8 @@ mod tests {
             config::CloudConnectorConfig,
             identity::InstallationIdentity,
             protocol::{
-                CommandAction, CommandPayload, ConnectorMessage, SessionChallengeMessage,
-                PROTOCOL_VERSION,
+                CommandAction, CommandEnvelope, CommandGrantClaims, CommandPayload,
+                ConnectorMessage, SessionChallengeMessage, PROTOCOL_VERSION,
             },
             state::{ControlEligibility, SemanticStateInput, SemanticZoneInput},
             transport::{RelayEndpoint, SessionEpochGuard},
@@ -857,7 +865,8 @@ mod tests {
         coordinator::AdapterCoordinator,
         knobs::KnobStore,
     };
-    use ed25519_dalek::SigningKey;
+    use base64::Engine as _;
+    use ed25519_dalek::{Signer as _, SigningKey};
     use futures::{SinkExt as _, StreamExt as _};
     use std::{
         sync::{
@@ -888,6 +897,65 @@ mod tests {
             connector_version: env!("UHC_VERSION").into(),
             issued_at: 1_800_000_000_000,
             signature: "proof_012345678901234567890123456789".into(),
+        }
+    }
+
+    fn signed_command(
+        key_id: &str,
+        key: &SigningKey,
+        installation_id: &str,
+        epoch: u64,
+        generation: u64,
+        now: i64,
+    ) -> crate::cloud_connector::protocol::CommandEnvelope {
+        let control_node_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let idempotency_key = Uuid::new_v4();
+        let payload = CommandPayload {
+            zone_handle: "zone_distinct_authority_test".into(),
+            action: CommandAction::Next,
+        };
+        let claims = CommandGrantClaims {
+            protocol_version: PROTOCOL_VERSION,
+            issuer: "hiphi-command-authorization".into(),
+            audience: super::UHC_AUDIENCE.into(),
+            installation_id: installation_id.into(),
+            control_node_id,
+            request_id,
+            idempotency_key,
+            scope: payload.action.scope().into(),
+            payload_sha256: payload.canonical_hash().unwrap(),
+            epoch,
+            issued_at: now - 100,
+            expires_at: now + 5_000,
+            grant_generation: generation,
+        };
+        let encoded_header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "alg": "EdDSA",
+                "kid": key_id,
+            }))
+            .unwrap(),
+        );
+        let encoded_claims = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&claims).unwrap());
+        let signature = key.sign(format!("{encoded_header}.{encoded_claims}").as_bytes());
+        let grant = format!(
+            "{encoded_header}.{encoded_claims}.{}",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        );
+        CommandEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            installation_id: installation_id.into(),
+            control_node_id,
+            epoch,
+            message_id: "message_distinct_authority_test".into(),
+            request_id,
+            idempotency_key,
+            created_at: claims.issued_at,
+            expires_at: claims.expires_at,
+            payload,
+            grant,
         }
     }
 
@@ -1254,10 +1322,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn production_run_connection_sends_hello_snapshot_then_honors_revocation() {
+    async fn production_connection_uses_distinct_command_authority_then_honors_revocation() {
         let installation_id = Uuid::new_v4().to_string();
         let identity = InstallationIdentity::generate(installation_id.clone()).unwrap();
-        let issuer = SigningKey::from_bytes(&[31; 32]);
+        let session_issuer = SigningKey::from_bytes(&[30; 32]);
+        let command_issuer = SigningKey::from_bytes(&[31; 32]);
         let temp = tempfile::tempdir().unwrap();
         let endpoint = "wss://cloud.invalid/v1/relay/connect";
         let config = CloudConnectorConfig {
@@ -1265,8 +1334,10 @@ mod tests {
             installation_id: installation_id.clone(),
             key_path: temp.path().join("installation.key"),
             epoch_path: temp.path().join("epoch"),
-            issuer_key_id: "issuer-1".into(),
-            issuer_public_key: issuer.verifying_key().to_bytes().to_vec(),
+            session_issuer_key_id: "session-issuer-1".into(),
+            session_issuer_public_key: session_issuer.verifying_key().to_bytes().to_vec(),
+            command_issuer_key_id: "command-issuer-1".into(),
+            command_issuer_public_key: command_issuer.verifying_key().to_bytes().to_vec(),
         };
         let state = empty_app_state().await;
         let (client_io, server_io) = tokio::io::duplex(128 * 1024);
@@ -1281,6 +1352,14 @@ mod tests {
             expires_at: now + 30_000,
         });
         let epoch = u64::try_from(now).unwrap();
+        let command = signed_command(
+            "command-issuer-1",
+            &command_issuer,
+            &installation_id,
+            epoch,
+            0,
+            now,
+        );
         let server_task = tokio::spawn(async move {
             server
                 .send(Message::Text(
@@ -1316,6 +1395,19 @@ mod tests {
                 if value.installation_id == installation_id && value.epoch == epoch));
             server
                 .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::Command(command))
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            let Message::Text(result) = server.next().await.unwrap().unwrap() else {
+                panic!("expected command result")
+            };
+            let result: ConnectorMessage = serde_json::from_str(&result).unwrap();
+            assert!(matches!(result, ConnectorMessage::CommandResult(_)));
+            server
+                .send(Message::Text(
                     serde_json::to_string(&RelayMessage::Revoke {
                         reason_code: "owner_revoked".into(),
                     })
@@ -1342,6 +1434,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(exit, ConnectionExit::Revoked);
+        assert_eq!(ledger.len(), 1, "the command authority grant was accepted");
         server_task.await.unwrap();
     }
 }

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -9,8 +9,7 @@
 use futures::{SinkExt, StreamExt};
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{mpsc, Semaphore};
-use tokio::task::JoinHandle;
+use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio_tungstenite::{
     connect_async_with_config,
     tungstenite::{
@@ -62,31 +61,149 @@ enum ConnectionExit {
     Shutdown,
 }
 
-pub fn spawn_from_env(
-    state: crate::api::AppState,
-    config_dir: impl Into<std::path::PathBuf>,
-) -> anyhow::Result<Option<JoinHandle<()>>> {
-    let Some(config) = CloudConnectorConfig::from_env(config_dir)? else {
-        return Ok(None);
-    };
-    let identity = if config.key_path.exists() {
-        InstallationIdentity::load(&config.key_path, config.installation_id.clone())?
-    } else {
-        let identity = InstallationIdentity::generate(config.installation_id.clone())?;
-        if let Some(parent) = config.key_path.parent() {
-            std::fs::create_dir_all(parent)?;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConnectorPhase {
+    Unconfigured,
+    Offline,
+    Connecting,
+    Online,
+    Revoked,
+}
+
+impl ConnectorPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unconfigured => "unconfigured",
+            Self::Offline => "offline",
+            Self::Connecting => "connecting",
+            Self::Online => "online",
+            Self::Revoked => "revoked",
         }
-        identity.save(&config.key_path)?;
-        identity
-    };
-    Ok(Some(tokio::spawn(run(state, config, identity))))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConnectorStatus {
+    pub configured: bool,
+    pub installation_id: Option<String>,
+    pub phase: ConnectorPhase,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConnectorStart {
+    NotConfigured,
+    Started,
+    AlreadyRunning,
+}
+
+#[derive(Default)]
+struct SupervisorState {
+    active: bool,
+    generation: u64,
+    installation_id: Option<String>,
+    phase: Option<ConnectorPhase>,
+}
+
+/// Owns the single outbound connector task for this UHC process. Pairing can
+/// activate it immediately, while startup reconstructs the same state from the
+/// owner-only persisted binding without relying on a package launcher.
+#[derive(Clone, Default)]
+pub struct ConnectorSupervisor {
+    inner: std::sync::Arc<Mutex<SupervisorState>>,
+}
+
+#[derive(Clone, Copy)]
+struct ConnectionLifecycle<'a> {
+    supervisor: &'a ConnectorSupervisor,
+    generation: u64,
+}
+
+impl ConnectorSupervisor {
+    pub async fn start_from_runtime(
+        &self,
+        state: crate::api::AppState,
+        config_dir: impl Into<std::path::PathBuf>,
+    ) -> anyhow::Result<ConnectorStart> {
+        let Some(config) = CloudConnectorConfig::from_runtime(config_dir)? else {
+            return Ok(ConnectorStart::NotConfigured);
+        };
+        let identity = InstallationIdentity::load(&config.key_path, config.installation_id.clone())
+            .map_err(|error| {
+                anyhow::anyhow!("paired HiPhi installation key is unavailable: {error}")
+            })?;
+
+        let generation = {
+            let mut inner = self.inner.lock().await;
+            if inner.active {
+                if inner.installation_id.as_deref() == Some(config.installation_id.as_str()) {
+                    return Ok(ConnectorStart::AlreadyRunning);
+                }
+                anyhow::bail!("a different HiPhi connector task is already active");
+            }
+            inner.generation = inner.generation.saturating_add(1);
+            inner.active = true;
+            inner.installation_id = Some(config.installation_id.clone());
+            inner.phase = Some(ConnectorPhase::Connecting);
+            inner.generation
+        };
+
+        let supervisor = self.clone();
+        tokio::spawn(async move {
+            let final_phase = run(state, config, identity, supervisor.clone(), generation).await;
+            supervisor.finish(generation, final_phase).await;
+        });
+        Ok(ConnectorStart::Started)
+    }
+
+    pub async fn status_from_runtime(
+        &self,
+        config_dir: impl Into<std::path::PathBuf>,
+    ) -> anyhow::Result<ConnectorStatus> {
+        let Some(config) = CloudConnectorConfig::from_runtime(config_dir)? else {
+            return Ok(ConnectorStatus {
+                configured: false,
+                installation_id: None,
+                phase: ConnectorPhase::Unconfigured,
+            });
+        };
+        let inner = self.inner.lock().await;
+        let phase = if inner.active
+            && inner.installation_id.as_deref() == Some(config.installation_id.as_str())
+        {
+            inner.phase.unwrap_or(ConnectorPhase::Offline)
+        } else {
+            ConnectorPhase::Offline
+        };
+        Ok(ConnectorStatus {
+            configured: true,
+            installation_id: Some(config.installation_id),
+            phase,
+        })
+    }
+
+    async fn set_phase(&self, generation: u64, phase: ConnectorPhase) {
+        let mut inner = self.inner.lock().await;
+        if inner.active && inner.generation == generation {
+            inner.phase = Some(phase);
+        }
+    }
+
+    async fn finish(&self, generation: u64, phase: ConnectorPhase) {
+        let mut inner = self.inner.lock().await;
+        if inner.generation == generation {
+            inner.active = false;
+            inner.phase = Some(phase);
+        }
+    }
 }
 
 async fn run(
     state: crate::api::AppState,
     config: CloudConnectorConfig,
     identity: InstallationIdentity,
-) {
+    supervisor: ConnectorSupervisor,
+    generation: u64,
+) -> ConnectorPhase {
     let mut backoff = super::transport::Backoff::default();
     let shutdown = state.shutdown.clone();
     let mut store = StateStore::default();
@@ -94,11 +211,15 @@ async fn run(
         Ok(guard) => guard,
         Err(error) => {
             tracing::error!("HiPhi Cloud epoch state is unavailable: {error}");
-            return;
+            return ConnectorPhase::Offline;
         }
     };
     let mut ledger = CommandLedger::default();
+    let mut final_phase = ConnectorPhase::Offline;
     loop {
+        supervisor
+            .set_phase(generation, ConnectorPhase::Connecting)
+            .await;
         let delay = backoff.next_delay();
         tokio::select! { _ = shutdown.cancelled() => break, _ = tokio::time::sleep(delay) => {} }
         let grant = match tokio::select! {
@@ -156,6 +277,10 @@ async fn run(
                     &mut store,
                     &mut epoch_guard,
                     &mut ledger,
+                    ConnectionLifecycle {
+                        supervisor: &supervisor,
+                        generation,
+                    },
                     socket,
                 )
                 .await
@@ -163,16 +288,30 @@ async fn run(
                     // Reset only after the authenticated session completed its
                     // challenge/proof ceremony.  A socket that accepts TCP
                     // and then rejects the protocol must still back off.
-                    Ok(ConnectionExit::Disconnected) => backoff.reset(),
-                    Ok(ConnectionExit::Revoked) => break,
+                    Ok(ConnectionExit::Disconnected) => {
+                        supervisor
+                            .set_phase(generation, ConnectorPhase::Offline)
+                            .await;
+                        backoff.reset();
+                    }
+                    Ok(ConnectionExit::Revoked) => {
+                        final_phase = ConnectorPhase::Revoked;
+                        break;
+                    }
                     Ok(ConnectionExit::Shutdown) => break,
-                    Err(error) => tracing::warn!("HiPhi Cloud relay disconnected: {error}"),
+                    Err(error) => {
+                        supervisor
+                            .set_phase(generation, ConnectorPhase::Offline)
+                            .await;
+                        tracing::warn!("HiPhi Cloud relay disconnected: {error}");
+                    }
                 }
             }
             Ok(Err(error)) => tracing::debug!("HiPhi Cloud relay unavailable: {error}"),
             Err(_) => tracing::debug!("HiPhi Cloud relay connect timed out"),
         }
     }
+    final_phase
 }
 
 async fn request_session_grant(
@@ -261,6 +400,7 @@ async fn run_connection<S>(
     store: &mut StateStore,
     epoch_guard: &mut SessionEpochGuard,
     ledger: &mut CommandLedger,
+    lifecycle: ConnectionLifecycle<'_>,
     mut socket: tokio_tungstenite::WebSocketStream<S>,
 ) -> anyhow::Result<ConnectionExit>
 where
@@ -340,6 +480,10 @@ where
         now_playing: projection.now_playing,
     });
     send_json(&mut socket, &snapshot).await?;
+    lifecycle
+        .supervisor
+        .set_phase(lifecycle.generation, ConnectorPhase::Online)
+        .await;
 
     let mut verifier = CommandGrantVerifier::new(
         "hiphi-command-authorization",
@@ -850,8 +994,8 @@ fn websocket_upgrade_request(
 mod tests {
     use super::{
         request_session_grant_at, run_connection, session_grant_client, validate_challenge,
-        websocket_upgrade_request, CommandLedger, ConnectionExit, RelayMessage, StateStore,
-        MAX_SESSION_GRANT_RESPONSE_BYTES,
+        websocket_upgrade_request, CommandLedger, ConnectionExit, ConnectionLifecycle,
+        ConnectorSupervisor, RelayMessage, StateStore, MAX_SESSION_GRANT_RESPONSE_BYTES,
     };
     use crate::{
         adapters::{
@@ -1000,6 +1144,98 @@ mod tests {
             Instant::now(),
             CancellationToken::new(),
         )
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn persisted_pairing_survives_restart_and_supervisor_is_duplicate_safe() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let directory = tempfile::tempdir().unwrap();
+        let installation_id = Uuid::new_v4().to_string();
+        let session_issuer = SigningKey::from_bytes(&[41; 32]);
+        let command_issuer = SigningKey::from_bytes(&[42; 32]);
+        let session_keys = serde_json::json!({
+            "version": 1,
+            "keys": [{
+                "kid": "session-v1",
+                "key": base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(session_issuer.verifying_key().to_bytes()),
+            }],
+        });
+        let command_keys = serde_json::json!({
+            "version": 1,
+            "keys": [{
+                "kid": "command-v1",
+                "key": base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(command_issuer.verifying_key().to_bytes()),
+            }],
+        });
+        let environment_path = directory.path().join("hiphi.env");
+        std::fs::write(
+            &environment_path,
+            format!(
+                "UHC_HIPHI_RELAY_URL=wss://cloud.invalid/v1/relay/connect\n\
+                 UHC_HIPHI_INSTALLATION_ID={installation_id}\n\
+                 UHC_HIPHI_SESSION_ISSUER_KEYS={session_keys}\n\
+                 UHC_HIPHI_COMMAND_ISSUER_KEYS={command_keys}\n"
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&environment_path, std::fs::Permissions::from_mode(0o600))
+            .unwrap();
+
+        let supervisor = ConnectorSupervisor::default();
+        let status = supervisor
+            .status_from_runtime(directory.path())
+            .await
+            .unwrap();
+        assert!(status.configured);
+        assert_eq!(
+            status.installation_id.as_deref(),
+            Some(installation_id.as_str())
+        );
+        assert_eq!(status.phase, super::ConnectorPhase::Offline);
+
+        let state = empty_app_state().await;
+        assert!(
+            supervisor
+                .start_from_runtime(state.clone(), directory.path())
+                .await
+                .is_err(),
+            "a persisted binding must not replace a missing private key"
+        );
+
+        let identity = InstallationIdentity::generate(installation_id.clone()).unwrap();
+        identity
+            .save(&directory.path().join("hiphi-installation.key"))
+            .unwrap();
+        assert_eq!(
+            supervisor
+                .start_from_runtime(state.clone(), directory.path())
+                .await
+                .unwrap(),
+            super::ConnectorStart::Started
+        );
+        assert_eq!(
+            supervisor
+                .start_from_runtime(state.clone(), directory.path())
+                .await
+                .unwrap(),
+            super::ConnectorStart::AlreadyRunning
+        );
+
+        state.shutdown.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if !supervisor.inner.lock().await.active {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("connector should stop on process shutdown");
     }
 
     #[derive(Default)]
@@ -1448,6 +1684,7 @@ mod tests {
         let mut store = StateStore::default();
         let mut epoch_guard = SessionEpochGuard::load(&config.epoch_path).unwrap();
         let mut ledger = CommandLedger::default();
+        let supervisor = ConnectorSupervisor::default();
         let exit = run_connection(
             &state,
             &config,
@@ -1457,6 +1694,10 @@ mod tests {
             &mut store,
             &mut epoch_guard,
             &mut ledger,
+            ConnectionLifecycle {
+                supervisor: &supervisor,
+                generation: 1,
+            },
             client,
         )
         .await
@@ -1561,6 +1802,7 @@ mod tests {
             let mut store = StateStore::default();
             let mut epoch_guard = SessionEpochGuard::load(&config.epoch_path).unwrap();
             let mut ledger = CommandLedger::default();
+            let supervisor = ConnectorSupervisor::default();
             let exit = run_connection(
                 &state,
                 &config,
@@ -1570,6 +1812,10 @@ mod tests {
                 &mut store,
                 &mut epoch_guard,
                 &mut ledger,
+                ConnectionLifecycle {
+                    supervisor: &supervisor,
+                    generation: 1,
+                },
                 client,
             )
             .await;

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -16,7 +16,7 @@ use tokio_tungstenite::{
     tungstenite::{
         client::IntoClientRequest as _,
         http::{header::AUTHORIZATION, HeaderValue},
-        protocol::WebSocketConfig,
+        protocol::{frame::coding::CloseCode, CloseFrame, WebSocketConfig},
         Message,
     },
 };
@@ -45,6 +45,7 @@ const ARTWORK_CONCURRENCY: usize = super::artwork::MAX_CONCURRENT;
 const ARTWORK_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const ARTWORK_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
 const MAX_SESSION_GRANT_RESPONSE_BYTES: usize = 16 * 1024;
+const SHUTDOWN_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
 
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -58,6 +59,7 @@ struct GrantResponse {
 enum ConnectionExit {
     Disconnected,
     Revoked,
+    Shutdown,
 }
 
 pub fn spawn_from_env(
@@ -99,7 +101,11 @@ async fn run(
     loop {
         let delay = backoff.next_delay();
         tokio::select! { _ = shutdown.cancelled() => break, _ = tokio::time::sleep(delay) => {} }
-        let grant = match request_session_grant(&config, &identity).await {
+        let grant = match tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            grant = request_session_grant(&config, &identity) => grant,
+        } {
             Ok(grant) => grant,
             Err(error) => {
                 tracing::debug!("HiPhi Cloud session grant unavailable: {error}");
@@ -139,12 +145,15 @@ async fn run(
                 break;
             }
         };
-        match tokio::time::timeout(
-            CONNECT_TIMEOUT,
-            connect_async_with_config(request, Some(websocket_limits), false),
-        )
-        .await
-        {
+        let connection = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => break,
+            connection = tokio::time::timeout(
+                CONNECT_TIMEOUT,
+                connect_async_with_config(request, Some(websocket_limits), false),
+            ) => connection,
+        };
+        match connection {
             Ok(Ok((socket, _))) => {
                 match run_connection(
                     &state,
@@ -164,6 +173,7 @@ async fn run(
                     // and then rejects the protocol must still back off.
                     Ok(ConnectionExit::Disconnected) => backoff.reset(),
                     Ok(ConnectionExit::Revoked) => break,
+                    Ok(ConnectionExit::Shutdown) => break,
                     Err(error) => tracing::warn!("HiPhi Cloud relay disconnected: {error}"),
                 }
             }
@@ -264,6 +274,10 @@ async fn run_connection<S>(
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
+    if state.shutdown.is_cancelled() {
+        close_socket_for_shutdown(&mut socket).await;
+        return Ok(ConnectionExit::Shutdown);
+    }
     let challenge = match tokio::time::timeout(
         std::time::Duration::from_secs(10),
         next_relay_message(&mut socket),
@@ -355,6 +369,10 @@ where
     loop {
         let message = tokio::select! {
             biased;
+            _ = state.shutdown.cancelled() => {
+                close_socket_for_shutdown(&mut socket).await;
+                return Ok(ConnectionExit::Shutdown);
+            }
             message = socket.next() => {
                 let Some(message) = message else { break; };
                 message?
@@ -380,6 +398,10 @@ where
                 continue;
             }
         };
+        if state.shutdown.is_cancelled() {
+            close_socket_for_shutdown(&mut socket).await;
+            return Ok(ConnectionExit::Shutdown);
+        }
         match message {
             Message::Text(text) if text.len() > MAX_COMMAND_BYTES => {
                 anyhow::bail!("relay command frame exceeds the command bound");
@@ -557,6 +579,25 @@ where
         .await
         .map_err(|_| anyhow::anyhow!("relay write timed out"))??;
     Ok(())
+}
+
+async fn close_socket_for_shutdown<S>(socket: &mut tokio_tungstenite::WebSocketStream<S>)
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let close = Message::Close(Some(CloseFrame {
+        code: CloseCode::Away,
+        reason: "connector shutdown".into(),
+    }));
+    let _ = tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, socket.send(close)).await;
+    let _ = tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, async {
+        while let Some(message) = socket.next().await {
+            if matches!(message, Ok(Message::Close(_)) | Err(_)) {
+                break;
+            }
+        }
+    })
+    .await;
 }
 async fn send_artwork_message<S>(
     socket: &mut tokio_tungstenite::WebSocketStream<S>,
@@ -1436,5 +1477,130 @@ mod tests {
         assert_eq!(exit, ConnectionExit::Revoked);
         assert_eq!(ledger.len(), 1, "the command authority grant was accepted");
         server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn authenticated_connection_closes_without_executing_or_reconnecting_on_shutdown() {
+        let installation_id = Uuid::new_v4().to_string();
+        let identity = InstallationIdentity::generate(installation_id.clone()).unwrap();
+        let session_issuer = SigningKey::from_bytes(&[50; 32]);
+        let command_issuer = SigningKey::from_bytes(&[51; 32]);
+        let temp = tempfile::tempdir().unwrap();
+        let endpoint = "wss://cloud.invalid/v1/relay/connect";
+        let config = CloudConnectorConfig {
+            endpoint: RelayEndpoint::parse(endpoint).unwrap(),
+            installation_id: installation_id.clone(),
+            key_path: temp.path().join("installation.key"),
+            epoch_path: temp.path().join("epoch"),
+            session_issuer_key_id: "session-issuer-1".into(),
+            session_issuer_public_key: session_issuer.verifying_key().to_bytes().to_vec(),
+            command_issuer_key_id: "command-issuer-1".into(),
+            command_issuer_public_key: command_issuer.verifying_key().to_bytes().to_vec(),
+        };
+        let state = empty_app_state().await;
+        let shutdown = state.shutdown.clone();
+        let (client_io, server_io) = tokio::io::duplex(128 * 1024);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let now = super::now_ms();
+        let challenge = RelayMessage::Challenge(SessionChallengeMessage {
+            protocol_version: PROTOCOL_VERSION,
+            challenge_id: Uuid::new_v4(),
+            endpoint: endpoint.into(),
+            nonce: "nonce_012345678901234567890123456789".into(),
+            expires_at: now + 30_000,
+        });
+        let epoch = u64::try_from(now).unwrap();
+        let command = signed_command(
+            "command-issuer-1",
+            &command_issuer,
+            &installation_id,
+            epoch,
+            0,
+            now,
+        );
+        let (authenticated_tx, authenticated_rx) = tokio::sync::oneshot::channel();
+        let (send_after_shutdown_tx, send_after_shutdown_rx) = tokio::sync::oneshot::channel();
+        let server_task = tokio::spawn(async move {
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&challenge).unwrap().into(),
+                ))
+                .await
+                .unwrap();
+            assert!(matches!(
+                server.next().await.unwrap().unwrap(),
+                Message::Text(_)
+            ));
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::SessionEstablished { epoch })
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            assert!(matches!(
+                server.next().await.unwrap().unwrap(),
+                Message::Text(_)
+            ));
+            assert!(matches!(
+                server.next().await.unwrap().unwrap(),
+                Message::Text(_)
+            ));
+            authenticated_tx.send(()).unwrap();
+            send_after_shutdown_rx.await.unwrap();
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::Command(command))
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            tokio::time::timeout(std::time::Duration::from_secs(1), server.next())
+                .await
+                .expect("connector must terminate the active socket within the shutdown bound")
+                .expect("connector must send a WebSocket close frame")
+                .expect("close frame must be readable")
+        });
+        let client_task = tokio::spawn(async move {
+            let mut store = StateStore::default();
+            let mut epoch_guard = SessionEpochGuard::load(&config.epoch_path).unwrap();
+            let mut ledger = CommandLedger::default();
+            let exit = run_connection(
+                &state,
+                &config,
+                &identity,
+                "test.session.grant",
+                0,
+                &mut store,
+                &mut epoch_guard,
+                &mut ledger,
+                client,
+            )
+            .await;
+            (exit, ledger)
+        });
+
+        authenticated_rx.await.unwrap();
+        shutdown.cancel();
+        send_after_shutdown_tx.send(()).unwrap();
+        let (exit, ledger) = tokio::time::timeout(std::time::Duration::from_secs(1), client_task)
+            .await
+            .expect("connector shutdown must be bounded")
+            .unwrap();
+        assert_eq!(exit.unwrap(), ConnectionExit::Shutdown);
+        assert_eq!(
+            ledger.len(),
+            0,
+            "shutdown must win before command verification"
+        );
+        let close = server_task.await.unwrap();
+        assert!(matches!(
+            close,
+            Message::Close(Some(frame))
+                if frame.code == tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Away
+        ));
     }
 }

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -441,7 +441,7 @@ where
     epoch_guard.accept_at(epoch, now_ms().try_into().unwrap_or_default())?;
 
     let projection = snapshot_from_aggregator(
-        &state.aggregator,
+        state,
         store,
         config.installation_id.clone(),
         epoch,
@@ -522,7 +522,7 @@ where
                 continue;
             }
             _ = refresh.tick() => {
-                let projection = snapshot_from_aggregator(&state.aggregator, store, config.installation_id.clone(), epoch, store.latest().map_or(1, |p| p.revision.saturating_add(1)), now_ms() as u64).await?;
+                let projection = snapshot_from_aggregator(state, store, config.installation_id.clone(), epoch, store.latest().map_or(1, |p| p.revision.saturating_add(1)), now_ms() as u64).await?;
                 send_json(&mut socket, &ConnectorMessage::Snapshot(StateSnapshot { protocol_version: PROTOCOL_VERSION, message_id: message_id(), installation_id: projection.installation_id, epoch: projection.epoch, revision: projection.revision, observed_at: projection.observed_at as i64, expires_at: projection.expires_at as i64, zones: projection.zones, now_playing: projection.now_playing })).await?;
                 continue;
             }

--- a/src/cloud_connector/session.rs
+++ b/src/cloud_connector/session.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::{
+    config::IssuerVerifyingKeyRing,
     identity::InstallationIdentity,
     protocol::{InstallationSessionGrantClaims, PROTOCOL_VERSION, RELAY_AUDIENCE},
     transport::RelayEndpoint,
@@ -66,8 +67,7 @@ pub enum SessionGrantError {
 /// authorizer key can produce a grant accepted here.
 pub fn verify_installation_session_grant(
     grant: &str,
-    expected_key_id: &str,
-    issuer_key: &VerifyingKey,
+    issuer_keys: &IssuerVerifyingKeyRing,
     identity: &InstallationIdentity,
     expected_endpoint: &str,
     now_ms: i64,
@@ -95,9 +95,9 @@ pub fn verify_installation_session_grant(
     if header.alg != "EdDSA" || header.typ != SESSION_JWS_TYPE {
         return Err(SessionGrantError::Malformed);
     }
-    if header.kid != expected_key_id {
-        return Err(SessionGrantError::UnknownKey);
-    }
+    let issuer_key = issuer_keys
+        .get(&header.kid)
+        .ok_or(SessionGrantError::UnknownKey)?;
     let signature = Signature::from_slice(
         &base64::engine::general_purpose::URL_SAFE_NO_PAD
             .decode(encoded_signature)

--- a/src/cloud_connector/state.rs
+++ b/src/cloud_connector/state.rs
@@ -18,14 +18,14 @@ pub enum StateError {
 /// provider image key is reduced to a revision digest; the key itself never
 /// enters the semantic snapshot.
 pub async fn snapshot_from_aggregator(
-    aggregator: &crate::aggregator::ZoneAggregator,
+    state: &crate::api::AppState,
     store: &mut StateStore,
     installation_id: String,
     epoch: u64,
     revision: u64,
     now_ms: u64,
 ) -> Result<StateProjection, StateError> {
-    let zones = aggregator.get_zones().await;
+    let zones = crate::zone_list::visible_zones(state).await;
     let input = SemanticStateInput {
         installation_id,
         epoch,

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,19 +609,18 @@ mod server {
         // pinned issuer configuration is present; it requests a fresh,
         // installation-signed short-lived session grant for every reconnect and
         // never adds a LAN route or proxies this server's HTTP API.
-        let _hiphi_connector =
-            match cloud_connector::runtime::spawn_from_env(state.clone(), config::get_config_dir())
-            {
-                Ok(Some(_handle)) => {
-                    tracing::info!("HiPhi Cloud connector started (outbound WSS)");
-                    true
-                }
-                Ok(None) => false,
-                Err(error) => {
-                    tracing::warn!("HiPhi Cloud connector disabled: {error}");
-                    false
-                }
-            };
+        match state
+            .hiphi_connector
+            .start_from_runtime(state.clone(), config::get_config_dir())
+            .await
+        {
+            Ok(cloud_connector::runtime::ConnectorStart::Started) => {
+                tracing::info!("HiPhi Cloud connector started (outbound WSS)");
+            }
+            Ok(cloud_connector::runtime::ConnectorStart::AlreadyRunning) => {}
+            Ok(cloud_connector::runtime::ConnectorStart::NotConfigured) => {}
+            Err(error) => tracing::warn!("HiPhi Cloud connector disabled: {error}"),
+        }
         provider_startables.push(state.musicassistant.clone());
         let mut startable_adapters = (*state.startable_adapters).clone();
         startable_adapters.push(state.musicassistant.clone());
@@ -885,6 +884,7 @@ mod server {
             // Installation-bound controller bootstrap/session boundary
             .route("/api/controller/bootstrap", post(controller_bootstrap))
             .route("/api/controller/status", get(controller_status))
+            .route("/api/hiphi/pairing/status", get(api::hiphi_pairing::status))
             .route("/api/hiphi/pairing/prepare", post(api::hiphi_pairing::prepare))
             .route("/api/hiphi/pairing/initiate", post(api::hiphi_pairing::initiate))
             .route("/api/hiphi/pairing/complete", post(api::hiphi_pairing::complete))

--- a/src/main.rs
+++ b/src/main.rs
@@ -885,6 +885,9 @@ mod server {
             // Installation-bound controller bootstrap/session boundary
             .route("/api/controller/bootstrap", post(controller_bootstrap))
             .route("/api/controller/status", get(controller_status))
+            .route("/api/hiphi/pairing/prepare", post(api::hiphi_pairing::prepare))
+            .route("/api/hiphi/pairing/initiate", post(api::hiphi_pairing::initiate))
+            .route("/api/hiphi/pairing/complete", post(api::hiphi_pairing::complete))
             // Provider authorization and native companion pairing
             .route("/api/providers/{provider}/oauth/start", get(api_oauth_start))
             .route("/api/providers/{provider}/oauth/callback", get(api_oauth_callback))

--- a/tests/cloud_connector.rs
+++ b/tests/cloud_connector.rs
@@ -341,15 +341,21 @@ fn canonical_payload_hash_is_key_order_independent() {
 }
 
 #[test]
-fn canonical_payload_hash_normalizes_integral_f64_like_javascript_json() {
-    let wire = json!({"action":"volume.absolute","value":39,"zone_handle":"zone_demo_lounge"});
-    let typed: CommandPayload = serde_json::from_value(wire.clone()).unwrap();
-    let typed_value = serde_json::to_value(&typed).unwrap();
+fn canonical_payload_hash_matches_javascript_for_fractional_and_negative_volume() {
+    for value in [json!(39), json!(-30), json!(0.5), json!(-24.5)] {
+        let wire = json!({
+            "action": "volume.absolute",
+            "value": value,
+            "zone_handle": "zone_demo_lounge"
+        });
+        let typed: CommandPayload = serde_json::from_value(wire.clone()).unwrap();
+        let typed_value = serde_json::to_value(&typed).unwrap();
 
-    assert_eq!(
-        canonical_json(&typed_value).unwrap(),
-        canonical_json(&wire).unwrap()
-    );
+        assert_eq!(
+            canonical_json(&typed_value).unwrap(),
+            canonical_json(&wire).unwrap()
+        );
+    }
 }
 
 #[test]

--- a/tests/cloud_connector.rs
+++ b/tests/cloud_connector.rs
@@ -341,6 +341,18 @@ fn canonical_payload_hash_is_key_order_independent() {
 }
 
 #[test]
+fn canonical_payload_hash_normalizes_integral_f64_like_javascript_json() {
+    let wire = json!({"action":"volume.absolute","value":39,"zone_handle":"zone_demo_lounge"});
+    let typed: CommandPayload = serde_json::from_value(wire.clone()).unwrap();
+    let typed_value = serde_json::to_value(&typed).unwrap();
+
+    assert_eq!(
+        canonical_json(&typed_value).unwrap(),
+        canonical_json(&wire).unwrap()
+    );
+}
+
+#[test]
 fn opaque_handles_round_trip_locally_without_provider_id_in_projection() {
     let mut store = StateStore::default();
     let projection = store

--- a/tests/cloud_connector.rs
+++ b/tests/cloud_connector.rs
@@ -384,6 +384,20 @@ fn opaque_handles_round_trip_locally_without_provider_id_in_projection() {
 }
 
 #[test]
+fn runtime_cloud_projection_uses_the_canonical_visible_zone_policy() {
+    let state_source = include_str!("../src/cloud_connector/state.rs");
+
+    assert!(
+        state_source.contains("crate::zone_list::visible_zones(state).await"),
+        "cloud projection must apply the same hidden-zone, adapter, rename, and ordering policy as every other zone list"
+    );
+    assert!(
+        !state_source.contains("aggregator.get_zones().await"),
+        "reading the aggregator directly leaks hidden zones and restores nondeterministic ordering"
+    );
+}
+
+#[test]
 fn spotify_projection_keeps_identity_credentials_urls_and_raw_artwork_local() {
     use cloud_connector::state::{
         ControlEligibility, NowPlayingInput, SemanticZoneInput, VolumeInput,

--- a/tests/cloud_connector.rs
+++ b/tests/cloud_connector.rs
@@ -22,9 +22,18 @@ fn signed_session_grant(
     key: &SigningKey,
     claims: &cloud_connector::protocol::InstallationSessionGrantClaims,
 ) -> String {
+    signed_session_grant_with_kid("issuer-1", key, claims)
+}
+
+fn signed_session_grant_with_kid(
+    key_id: &str,
+    key: &SigningKey,
+    claims: &cloud_connector::protocol::InstallationSessionGrantClaims,
+) -> String {
     use base64::Engine as _;
-    let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .encode(r#"{"alg":"EdDSA","kid":"issuer-1","typ":"hiphi-session+jwt"}"#);
+    let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
+        r#"{{"alg":"EdDSA","kid":"{key_id}","typ":"hiphi-session+jwt"}}"#
+    ));
     let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .encode(serde_json::to_vec(claims).unwrap());
     let signature = key.sign(format!("{header}.{payload}").as_bytes());
@@ -32,6 +41,58 @@ fn signed_session_grant(
         "{header}.{payload}.{}",
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(signature.to_bytes())
     )
+}
+
+#[test]
+fn session_issuer_rotation_overlaps_then_retires_the_old_key() {
+    use sha2::{Digest as _, Sha256};
+
+    let old = SigningKey::generate(&mut OsRng);
+    let new = SigningKey::generate(&mut OsRng);
+    let identity =
+        InstallationIdentity::generate("11111111-1111-4111-8111-111111111111".to_owned()).unwrap();
+    let now = 1_800_000_000_000_i64;
+    let claims = cloud_connector::protocol::InstallationSessionGrantClaims {
+        protocol_version: 1,
+        connector_version: env!("UHC_VERSION").into(),
+        issuer: "hiphi-installation-authorization".into(),
+        audience: "hiphi-relay".into(),
+        installation_id: identity.installation_id().to_owned(),
+        endpoint: "wss://cloud.example/v1/relay/connect".into(),
+        public_key_sha256: hex::encode(Sha256::digest(identity.verifying_key().as_bytes())),
+        grant_jti: uuid(102),
+        issued_at: now - 1_000,
+        expires_at: now + 60_000,
+        grant_generation: 7,
+    };
+    let overlapping = IssuerVerifyingKeyRing::from_entries([
+        ("session-old".to_owned(), old.verifying_key()),
+        ("session-new".to_owned(), new.verifying_key()),
+    ])
+    .unwrap();
+    for (kid, key) in [("session-old", &old), ("session-new", &new)] {
+        assert!(verify_installation_session_grant(
+            &signed_session_grant_with_kid(kid, key, &claims),
+            &overlapping,
+            &identity,
+            "wss://cloud.example/v1/relay/connect",
+            now,
+        )
+        .is_ok());
+    }
+    let retired =
+        IssuerVerifyingKeyRing::from_entries([("session-new".to_owned(), new.verifying_key())])
+            .unwrap();
+    assert_eq!(
+        verify_installation_session_grant(
+            &signed_session_grant_with_kid("session-old", &old, &claims),
+            &retired,
+            &identity,
+            "wss://cloud.example/v1/relay/connect",
+            now,
+        ),
+        Err(SessionGrantError::UnknownKey)
+    );
 }
 
 #[test]
@@ -56,10 +117,12 @@ fn session_grant_is_verified_before_it_can_authenticate_the_websocket_upgrade() 
         grant_generation: 7,
     };
     let grant = signed_session_grant(&issuer, &claims);
+    let issuer_keys =
+        IssuerVerifyingKeyRing::from_entries([("issuer-1".to_owned(), issuer.verifying_key())])
+            .unwrap();
     let verified = verify_installation_session_grant(
         &grant,
-        "issuer-1",
-        &issuer.verifying_key(),
+        &issuer_keys,
         &identity,
         "wss://cloud.example/v1/relay/connect",
         now,
@@ -73,8 +136,7 @@ fn session_grant_is_verified_before_it_can_authenticate_the_websocket_upgrade() 
     assert_eq!(
         verify_installation_session_grant(
             &wrong_version_grant,
-            "issuer-1",
-            &issuer.verifying_key(),
+            &issuer_keys,
             &identity,
             "wss://cloud.example/v1/relay/connect",
             now,
@@ -88,8 +150,7 @@ fn session_grant_is_verified_before_it_can_authenticate_the_websocket_upgrade() 
     assert_eq!(
         verify_installation_session_grant(
             &forged_payload,
-            "issuer-1",
-            &issuer.verifying_key(),
+            &issuer_keys,
             &identity,
             "wss://cloud.example/v1/relay/connect",
             now,
@@ -563,10 +624,10 @@ fn session_epoch_high_water_mark_survives_reconnect_and_process_restart() {
     }
 }
 
-fn signed_grant(identity: &SigningKey, claims: &GrantClaims) -> String {
+fn signed_grant_with_kid(key_id: &str, identity: &SigningKey, claims: &GrantClaims) -> String {
     use base64::Engine as _;
     let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .encode(r#"{"alg":"EdDSA","kid":"issuer-1"}"#);
+        .encode(format!(r#"{{"alg":"EdDSA","kid":"{key_id}"}}"#));
     let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .encode(serde_json::to_vec(claims).unwrap());
     let sig = identity.sign(format!("{header}.{payload}").as_bytes());
@@ -576,12 +637,57 @@ fn signed_grant(identity: &SigningKey, claims: &GrantClaims) -> String {
     )
 }
 
+#[test]
+fn command_issuer_rotation_overlaps_then_retires_the_old_key() {
+    let old = SigningKey::generate(&mut OsRng);
+    let new = SigningKey::generate(&mut OsRng);
+    let overlapping = || {
+        let mut verifier = CommandGrantVerifier::new(
+            "hiphi-command-authorization",
+            "uhc-connector",
+            id("install"),
+            7,
+            3,
+        );
+        verifier.pin_key("command-old", old.verifying_key());
+        verifier.pin_key("command-new", new.verifying_key());
+        verifier
+    };
+    let old_command = command_with_claims_and_kid(1_000, "command-old", &old, 3, |_| {});
+    let new_command = command_with_claims_and_kid(1_000, "command-new", &new, 3, |_| {});
+    assert!(overlapping().verify(&old_command, 1_000).is_ok());
+    assert!(overlapping().verify(&new_command, 1_000).is_ok());
+
+    let mut retired = CommandGrantVerifier::new(
+        "hiphi-command-authorization",
+        "uhc-connector",
+        id("install"),
+        7,
+        3,
+    );
+    retired.pin_key("command-new", new.verifying_key());
+    assert_eq!(
+        retired.verify(&old_command, 1_000),
+        Err(GrantError::UnknownKey)
+    );
+}
+
 fn command_and_grant(now: u64, key: &SigningKey, generation: u64) -> CommandEnvelope {
     command_with_claims(now, key, generation, |_| {})
 }
 
 fn command_with_claims(
     now: u64,
+    key: &SigningKey,
+    generation: u64,
+    mutate: impl FnOnce(&mut GrantClaims),
+) -> CommandEnvelope {
+    command_with_claims_and_kid(now, "issuer-1", key, generation, mutate)
+}
+
+fn command_with_claims_and_kid(
+    now: u64,
+    key_id: &str,
     key: &SigningKey,
     generation: u64,
     mutate: impl FnOnce(&mut GrantClaims),
@@ -621,7 +727,7 @@ fn command_with_claims(
         created_at: claims.issued_at,
         expires_at: claims.expires_at,
         payload,
-        grant: signed_grant(key, &claims),
+        grant: signed_grant_with_kid(key_id, key, &claims),
     }
 }
 

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -21,6 +21,7 @@ GET /api/bridges/applemusic/content
 GET /api/bridges/applemusic/status
 GET /api/collections/image
 GET /api/controller/status
+GET /api/hiphi/pairing/status
 GET /api/home-assistant/integration
 GET /api/mqtt/status
 GET /api/providers/musicassistant/status

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -85,6 +85,9 @@ POST /api/bridges/applemusic/revoke
 POST /api/bridges/applemusic/state
 POST /api/collections
 POST /api/controller/bootstrap
+POST /api/hiphi/pairing/complete
+POST /api/hiphi/pairing/initiate
+POST /api/hiphi/pairing/prepare
 POST /api/mqtt/configure
 POST /api/play_ref
 POST /api/providers/spotify/tunnel/start

--- a/tests/hiphi_package_contract.rs
+++ b/tests/hiphi_package_contract.rs
@@ -1,0 +1,70 @@
+//! Package-neutral HiPhi enrollment contract.
+//!
+//! Settings invokes `uhc-hiphi-pair` beside the running server. Every package
+//! must therefore ship both executables and keep `UHC_CONFIG_DIR` on durable
+//! storage; otherwise the browser ceremony appears to work only on QNAP.
+
+const WORKFLOW: &str = include_str!("../.github/workflows/build.yml");
+const RELEASE_DOCKERFILE: &str = include_str!("../Dockerfile.release");
+const CI_DOCKERFILE: &str = include_str!("../Dockerfile.ci");
+const COMPOSE: &str = include_str!("../docker-compose.yml");
+const SYNOLOGY_BUILD: &str = include_str!("../build/synology/build-spk.sh");
+const SYNOLOGY_SERVICE: &str = include_str!("../build/synology/scripts/start-stop-status");
+const LMS_HELPER: &str = include_str!("../lms-plugin/Helper.pm");
+const LINUX_SERVICE: &str = include_str!("../build/linux/unified-hifi-control.service");
+const PAIRING_API: &str = include_str!("../src/api/hiphi_pairing.rs");
+
+#[test]
+fn docker_and_home_assistant_ship_pairing_with_durable_identity() {
+    for dockerfile in [RELEASE_DOCKERFILE, CI_DOCKERFILE] {
+        assert!(dockerfile.contains("/app/uhc-hiphi-pair"));
+        assert!(dockerfile.contains("chmod +x /app/unified-hifi-control /app/uhc-hiphi-pair"));
+        assert!(dockerfile.contains("CONFIG_DIR=/data"));
+    }
+    assert!(COMPOSE.contains("- ./data:/data"));
+    assert!(WORKFLOW.contains("dist/uhc-hiphi-pair"));
+}
+
+#[test]
+fn synology_ships_pairing_beside_server_and_uses_package_state() {
+    assert!(SYNOLOGY_BUILD.contains("<pairing-helper>"));
+    assert!(SYNOLOGY_BUILD.contains("package/uhc-hiphi-pair"));
+    assert!(SYNOLOGY_SERVICE.contains("export UHC_CONFIG_DIR=\"$VAR_DIR\""));
+    assert!(WORKFLOW.contains("pairing_helper: uhc-hiphi-pair-x64"));
+    assert!(WORKFLOW.contains("pairing_helper: uhc-hiphi-pair-arm64"));
+}
+
+#[test]
+fn lms_ships_pairing_for_every_bundled_platform_and_uses_cache_state() {
+    for directory in [
+        "Bin/x86_64-linux/uhc-hiphi-pair",
+        "Bin/aarch64-linux/uhc-hiphi-pair",
+        "Bin/arm-linux/uhc-hiphi-pair",
+        "Bin/darwin/uhc-hiphi-pair",
+        "Bin/MSWin32-x64-multi-thread/uhc-hiphi-pair.exe",
+    ] {
+        assert!(
+            WORKFLOW.contains(directory),
+            "missing LMS helper {directory}"
+        );
+    }
+    assert!(LMS_HELPER.contains("local $ENV{UHC_CONFIG_DIR} = $configDir"));
+    assert!(LMS_HELPER.contains("my $binaryDir = dirname($binary)"));
+    assert!(LMS_HELPER.contains("system('xattr', '-cr', $binaryDir)"));
+}
+
+#[test]
+fn native_packages_and_direct_artifacts_ship_the_matching_helper() {
+    for helper in [
+        "uhc-hiphi-pair-x64=/usr/bin/uhc-hiphi-pair",
+        "uhc-hiphi-pair-arm64=/usr/bin/uhc-hiphi-pair",
+        "uhc-hiphi-pair-armv7=/usr/bin/uhc-hiphi-pair",
+        "uhc-hiphi-pair-macos-universal",
+        "uhc-hiphi-pair-win64.exe",
+    ] {
+        assert!(WORKFLOW.contains(helper), "missing native helper {helper}");
+    }
+    assert!(LINUX_SERVICE.contains("Environment=CONFIG_DIR=/etc/unified-hifi-control"));
+    assert!(LINUX_SERVICE.contains("ConfigurationDirectory=unified-hifi-control"));
+    assert!(PAIRING_API.contains("helper_candidates"));
+}

--- a/tests/hiphi_pairing_ui_contract.rs
+++ b/tests/hiphi_pairing_ui_contract.rs
@@ -51,3 +51,11 @@ fn pairing_origin_is_server_pinned() {
     assert!(API.contains("https://relay.hiphi.audio"));
     assert!(!API.contains("request.cloud_origin"));
 }
+
+#[test]
+fn browser_handoff_explicitly_clears_inherited_group_and_other_permissions() {
+    assert!(
+        API.contains("file.set_permissions"),
+        "the QNAP config volume may inherit ACL mode bits despite create mode 0600"
+    );
+}

--- a/tests/hiphi_pairing_ui_contract.rs
+++ b/tests/hiphi_pairing_ui_contract.rs
@@ -11,6 +11,7 @@ const SETTINGS: &str = include_str!("../src/app/pages/settings.rs");
 #[test]
 fn settings_exposes_the_complete_local_pairing_ceremony() {
     for route in [
+        "/api/hiphi/pairing/status",
         "/api/hiphi/pairing/prepare",
         "/api/hiphi/pairing/initiate",
         "/api/hiphi/pairing/complete",
@@ -30,6 +31,17 @@ fn settings_exposes_the_complete_local_pairing_ceremony() {
     ] {
         assert!(SETTINGS.contains(copy), "missing onboarding copy: {copy}");
     }
+
+    assert!(
+        SETTINGS.contains("This UHC installation is paired"),
+        "paired state must survive a page reload through server authority"
+    );
+    assert!(
+        !SETTINGS.contains("QNAP App Center")
+            && !SETTINGS.contains("Prepare this NAS")
+            && !SETTINGS.contains("This NAS is paired"),
+        "HiPhi onboarding must not assume one installation package"
+    );
 }
 
 #[test]

--- a/tests/hiphi_pairing_ui_contract.rs
+++ b/tests/hiphi_pairing_ui_contract.rs
@@ -45,6 +45,15 @@ fn settings_exposes_the_complete_local_pairing_ceremony() {
 }
 
 #[test]
+fn paired_status_keeps_refreshing_after_the_page_loads() {
+    assert!(
+        SETTINGS.contains("dioxus_sdk_time::sleep(HIPHI_STATUS_POLL_INTERVAL)")
+            && SETTINGS.contains("pairing_status.restart()"),
+        "Settings must refresh connector state so online, reconnecting, and revoked do not go stale"
+    );
+}
+
+#[test]
 fn browser_contract_never_serializes_the_private_installation_key() {
     assert!(!API.contains("installation_private_key"));
     assert!(!API.contains("private_key"));

--- a/tests/hiphi_pairing_ui_contract.rs
+++ b/tests/hiphi_pairing_ui_contract.rs
@@ -1,0 +1,53 @@
+//! Browser onboarding contract for the packaged HiPhi connector.
+//!
+//! A QPKG that merely contains `uhc-hiphi-pair` still strands an owner who
+//! installed it through App Center. These checks keep the three-step local
+//! ceremony reachable from Settings while preserving the private-key boundary.
+
+const MAIN: &str = include_str!("../src/main.rs");
+const API: &str = include_str!("../src/api/hiphi_pairing.rs");
+const SETTINGS: &str = include_str!("../src/app/pages/settings.rs");
+
+#[test]
+fn settings_exposes_the_complete_local_pairing_ceremony() {
+    for route in [
+        "/api/hiphi/pairing/prepare",
+        "/api/hiphi/pairing/initiate",
+        "/api/hiphi/pairing/complete",
+    ] {
+        assert!(MAIN.contains(route), "server must mount {route}");
+        assert!(SETTINGS.contains(route), "Settings must call {route}");
+    }
+
+    for copy in [
+        "Connect HiPhi Cloud",
+        "Installation public key",
+        "Choose enrollment file",
+        "Pairing fingerprint",
+        "Complete pairing",
+        "https://hiphi.audio/#cloud",
+        "Why sign up?",
+    ] {
+        assert!(SETTINGS.contains(copy), "missing onboarding copy: {copy}");
+    }
+}
+
+#[test]
+fn browser_contract_never_serializes_the_private_installation_key() {
+    assert!(!API.contains("installation_private_key"));
+    assert!(!API.contains("private_key"));
+    assert!(API.contains("installation_public_key"));
+    assert!(API.contains("installation_fingerprint"));
+}
+
+#[test]
+fn pairing_routes_are_owner_gated() {
+    let auth = include_str!("../src/api/controller_auth.rs");
+    assert!(auth.contains("path.starts_with(\"/api/hiphi/pairing/\")"));
+}
+
+#[test]
+fn pairing_origin_is_server_pinned() {
+    assert!(API.contains("https://relay.hiphi.audio"));
+    assert!(!API.contains("request.cloud_origin"));
+}

--- a/tests/hiphi_security_docs.rs
+++ b/tests/hiphi_security_docs.rs
@@ -1,0 +1,43 @@
+//! Public security-documentation contract for the HiPhi connector.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_file(path: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("cannot read {}: {error}", path.display()))
+}
+
+#[test]
+fn public_threat_model_states_boundaries_invariants_and_residual_risks() {
+    let threat_model = repo_file("docs/hiphi-cloud-threat-model.md");
+
+    for required in [
+        "## Security goals",
+        "## Trust boundaries",
+        "## Data that crosses the boundary",
+        "## Security invariants",
+        "## Residual risks and non-goals",
+        "open source",
+        "command-signing authority",
+        "source IP",
+        "now-playing",
+        "provider credentials",
+        "arbitrary URL",
+        "outbound",
+        "does not mean that the cloud service is trustless",
+        "cloud implementation is not made auditable by publishing UHC",
+    ] {
+        assert!(
+            threat_model.contains(required),
+            "public threat model must state {required:?}"
+        );
+    }
+}
+
+#[test]
+fn relay_boundary_adr_links_the_public_threat_model() {
+    let adr = repo_file("docs/adr/005-cloud-relay-zero-trust-boundary.md");
+    assert!(adr.contains("../hiphi-cloud-threat-model.md"));
+}

--- a/tests/qnap_package_contract.sh
+++ b/tests/qnap_package_contract.sh
@@ -44,6 +44,16 @@ assert_contains "${QNAP_DIR}/shared/install.sh" 'chmod 700 .*QPKG_ROOT.*/config'
     "QNAP config directory must be owner-only"
 assert_contains "${QNAP_DIR}/shared/unified-hifi-control.sh" 'UHC_CONFIG_DIR=.*QPKG_ROOT.*/config' \
     "QNAP service must default UHC_CONFIG_DIR to the package config directory"
+assert_contains "${QNAP_DIR}/shared/install.sh" 'touch .*QPKG_ROOT.*/config/hiphi.env' \
+    "QNAP install must create the persistent HiPhi connector environment"
+assert_contains "${QNAP_DIR}/shared/install.sh" 'chmod 600 .*QPKG_ROOT.*/config/hiphi.env' \
+    "QNAP HiPhi connector environment must be owner-only"
+assert_contains "${QNAP_DIR}/shared/unified-hifi-control.sh" 'HIPHI_ENV_FILE=.*UHC_CONFIG_DIR.*/hiphi.env' \
+    "QNAP service must load persistent HiPhi connector settings"
+assert_contains "${QNAP_DIR}/shared/unified-hifi-control.sh" 'UHC_HIPHI_SESSION_ISSUER_KEYS' \
+    "QNAP service must load the dedicated session verifier ring"
+assert_contains "${QNAP_DIR}/shared/unified-hifi-control.sh" 'UHC_HIPHI_COMMAND_ISSUER_KEYS' \
+    "QNAP service must load the dedicated command verifier ring"
 
 for script in "${QNAP_DIR}/shared"/*.sh; do
     [[ -f "$script" ]] || continue
@@ -58,6 +68,8 @@ assert_contains "$WORKFLOW" 'name: binary-x86_64-unknown-linux-musl' \
     "QNAP x86_64 must download the x86_64 musl artifact"
 assert_contains "$WORKFLOW" 'cp dist/bin/unified-hifi-linux-x64 qnap-build/shared/unified-hifi-control' \
     "QNAP x86_64 must package the Linux x64 binary"
+assert_contains "$WORKFLOW" 'cp dist/bin/uhc-hiphi-pair-x64 qnap-build/shared/uhc-hiphi-pair' \
+    "QNAP x86_64 must package the local HiPhi pairing helper"
 assert_contains "$WORKFLOW" 'docker run --rm --platform linux/amd64' \
     "QDK must run with an explicit amd64 builder platform"
 assert_contains "$WORKFLOW" 'unified-hifi-control_\$\{\{ needs\.plan\.outputs\.version \}\}_x86_64\.qpkg' \

--- a/tests/qnap_service_contract.rs
+++ b/tests/qnap_service_contract.rs
@@ -1,6 +1,7 @@
 //! Safety and packaging contract for the privileged QNAP service wrapper.
 
 const SERVICE: &str = include_str!("../build/qnap/shared/unified-hifi-control.sh");
+const INSTALL: &str = include_str!("../build/qnap/shared/install.sh");
 const UNINSTALL: &str = include_str!("../build/qnap/shared/uninstall.sh");
 const QPKG_CONFIG: &str = include_str!("../build/qnap/qpkg.cfg");
 const BUILD_WORKFLOW: &str = include_str!("../.github/workflows/build.yml");
@@ -89,6 +90,65 @@ fn qnap_service_keeps_credentials_private_and_stops_only_its_recorded_process() 
         !SERVICE.contains("pkill -9"),
         "the package must not use a broad force-kill fallback"
     );
+}
+
+#[test]
+fn qnap_package_persists_and_loads_the_complete_hiphi_connector_configuration() {
+    assert!(
+        INSTALL.contains("touch \"${QPKG_ROOT}/config/hiphi.env\""),
+        "the package must create a stable connector configuration file"
+    );
+    assert!(
+        INSTALL.contains("chmod 600 \"${QPKG_ROOT}/config/hiphi.env\""),
+        "connector configuration must not be readable by other NAS users"
+    );
+    assert!(
+        INSTALL.contains("[ -L \"${QPKG_ROOT}/config/hiphi.env\" ]"),
+        "install must not chmod through a connector-config symlink"
+    );
+    for setting in [
+        "UHC_HIPHI_RELAY_URL",
+        "UHC_HIPHI_INSTALLATION_ID",
+        "UHC_HIPHI_SESSION_ISSUER_KEYS",
+        "UHC_HIPHI_COMMAND_ISSUER_KEYS",
+    ] {
+        assert!(
+            SERVICE.contains(setting),
+            "the service wrapper must load {setting} before starting UHC"
+        );
+    }
+    assert!(
+        !SERVICE.contains(". \"$HIPHI_ENV_FILE\"")
+            && !SERVICE.contains("source \"$HIPHI_ENV_FILE\""),
+        "the privileged service wrapper must parse known keys rather than execute the config file as shell"
+    );
+    let symlink_check = SERVICE
+        .find("[ -L \"$HIPHI_ENV_FILE\" ]")
+        .expect("service rejects connector-config symlinks");
+    let missing_check = SERVICE
+        .find("[ -e \"$HIPHI_ENV_FILE\" ] || return 0")
+        .expect("service permits a fresh unpaired install");
+    assert!(
+        symlink_check < missing_check,
+        "a dangling config symlink must not bypass the safety check"
+    );
+}
+
+#[test]
+fn qnap_artifact_contains_the_pairing_helper_for_each_packaged_architecture() {
+    let x64_job = BUILD_WORKFLOW
+        .split("build-qnap-x64:")
+        .nth(1)
+        .and_then(|tail| tail.split("build-qnap-arm:").next())
+        .expect("x64 QNAP job exists");
+    let arm_job = BUILD_WORKFLOW
+        .split("build-qnap-arm:")
+        .nth(1)
+        .and_then(|tail| tail.split("build-docker-x64:").next())
+        .expect("ARM QNAP job exists");
+
+    assert!(x64_job.contains("cp dist/bin/uhc-hiphi-pair-x64 qnap-build/shared/uhc-hiphi-pair"));
+    assert!(arm_job.contains("cp dist/bin/uhc-hiphi-pair-arm64 qnap-build/shared/uhc-hiphi-pair"));
 }
 
 #[test]

--- a/tests/synology_package_contract.sh
+++ b/tests/synology_package_contract.sh
@@ -64,7 +64,7 @@ else
         expected_version=${version_case#*:}
         output_spk="${test_tmp}/${input_version}.spk"
 
-        if ! "${SYNOLOGY_DIR}/build-spk.sh" "$input_version" x86_64 "$test_binary" "$output_spk"; then
+        if ! "${SYNOLOGY_DIR}/build-spk.sh" "$input_version" x86_64 "$test_binary" "$test_binary" "$output_spk"; then
             fail "build-spk.sh failed for version ${input_version}"
             continue
         fi
@@ -86,15 +86,17 @@ else
 
         tar -xOf "$output_spk" package.tgz | tar -tzf - | grep -q '^./port_conf/unified-hifi-control.sc$' \
             || fail "SPK must contain its DSM firewall protocol file"
+        tar -xOf "$output_spk" package.tgz | tar -tzf - | grep -q '^./uhc-hiphi-pair$' \
+            || fail "SPK must contain the HiPhi pairing helper"
     done
 
     arm_spk="${test_tmp}/armv8.spk"
-    "${SYNOLOGY_DIR}/build-spk.sh" 3.4.1 armv8 "$test_binary" "$arm_spk" \
+    "${SYNOLOGY_DIR}/build-spk.sh" 3.4.1 armv8 "$test_binary" "$test_binary" "$arm_spk" \
         || fail "build-spk.sh failed for armv8"
     arm_arch=$(tar -xOf "$arm_spk" INFO | sed -n 's/^arch="\([^"]*\)"$/\1/p')
     [[ "$arm_arch" == 'armv8' ]] || fail "ARM SPK arch is ${arm_arch}, expected armv8"
 
-    if "${SYNOLOGY_DIR}/build-spk.sh" 3.5.0-alpha.1 x86_64 "$test_binary" "${test_tmp}/invalid.spk" 2>/dev/null; then
+    if "${SYNOLOGY_DIR}/build-spk.sh" 3.5.0-alpha.1 x86_64 "$test_binary" "$test_binary" "${test_tmp}/invalid.spk" 2>/dev/null; then
         fail "build-spk.sh must reject prerelease formats without an explicit DSM ordering rule"
     fi
 fi


### PR DESCRIPTION
## Outcome

UHC independently pins bounded HiPhi session-grant and command-grant verifier rings. A paired installation can authenticate its relay session and verify remote commands while the cloud keeps those signing roles on distinct keys and rotates either authority through a short overlap without accepting arbitrary keys. Active relay sockets terminate cleanly on process shutdown without executing raced work or reconnecting.

The same owner enrollment ceremony now works from every supported distribution because the pairing helper ships beside the server and uses that package's durable configuration location.

Fixes #658
Fixes #661
Related: #635
Private tracking: https://github.com/open-horizon-labs/hiphi-cloud/issues/1

## Changes

- require separate versioned session and command verifier rings when the connector is enabled
- bound each ring to 1–8 Ed25519 keys and select the exact session verifier by JWS `kid`
- use only the session authority for relay session grants
- use only the command authority for request-specific command grants
- fail closed on malformed, oversized, duplicate, weak, cross-authority, or retired keys
- document publish-overlap-switch-retain-retire rotation across both cloud and connectors
- observe shutdown during grant acquisition, connect, and the active socket
- send WebSocket Close 1001 with a bounded wait, return terminal Shutdown, and never dispatch or reconnect after cancellation
- ship `uhc-hiphi-pair` in Docker/Home Assistant, Synology, LMS, deb/rpm, macOS, Windows, and direct PR artifacts
- retain pairing in each package's existing durable config directory and preserve current native Linux settings across upgrades
- clear macOS LMS quarantine for both bundled executables and include the helper in future Windows signing
- let direct-download server binaries locate their matching architecture-suffixed pairing helper
- update Synology and package-neutral distribution contracts

The former singular-key environment variables are deliberately no longer accepted. No public HTTP routes or payloads change.

## Verification

- `cargo test --features server cloud_connector` — 11 passed
- `cargo test --features server --test cloud_connector` — 39 passed
- `cargo test --features server --bin uhc-hiphi-pair` — 5 passed
- `cargo test --features server --test hiphi_package_contract` — 4 passed
- `cargo test --features server --test qnap_service_contract` — 8 passed
- `tests/qnap_package_contract.sh` — passed
- `tests/synology_package_contract.sh` — passed across stable, beta, RC, PR, dev, x64, and armv8 cases
- `cargo test --features server --test hiphi_pairing_ui_contract` — 5 passed
- `cargo test --features server --test api_contract` — 2 passed
- serialized full server library suite — 665 passed before the packaging-only extension
- `cargo clippy --features server --lib --bin uhc-hiphi-pair -- -D warnings`
- `cargo fmt --all -- --check`
- workflow YAML parse and `git diff --check`

Physical production enrollment, reconnect, restart retention, and cloud-outage behavior remain the final installed-artifact checks after the replacement PR build completes.
