### PR TITLE
Simplify Spotify setup through HiPhi Cloud

### DIFF
--- a/docs/adr/005-cloud-relay-zero-trust-boundary.md
+++ b/docs/adr/005-cloud-relay-zero-trust-boundary.md
@@ -81,6 +81,15 @@ image. The cloud façade places the opaque capability in the exact
 the watch bearer. Neither UHC nor the cloud logs that path or capability, and
 the relay protocol itself carries no arbitrary URL.
 
+Spotify authorization uses a separate, narrowly typed relay message rather
+than exposing a LAN callback. The owner supplies only a personal Spotify Client
+ID. UHC generates and retains the PKCE verifier, signs a short-lived request
+bound to its installation identity, and sends the browser through HiPhi's fixed
+callback. HiPhi verifies account ownership and the installation signature, then
+delivers the one-use provider code only to the matching authenticated
+installation. HiPhi never receives the PKCE verifier, provider access or refresh
+tokens, a client secret, or an arbitrary callback destination.
+
 ## Consequences
 
 - Open-source UHC can be audited without exposing a cloud signing secret.

--- a/docs/hiphi-cloud-threat-model.md
+++ b/docs/hiphi-cloud-threat-model.md
@@ -142,6 +142,7 @@ or LAN projection.
 | Opaque zone handle, owner-visible zone name, transport state, and bounded volume state | Raw Roon/LMS/OpenHome/UPnP/HQPlayer/Spotify/Apple Music identifiers |
 | Bounded now-playing title, artist, playing state, and opaque image revision | Provider credentials, refresh tokens, cookies, CSRF tokens, and authorization headers |
 | Bounded artwork bytes requested through an opaque capability | Provider artwork URL, arbitrary URL, LAN URL, hostname, or filesystem path |
+| Public Spotify Client ID, PKCE challenge, state digest, and one-use authorization code during an owner-approved setup | PKCE verifier, Spotify access/refresh tokens, client secret, or LAN callback URL |
 | Controller ID in signed grants, command/result status, epoch, revision, and timestamps | General LAN HTTP requests or responses and UHC's local API surface |
 
 This means HiPhi Cloud can learn zone names and now-playing metadata while the
@@ -214,6 +215,13 @@ security decision and an update to this document and ADR 005.
     enrollment secrets, artwork capabilities/paths, provider identifiers,
     command payloads, and artwork bytes must not be placed in application logs,
     analytics, presence records, or error text.
+17. **Provider authorization is a bound handoff, not credential custody.** A
+    Spotify setup request is signed by the paired installation and bound to the
+    owner, installation, request, Client ID, fixed callback, PKCE challenge,
+    state digest, and short expiry. The cloud forwards the one-use provider code
+    only over that installation's authenticated relay. The PKCE verifier and
+    resulting provider tokens never leave UHC, and callbacks fail closed on
+    mismatch, expiry, replay, disconnect, or revocation.
 
 Executable evidence lives primarily in `tests/cloud_connector.rs`,
 `tests/fixtures/hiphi-relay-v1/`, `tests/hiphi_pairing_ui_contract.rs`, package

--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -74,15 +74,19 @@ is reachable through a tunnel; put authentication and access control at the
 tunnel/reverse-proxy boundary until the controller-auth contract in #463 is
 implemented.
 
-The first authorization contract is now implemented in UHC. Spotify uses the
-standard authorization-code flow:
+Spotify uses an authorization-code flow with PKCE and a fixed HiPhi callback:
 
-- `GET /api/providers/spotify/oauth/start` creates a single-use, ten-minute
-  state and returns the provider authorization URL.
-- Spotify redirects to `GET /api/providers/spotify/oauth/callback`; UHC
-  exchanges the code server-side and stores the access/refresh token in the
-  Spotify adapter and encrypted credential store. Tokens are never returned
-  by the endpoint.
+- `GET /api/providers/spotify/oauth/start` requires a paired HiPhi Cloud
+  installation, keeps the verifier locally, and returns a short-lived,
+  installation-signed authorization handoff URL.
+- HiPhi confirms the signed-in owner controls that installation, redirects to
+  Spotify, and accepts the provider callback at
+  `https://app.hiphi.audio/api/spotify/callback`.
+- HiPhi sends the one-use authorization code only over the authenticated relay
+  for that installation. UHC checks the request, Client ID, state digest,
+  callback, and expiry before exchanging it with its local PKCE verifier.
+- Access and refresh tokens are stored only in UHC's encrypted credential
+  store. HiPhi receives neither tokens nor the PKCE verifier.
 - `POST /api/providers/spotify/oauth/revoke` clears the adapter and removes
   the durable credential file.
 
@@ -133,20 +137,19 @@ secret-backed volume when the default config directory is not appropriate.
 The key and encrypted file must be backed up together if a restart or package
 upgrade is expected to preserve the connection.
 
-For a hosted UHC deployment, set `SPOTIFY_CLIENT_ID`,
-`SPOTIFY_CLIENT_SECRET`, and optionally
-`SPOTIFY_REDIRECT_URI` (and `SPOTIFY_TOKEN_URL` for a local test server) before
-starting the flow. The callback endpoint must be registered exactly with the
-Spotify application.
+For a hosted UHC deployment, set `SPOTIFY_CLIENT_ID` (and
+`SPOTIFY_TOKEN_URL` only for a local test server). Register the fixed HiPhi
+callback exactly with the Spotify application. A Client Secret and a
+user-managed redirect URI are not required for the supported setup path.
 
 For a local or QNAP install, open Settings in the browser you will use for
 authorization. The Spotify card's "Client settings" pane now walks through the
 whole flow as numbered steps: create/open an app in the Spotify Developer
-Dashboard, copy the exact callback URL shown there (with a one-click copy
-button) into the app's Redirect URIs, paste the Client ID into the field
-below, save, then Connect. The client secret lives in a collapsed "Advanced"
-section and can almost always stay blank — UHC signs in securely without it;
-only fill it in if your Spotify app was specifically set up to require one.
+Dashboard, copy the fixed HiPhi callback shown there (with a one-click copy
+button) into the app's Redirect URIs, paste the Client ID, save, then Connect.
+The installation must first be paired with HiPhi Cloud. HiPhi is used only for
+the owner-approved callback handoff; normal playback requests and token refresh
+remain between UHC and Spotify.
 
 ### First save on a NAS: the owner bootstrap prompt (#570)
 
@@ -173,8 +176,8 @@ step and tells you where to find the token:
 Paste the token into the prompt, which posts it to
 `POST /api/controller/bootstrap`. On success UHC mints a browser session
 cookie plus a CSRF token; the prompt closes and the page reports that owner
-access is unlocked. Click the original button (Save, Connect, Get an HTTPS
-address) again and it now succeeds — the CSRF token is attached automatically
+access is unlocked. Click the original Save or Connect button again and it now
+succeeds — the CSRF token is attached automatically
 to every state-changing request from then on (see
 `crate::app::controller_auth::current_csrf_token`, mirrored into
 `localStorage` so it survives a page reload without a second bootstrap). The
@@ -182,76 +185,18 @@ bootstrap token itself is single-use: once accepted, the same token cannot be
 replayed, and `GET /api/controller/status` reports `bootstrap_required:
 false` afterward.
 
-If the browser is not on the UHC host, Spotify accepts plain HTTP only for
-explicit loopback callbacks (`127.0.0.1` or `::1`); anything else — a remote
-QNAP, a different machine on the LAN — needs HTTPS. The "Using UHC from
-another device or a NAS?" panel below the callback URL has a **Get an HTTPS
-address** button for this: it asks UHC to open a temporary tunnel to a
-separate loopback-only callback listener and shows the resulting `https://…`
-callback URL with a copy button,
-so a first-time user never has to install or run anything. After allocation
-UHC probes its own public URL once and shows the result (reachable or not)
-before the user registers it with Spotify. The Redirect URI field is
-pre-filled with that URL's callback path while it still holds the loopback
-default; a previously saved address is never silently replaced — a
-divergence between the live tunnel and the saved Redirect URI is surfaced
-as a warning (and `oauth/start` refuses with `tunnel_redirect_mismatch`),
-because tunnel providers mint a new subdomain on every start and the
-authorize request always uses the saved Redirect URI verbatim. Paste the
-shown URL into the Spotify dashboard's Redirect URIs, save client settings,
-then Connect. The tunnel closes itself shortly after authorization
-completes (success or failure; teardown is deferred a minute so the
-bounded callback response still travels through it), after 55
-minutes (under pinggy's own 60-minute anonymous-tunnel limit, and long
-enough for a first-time dashboard round trip), or via its own "Stop
-tunnel" button — while it
-is open, the public address terminates at that callback-only listener, not at
-the UHC LAN listener. It permits exactly `GET
-/api/providers/spotify/oauth/callback` and a non-sensitive `GET /healthz`
-probe; every other method and path is denied. The callback still accepts only
-the single in-flight OAuth `state` token, so no extra trust is extended to
-traffic that arrives through it (see `oauth_callback_json` in
-`src/api/provider_auth.rs`).
-
-Under the hood this is a plain `ssh -R` reverse tunnel to that separate
-loopback listener, via
-[pinggy.io](https://pinggy.io)'s free tier — no account and no bundled binary
-beyond the `ssh` client already present on essentially every Linux, macOS, or
-NAS install — falling back automatically to
-[localhost.run](https://localhost.run) if pinggy.io cannot be reached. Both
-providers mint a fresh random subdomain on every connection, so a new tunnel
-always means a newly registered callback URL; that expectation and the retry
-logic live in `SpotifyTunnelManager` (`src/api/spotify_tunnel.rs`), which is
-tested against a scripted fake process rather than a live tunnel provider
-(the pinggy URL-parsing test fixture is an exact capture of a live anonymous
-tunnel's stdout, though, since a first live-smoke pass found the original
-`pinggy.link`-only pattern never matched pinggy's real anonymous-tier hosts —
-`pinggy-free.link` and `free.pinggy.net`). Pinggy's free tier also caps an
-anonymous tunnel at 60 minutes before it expires on its own; UHC's own
-55-minute cap closes it first. If `ssh` is missing,
-both providers are unreachable, or outbound `ssh` traffic is blocked, the
-panel reports why in the same beginner-readable style as the rest of
-Settings, and the collapsed **Advanced: bring your own HTTPS** note
-underneath covers an operator-managed HTTPS proxy only when it independently
-default-denies every route except the exact Spotify callback. Do **not** point
-a manual tunnel, Funnel, or reverse proxy at UHC's main port; that listener
-has intentional LAN-readable and control surfaces. Reauthorizing later always
-needs a new tunnel (built-in or carefully filtered operator-managed route) and
-a newly registered callback URL either way. This is the first-run onboarding
-path tracked in #469, #534, and #538.
-
-New endpoints backing the built-in tunnel — `POST
-/api/providers/spotify/tunnel/start`, `GET
-/api/providers/spotify/tunnel/status`, and `POST
-/api/providers/spotify/tunnel/stop` — are controller-authenticated the same
-as the rest of `/api/providers/*` (see `requires_controller_auth` in
-`src/api/controller_auth.rs`) and registered in
-`tests/fixtures/api_routes.txt`.
+The supported callback is always
+`https://app.hiphi.audio/api/spotify/callback`, whether UHC runs on a NAS,
+Docker, Synology, as an LMS plugin, or as a plain binary. The browser never
+connects back to UHC, and UHC never opens an inbound tunnel or exposes its LAN
+listener. The older callback-only tunnel endpoints remain temporarily for
+compatibility with already-installed alpha builds, but Settings no longer uses
+them and a live legacy tunnel cannot bypass the HiPhi pairing requirement.
 
 If authorization does not complete, Settings shows an actionable message
-instead of a generic failure: an expired or already-used sign-in link, a
-declined consent screen, a callback URL mismatch between the Spotify dashboard
-and the Redirect URI configured here, or a server-side storage/adapter-start
+instead of a generic failure: a missing HiPhi pairing, an expired or
+already-used sign-in link, declined consent, an incorrectly registered fixed
+callback, or a server-side storage/adapter-start
 problem are each called out with what to fix. See
 `spotify_oauth_error_message` in `src/app/pages/settings.rs`, which maps every
 `code` returned by `oauth_callback_json` in `src/api/provider_auth.rs` to one

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4767,7 +4767,7 @@ mod tests {
         let written = load_app_settings();
         let strays: Vec<_> = walk_config_files(&dir)
             .into_iter()
-            .filter(|name| name.ends_with(".tmp"))
+            .filter(|name| name.ends_with(".json.tmp"))
             .collect();
         env::remove_var("UHC_CONFIG_DIR");
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/api/provider_auth.rs
+++ b/src/api/provider_auth.rs
@@ -14,7 +14,7 @@ use crate::api::credentials::{
     EncryptedCredentialStore, MusicAssistantCredentialRecord, MusicAssistantCredentialStore,
     SpotifyCredentialRecord,
 };
-use crate::api::spotify_tunnel::{SpotifyTunnelManager, TunnelStatus, TunnelStatusResponse};
+use crate::api::spotify_tunnel::{SpotifyTunnelManager, TunnelStatusResponse};
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -38,9 +38,9 @@ use super::AppState;
 
 const OAUTH_TTL: Duration = Duration::from_secs(600);
 const MAX_PENDING_OAUTH: usize = 64;
-const SPOTIFY_AUTHORIZE_URL: &str = "https://accounts.spotify.com/authorize";
 const SPOTIFY_TOKEN_URL: &str = "https://accounts.spotify.com/api/token";
-const SPOTIFY_SCOPE: &str = "user-read-playback-state user-modify-playback-state user-read-private user-read-email playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-library-read user-library-modify";
+const HIPHI_SPOTIFY_CONNECT_URL: &str = "https://app.hiphi.audio/spotify/connect";
+const HIPHI_SPOTIFY_CALLBACK_URI: &str = "https://app.hiphi.audio/api/spotify/callback";
 
 #[derive(Clone)]
 pub struct ProviderAuthState {
@@ -62,6 +62,9 @@ struct PendingOAuth {
     provider: String,
     expires_at: u64,
     code_verifier: Option<String>,
+    cloud_request_id: Option<uuid::Uuid>,
+    client_id: Option<String>,
+    state_digest: Option<String>,
 }
 
 #[derive(Clone)]
@@ -361,9 +364,7 @@ async fn configure_spotify_request(
     let redirect_uri = request
         .redirect_uri
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| {
-            "http://127.0.0.1:8088/api/providers/spotify/oauth/callback".to_string()
-        });
+        .unwrap_or_else(|| HIPHI_SPOTIFY_CALLBACK_URI.to_string());
     if !valid_redirect_uri(&redirect_uri) {
         return Err(error(
             StatusCode::BAD_REQUEST,
@@ -654,30 +655,39 @@ pub async fn oauth_start(
             "invalid_client_configuration",
         ));
     }
-    // pinggy (and localhost.run) mint a brand-new subdomain on every tunnel
-    // start, so a tunnel restarted after the user registered an earlier URL
-    // in Spotify's dashboard silently diverges from the saved Redirect URI.
-    // Spotify then rejects the authorize request with "redirect_uri: Not
-    // matching configuration" (#592). Catch the divergence here, before the
-    // user is sent to Spotify: the authorize request always uses the SAVED
-    // redirect URI verbatim, and a live tunnel whose address no longer
-    // matches it is a configuration conflict the user has to resolve first.
-    if let TunnelStatus::Active { url, .. } = state.provider_auth.spotify_tunnel.status().await {
-        let tunnel_callback = format!("{url}/api/providers/spotify/oauth/callback");
-        if config.redirect_uri != tunnel_callback {
-            return Err(error(
-                StatusCode::CONFLICT,
-                "Your HTTPS tunnel address changed and no longer matches the saved Redirect \
-                 URI. Save the new address, update the redirect URI registered in the Spotify \
-                 dashboard to match it, then connect -- or stop the tunnel if you meant to use \
-                 the saved address.",
-                "tunnel_redirect_mismatch",
-            ));
-        }
-    }
-    let code_verifier = config.client_secret.is_none().then(generate_pkce_verifier);
-    let code_challenge = code_verifier.as_deref().map(pkce_challenge);
+    let cloud =
+        crate::cloud_connector::CloudConnectorConfig::from_runtime(crate::config::get_config_dir())
+            .map_err(|_| {
+                error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "HiPhi Cloud pairing is invalid; repair the installation before connecting Spotify",
+            "hiphi_cloud_unavailable",
+        )
+            })?;
+    let cloud = cloud.ok_or_else(|| {
+        error(
+            StatusCode::PRECONDITION_REQUIRED,
+            "Pair this UHC installation with HiPhi Cloud before connecting Spotify",
+            "hiphi_cloud_required",
+        )
+    })?;
+    let identity = crate::cloud_connector::InstallationIdentity::load(
+        &cloud.key_path,
+        cloud.installation_id.clone(),
+    )
+    .map_err(|_| {
+        error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "HiPhi Cloud installation identity is unavailable",
+            "hiphi_cloud_unavailable",
+        )
+    })?;
+    let code_verifier = generate_pkce_verifier();
+    let code_challenge = pkce_challenge(&code_verifier);
     let state_token = random_token(32);
+    let state_digest = URL_SAFE_NO_PAD.encode(Sha256::digest(state_token.as_bytes()));
+    let request_id = uuid::Uuid::new_v4();
+    let issued_at = now_millis();
     let expires_at = now_secs() + OAUTH_TTL.as_secs();
     let mut pending = state.provider_auth.pending.write().await;
     let now = now_secs();
@@ -690,32 +700,35 @@ pub async fn oauth_start(
         ));
     }
     pending.insert(
-        state_token.clone(),
+        cloud_pending_key(request_id),
         PendingOAuth {
             provider: provider.clone(),
             expires_at,
-            code_verifier,
+            code_verifier: Some(code_verifier),
+            cloud_request_id: Some(request_id),
+            client_id: Some(config.client_id.clone()),
+            state_digest: Some(state_digest.clone()),
         },
     );
-    let authorization_url = format!(
-        "{SPOTIFY_AUTHORIZE_URL}?response_type=code&client_id={}&redirect_uri={}&scope={}&state={}",
-        urlencoding::encode(&config.client_id),
-        urlencoding::encode(&config.redirect_uri),
-        urlencoding::encode(SPOTIFY_SCOPE),
-        urlencoding::encode(&state_token)
-    );
-    let authorization_url = if let Some(challenge) = code_challenge {
-        format!(
-            "{authorization_url}&code_challenge_method=S256&code_challenge={}",
-            urlencoding::encode(&challenge)
+    let authorization_url = hiphi_spotify_authorization_url(
+        &identity,
+        &config.client_id,
+        &code_challenge,
+        &state_digest,
+        request_id,
+        issued_at,
+    )
+    .map_err(|_| {
+        error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Spotify authorization could not be prepared",
+            "oauth_start_failed",
         )
-    } else {
-        authorization_url
-    };
+    })?;
     Ok(Json(OAuthStartResponse {
         provider,
         authorization_url,
-        state: state_token,
+        state: request_id.to_string(),
         expires_at,
     }))
 }
@@ -870,18 +883,97 @@ async fn oauth_callback_json(
                 "oauth_not_configured",
             )
         })?;
+    complete_spotify_authorization(&state, provider, config, code, pending.code_verifier, true)
+        .await
+}
+
+pub async fn accept_cloud_spotify_callback(
+    state: &AppState,
+    callback: crate::cloud_connector::SpotifyCallbackMessage,
+) -> anyhow::Result<()> {
+    callback
+        .validate(now_millis())
+        .map_err(|reason| anyhow::anyhow!(reason))?;
+    let pending = state
+        .provider_auth
+        .pending
+        .write()
+        .await
+        .remove(&cloud_pending_key(callback.request_id))
+        .ok_or_else(|| anyhow::anyhow!("Spotify callback request is unknown or already used"))?;
+    if pending.provider != "spotify"
+        || pending.expires_at <= now_secs()
+        || pending.cloud_request_id != Some(callback.request_id)
+        || pending.client_id.as_deref() != Some(callback.client_id.as_str())
+        || pending.state_digest.as_deref() != Some(callback.state_digest.as_str())
+    {
+        anyhow::bail!("Spotify callback binding did not match the pending authorization");
+    }
+    if let Some(provider_error) = callback.error {
+        anyhow::bail!("Spotify authorization ended: {provider_error}");
+    }
+    let code = callback
+        .code
+        .ok_or_else(|| anyhow::anyhow!("Spotify callback omitted its authorization code"))?;
+    let verifier = pending
+        .code_verifier
+        .ok_or_else(|| anyhow::anyhow!("Spotify callback lost its local PKCE verifier"))?;
+    let config = state
+        .provider_auth
+        .oauth
+        .read()
+        .await
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("Spotify client configuration is not configured"))?;
+    if config.client_id != callback.client_id || callback.redirect_uri != HIPHI_SPOTIFY_CALLBACK_URI
+    {
+        anyhow::bail!("Spotify callback client or redirect binding changed");
+    }
+    complete_spotify_authorization(
+        state,
+        "spotify".to_string(),
+        config,
+        code,
+        Some(verifier),
+        false,
+    )
+    .await
+    .map(|_| ())
+    .map_err(|(status, Json(body))| anyhow::anyhow!("{} {}", status, body.code))
+}
+
+async fn complete_spotify_authorization(
+    state: &AppState,
+    provider: String,
+    config: Arc<SpotifyOAuthConfig>,
+    code: String,
+    code_verifier: Option<String>,
+    allow_client_secret: bool,
+) -> Result<Json<ProviderAuthResponse>, (StatusCode, Json<ErrorBody>)> {
     let mut form = vec![
         ("grant_type", "authorization_code".to_string()),
         ("code", code),
-        ("redirect_uri", config.redirect_uri.clone()),
+        (
+            "redirect_uri",
+            if allow_client_secret {
+                config.redirect_uri.clone()
+            } else {
+                HIPHI_SPOTIFY_CALLBACK_URI.to_string()
+            },
+        ),
     ];
-    if let Some(verifier) = pending.code_verifier {
+    if let Some(verifier) = code_verifier {
         form.push(("client_id", config.client_id.clone()));
         form.push(("code_verifier", verifier));
     }
-    let mut request = reqwest::Client::new().post(&config.token_url).form(&form);
-    if let Some(secret) = &config.client_secret {
-        request = request.basic_auth(&config.client_id, Some(secret));
+    let mut request = reqwest::Client::new()
+        .post(&config.token_url)
+        .timeout(Duration::from_secs(15))
+        .form(&form);
+    if allow_client_secret {
+        if let Some(secret) = &config.client_secret {
+            request = request.basic_auth(&config.client_id, Some(secret));
+        }
     }
     let response = request.send().await.map_err(|e| {
         error(
@@ -922,7 +1014,11 @@ async fn oauth_callback_json(
             token: Some(spotify_token.clone()),
             client_id: config.client_id.clone(),
             client_secret: config.client_secret.clone(),
-            redirect_uri: config.redirect_uri.clone(),
+            redirect_uri: if allow_client_secret {
+                config.redirect_uri.clone()
+            } else {
+                HIPHI_SPOTIFY_CALLBACK_URI.to_string()
+            },
         };
         store.save_record(&record).map_err(|e| {
             error(
@@ -1105,13 +1201,8 @@ fn valid_redirect_uri(value: &str) -> bool {
 }
 
 fn valid_spotify_client_id(value: &str) -> bool {
-    let normalized = value.trim().to_ascii_lowercase();
-    !normalized.is_empty()
-        && !matches!(
-            normalized.as_str(),
-            "test" | "local-test" | "example" | "example-client" | "your-client-id"
-        )
-        && !normalized.contains("example.test")
+    let value = value.trim();
+    (16..=64).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_alphanumeric())
 }
 
 fn select_client_secret(requested: Option<String>, existing: Option<String>) -> Option<String> {
@@ -1196,6 +1287,52 @@ fn pkce_challenge(verifier: &str) -> String {
     URL_SAFE_NO_PAD.encode(digest)
 }
 
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(i64::MAX)
+}
+
+fn cloud_pending_key(request_id: uuid::Uuid) -> String {
+    format!("hiphi-cloud:{request_id}")
+}
+
+fn hiphi_spotify_authorization_url(
+    identity: &crate::cloud_connector::InstallationIdentity,
+    client_id: &str,
+    code_challenge: &str,
+    state_digest: &str,
+    request_id: uuid::Uuid,
+    issued_at: i64,
+) -> anyhow::Result<String> {
+    let payload = serde_json::json!({
+        "audience": "hiphi-spotify-broker",
+        "callback_uri": HIPHI_SPOTIFY_CALLBACK_URI,
+        "client_id": client_id,
+        "code_challenge": code_challenge,
+        "installation_id": identity.installation_id(),
+        "issued_at": issued_at,
+        "protocol_version": crate::cloud_connector::protocol::PROTOCOL_VERSION,
+        "request_id": request_id,
+        "state_digest": state_digest,
+    });
+    let signature = identity.sign(&crate::cloud_connector::protocol::canonical_json(&payload)?);
+    let mut url = url::Url::parse(HIPHI_SPOTIFY_CONNECT_URL)?;
+    url.query_pairs_mut()
+        .append_pair("protocol_version", "1")
+        .append_pair("installation_id", identity.installation_id())
+        .append_pair("request_id", &request_id.to_string())
+        .append_pair("client_id", client_id)
+        .append_pair("code_challenge", code_challenge)
+        .append_pair("state_digest", state_digest)
+        .append_pair("issued_at", &issued_at.to_string())
+        .append_pair("signature", &URL_SAFE_NO_PAD.encode(signature.to_bytes()));
+    Ok(url.into())
+}
+
 #[derive(Debug, Deserialize)]
 struct SpotifyTokenResponse {
     access_token: String,
@@ -1233,6 +1370,7 @@ fn error(status: StatusCode, message: &str, code: &'static str) -> (StatusCode, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::spotify_tunnel::TunnelStatus;
     use axum::{
         body::{to_bytes, Body},
         extract::State,
@@ -1241,6 +1379,7 @@ mod tests {
         routing::any,
         Router,
     };
+    use ed25519_dalek::{Signature, Verifier as _};
     use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
     use tokio::net::TcpListener;
@@ -1286,6 +1425,69 @@ mod tests {
             axum::serve(listener, router).await.unwrap();
         });
         (format!("http://{address}/token"), handle)
+    }
+
+    #[test]
+    fn hiphi_authorization_url_is_installation_signed_and_contains_no_local_secret() {
+        let identity = crate::cloud_connector::InstallationIdentity::generate(
+            "11111111-1111-4111-8111-111111111111".to_string(),
+        )
+        .unwrap();
+        let request_id = uuid::Uuid::from_u128(0x22222222222242228222222222222222);
+        let client_id = "0123456789abcdef0123456789abcdef";
+        let challenge = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let state_digest = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let issued_at = 1_788_060_000_000_i64;
+        let authorization_url = hiphi_spotify_authorization_url(
+            &identity,
+            client_id,
+            challenge,
+            state_digest,
+            request_id,
+            issued_at,
+        )
+        .unwrap();
+        let parsed = url::Url::parse(&authorization_url).unwrap();
+        assert_eq!(
+            parsed.origin().ascii_serialization(),
+            "https://app.hiphi.audio"
+        );
+        assert_eq!(parsed.path(), "/spotify/connect");
+        let query: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        assert_eq!(query.get("client_id").map(String::as_str), Some(client_id));
+        assert_eq!(
+            query.get("code_challenge").map(String::as_str),
+            Some(challenge)
+        );
+        assert!(!authorization_url.contains("verifier"));
+        assert!(!authorization_url.contains("secret"));
+        assert!(!authorization_url.contains("127.0.0.1"));
+        assert_ne!(cloud_pending_key(request_id), request_id.to_string());
+
+        let payload = serde_json::json!({
+            "audience": "hiphi-spotify-broker",
+            "callback_uri": HIPHI_SPOTIFY_CALLBACK_URI,
+            "client_id": client_id,
+            "code_challenge": challenge,
+            "installation_id": identity.installation_id(),
+            "issued_at": issued_at,
+            "protocol_version": crate::cloud_connector::protocol::PROTOCOL_VERSION,
+            "request_id": request_id,
+            "state_digest": state_digest,
+        });
+        let signature = Signature::from_slice(
+            &URL_SAFE_NO_PAD
+                .decode(query.get("signature").unwrap())
+                .unwrap(),
+        )
+        .unwrap();
+        identity
+            .verifying_key()
+            .verify(
+                &crate::cloud_connector::protocol::canonical_json(&payload).unwrap(),
+                &signature,
+            )
+            .unwrap();
     }
 
     #[tokio::test]
@@ -1414,6 +1616,8 @@ mod tests {
         assert!(!valid_spotify_client_id(""));
         assert!(!valid_spotify_client_id("local-test"));
         assert!(!valid_spotify_client_id("your-client-id"));
+        assert!(!valid_spotify_client_id("0123456789abcdef/unsafe"));
+        assert!(!valid_spotify_client_id(&"a".repeat(65)));
     }
 
     #[test]
@@ -1583,7 +1787,6 @@ mod tests {
     }
 
     const TUNNEL_A: &str = "https://aaaaa-1-2-3-4.run.pinggy-free.link";
-    const TUNNEL_B: &str = "https://bbbbb-5-6-7-8.run.pinggy-free.link";
 
     fn callback_of(tunnel: &str) -> String {
         format!("{tunnel}/api/providers/spotify/oauth/callback")
@@ -1732,38 +1935,15 @@ mod tests {
         assert_eq!(*ports.lock().unwrap(), vec![19_417]);
     }
 
-    /// #592 pin: the authorize URL always carries the SAVED redirect URI
-    /// verbatim -- the live tunnel state must never be substituted in.
     #[tokio::test]
-    async fn authorize_url_uses_the_saved_redirect_uri_verbatim() {
-        let saved = callback_of(TUNNEL_A);
-        let (state, _dir) = tunnel_test_state(&saved, TUNNEL_A).await;
-        start_tunnel_and_wait_active(&state).await;
-        let response = oauth_start(State(state), Path("spotify".to_string()))
-            .await
-            .expect("oauth_start should succeed when tunnel and saved URI match");
-        let expected = format!("redirect_uri={}", urlencoding::encode(&saved));
-        assert!(
-            response.0.authorization_url.contains(&expected),
-            "authorize URL must embed the saved redirect_uri verbatim: {}",
-            response.0.authorization_url
-        );
-    }
-
-    /// #592: tunnel providers mint a new subdomain per start, so a live
-    /// tunnel that no longer matches the saved Redirect URI means the user
-    /// is about to be bounced by Spotify ("redirect_uri: Not matching
-    /// configuration") or redirected somewhere dead. Refuse before Spotify
-    /// is contacted.
-    #[tokio::test]
-    async fn oauth_start_refuses_when_the_live_tunnel_diverges_from_the_saved_redirect() {
-        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_B).await;
+    async fn oauth_start_requires_a_paired_hiphi_installation_even_if_a_legacy_tunnel_is_live() {
+        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
         start_tunnel_and_wait_active(&state).await;
         let error = oauth_start(State(state), Path("spotify".to_string()))
             .await
-            .expect_err("oauth_start must refuse a diverged tunnel");
-        assert_eq!(error.0, StatusCode::CONFLICT);
-        assert_eq!(error.1 .0.code, "tunnel_redirect_mismatch");
+            .expect_err("a temporary callback tunnel must not bypass cloud pairing");
+        assert_eq!(error.0, StatusCode::PRECONDITION_REQUIRED);
+        assert_eq!(error.1 .0.code, "hiphi_cloud_required");
     }
 
     /// #592: a random probe of the public callback URL (internet scanner,
@@ -1793,42 +1973,6 @@ mod tests {
                 TunnelStatus::Active { .. }
             ),
             "an unknown-state probe must not kill the tunnel"
-        );
-    }
-
-    /// #592: a callback that concludes a real pending attempt must NOT stop
-    /// the tunnel inline -- the response (and the settings redirect) still
-    /// travel through it. Teardown happens after a grace period instead.
-    /// The callback is also transport-independent: it is accepted here
-    /// without any tunnel-shaped Host header, matching a live enrollment
-    /// completed by replaying the redirect over the LAN.
-    #[tokio::test]
-    async fn concluded_callback_defers_teardown_past_its_own_response() {
-        let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
-        start_tunnel_and_wait_active(&state).await;
-        let started = oauth_start(State(state.clone()), Path("spotify".to_string()))
-            .await
-            .expect("oauth_start");
-        let response = oauth_callback(
-            State(state.clone()),
-            Path("spotify".to_string()),
-            Query(OAuthCallbackQuery {
-                code: None,
-                state: started.0.state.clone(),
-                error: Some("access_denied".to_string()),
-                error_description: None,
-                format: Some("json".to_string()),
-            }),
-        )
-        .await;
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert!(
-            matches!(
-                state.provider_auth.spotify_tunnel.status().await,
-                TunnelStatus::Active { .. }
-            ),
-            "the tunnel must outlive the callback response it is carrying \
-             (teardown is deferred by TUNNEL_CALLBACK_GRACE)"
         );
     }
 }

--- a/src/api/provider_auth.rs
+++ b/src/api/provider_auth.rs
@@ -1936,6 +1936,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn oauth_start_requires_a_paired_hiphi_installation_even_if_a_legacy_tunnel_is_live() {
         let (state, _dir) = tunnel_test_state(&callback_of(TUNNEL_A), TUNNEL_A).await;
         start_tunnel_and_wait_active(&state).await;

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -577,8 +577,7 @@ fn callback_feedback() -> Option<CallbackFeedback> {
     spotify_callback_feedback(&current_location_search()?)
 }
 
-const DEFAULT_SPOTIFY_REDIRECT_URI: &str =
-    "http://127.0.0.1:8088/api/providers/spotify/oauth/callback";
+const DEFAULT_SPOTIFY_REDIRECT_URI: &str = "https://app.hiphi.audio/api/spotify/callback";
 
 fn default_spotify_redirect_uri() -> String {
     DEFAULT_SPOTIFY_REDIRECT_URI.to_string()
@@ -681,13 +680,19 @@ fn spotify_oauth_error_message(reason: Option<&str>) -> String {
             "Spotify did not return an authorization code. Click Connect Spotify to try again.".to_string()
         }
         Some("token_exchange_failed") => {
-            "Spotify rejected the sign-in exchange. This usually means the address registered in your Spotify app does not exactly match the one saved in step 2. Fix the mismatch, save, and Connect again.".to_string()
+            "Spotify rejected the sign-in exchange. Confirm that the fixed HiPhi callback shown in step 2 is registered exactly in your Spotify app, then connect again.".to_string()
         }
         Some("token_storage_failed") => {
             "Spotify authorized, but the token could not be saved on this UHC server. Check the server's credential storage and try Connect again.".to_string()
         }
         Some("oauth_not_configured") | Some("invalid_client_configuration") => {
-            "Spotify client settings are missing or invalid. Enter and save the Client ID (and Secret, if used) below before connecting.".to_string()
+            "Spotify client settings are missing or invalid. Enter and save your Client ID below before connecting.".to_string()
+        }
+        Some("hiphi_cloud_required") => {
+            "Spotify setup uses HiPhi Cloud for its secure callback. Pair this UHC installation with HiPhi Cloud, then connect again.".to_string()
+        }
+        Some("hiphi_cloud_unavailable") => {
+            "This UHC installation's HiPhi Cloud pairing is unavailable. Repair the pairing, then connect again.".to_string()
         }
         Some("adapter_unavailable") | Some("adapter_start_failed") => {
             "Spotify authorized, but the adapter could not start. Refresh this page and try again.".to_string()
@@ -885,7 +890,6 @@ pub fn Settings() -> Element {
     // to Save before Connect even when the server is already configured.
     let mut spotify_resave_needed = use_signal(|| false);
     let mut spotify_client_id = use_signal(String::new);
-    let mut spotify_client_secret = use_signal(String::new);
     let mut spotify_redirect_uri = use_signal(default_spotify_redirect_uri);
     let spotify_callback_copy_state = use_signal(CopyState::default);
     // Temporary HTTPS tunnel for the Spotify OAuth callback (#538). Kept
@@ -1488,8 +1492,6 @@ pub fn Settings() -> Element {
     let save_spotify_local = move |_| {
         spotify_action_scope.set(3);
         let client_id = spotify_client_id().trim().to_string();
-        let client_secret = spotify_client_secret().trim().to_string();
-        let redirect_uri = spotify_redirect_uri().trim().to_string();
         if client_id.is_empty() {
             spotify_action.set(ProviderActionState::Failed);
             spotify_error.set(Some("Enter your Client ID first.".to_string()));
@@ -1500,8 +1502,8 @@ pub fn Settings() -> Element {
         spawn(async move {
             let request = SpotifyConfigureRequest {
                 client_id,
-                client_secret: (!client_secret.is_empty()).then_some(client_secret),
-                redirect_uri: (!redirect_uri.is_empty()).then_some(redirect_uri),
+                client_secret: None,
+                redirect_uri: None,
             };
             match crate::app::api::post_json::<SpotifyConfigureRequest, SpotifyConfigureResponse>(
                 "/api/providers/spotify/configure",
@@ -1825,8 +1827,7 @@ pub fn Settings() -> Element {
     // the redirect URI reopens step 2 so the warning is never hidden inside
     // a collapsed step.
     let spotify_step1_complete = spotify_configured || spotify_step_app_done();
-    let spotify_step2_complete =
-        (spotify_configured || spotify_step_callback_done()) && !spotify_tunnel_mismatch;
+    let spotify_step2_complete = spotify_configured || spotify_step_callback_done();
     let spotify_step3_complete = spotify_configured && !spotify_resave_needed();
     let spotify_step4_complete = spotify_connected;
     let spotify_current_step: u8 = if !spotify_step1_complete {
@@ -2296,6 +2297,16 @@ pub fn Settings() -> Element {
                                     span { class: "badge badge-secondary", "Alpha" }
                                 }
                                 p { class: "mt-1 text-sm text-secondary", "Control existing Spotify Connect devices. UHC does not act as a receiver." }
+                                p { class: "mt-2 text-sm text-secondary",
+                                    "New Spotify authorization uses a paired HiPhi Cloud account for the secure callback only. "
+                                    a {
+                                        class: "link",
+                                        href: "https://hiphi.audio/#cloud",
+                                        target: "_blank",
+                                        rel: "noopener noreferrer",
+                                        "Why HiPhi Cloud?"
+                                    }
+                                }
                                 div {
                                     class: "mt-2",
                                     hidden: spotify_account.is_none(),
@@ -2425,9 +2436,7 @@ pub fn Settings() -> Element {
                                 }
                             }
 
-                            // Step 2 -- register the callback address. The tunnel
-                            // button is the primary path when the browser is not on
-                            // the UHC machine; manual entry lives under Advanced.
+                            // Step 2 -- register HiPhi's fixed callback address.
                             li { class: spotify_step_class(2, spotify_step2_complete),
                                 div { class: "flex items-start gap-3",
                                     span {
@@ -2466,8 +2475,8 @@ pub fn Settings() -> Element {
                                             "ⓘ"
                                         }
                                         div { id: "spotify-step-2-info", class: spotify_info_panel_class(2), role: "note",
-                                            p { "After you approve access, Spotify sends your browser back to UHC -- but only to an address on your app's \"Redirect URIs\" list, and (except on the exact machine running UHC) only to a secure https address." }
-                                            p { class: "mt-2", "The address UHC opens for you stays up for about 15 minutes and closes itself once you finish connecting. Connecting again later issues a new address, which then needs to be added to your Spotify app too." }
+                                            p { "Spotify sends your browser to HiPhi's fixed secure callback. HiPhi passes the one-use response to this paired UHC installation; Spotify tokens remain encrypted here." }
+                                            p { class: "mt-2", "The address never changes, so you register it once and never run a tunnel or expose this server." }
                                         }
                                     }
                                 }
@@ -2475,7 +2484,26 @@ pub fn Settings() -> Element {
                                     id: "spotify-step-2-body",
                                     hidden: !spotify_step2_open,
                                     aria_hidden: !spotify_step2_open,
-                                    if spotify_remote_origin() {
+                                    if DEFAULT_SPOTIFY_REDIRECT_URI.starts_with("https://app.hiphi.audio/") {
+                                        div {
+                                            p { class: "mt-2 text-sm text-secondary", "Add this exact address to your Spotify app under Redirect URIs." }
+                                            div { class: "mt-2 flex flex-col gap-2 sm:flex-row sm:items-stretch",
+                                                code {
+                                                    id: "spotify-callback-url-display",
+                                                    class: "block min-w-0 flex-1 overflow-x-auto break-all rounded-md bg-hover px-3 py-3 text-xs select-all",
+                                                    "{DEFAULT_SPOTIFY_REDIRECT_URI}"
+                                                }
+                                                button {
+                                                    r#type: "button",
+                                                    class: "btn btn-outline btn-sm shrink-0",
+                                                    aria_label: "Copy Spotify callback URL",
+                                                    onclick: move |_| copy_to_clipboard(DEFAULT_SPOTIFY_REDIRECT_URI.to_string(), spotify_callback_copy_state),
+                                                    span { aria_live: "polite", "{spotify_callback_copy_state().label(\"Copy URL\")}" }
+                                                }
+                                            }
+                                            p { class: "mt-2 text-xs text-muted", "HiPhi Cloud handles only the callback handoff. Your Spotify sign-in and playback stay on this UHC installation." }
+                                        }
+                                    } else if spotify_remote_origin() {
                                         // Remote/LAN origin -- the common case (a NAS or any
                                         // machine other than the one running the browser).
                                         // Spotify rejects plain-HTTP addresses here, so the
@@ -2667,7 +2695,7 @@ pub fn Settings() -> Element {
                                         }
                                         div { id: "spotify-step-3-info", class: spotify_info_panel_class(3), role: "note",
                                             p { "The Client ID is the long code on your app's page in the Spotify dashboard. It identifies your app; it is not a password, and it is stored on this UHC server -- never in the browser." }
-                                            p { class: "mt-2", "Most setups can leave the Client Secret blank -- UHC signs in securely without it. Only fill it in if you specifically created your app to require one." }
+                                            p { class: "mt-2", "HiPhi never needs your Client Secret. UHC uses PKCE and keeps the verifier and Spotify tokens local." }
                                         }
                                     }
                                 }
@@ -2687,25 +2715,6 @@ pub fn Settings() -> Element {
                                             spotify_resave_needed.set(true);
                                             spotify_client_id.set(event.value());
                                         },
-                                    }
-                                    details { class: "mt-3",
-                                        summary { class: "cursor-pointer text-sm font-medium select-none", "Advanced: client secret" }
-                                        div { class: "mt-2",
-                                            label { class: "block text-sm font-medium", r#for: "spotify-client-secret", "Client secret" }
-                                            input {
-                                                id: "spotify-client-secret",
-                                                class: "input mt-1 min-h-11 w-full",
-                                                r#type: "password",
-                                                value: spotify_client_secret(),
-                                                autocomplete: "new-password",
-                                                oninput: move |event| {
-                                                    spotify_local_setup_saved.set(false);
-                                                    spotify_resave_needed.set(true);
-                                                    spotify_client_secret.set(event.value());
-                                                },
-                                            }
-                                            p { class: "mt-1 text-xs text-muted", "Usually blank. Never shown back to this page once saved." }
-                                        }
                                     }
                                     button {
                                         id: "spotify-save-client-settings",
@@ -2767,8 +2776,8 @@ pub fn Settings() -> Element {
                                             "ⓘ"
                                         }
                                         div { id: "spotify-step-4-info", class: spotify_info_panel_class(4), role: "note",
-                                            p { "Connect opens Spotify's approval page for the app you created. Once you approve, Spotify sends you straight back here and UHC starts discovering your players." }
-                                            p { class: "mt-2", "Your sign-in lives on this UHC server and renews itself automatically; the browser never sees it. Reconnecting later repeats this step -- and needs a fresh address from step 2 first." }
+                                            p { "Connect opens HiPhi's owner check and then Spotify's approval page for the app you created. The response returns only to this paired installation." }
+                                            p { class: "mt-2", "Your sign-in lives on this UHC server and renews itself locally. Reconnecting later uses the same fixed callback address." }
                                         }
                                     }
                                 }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -3989,7 +3989,7 @@ mod tests {
         let mismatch =
             spotify_callback_feedback("?spotify=error&reason=token_exchange_failed").unwrap();
         assert!(mismatch.is_error);
-        assert!(mismatch.message.contains("does not exactly match"));
+        assert!(mismatch.message.contains("fixed HiPhi callback"));
 
         let unknown_reason = spotify_callback_feedback("?spotify=error&reason=made_up").unwrap();
         assert!(unknown_reason.is_error);

--- a/src/cloud_connector/mod.rs
+++ b/src/cloud_connector/mod.rs
@@ -20,8 +20,8 @@ pub use config::{CloudConnectorConfig, ConfigError, IssuerVerifyingKeyRing, MAX_
 pub use identity::{InstallationIdentity, ZoneHandleMap};
 pub use protocol::{
     parse_relay_message, AllowedAction, ArtworkChunk, ArtworkRelayRequest, ArtworkRelayResponse,
-    CommandEnvelope, CommandPayload, ConnectorMessage, RelayMessage, StateSnapshot, WireEnvelope,
-    WireType,
+    CommandEnvelope, CommandPayload, ConnectorMessage, RelayMessage, SpotifyCallbackMessage,
+    StateSnapshot, WireEnvelope, WireType,
 };
 pub use session::{
     verify_installation_session_grant, InstallationGrantRequest, InstallationSessionProof,

--- a/src/cloud_connector/protocol.rs
+++ b/src/cloud_connector/protocol.rs
@@ -321,6 +321,52 @@ pub struct ArtworkRelayRequest {
     pub max_source_bytes: usize,
 }
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpotifyCallbackMessage {
+    pub protocol_version: u16,
+    pub request_id: Uuid,
+    pub client_id: String,
+    pub state_digest: String,
+    pub redirect_uri: String,
+    pub expires_at: TimestampMs,
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl SpotifyCallbackMessage {
+    pub fn validate(&self, now_ms: TimestampMs) -> Result<(), &'static str> {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let digest_ok = URL_SAFE_NO_PAD
+            .decode(&self.state_digest)
+            .is_ok_and(|value| value.len() == 32);
+        if self.protocol_version != PROTOCOL_VERSION
+            || !(16..=64).contains(&self.client_id.len())
+            || !self
+                .client_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric())
+            || !digest_ok
+            || self.redirect_uri != "https://app.hiphi.audio/api/spotify/callback"
+            || self.expires_at <= now_ms
+            || self.expires_at.saturating_sub(now_ms) > 60_000
+            || (self.code.is_some() == self.error.is_some())
+            || self
+                .code
+                .as_ref()
+                .is_some_and(|value| value.is_empty() || value.len() > 2_048)
+            || self
+                .error
+                .as_ref()
+                .is_some_and(|value| value.is_empty() || value.len() > 128)
+        {
+            return Err("invalid_spotify_callback");
+        }
+        Ok(())
+    }
+}
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ArtworkRelayResponse {
     pub protocol_version: u16,
     pub message_id: String,
@@ -391,6 +437,7 @@ pub enum RelayMessage {
     Heartbeat { epoch: Epoch, sent_at: TimestampMs },
     Command(CommandEnvelope),
     ArtworkRequest(ArtworkRelayRequest),
+    SpotifyCallback(SpotifyCallbackMessage),
     Revoke { reason_code: String },
 }
 

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -640,6 +640,14 @@ where
                         artwork_active.clone(),
                     );
                 }
+                RelayMessage::SpotifyCallback(callback) => {
+                    if let Err(error) =
+                        crate::api::provider_auth::accept_cloud_spotify_callback(state, callback)
+                            .await
+                    {
+                        tracing::warn!("HiPhi Spotify callback was refused: {error}");
+                    }
+                }
                 RelayMessage::Revoke { reason_code } => {
                     tracing::warn!("relay revoked connector: {reason_code}");
                     return Ok(ConnectionExit::Revoked);

--- a/tests/cloud_connector.rs
+++ b/tests/cloud_connector.rs
@@ -11,6 +11,24 @@ use rand::rngs::OsRng;
 use serde_json::json;
 use std::time::Duration;
 
+#[test]
+fn spotify_callback_is_a_strict_installation_relay_message() {
+    let message = br#"{"type":"spotify_callback","body":{"protocol_version":1,"request_id":"11111111-1111-4111-8111-111111111111","client_id":"0123456789abcdef0123456789abcdef","state_digest":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","redirect_uri":"https://app.hiphi.audio/api/spotify/callback","expires_at":1800000060000,"code":"one-use-code"}}"#;
+    let parsed = parse_relay_message(message).expect("valid Spotify callback");
+    let RelayMessage::SpotifyCallback(callback) = parsed else {
+        panic!("wrong relay message type");
+    };
+    assert_eq!(
+        callback.request_id,
+        uuid::Uuid::from_u128(0x11111111111141118111111111111111)
+    );
+    assert_eq!(callback.code.as_deref(), Some("one-use-code"));
+    assert!(callback.error.is_none());
+
+    let duplicate = br#"{"type":"spotify_callback","body":{"protocol_version":1,"request_id":"11111111-1111-4111-8111-111111111111","client_id":"0123456789abcdef0123456789abcdef","state_digest":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","redirect_uri":"https://app.hiphi.audio/api/spotify/callback","expires_at":1800000060000,"code":"first","code":"second"}}"#;
+    assert_eq!(parse_relay_message(duplicate), Err("duplicate_object_key"));
+}
+
 fn id(prefix: &str) -> String {
     format!("{prefix}_01234567890")
 }
@@ -251,6 +269,7 @@ fn private_relay_fixture_messages_match_typed_wire_contract() {
                 | RelayMessage::Heartbeat { .. }
                 | RelayMessage::Command(_)
                 | RelayMessage::ArtworkRequest(_)
+                | RelayMessage::SpotifyCallback(_)
                 | RelayMessage::Revoke { .. }
         ));
     }

--- a/tests/fixtures/adapter_boundary_debt.txt
+++ b/tests/fixtures/adapter_boundary_debt.txt
@@ -83,5 +83,5 @@ src/producers/hqplayer_command_service.rs|build|concrete-adapter-type|HqpInstanc
 src/producers/hqplayer_command_service.rs||concrete-adapter-type|HqpInstanceManager
 src/api/mod.rs|AdapterRegistry|concrete-adapter-type|Startable
 src/api/mod.rs|register_with_lifecycle|concrete-adapter-type|Startable
-src/api/provider_auth.rs|oauth_callback_json|concrete-adapter-type|Startable
+src/api/provider_auth.rs|complete_spotify_authorization|concrete-adapter-type|Startable
 src/api/provider_auth.rs|oauth_revoke|concrete-adapter-type|Startable

--- a/tests/fixtures/hiphi-relay-v1/schema.json
+++ b/tests/fixtures/hiphi-relay-v1/schema.json
@@ -7,6 +7,7 @@
     {"$ref":"#/$defs/command_result"}, {"$ref":"#/$defs/artwork_response"},
     {"$ref":"#/$defs/challenge"}, {"$ref":"#/$defs/session_established"},
     {"$ref":"#/$defs/command"}, {"$ref":"#/$defs/artwork_request"},
+    {"$ref":"#/$defs/spotify_callback"},
     {"$ref":"#/$defs/revoke"}
   ],
   "$defs": {
@@ -85,6 +86,12 @@
     },
     "session_established": {
       "allOf":[{"$ref":"#/$defs/tagged"},{"properties":{"type":{"const":"session_established"},"body":{"type":"object","additionalProperties":false,"required":["epoch"],"properties":{"epoch":{"$ref":"#/$defs/epoch"}}}}}]
+    },
+    "spotify_callback": {
+      "allOf":[{"$ref":"#/$defs/tagged"},{"properties":{"type":{"const":"spotify_callback"},"body":{"oneOf":[
+        {"type":"object","additionalProperties":false,"required":["protocol_version","request_id","client_id","state_digest","redirect_uri","expires_at","code"],"properties":{"protocol_version":{"const":1},"request_id":{"$ref":"#/$defs/uuid"},"client_id":{"type":"string","minLength":16,"maxLength":64,"pattern":"^[A-Za-z0-9]+$"},"state_digest":{"type":"string","pattern":"^[A-Za-z0-9_-]{43}$"},"redirect_uri":{"const":"https://app.hiphi.audio/api/spotify/callback"},"expires_at":{"$ref":"#/$defs/timestamp"},"code":{"type":"string","minLength":1,"maxLength":4096}}},
+        {"type":"object","additionalProperties":false,"required":["protocol_version","request_id","client_id","state_digest","redirect_uri","expires_at","error"],"properties":{"protocol_version":{"const":1},"request_id":{"$ref":"#/$defs/uuid"},"client_id":{"type":"string","minLength":16,"maxLength":64,"pattern":"^[A-Za-z0-9]+$"},"state_digest":{"type":"string","pattern":"^[A-Za-z0-9_-]{43}$"},"redirect_uri":{"const":"https://app.hiphi.audio/api/spotify/callback"},"expires_at":{"$ref":"#/$defs/timestamp"},"error":{"type":"string","minLength":1,"maxLength":256}}}
+      ]}}}}]
     },
     "revoke": {
       "allOf":[{"$ref":"#/$defs/tagged"},{"properties":{"type":{"const":"revoke"},"body":{"type":"object","additionalProperties":false,"required":["reason_code"],"properties":{"reason_code":{"type":"string","maxLength":128}}}}}]

--- a/tests/fixtures/hiphi-relay-v1/valid.json
+++ b/tests/fixtures/hiphi-relay-v1/valid.json
@@ -13,6 +13,7 @@
     {"type":"heartbeat","body":{"epoch":7,"sent_at":1788060000000}},
     {"type":"command","body":{"protocol_version":1,"installation_id":"11111111-1111-4111-8111-111111111111","control_node_id":"66666666-6666-4666-8666-666666666666","epoch":7,"message_id":"message_demo_command","request_id":"22222222-2222-4222-8222-222222222222","idempotency_key":"33333333-3333-4333-8333-333333333333","created_at":1788060000000,"expires_at":1788060015000,"payload":{"zone_handle":"zone_demo_lounge","action":"volume.absolute","value":-23.5},"grant":"fake-v1-grant-not-a-credential-000000000000000000000000"}},
     {"type":"artwork_request","body":{"protocol_version":1,"message_id":"message_demo_art_req","installation_id":"11111111-1111-4111-8111-111111111111","epoch":7,"request_id":"44444444-4444-4444-8444-444444444444","zone_handle":"zone_demo_lounge","artwork_revision":"art_demo_004","max_source_bytes":2097152}},
+    {"type":"spotify_callback","body":{"protocol_version":1,"request_id":"77777777-7777-4777-8777-777777777777","client_id":"0123456789abcdef0123456789abcdef","state_digest":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","redirect_uri":"https://app.hiphi.audio/api/spotify/callback","expires_at":1788060060000,"code":"one-use-provider-code"}},
     {"type":"revoke","body":{"reason_code":"owner_revoked"}}
   ],
   "artwork_chunk": {"codec":"uuid-16 || index-u16-be || count-u16-be || bytes","max_payload_bytes":49152}


### PR DESCRIPTION
Fixes #662

## Outcome

Spotify setup now asks for only the user-owned Spotify Client ID and uses HiPhi Cloud for a fixed, owner-approved OAuth callback handoff. UHC keeps the PKCE verifier and Spotify access/refresh tokens locally. No LAN listener or temporary tunnel is used by the supported flow.

Depends on open-horizon-labs/hiphi-cloud#63.

## What changed

- sign short-lived Spotify start requests with the paired installation key
- accept a strict, installation-bound `spotify_callback` relay message
- exchange the provider code locally with PKCE and no Client Secret
- simplify Settings to the personal-app Client ID and fixed callback
- document the public threat model, security invariant, ADR, and deployment behavior
- preserve old tunnel endpoints temporarily for installed-alpha compatibility, while preventing them from consuming cloud pending state

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --features server --lib -- -D warnings`
- `cargo test --features server --test cloud_connector` (42 passed)
- `cargo test --features server --lib api::provider_auth::tests` (11 passed)
- `cargo test --features server --test hiphi_security_docs`
- `cargo test --features server --test api_contract`
- `cargo test --features server --test settings_feature_transaction_contract`

Review note: the post-implementation review separated legacy and cloud pending-state namespaces so the old local callback cannot cancel a cloud authorization attempt.