### PR TITLE
Clarify Spotify Premium and credential boundaries in onboarding

### DIFF
--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -92,6 +92,13 @@ Spotify uses an authorization-code flow with PKCE and a fixed HiPhi callback:
 
 ### Spotify's 2026 Development Mode boundary
 
+The owner of a Development Mode app must have an active Spotify Premium
+subscription. If that subscription lapses, the app stops working until the
+owner resubscribes. Each account using Spotify playback control also needs
+Premium. A Development Mode app supports up to five authenticated Spotify
+users; add accounts other than the owner under **Users Management** in the
+Spotify Developer Dashboard before they authorize UHC.
+
 UHC controls existing Spotify Connect devices; it is not a Connect receiver
 and receives no audio. For applications created under Spotify's current
 Development Mode rules, UHC uses `/me/playlists`, parses a playlist's `items`
@@ -146,10 +153,13 @@ For a local or QNAP install, open Settings in the browser you will use for
 authorization. The Spotify card's "Client settings" pane now walks through the
 whole flow as numbered steps: create/open an app in the Spotify Developer
 Dashboard, copy the fixed HiPhi callback shown there (with a one-click copy
-button) into the app's Redirect URIs, paste the Client ID, save, then Connect.
+button) into the app's Redirect URIs, select **Web API**, paste the Client ID,
+save, then Connect.
 The installation must first be paired with HiPhi Cloud. HiPhi is used only for
-the owner-approved callback handoff; normal playback requests and token refresh
-remain between UHC and Spotify.
+the owner-approved callback handoff. It routes the one-use response to the
+paired installation and does not retain the authorization code. The PKCE
+verifier and encrypted Spotify access and refresh tokens stay on UHC; normal
+playback requests and token refresh remain between UHC and Spotify.
 
 ### First save on a NAS: the owner bootstrap prompt (#570)
 

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -2307,6 +2307,25 @@ pub fn Settings() -> Element {
                                         "Why HiPhi Cloud?"
                                     }
                                 }
+                                div { class: "mt-4 rounded-md border border-default bg-elevated p-4 text-sm",
+                                    p { class: "font-medium text-primary", "Before you start" }
+                                    p { class: "mt-1 text-secondary",
+                                        "Spotify requires the owner of a Development Mode app to have an active Spotify Premium subscription. Each Spotify account using playback control also needs Premium. If the owner's Premium lapses, the app stops working until the owner resubscribes."
+                                    }
+                                    p { class: "mt-2 text-secondary",
+                                        "A Development Mode app supports up to five authenticated Spotify users. Add any account other than the app owner under Users Management in the Spotify dashboard."
+                                    }
+                                    p { class: "mt-2 text-secondary",
+                                        "HiPhi Cloud routes a one-use authorization response to this paired installation. It does not retain the authorization code. It never receives your Client Secret, PKCE verifier, or Spotify access and refresh tokens. UHC exchanges the code directly with Spotify and keeps the access and refresh tokens encrypted on this UHC server."
+                                    }
+                                    a {
+                                        class: "link mt-2 inline-block",
+                                        href: "https://developer.spotify.com/documentation/web-api/concepts/quota-modes",
+                                        target: "_blank",
+                                        rel: "noopener noreferrer",
+                                        "Spotify Premium and Development Mode requirements"
+                                    }
+                                }
                                 div {
                                     class: "mt-2",
                                     hidden: spotify_account.is_none(),
@@ -2405,8 +2424,8 @@ pub fn Settings() -> Element {
                                             "ⓘ"
                                         }
                                         div { id: "spotify-step-1-info", class: spotify_info_panel_class(1), role: "note",
-                                            p { "Spotify only lets an app you own control your players, so you create a free one to act as your personal key. In the dashboard, choose \"Create app\", give it any name, and accept Spotify's terms. Nothing gets published anywhere." }
-                                            p { class: "mt-2", "New apps run in development mode: the Spotify accounts allowed to sign in must be listed on the app's User Management page." }
+                                            p { "Create a personal Development Mode app in Spotify's dashboard. Give it any name, select Web API, and accept Spotify's terms. The app is not published." }
+                                            p { class: "mt-2", "The app owner needs active Spotify Premium. Add any other Spotify account that will authorize UHC under Users Management." }
                                         }
                                     }
                                 }
@@ -2414,7 +2433,7 @@ pub fn Settings() -> Element {
                                     id: "spotify-step-1-body",
                                     hidden: !spotify_step1_open,
                                     aria_hidden: !spotify_step1_open,
-                                    p { class: "mt-2 text-sm text-secondary", "Create a free app in Spotify's developer dashboard -- it takes about a minute." }
+                                    p { class: "mt-2 text-sm text-secondary", "Create an app in Spotify's developer dashboard. Select Web API when Spotify asks which API you plan to use." }
                                     div { class: "mt-3 flex flex-wrap gap-2",
                                         a {
                                             class: "btn btn-primary min-h-11 inline-flex items-center",
@@ -2475,7 +2494,8 @@ pub fn Settings() -> Element {
                                             "ⓘ"
                                         }
                                         div { id: "spotify-step-2-info", class: spotify_info_panel_class(2), role: "note",
-                                            p { "Spotify sends your browser to HiPhi's fixed secure callback. HiPhi passes the one-use response to this paired UHC installation; Spotify tokens remain encrypted here." }
+                                            p { "Spotify sends your browser to HiPhi's fixed secure callback. HiPhi routes the one-use response to this paired UHC installation and does not retain the authorization code." }
+                                            p { class: "mt-2", "UHC keeps the PKCE verifier local, exchanges the code directly with Spotify, and stores the access and refresh tokens encrypted on this UHC server." }
                                             p { class: "mt-2", "The address never changes, so you register it once and never run a tunnel or expose this server." }
                                         }
                                     }
@@ -2501,7 +2521,7 @@ pub fn Settings() -> Element {
                                                     span { aria_live: "polite", "{spotify_callback_copy_state().label(\"Copy URL\")}" }
                                                 }
                                             }
-                                            p { class: "mt-2 text-xs text-muted", "HiPhi Cloud handles only the callback handoff. Your Spotify sign-in and playback stay on this UHC installation." }
+                                            p { class: "mt-2 text-xs text-muted", "HiPhi Cloud routes the callback response but does not retain the authorization code. Spotify tokens and playback authority stay on this UHC installation." }
                                         }
                                     } else if spotify_remote_origin() {
                                         // Remote/LAN origin -- the common case (a NAS or any
@@ -2695,7 +2715,7 @@ pub fn Settings() -> Element {
                                         }
                                         div { id: "spotify-step-3-info", class: spotify_info_panel_class(3), role: "note",
                                             p { "The Client ID is the long code on your app's page in the Spotify dashboard. It identifies your app; it is not a password, and it is stored on this UHC server -- never in the browser." }
-                                            p { class: "mt-2", "HiPhi never needs your Client Secret. UHC uses PKCE and keeps the verifier and Spotify tokens local." }
+                                            p { class: "mt-2", "HiPhi never receives your Client Secret or PKCE verifier. UHC stores the Spotify access and refresh tokens encrypted on this server." }
                                         }
                                     }
                                 }

--- a/tests/spotify_onboarding_copy_contract.rs
+++ b/tests/spotify_onboarding_copy_contract.rs
@@ -1,0 +1,42 @@
+//! Spotify setup copy is part of the safety and support contract.
+
+const SETTINGS: &str = include_str!("../src/app/pages/settings.rs");
+
+#[test]
+fn spotify_onboarding_states_prerequisites_and_complete_setup_path() {
+    for required in [
+        "active Spotify Premium subscription",
+        "Select Web API",
+        "Users Management",
+        "https://app.hiphi.audio/api/spotify/callback",
+        "Copy the Client ID",
+        "Connect Spotify",
+    ] {
+        assert!(
+            SETTINGS.contains(required),
+            "Spotify onboarding must contain {:?}",
+            required
+        );
+    }
+}
+
+#[test]
+fn spotify_onboarding_explains_the_cloud_credential_boundary_precisely() {
+    for required in [
+        "does not retain the authorization code",
+        "PKCE verifier",
+        "access and refresh tokens",
+        "encrypted on this UHC server",
+    ] {
+        assert!(
+            SETTINGS.contains(required),
+            "Spotify credential-boundary copy must contain {:?}",
+            required
+        );
+    }
+
+    assert!(
+        !SETTINGS.contains("HiPhi never receives the authorization code"),
+        "HiPhi transiently receives the provider callback code and must not claim otherwise"
+    );
+}


### PR DESCRIPTION
Fixes #665

## What changed

- puts the active Spotify Premium requirement before setup begins
- explains Development Mode user access and the complete Web API / callback / Client ID / Connect sequence
- distinguishes the transient HiPhi callback handoff from the PKCE verifier and encrypted access/refresh tokens retained by UHC
- updates the operator documentation and adds a source-level onboarding contract

## Verification

- `cargo test --test spotify_onboarding_copy_contract`
- `cargo fmt --check`
- `git diff --check`

## Sources checked

- Spotify Web API quota modes and February 2026 Development Mode migration guide
- HiPhi personal Spotify app protocol and public threat model