### PR TITLE
Establish v4 development, CI, and installation guidance

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -33,7 +33,7 @@ Search for "Unified Hi-Fi Control" in Roon Extension Manager and install.
 
 Add this repository URL in LMS Settings → Plugins → Additional Repositories:
 ```
-https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-plugin/repo.xml
+https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v4/lms-plugin/repo.xml
 ```
 Then install "Unified Hi-Fi Control" from the plugin list.
 
@@ -86,7 +86,7 @@ cosign verify muness/unified-hifi-control:{{VERSION}} \
 ```
 
 Full details, including which platforms are signed today versus pending
-owner credentials: [docs/gh-release.md#release-signing](https://github.com/open-horizon-labs/unified-hifi-control/blob/v3/docs/gh-release.md#release-signing).
+owner credentials: [docs/gh-release.md#release-signing](https://github.com/open-horizon-labs/unified-hifi-control/blob/v4/docs/gh-release.md#release-signing).
 
 ---
 

--- a/.github/workflows/api-guard.yml
+++ b/.github/workflows/api-guard.yml
@@ -2,7 +2,7 @@ name: API Guard
 
 on:
   pull_request:
-    branches: [master, v3, 'integration/streaming-ha-alpha']
+    branches: [master, v3, v4]
     paths:
       - 'src/main.rs'
       - 'src/api/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build
 
 on:
   pull_request:
-    branches: [master, v3, 'integration/streaming-ha-alpha']
+    branches: [master, v3, v4]
     types: [opened, synchronize, reopened, labeled]
   push:
-    branches: [v3, 'feature/**']
+    branches: [v3, v4, 'feature/**']
     # Tag pushes are the single release trigger. `release: [published]` used to be
     # listed here as well, which meant `gh release create` — the way releases are
     # actually cut — fired both events for the same commit and built the entire
@@ -2055,7 +2055,7 @@ jobs:
           ### macOS Companion Apps
           - `unified-hifi-applemusic-companion-macos-arm64-*.dmg` - Apple Music
             companion (Apple Silicon only). Unsigned: see the "Unsigned app"
-            note in [companion/apple_music/README.md](https://github.com/${{ github.repository }}/blob/v3/companion/apple_music/README.md)
+            note in [companion/apple_music/README.md](https://github.com/${{ github.repository }}/blob/v4/companion/apple_music/README.md)
             for the right-click-Open / xattr workaround required on first launch.
 
           ### LMS Plugin
@@ -2066,7 +2066,7 @@ jobs:
           - `SHA256SUMS.asc` - detached GPG signature over `SHA256SUMS` (present once the owner has enrolled the signing key; see below if absent)
           - Docker images (`muness/unified-hifi-control`) are signed keylessly with [cosign](https://docs.sigstore.dev/cosign/overview/) via GitHub Actions OIDC
 
-          See [Verifying Release Artifacts](https://github.com/${{ github.repository }}/blob/v3/docs/gh-release.md#release-signing) for step-by-step verification commands.
+          See [Verifying Release Artifacts](https://github.com/${{ github.repository }}/blob/v4/docs/gh-release.md#release-signing) for step-by-step verification commands.
           EOF
 
       - name: Generate beta LMS repository feed
@@ -2119,7 +2119,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: v3
+          ref: v4
 
       - name: Get release version
         id: version
@@ -2183,7 +2183,7 @@ jobs:
           title: "chore: Update LMS plugin to v${{ steps.version.outputs.version }}"
           body: "Auto-generated PR to update LMS plugin metadata for release v${{ steps.version.outputs.version }}."
           branch: chore/lms-update-${{ steps.version.outputs.version }}
-          base: v3
+          base: v4
           add-paths: |
             lms-plugin/repo.xml
             lms-plugin/install.xml
@@ -2201,7 +2201,7 @@ jobs:
   # that: they would have to re-point their Additional Repositories entry at each new build, and
   # nothing told them the channel existed. The feed was generated and then unreachable.
   #
-  # This commits the same file to a fixed path on `v3`, so the beta channel gets a permanent URL the
+  # This commits the same file to a fixed path on `v4`, so the beta channel gets a permanent URL the
   # way the stable channel already has one via `lms-plugin/repo.xml`.
   #
   # It downloads the asset rather than regenerating the XML, so there is exactly one definition of
@@ -2218,7 +2218,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: v3
+          ref: v4
 
       - name: Fetch the published beta feed
         run: |
@@ -2244,7 +2244,7 @@ jobs:
           title: "chore: Point LMS beta feed at v${{ needs.plan.outputs.version }}"
           body: "Auto-generated. Updates `lms-plugin/repo-beta.xml` so the beta repository URL serves v${{ needs.plan.outputs.version }}."
           branch: chore/lms-beta-feed-${{ needs.plan.outputs.version }}
-          base: v3
+          base: v4
           add-paths: lms-plugin/repo-beta.xml
 
       - name: Enable auto-merge

--- a/.github/workflows/ha-integration.yml
+++ b/.github/workflows/ha-integration.yml
@@ -4,19 +4,18 @@ name: Home Assistant integration
 # package. This job is intentionally independent of the Rust crate's
 # build/CI (build.yml) since it has its own toolchain and dependencies.
 #
-# The streaming/companion alpha branch is also an active integration target;
-# changes there need the same package-level evidence before review.
+# The maintained v3 and active v4 lines both require package-level evidence.
 
 on:
   push:
-    branches: [v3, 'integration/streaming-ha-alpha']
+    branches: [v3, v4]
     paths:
       - "custom_components/unified_hifi_control/**"
       - "hacs.json"
       - "pyproject.toml"
       - ".github/workflows/ha-integration.yml"
   pull_request:
-    branches: [v3, 'integration/streaming-ha-alpha']
+    branches: [v3, v4]
     paths:
       - "custom_components/unified_hifi_control/**"
       - "hacs.json"

--- a/.github/workflows/hiphi-cloud-connector.yml
+++ b/.github/workflows/hiphi-cloud-connector.yml
@@ -2,7 +2,7 @@ name: HiPhi Cloud connector
 
 on:
   pull_request:
-    branches: [integration/streaming-ha-alpha]
+    branches: [v4]
     paths:
       - '.github/workflows/hiphi-cloud-connector.yml'
       - 'Cargo.toml'

--- a/.github/workflows/streaming-alpha.yml
+++ b/.github/workflows/streaming-alpha.yml
@@ -1,8 +1,8 @@
-name: Streaming Alpha Rust
+name: v4 Streaming and Companion Rust
 
 on:
   pull_request:
-    branches: [integration/streaming-ha-alpha]
+    branches: [v4]
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
@@ -43,7 +43,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "streaming-alpha"
+          shared-key: "v4-streaming"
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - v3
-      - integration/streaming-ha-alpha
+      - v4
     paths:
       - Package.swift
       - companion/uhckit/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Use GitHub for all task tracking:
 ### Branches
 **Purpose:** Isolate work in progress
 - Create a branch for each issue: `fix/issue-123-description` or `feat/issue-123-description`
-- Base Rust work on `v3`, not `master`
+- Base new Rust work on `v4`, not `master` or the maintained `v3` line
 - Keep branches focused on a single issue
 
 ### Pull Requests
@@ -66,9 +66,10 @@ Use GitHub for all task tracking:
 ## Branch Strategy
 
 - `master` = Node.js v2.x (legacy, stable)
-- `v3` = Rust v3.x (active development)
+- `v3` = Rust v3.x (maintenance)
+- `v4` = Rust streaming, companion, Home Assistant, and optional HiPhi line (active development)
 
-**Default branch for Rust development: `v3`**
+**Default branch for Rust development: `v4`**
 
 ## Test-Driven Development (TDD)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,51 @@
+# Install Unified Hi-Fi Control
+
+Choose the host that already stays on with your hi-fi. All local playback and
+discovery remain local; a HiPhi account is optional and is used only for hosted
+features such as authenticated remote controllers and Spotify's secure callback.
+
+## Home Assistant OS, Green, or Supervised
+
+The supported add-on is the shortest path: it runs UHC, embeds the UI through
+Home Assistant ingress, and installs the matching `media_player` integration.
+
+[![Add add-on repository to Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fopen-horizon-labs%2Fuhc-home-assistant-addon)
+
+Manual repository URL:
+
+```text
+https://github.com/open-horizon-labs/uhc-home-assistant-addon
+```
+
+Follow the add-on's [complete installation guide](https://github.com/open-horizon-labs/uhc-home-assistant-addon/blob/main/unified-hifi-control/DOCS.md).
+
+## NAS, Docker, LMS, or standalone binary
+
+- **QNAP and Synology:** download the matching QPKG or SPK from
+  [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases/latest).
+- **Docker:** use a versioned `muness/unified-hifi-control:<version>` image for
+  reproducible installs. `latest` follows the newest stable release.
+- **Lyrion Music Server:** add
+  `https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v4/lms-plugin/repo.xml`
+  under Additional Repositories.
+- **Linux, macOS, and Windows:** download the matching standalone artifact from
+  [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases/latest).
+
+See the README's [installation section](README.md#installation) for package
+names, Docker Compose, checksums, and signature verification.
+
+## Apple Music companion
+
+- **iPhone and iPad:** the companion is in alpha. [Request TestFlight access](https://github.com/open-horizon-labs/unified-hifi-control/issues/new?title=Request%20Apple%20Music%20Companion%20TestFlight%20access).
+- **Apple Silicon Mac:** download
+  `unified-hifi-applemusic-companion-macos-arm64-*.dmg` from the latest
+  [release assets](https://github.com/open-horizon-labs/unified-hifi-control/releases/latest).
+
+After installing the companion, open **UHC → Settings → Apple Music** and
+confirm that the pairing code shown by UHC matches the companion.
+
+## HiPhi Cloud and Garmin
+
+UHC works without the cloud. To add authenticated remote access or a Garmin
+watch, open **UHC → Settings → Connect HiPhi Cloud** and follow the owner-bound
+enrollment flow. Never port-forward UHC's trusted-LAN HTTP port.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unified Hi-Fi Control
 
-[![Build](https://github.com/open-horizon-labs/unified-hifi-control/actions/workflows/build.yml/badge.svg?branch=v3)](https://github.com/open-horizon-labs/unified-hifi-control/actions/workflows/build.yml)
+[![Build](https://github.com/open-horizon-labs/unified-hifi-control/actions/workflows/build.yml/badge.svg?branch=v4)](https://github.com/open-horizon-labs/unified-hifi-control/actions/workflows/build.yml)
 [![GitHub Release](https://img.shields.io/github/v/release/open-horizon-labs/unified-hifi-control)](https://github.com/open-horizon-labs/unified-hifi-control/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/open-horizon-labs/unified-hifi-control/total)](https://github.com/open-horizon-labs/unified-hifi-control/releases)
 
@@ -14,10 +14,12 @@ Once the bridge is running, control your system from:
 
 - **Web UI** — Built-in at `http://your-bridge:8088`
 - **[roon-knob](https://github.com/muness/roon-knob)** — ESP32-S3 hardware knob with OLED display
-- **iOS & Apple Watch** — In alpha testing. [Get in touch](https://github.com/open-horizon-labs/unified-hifi-control/issues) if you'd like to try it.
+- **iPhone, iPad & Apple Watch** — In alpha testing. [Request TestFlight access](https://github.com/open-horizon-labs/unified-hifi-control/issues/new?title=Request%20Apple%20Music%20Companion%20TestFlight%20access).
 - **Claude & AI agents** — Via the built-in MCP server (see [MCP Server](#mcp-server-claude-integration) below)
 
 ## Installation
+
+See [INSTALL.md](INSTALL.md) for every supported installation and companion path.
 
 ### Docker (Recommended)
 
@@ -45,13 +47,13 @@ Download the QPKG package from [Releases](https://github.com/open-horizon-labs/u
 
 Add this repository URL in LMS Settings → Plugins → Additional Repositories:
 ```text
-https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-plugin/repo.xml
+https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v4/lms-plugin/repo.xml
 ```
 Then install "Unified Hi-Fi Control" from the plugin list. The plugin automatically downloads and manages the bridge binary.
 
 **Beta channel.** To test pre-releases instead, use this URL — it always points at the newest beta, so LMS picks up each one without you re-pointing it:
 ```text
-https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v3/lms-plugin/repo-beta.xml
+https://raw.githubusercontent.com/open-horizon-labs/unified-hifi-control/v4/lms-plugin/repo-beta.xml
 ```
 Betas are less soaked than releases. Use one channel or the other, not both at once — LMS would see two entries for the same plugin.
 
@@ -65,12 +67,10 @@ no separate server, no Docker Compose, no terminal. In Home Assistant, go to
 https://github.com/open-horizon-labs/uhc-home-assistant-addon
 ```
 
-Then install **Unified Hi-Fi Control** from the store. This is the Tier 1
-add-on: the UI opens in its own browser tab at `http://<your-ha-host>:8088`,
-not embedded in the HA dashboard (that's a separate, later "ingress" add-on).
-It runs with host networking, same as the Docker install above, for Roon/mDNS
-discovery. Full walkthrough, including where to find the one-time controller
-bootstrap token on first start, is in the
+Then install **Unified Hi-Fi Control** from the store. It runs with host
+networking for Roon/mDNS discovery, opens inside Home Assistant through ingress,
+and also remains available to trusted-LAN controllers at
+`http://<your-ha-host>:8088`. Full setup and security behavior are in the
 [add-on repo's DOCS.md](https://github.com/open-horizon-labs/uhc-home-assistant-addon/blob/main/unified-hifi-control/DOCS.md).
 
 ### Binary Downloads
@@ -179,7 +179,10 @@ mature:
   receiver itself.
 - **Apple Music** — pairs with the native iOS/macOS companion
   (`companion/apple_music_ios`, `companion/apple_music`) to control a
-  `SystemMusicPlayer` session from UHC.
+  `SystemMusicPlayer` session from UHC. [Request TestFlight access](https://github.com/open-horizon-labs/unified-hifi-control/issues/new?title=Request%20Apple%20Music%20Companion%20TestFlight%20access)
+  for iPhone/iPad, or download the Apple Silicon companion DMG named
+  `unified-hifi-applemusic-companion-macos-arm64-*.dmg` from
+  [Releases](https://github.com/open-horizon-labs/unified-hifi-control/releases/latest).
 - **Music Assistant** — an optional peer adapter for an existing Music
   Assistant server, using its authenticated JSON API and a long-lived
   access token.
@@ -310,6 +313,7 @@ The bridge automatically downloads new [roon-knob](https://github.com/muness/roo
 | **v1** | Node.js | Proof of concept — validated the idea of a unified control surface |
 | **v2** | Node.js | Production release — in-memory event bus, multi-backend support |
 | **v3** | Rust | Complete rewrite — native packages (Synology, QNAP, LMS plugin), 10x smaller memory footprint, single static binary |
+| **v4** | Rust | Streaming services, native companions, Home Assistant/Music Assistant, and optional authenticated HiPhi remote access |
 
 The v3 rewrite was motivated by packaging requests (NAS users wanted native packages, not Docker) and the opportunity to dramatically reduce resource usage. The Rust binary uses ~15MB RAM vs ~150MB for Node.js.
 

--- a/docs/arch-linux.md
+++ b/docs/arch-linux.md
@@ -137,7 +137,7 @@ cargo install dioxus-cli@0.7.10 --locked
 ```bash
 git clone https://github.com/open-horizon-labs/unified-hifi-control.git
 cd unified-hifi-control
-git checkout v3
+git checkout v4
 
 # Build matching CSS, server, and WASM hydration bundle, then run it.
 UHC_PORT=8088 make web-run

--- a/docs/home_assistant_integration.md
+++ b/docs/home_assistant_integration.md
@@ -228,10 +228,10 @@ without weakening the check for genuine leaks.
 CI: `.github/workflows/ha-integration.yml` runs the test suite plus
 `hacs/action` (HACS repository validation) and
 `home-assistant/actions/hassfest` (manifest/schema validation) on pushes
-and PRs to `v3` that touch the integration. Per this repo's stacked-PR
+and PRs to `v4` that touch the integration. Per this repo's stacked-PR
 convention, feature-branch-based PRs (including the one that introduced
 this integration) do not run CI — the workflow was verified locally and
-becomes active once this lands on `v3`.
+becomes active once this lands on `v4`.
 
 ## Known follow-ups
 

--- a/tests/ci_workflow_contract.rs
+++ b/tests/ci_workflow_contract.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-const ALPHA: &str = "integration/streaming-ha-alpha";
+const DEVELOPMENT_BRANCH: &str = "v4";
 
 fn workflow(name: &str) -> String {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -11,7 +11,7 @@ fn workflow(name: &str) -> String {
 }
 
 #[test]
-fn alpha_pull_requests_run_rust_and_api_contract_checks() {
+fn development_pull_requests_run_rust_and_api_contract_checks() {
     for name in ["build.yml", "api-guard.yml"] {
         let source = workflow(name);
         let pull_request = source
@@ -20,27 +20,35 @@ fn alpha_pull_requests_run_rust_and_api_contract_checks() {
             .unwrap_or_else(|| panic!("{name} has no pull_request trigger"));
         let trigger = pull_request.split("jobs:").next().unwrap_or(pull_request);
         assert!(
-            trigger.contains(ALPHA),
-            "{name} must run for pull requests targeting {ALPHA}"
+            trigger.contains(DEVELOPMENT_BRANCH),
+            "{name} must run for pull requests targeting {DEVELOPMENT_BRANCH}"
         );
     }
 }
 
 #[test]
-fn alpha_home_assistant_changes_run_the_ha_workflow() {
+fn development_home_assistant_changes_run_the_ha_workflow() {
     let source = workflow("ha-integration.yml");
+    let development_branch_triggers = source
+        .lines()
+        .filter(|line| {
+            line.trim_start().starts_with("branches:") && line.contains(DEVELOPMENT_BRANCH)
+        })
+        .count();
     assert_eq!(
-        source.matches(ALPHA).count(),
-        2,
-        "HA integration must cover alpha push and pull-request triggers"
+        development_branch_triggers, 2,
+        "HA integration must cover v4 push and pull-request triggers"
     );
 }
 
 #[test]
-fn alpha_does_not_enable_edge_image_publication() {
+fn development_does_not_enable_edge_image_publication() {
     let source = workflow("docker.yml");
+    let development_branch_triggers = source.lines().any(|line| {
+        line.trim_start().starts_with("branches:") && line.contains(DEVELOPMENT_BRANCH)
+    });
     assert!(
-        !source.contains(ALPHA),
-        "alpha work must not enter the Docker edge publication workflow"
+        !development_branch_triggers,
+        "v4 work must not enter the Docker edge publication workflow"
     );
 }


### PR DESCRIPTION
Fixes #669

## Outcome

Make the clean #542 product line operational as the repository's v4 default without absorbing the unrelated experimental branch formerly named v4.

## Changes

- Route active Rust, connector, Swift, Home Assistant, API guard, release-feed, and package CI to v4 while retaining intentional v3 maintenance checks.
- Update contributor guidance, build badges, release links, and LMS feed URLs.
- Add INSTALL.md with a prominent Home Assistant add-on path, Apple Music TestFlight request, macOS DMG, and HiPhi/Garmin guidance.
- Correct the README's outdated Home Assistant ingress description.

## Branch evidence

- The former experimental v4 tip is preserved unchanged at `experimental/manifest-pi-control-plane` (`4232dc7b`).
- Protected/default `v4` began exactly at #542's merged state (`7186f6fc`).
- No experimental commits are ancestors of the new v4.

## Verification

- Every GitHub Actions YAML file parses successfully.
- Active docs/workflows contain no stale streaming-alpha branch or operational v3 source/ref/base links.
- Pre-commit clippy passes after generating the embedded CSS prerequisite.
- `git diff --check` passes.

OH: 80222d6d-63ab-45d8-a262-ee00303f18c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added unified installation guidance for Home Assistant, NAS, Docker, LMS, standalone deployments, and Apple Music companions.
  - Updated setup links and instructions for the v4 release.
  - Added Apple device support details, companion download links, and TestFlight information.
  - Clarified Home Assistant ingress access and trusted-LAN behavior.
  - Added a warning against port-forwarding the trusted-LAN HTTP port.

- **Chores**
  - Updated automated validation and build workflows to support the v4 development branch.
  - Updated branch references, release links, and caching configuration across project automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->