### PR TITLE
fix: compile HiPhi connector securely on Windows

### DIFF
--- a/.github/workflows/windows-connector.yml
+++ b/.github/workflows/windows-connector.yml
@@ -1,0 +1,51 @@
+name: Windows connector compile
+
+on:
+  pull_request:
+    branches: [v4]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/cloud_connector/**"
+      - "src/api/hiphi_pairing.rs"
+      - "src/bin/uhc_hiphi_pair.rs"
+      - ".github/workflows/windows-connector.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Compile connector and pairing helper
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache generated CSS
+        id: cache-css
+        uses: actions/cache@v5
+        with:
+          path: public/tailwind.css
+          key: css-v4.1.18-${{ hashFiles('src/input.css', 'src/app/pages/*.rs', 'src/app/components/*.rs') }}
+
+      - name: Build Tailwind CSS
+        if: steps.cache-css.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.18/tailwindcss-windows-x64.exe
+          ./tailwindcss-windows-x64.exe -i src/input.css -o public/tailwind.css --content "src/app/**/*.rs"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-connector-check
+
+      - name: Compile Windows connector surfaces
+        run: cargo check --features server --lib --bin uhc-hiphi-pair

--- a/src/bin/uhc_hiphi_pair.rs
+++ b/src/bin/uhc_hiphi_pair.rs
@@ -438,6 +438,7 @@ mod command {
         ok: bool,
     }
 
+    #[cfg(unix)]
     fn write_owner_only(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
         use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
         let mut file = fs::OpenOptions::new()
@@ -451,6 +452,12 @@ mod command {
         Ok(())
     }
 
+    #[cfg(not(unix))]
+    fn write_owner_only(_path: &Path, _bytes: &[u8]) -> anyhow::Result<()> {
+        anyhow::bail!("HiPhi enrollment requires verified owner-only file permissions")
+    }
+
+    #[cfg(unix)]
     fn persist_connector_environment(
         path: &Path,
         relay_endpoint: &str,
@@ -486,6 +493,17 @@ mod command {
             let _ = fs::remove_file(&temporary);
         }
         write_result
+    }
+
+    #[cfg(not(unix))]
+    fn persist_connector_environment(
+        _path: &Path,
+        _relay_endpoint: &str,
+        _installation_id: &str,
+        _session_keys: &str,
+        _command_keys: &str,
+    ) -> anyhow::Result<()> {
+        anyhow::bail!("HiPhi enrollment requires verified owner-only file permissions")
     }
 
     #[cfg(test)]

--- a/src/cloud_connector/identity.rs
+++ b/src/cloud_connector/identity.rs
@@ -38,36 +38,49 @@ impl InstallationIdentity {
             return Err(IdentityError::InvalidInstallationId);
         }
         let path = path.as_ref();
-        let metadata = fs::symlink_metadata(path)?;
-        if !metadata.file_type().is_file() {
+        #[cfg(not(unix))]
+        {
+            let _ = path;
             return Err(IdentityError::InsecurePermissions);
         }
         #[cfg(unix)]
         {
+            let metadata = fs::symlink_metadata(path)?;
+            if !metadata.file_type().is_file() {
+                return Err(IdentityError::InsecurePermissions);
+            }
             use std::os::unix::fs::PermissionsExt as _;
             if metadata.permissions().mode() & 0o077 != 0 {
                 return Err(IdentityError::InsecurePermissions);
             }
+            let bytes = fs::read(path)?;
+            let raw: [u8; 32] = bytes.try_into().map_err(|_| IdentityError::InvalidKey)?;
+            Ok(Self {
+                installation_id,
+                signing_key: SigningKey::from_bytes(&raw),
+            })
         }
-        let bytes = fs::read(path)?;
-        let raw: [u8; 32] = bytes.try_into().map_err(|_| IdentityError::InvalidKey)?;
-        Ok(Self {
-            installation_id,
-            signing_key: SigningKey::from_bytes(&raw),
-        })
     }
 
     pub fn save(&self, path: impl AsRef<Path>) -> Result<(), IdentityError> {
-        use std::os::unix::fs::OpenOptionsExt;
         let path = path.as_ref();
-        let mut options = fs::OpenOptions::new();
-        options.create(true).truncate(true).write(true).mode(0o600);
-        let mut file = options.open(path)?;
-        use std::io::Write;
-        file.write_all(&self.signing_key.to_bytes())?;
-        file.sync_all()?;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-        Ok(())
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            return Err(IdentityError::InsecurePermissions);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+            let mut options = fs::OpenOptions::new();
+            options.create(true).truncate(true).write(true).mode(0o600);
+            let mut file = options.open(path)?;
+            use std::io::Write;
+            file.write_all(&self.signing_key.to_bytes())?;
+            file.sync_all()?;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+            Ok(())
+        }
     }
 
     pub fn installation_id(&self) -> &str {
@@ -129,5 +142,3 @@ impl ZoneHandleMap {
 }
 
 use base64::Engine as _;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
Fixes #673

## What changed
- gate Unix-only key-file APIs behind `cfg(unix)`
- fail HiPhi identity loading, saving, and enrollment closed on non-Unix targets until native ACL verification exists
- add a path-scoped Windows compile check for the connector and pairing helper

## Verification
- `cargo test --features server --test cloud_connector` (42 passed)
- `cargo clippy --features server --bin uhc-hiphi-pair -- -D warnings`
- `cargo fmt --all --check`
- Windows compile is a required check on this PR

This fixes the v4.0.0-alpha.1 Windows release failure without weakening the public zero-trust key-file invariant.