### PR TITLE
Add platform-neutral daily log retention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -558,7 +558,7 @@ jobs:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: |
           # Version is fetched from server at runtime, no need to bake into WASM
-          dx build --fullstack --release @client --no-default-features --features web @server --features server
+          dx build --fullstack=false --release --platform web --no-default-features --features web
           echo "Generated assets:"
           find target/dx -name "*.wasm" -o -name "*.js" | head -10
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -558,7 +558,7 @@ jobs:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: |
           # Version is fetched from server at runtime, no need to bake into WASM
-          dx build --fullstack=false --release --platform web --no-default-features --features web
+          dx build --fullstack=false --release @client --no-default-features --features web
           echo "Generated assets:"
           find target/dx -name "*.wasm" -o -name "*.js" | head -10
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -488,7 +488,7 @@ jobs:
           # Only inputs that can change the generated web assets belong here.
           # Server-only changes (adapters, logging, cloud runtime, packaging) do
           # not require rebuilding the client bundle or its static shell.
-          key: wasm-v4-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/lib.rs', 'src/app/**/*.rs', 'src/components/**/*.rs', 'src/adaptive/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
+          key: wasm-v4-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/lib.rs', 'src/app/**/*.rs', 'src/components/**/*.rs', 'src/adaptive/**/*.rs', 'assets/**', 'src/input.css', 'public/**') }}
           restore-keys: |
             wasm-v4-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -485,7 +485,10 @@ jobs:
           # Version is baked in at compile time, but we accept stale version display
           # for PRs in exchange for cache efficiency. Releases change Cargo.toml anyway.
           # Note: Tailwind version pinned in Makefile - update cache key when upgrading
-          key: wasm-v4-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
+          # Only inputs that can change the generated web assets belong here.
+          # Server-only changes (adapters, logging, cloud runtime, packaging) do
+          # not require rebuilding the client bundle or its static shell.
+          key: wasm-v4-tw4.1.18-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', 'Dioxus.toml', 'src/lib.rs', 'src/app/**/*.rs', 'src/components/**/*.rs', 'src/adaptive/**/*.rs', 'assets/**', 'src/input.css', 'public/dx-components-theme.css') }}
           restore-keys: |
             wasm-v4-
 
@@ -547,6 +550,12 @@ jobs:
 
       - name: Build WASM assets (ADR 002)
         if: steps.check-cache.outputs.needs_build == 'true'
+        # Asset generation does not produce a shipped server binary. Avoid the
+        # project's production LTO/link profile here; native packaging jobs below
+        # retain the optimized release profile when they build the actual binary.
+        env:
+          CARGO_PROFILE_RELEASE_LTO: "false"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: |
           # Version is fetched from server at runtime, no need to bake into WASM
           dx build --fullstack --release @client --no-default-features --features web @server --features server

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,6 +4714,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5170,6 +5185,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5466,6 +5494,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
  "urlencoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5454,6 +5454,7 @@ dependencies = [
  "dioxus",
  "dioxus-primitives",
  "dioxus-sdk-time",
+ "dioxus-web",
  "ed25519-dalek",
  "futures",
  "gethostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/open-horizon-labs/unified-hifi-control"
 # Default to server for standalone cargo build/test (dx build uses explicit features)
 default = ["server"]
 server = [
+    "dioxus/fullstack",
     "dioxus/server",
     "dep:axum",
     "dep:tokio",
@@ -42,7 +43,7 @@ web = ["dioxus/web"]
 
 [dependencies]
 # Dioxus UI framework (SSR + client hydration + router)
-dioxus = { version = "0.7.10", features = ["fullstack", "router"] }
+dioxus = { version = "0.7.10", features = ["router"] }
 dioxus-sdk-time = "0.7"
 
 # Serialization (shared)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,14 +39,18 @@ server = [
     "dep:ed25519-dalek",
     "dep:uuid",
 ]
-# The browser bundle still needs Dioxus fullstack's hydration support so it
-# can attach to SSR markup. This does not enable the server target; that stays
-# behind the separate `server` feature used by native binaries.
-web = ["dioxus/web", "dioxus/fullstack"]
+# Hydrate SSR markup in the browser without enabling the Dioxus CLI's inferred
+# fullstack server build. Native server binaries enable the separate `server`
+# feature explicitly.
+web = ["dioxus/web", "dep:dioxus_web_hydrate"]
 
 [dependencies]
 # Dioxus UI framework (SSR + client hydration + router)
 dioxus = { version = "0.7.10", features = ["router"] }
+# Enable the browser renderer's hydration support without enabling Dioxus
+# fullstack inference in the CLI. The server target remains an explicit
+# `server` feature, while the web bundle can still hydrate SSR markup.
+dioxus_web_hydrate = { package = "dioxus-web", version = "0.7.10", default-features = false, features = ["document", "hydrate", "mounted", "devtools"], optional = true }
 dioxus-sdk-time = "0.7"
 
 # Serialization (shared)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,10 @@ server = [
     "dep:ed25519-dalek",
     "dep:uuid",
 ]
-web = ["dioxus/web"]
+# The browser bundle still needs Dioxus fullstack's hydration support so it
+# can attach to SSR markup. This does not enable the server target; that stays
+# behind the separate `server` feature used by native binaries.
+web = ["dioxus/web", "dioxus/fullstack"]
 
 [dependencies]
 # Dioxus UI framework (SSR + client hydration + router)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ server = [
     "dep:reqwest",
     "dep:tokio-tungstenite",
     "dep:tracing-subscriber",
+    "dep:tracing-appender",
     "dep:config",
     "dep:image",
     "dep:resvg",
@@ -111,6 +112,7 @@ tokio-tungstenite = { version = "0.21", default-features = false, features = ["c
 
 # Logging subscriber (server only - needs tokio)
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+tracing-appender = { version = "0.2.5", optional = true }
 
 # Config (server only)
 config = { version = "0.15", optional = true }

--- a/README.md
+++ b/README.md
@@ -130,11 +130,17 @@ docker compose up -d
 |----------|-------------|---------|
 | `UHC_PORT` | Bridge HTTP port | `8088` |
 | `CONFIG_DIR` | Directory for config/state files | `/data` |
-| `RUST_LOG` | Log filter (e.g., `info`, `debug`, `unified_hifi_control=debug`) | `debug` |
+| `RUST_LOG` | Log filter (e.g., `info`, `debug`, `unified_hifi_control=debug`) | `info` |
+| `UHC_LOG_DIR` | Write daily rotating UHC logs here; unset uses stdout | — |
+| `UHC_LOG_RETENTION_DAYS` | Completed daily log files to retain (`1`–`365`) | `7` |
 | `LMS_HOST` | Auto-configure LMS backend (used by LMS plugin) | — |
 | `LMS_PORT` | LMS server port | `9000` |
 
 Legacy aliases: `PORT` (→ `UHC_PORT`), `LOG_LEVEL` (→ `RUST_LOG`)
+
+UHC owns daily rotation and bounded retention whenever `UHC_LOG_DIR` is set.
+Native packages set that destination automatically. Docker and systemd leave it
+unset so the container log driver or journal remains the single log authority.
 
 **Note:** Port 8088 is also HQPlayer's default. If running both on the same host, change one.
 

--- a/build/macos/com.cloudatlas.unified-hifi-control.plist
+++ b/build/macos/com.cloudatlas.unified-hifi-control.plist
@@ -23,10 +23,10 @@
     <true/>
 
     <key>StandardOutPath</key>
-    <string>/usr/local/var/log/unified-hifi-control.log</string>
+    <string>/usr/local/var/log/unified-hifi-control-launcher.log</string>
 
     <key>StandardErrorPath</key>
-    <string>/usr/local/var/log/unified-hifi-control.log</string>
+    <string>/usr/local/var/log/unified-hifi-control-launcher.log</string>
 
     <key>EnvironmentVariables</key>
     <dict>
@@ -34,6 +34,8 @@
         <string>8088</string>
         <key>CONFIG_DIR</key>
         <string>/usr/local/var/unified-hifi-control</string>
+        <key>UHC_LOG_DIR</key>
+        <string>/usr/local/var/log/unified-hifi-control</string>
     </dict>
 
     <key>WorkingDirectory</key>

--- a/build/macos/resources/conclusion.html
+++ b/build/macos/resources/conclusion.html
@@ -36,7 +36,7 @@
 
     <p><strong>Logs:</strong></p>
     <div class="box">
-        <code>tail -f /usr/local/var/log/unified-hifi-control.log</code>
+        <code>tail -f /usr/local/var/log/unified-hifi-control/uhc-server.*.log</code>
     </div>
 </body>
 </html>

--- a/build/macos/scripts/postinstall
+++ b/build/macos/scripts/postinstall
@@ -7,9 +7,13 @@ set -e
 # Create data directory
 mkdir -p /usr/local/var/unified-hifi-control
 mkdir -p /usr/local/var/log
+mkdir -p /usr/local/var/log/unified-hifi-control
 
 # Set permissions
 chmod 755 /usr/local/bin/unified-hifi-control
+chown -R _www:_www /usr/local/var/unified-hifi-control
+chown -R _www:_www /usr/local/var/log/unified-hifi-control
+chmod 700 /usr/local/var/log/unified-hifi-control
 
 # Load the LaunchDaemon
 launchctl load /Library/LaunchDaemons/com.cloudatlas.unified-hifi-control.plist 2>/dev/null || true

--- a/build/qnap/shared/install.sh
+++ b/build/qnap/shared/install.sh
@@ -22,6 +22,7 @@ chmod +x "${QPKG_ROOT}/unified-hifi-control.sh"
 
 # Create log file
 touch "${QPKG_ROOT}/unified-hifi-control.log"
+chmod 600 "${QPKG_ROOT}/unified-hifi-control.log"
 
 # Keep provider credentials in the package-owned config volume.  The server's
 # config resolver creates the `unified-hifi` subdirectory below this path;

--- a/build/qnap/shared/install.sh
+++ b/build/qnap/shared/install.sh
@@ -20,8 +20,12 @@ chmod +x "${QPKG_ROOT}/unified-hifi-control"
 chmod +x "${QPKG_ROOT}/uhc-hiphi-pair"
 chmod +x "${QPKG_ROOT}/unified-hifi-control.sh"
 
-# Create log file
-touch "${QPKG_ROOT}/unified-hifi-control.log"
+# Core UHC logging rotates daily here with bounded retention. The launcher log
+# is truncated on every start and contains only pre-initialization failures.
+mkdir -p "${QPKG_ROOT}/logs"
+chmod 700 "${QPKG_ROOT}/logs"
+touch "${QPKG_ROOT}/unified-hifi-control-launcher.log"
+chmod 600 "${QPKG_ROOT}/unified-hifi-control-launcher.log"
 
 # Keep provider credentials in the package-owned config volume.  The server's
 # config resolver creates the `unified-hifi` subdirectory below this path;

--- a/build/qnap/shared/install.sh
+++ b/build/qnap/shared/install.sh
@@ -22,7 +22,6 @@ chmod +x "${QPKG_ROOT}/unified-hifi-control.sh"
 
 # Create log file
 touch "${QPKG_ROOT}/unified-hifi-control.log"
-chmod 600 "${QPKG_ROOT}/unified-hifi-control.log"
 
 # Keep provider credentials in the package-owned config volume.  The server's
 # config resolver creates the `unified-hifi` subdirectory below this path;

--- a/build/qnap/shared/unified-hifi-control.sh
+++ b/build/qnap/shared/unified-hifi-control.sh
@@ -20,15 +20,6 @@ HIPHI_ENV_FILE=${UHC_CONFIG_DIR}/hiphi.env
 
 export PIDF=${QPKG_ROOT}/unified-hifi-control.pid
 export LOGF=${QPKG_ROOT}/unified-hifi-control.log
-export LOG_ROTATOR_PIDF=${QPKG_ROOT}/unified-hifi-control-log-rotator.pid
-
-# Appliance defaults: keep the live log plus three bounded archives (100 MiB
-# total at the defaults), and check once a minute. Operators may tighten these
-# values without modifying the package script.
-LOG_MAX_BYTES=${UHC_LOG_MAX_BYTES:-26214400}
-LOG_ARCHIVES=${UHC_LOG_ARCHIVES:-3}
-LOG_CHECK_SECONDS=${UHC_LOG_CHECK_SECONDS:-60}
-export RUST_LOG=${RUST_LOG:-unified_hifi_control=info,tower_http=info,roon_api=info}
 
 # Configuration contains server-side credentials and persistent-operation backups.
 # Do not let a permissive NAS-wide umask make newly-created package state readable
@@ -102,72 +93,7 @@ is_our_pid() {
     [ -n "$EXPECTED_EXE" ] && [ "$ACTUAL_EXE" = "$EXPECTED_EXE" ]
 }
 
-is_positive_integer() {
-    case "$1" in
-        ''|*[!0-9]*|0) return 1 ;;
-        *) return 0 ;;
-    esac
-}
-
-validate_log_policy() {
-    is_positive_integer "$LOG_MAX_BYTES" || { echo "Invalid UHC_LOG_MAX_BYTES"; return 1; }
-    is_positive_integer "$LOG_ARCHIVES" || { echo "Invalid UHC_LOG_ARCHIVES"; return 1; }
-    is_positive_integer "$LOG_CHECK_SECONDS" || { echo "Invalid UHC_LOG_CHECK_SECONDS"; return 1; }
-    [ "$LOG_ARCHIVES" -le 9 ] || { echo "UHC_LOG_ARCHIVES must be between 1 and 9"; return 1; }
-}
-
-rotate_log_if_needed() {
-    [ -f "$LOGF" ] || { : > "$LOGF" || return 1; }
-    LOG_BYTES=$(wc -c < "$LOGF" 2>/dev/null | tr -d ' ')
-    case "$LOG_BYTES" in ''|*[!0-9]*) return 1 ;; esac
-    [ "$LOG_BYTES" -gt "$LOG_MAX_BYTES" ] || return 0
-
-    # Preserve only a bounded tail. Copying a multi-gigabyte runaway log would
-    # consume the remaining volume before rotation could reclaim it.
-    ROTATE_TMP=${LOGF}.rotate.$$
-    tail -c "$LOG_MAX_BYTES" "$LOGF" > "$ROTATE_TMP" || {
-        rm -f "$ROTATE_TMP"
-        return 1
-    }
-    chmod 600 "$ROTATE_TMP"
-
-    ARCHIVE=$LOG_ARCHIVES
-    while [ "$ARCHIVE" -gt 1 ]; do
-        PREVIOUS=$((ARCHIVE - 1))
-        [ ! -e "${LOGF}.${PREVIOUS}" ] || mv -f "${LOGF}.${PREVIOUS}" "${LOGF}.${ARCHIVE}"
-        ARCHIVE=$PREVIOUS
-    done
-    mv -f "$ROTATE_TMP" "${LOGF}.1"
-    : > "$LOGF"
-    chmod 600 "$LOGF"
-}
-
-is_our_rotator_pid() {
-    ROTATOR_PID_TO_CHECK=$1
-    EXPECTED_SERVICE_PID=$2
-    case "$ROTATOR_PID_TO_CHECK:$EXPECTED_SERVICE_PID" in
-        *[!0-9:]*) return 1 ;;
-    esac
-    [ "$ROTATOR_PID_TO_CHECK" -gt 1 ] 2>/dev/null || return 1
-    kill -0 "$ROTATOR_PID_TO_CHECK" 2>/dev/null || return 1
-    ROTATOR_COMMAND=$(tr '\000' ' ' < "/proc/${ROTATOR_PID_TO_CHECK}/cmdline" 2>/dev/null) || return 1
-    case "$ROTATOR_COMMAND" in
-        *"${QPKG_ROOT}/unified-hifi-control.sh rotate ${EXPECTED_SERVICE_PID}"*) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
 case "$1" in
-  rotate)
-    SERVICE_PID=$2
-    validate_log_policy || exit 1
-    while is_our_pid "$SERVICE_PID"; do
-        sleep "$LOG_CHECK_SECONDS"
-        is_our_pid "$SERVICE_PID" || break
-        rotate_log_if_needed || echo "Unified Hi-Fi Control log rotation failed" >&2
-    done
-    ;;
-
   start)
     ENABLED=$(/sbin/getcfg $QPKG_NAME Enable -u -d FALSE -f $CONF)
     if [ "$ENABLED" != "TRUE" ]; then
@@ -178,15 +104,10 @@ case "$1" in
     cd "$QPKG_ROOT" || { echo "Failed to cd to $QPKG_ROOT"; exit 1; }
 
     load_hiphi_config || { echo "Failed to load HiPhi connector configuration"; exit 1; }
-    validate_log_policy || exit 1
-    rotate_log_if_needed || { echo "Failed to apply log retention policy"; exit 1; }
 
     # Start the static binary (musl-linked, no dependencies)
     "${QPKG_ROOT}/unified-hifi-control" >> "$LOGF" 2>&1 &
-    SERVICE_PID=$!
-    echo "$SERVICE_PID" > "$PIDF"
-    "${QPKG_ROOT}/unified-hifi-control.sh" rotate "$SERVICE_PID" >> "$LOGF" 2>&1 &
-    echo $! > "$LOG_ROTATOR_PIDF"
+    echo $! > "$PIDF"
 
     echo "$QPKG_NAME started."
     ;;
@@ -202,13 +123,6 @@ case "$1" in
             # Re-check identity: the original process may have exited and the PID may already
             # have been reused during the grace period.
             is_our_pid "$PID" && kill -9 "$PID" 2>/dev/null
-        fi
-        if [ -e "$LOG_ROTATOR_PIDF" ]; then
-            ROTATOR_PID=$(cat "$LOG_ROTATOR_PIDF")
-            if is_our_rotator_pid "$ROTATOR_PID" "$PID"; then
-                kill "$ROTATOR_PID" 2>/dev/null
-            fi
-            rm -f "$LOG_ROTATOR_PIDF"
         fi
         rm -f "$PIDF"
     fi

--- a/build/qnap/shared/unified-hifi-control.sh
+++ b/build/qnap/shared/unified-hifi-control.sh
@@ -19,7 +19,8 @@ export PATH=$QPKG_ROOT:$PATH
 HIPHI_ENV_FILE=${UHC_CONFIG_DIR}/hiphi.env
 
 export PIDF=${QPKG_ROOT}/unified-hifi-control.pid
-export LOGF=${QPKG_ROOT}/unified-hifi-control.log
+export UHC_LOG_DIR=${UHC_LOG_DIR:-${QPKG_ROOT}/logs}
+export LAUNCH_LOG=${QPKG_ROOT}/unified-hifi-control-launcher.log
 
 # Configuration contains server-side credentials and persistent-operation backups.
 # Do not let a permissive NAS-wide umask make newly-created package state readable
@@ -105,8 +106,9 @@ case "$1" in
 
     load_hiphi_config || { echo "Failed to load HiPhi connector configuration"; exit 1; }
 
-    # Start the static binary (musl-linked, no dependencies)
-    "${QPKG_ROOT}/unified-hifi-control" >> "$LOGF" 2>&1 &
+    # UHC owns daily rotation inside UHC_LOG_DIR. This small launcher file is
+    # truncated on each start and captures only failures before logging starts.
+    "${QPKG_ROOT}/unified-hifi-control" > "$LAUNCH_LOG" 2>&1 &
     echo $! > "$PIDF"
 
     echo "$QPKG_NAME started."

--- a/build/qnap/shared/unified-hifi-control.sh
+++ b/build/qnap/shared/unified-hifi-control.sh
@@ -20,6 +20,15 @@ HIPHI_ENV_FILE=${UHC_CONFIG_DIR}/hiphi.env
 
 export PIDF=${QPKG_ROOT}/unified-hifi-control.pid
 export LOGF=${QPKG_ROOT}/unified-hifi-control.log
+export LOG_ROTATOR_PIDF=${QPKG_ROOT}/unified-hifi-control-log-rotator.pid
+
+# Appliance defaults: keep the live log plus three bounded archives (100 MiB
+# total at the defaults), and check once a minute. Operators may tighten these
+# values without modifying the package script.
+LOG_MAX_BYTES=${UHC_LOG_MAX_BYTES:-26214400}
+LOG_ARCHIVES=${UHC_LOG_ARCHIVES:-3}
+LOG_CHECK_SECONDS=${UHC_LOG_CHECK_SECONDS:-60}
+export RUST_LOG=${RUST_LOG:-unified_hifi_control=info,tower_http=info,roon_api=info}
 
 # Configuration contains server-side credentials and persistent-operation backups.
 # Do not let a permissive NAS-wide umask make newly-created package state readable
@@ -93,7 +102,72 @@ is_our_pid() {
     [ -n "$EXPECTED_EXE" ] && [ "$ACTUAL_EXE" = "$EXPECTED_EXE" ]
 }
 
+is_positive_integer() {
+    case "$1" in
+        ''|*[!0-9]*|0) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+validate_log_policy() {
+    is_positive_integer "$LOG_MAX_BYTES" || { echo "Invalid UHC_LOG_MAX_BYTES"; return 1; }
+    is_positive_integer "$LOG_ARCHIVES" || { echo "Invalid UHC_LOG_ARCHIVES"; return 1; }
+    is_positive_integer "$LOG_CHECK_SECONDS" || { echo "Invalid UHC_LOG_CHECK_SECONDS"; return 1; }
+    [ "$LOG_ARCHIVES" -le 9 ] || { echo "UHC_LOG_ARCHIVES must be between 1 and 9"; return 1; }
+}
+
+rotate_log_if_needed() {
+    [ -f "$LOGF" ] || { : > "$LOGF" || return 1; }
+    LOG_BYTES=$(wc -c < "$LOGF" 2>/dev/null | tr -d ' ')
+    case "$LOG_BYTES" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$LOG_BYTES" -gt "$LOG_MAX_BYTES" ] || return 0
+
+    # Preserve only a bounded tail. Copying a multi-gigabyte runaway log would
+    # consume the remaining volume before rotation could reclaim it.
+    ROTATE_TMP=${LOGF}.rotate.$$
+    tail -c "$LOG_MAX_BYTES" "$LOGF" > "$ROTATE_TMP" || {
+        rm -f "$ROTATE_TMP"
+        return 1
+    }
+    chmod 600 "$ROTATE_TMP"
+
+    ARCHIVE=$LOG_ARCHIVES
+    while [ "$ARCHIVE" -gt 1 ]; do
+        PREVIOUS=$((ARCHIVE - 1))
+        [ ! -e "${LOGF}.${PREVIOUS}" ] || mv -f "${LOGF}.${PREVIOUS}" "${LOGF}.${ARCHIVE}"
+        ARCHIVE=$PREVIOUS
+    done
+    mv -f "$ROTATE_TMP" "${LOGF}.1"
+    : > "$LOGF"
+    chmod 600 "$LOGF"
+}
+
+is_our_rotator_pid() {
+    ROTATOR_PID_TO_CHECK=$1
+    EXPECTED_SERVICE_PID=$2
+    case "$ROTATOR_PID_TO_CHECK:$EXPECTED_SERVICE_PID" in
+        *[!0-9:]*) return 1 ;;
+    esac
+    [ "$ROTATOR_PID_TO_CHECK" -gt 1 ] 2>/dev/null || return 1
+    kill -0 "$ROTATOR_PID_TO_CHECK" 2>/dev/null || return 1
+    ROTATOR_COMMAND=$(tr '\000' ' ' < "/proc/${ROTATOR_PID_TO_CHECK}/cmdline" 2>/dev/null) || return 1
+    case "$ROTATOR_COMMAND" in
+        *"${QPKG_ROOT}/unified-hifi-control.sh rotate ${EXPECTED_SERVICE_PID}"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 case "$1" in
+  rotate)
+    SERVICE_PID=$2
+    validate_log_policy || exit 1
+    while is_our_pid "$SERVICE_PID"; do
+        sleep "$LOG_CHECK_SECONDS"
+        is_our_pid "$SERVICE_PID" || break
+        rotate_log_if_needed || echo "Unified Hi-Fi Control log rotation failed" >&2
+    done
+    ;;
+
   start)
     ENABLED=$(/sbin/getcfg $QPKG_NAME Enable -u -d FALSE -f $CONF)
     if [ "$ENABLED" != "TRUE" ]; then
@@ -104,10 +178,15 @@ case "$1" in
     cd "$QPKG_ROOT" || { echo "Failed to cd to $QPKG_ROOT"; exit 1; }
 
     load_hiphi_config || { echo "Failed to load HiPhi connector configuration"; exit 1; }
+    validate_log_policy || exit 1
+    rotate_log_if_needed || { echo "Failed to apply log retention policy"; exit 1; }
 
     # Start the static binary (musl-linked, no dependencies)
     "${QPKG_ROOT}/unified-hifi-control" >> "$LOGF" 2>&1 &
-    echo $! > "$PIDF"
+    SERVICE_PID=$!
+    echo "$SERVICE_PID" > "$PIDF"
+    "${QPKG_ROOT}/unified-hifi-control.sh" rotate "$SERVICE_PID" >> "$LOGF" 2>&1 &
+    echo $! > "$LOG_ROTATOR_PIDF"
 
     echo "$QPKG_NAME started."
     ;;
@@ -123,6 +202,13 @@ case "$1" in
             # Re-check identity: the original process may have exited and the PID may already
             # have been reused during the grace period.
             is_our_pid "$PID" && kill -9 "$PID" 2>/dev/null
+        fi
+        if [ -e "$LOG_ROTATOR_PIDF" ]; then
+            ROTATOR_PID=$(cat "$LOG_ROTATOR_PIDF")
+            if is_our_rotator_pid "$ROTATOR_PID" "$PID"; then
+                kill "$ROTATOR_PID" 2>/dev/null
+            fi
+            rm -f "$LOG_ROTATOR_PIDF"
         fi
         rm -f "$PIDF"
     fi

--- a/build/synology/scripts/start-stop-status
+++ b/build/synology/scripts/start-stop-status
@@ -7,7 +7,8 @@ VAR_DIR="${PACKAGE_DIR}/var"
 HOME_DIR="${PACKAGE_DIR}/home"
 BINARY="${TARGET_DIR}/unified-hifi-control"
 PID_FILE="${VAR_DIR}/${PACKAGE_NAME}.pid"
-LOG_FILE="${VAR_DIR}/${PACKAGE_NAME}.log"
+LOG_DIR="${VAR_DIR}/logs"
+LAUNCH_LOG="${VAR_DIR}/${PACKAGE_NAME}-launcher.log"
 
 read_pid() {
     cat "$PID_FILE" 2>/dev/null || true
@@ -41,6 +42,7 @@ start_daemon() {
     echo "Starting ${PACKAGE_NAME}..."
 
     mkdir -p "$VAR_DIR"
+    mkdir -p "$LOG_DIR"
 
     if ! cd "$TARGET_DIR"; then
         echo "Failed to change to ${TARGET_DIR}"
@@ -50,9 +52,12 @@ start_daemon() {
     export HOME="$HOME_DIR"
     export UHC_CONFIG_DIR="$VAR_DIR"
     export UHC_DATA_DIR="$VAR_DIR"
+    export UHC_LOG_DIR="$LOG_DIR"
     export RUST_LOG="${RUST_LOG:-info}"
 
-    nohup "$BINARY" >> "$LOG_FILE" 2>&1 &
+    # UHC owns daily rotation. This file is truncated on each start and only
+    # captures failures that occur before the logging subsystem initializes.
+    nohup "$BINARY" > "$LAUNCH_LOG" 2>&1 &
     echo $! > "$PID_FILE"
 
     # Wait for process to start (configurable via STARTUP_WAIT)

--- a/docs/streaming-adapters.md
+++ b/docs/streaming-adapters.md
@@ -175,11 +175,11 @@ or click **Get an HTTPS address**, UHC does not just fail with a raw
 prompt instead. It explains, in beginner language, that this is a one-time
 step and tells you where to find the token:
 
-- **QNAP**: `$QPKG_ROOT/unified-hifi-control.log` (the log file icon in QTS
-  App Center → UHC).
-- **Synology, Docker, or a plain binary install**: the server log or console
-  output where UHC started — look for the line beginning
-  `UHC controller bootstrap token`.
+- **Native packages**: open the current `uhc-server.YYYY-MM-DD.log` in the
+  package's log directory.
+- **Docker, systemd, or a plain binary install**: check the managed server log
+  or console output where UHC started.
+- In either case, look for the line beginning `UHC controller bootstrap token`.
 - If your operator set `UHC_BOOTSTRAP_TOKEN` in the environment, use that
   value instead; UHC never echoes an operator-supplied token to the log.
 

--- a/src/app/components/bootstrap_prompt.rs
+++ b/src/app/components/bootstrap_prompt.rs
@@ -35,8 +35,8 @@ pub fn BootstrapPrompt() -> Element {
                     div { class: "card bg-elevated p-3 mb-4 text-sm",
                         p { class: "font-medium mb-1", "Where to find the token:" }
                         ul { class: "list-disc list-inside space-y-1 text-secondary",
-                            li { "QNAP: open " code { "$QPKG_ROOT/unified-hifi-control.log" } " (QTS App Center → UHC → the log file icon)." }
-                            li { "Synology, Docker, or a plain binary install: check the server log or console output where UHC started." }
+                            li { "Native package: open today's " code { "uhc-server.YYYY-MM-DD.log" } " in the package log directory." }
+                            li { "Docker, systemd, or a plain binary install: check the managed server log or console output where UHC started." }
                             li { "Look for a line starting with " code { "UHC controller bootstrap token" } "." }
                             li { "If your operator set " code { "UHC_BOOTSTRAP_TOKEN" } " in the environment, use that value instead." }
                         }

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -520,7 +520,9 @@ pub fn HqPlayer() -> Element {
         .map(|link| format!("{}={}", link.zone_id, link.instance))
         .collect::<Vec<_>>();
     zone_match_key_parts.sort();
-    let zone_match_key = zone_match_key_parts.join("|");
+    // The server-side RSX expansion drops DOM keys, so prefix this value with `_` to
+    // keep server builds warning-free while the web build still uses it for remounting.
+    let _zone_match_key = zone_match_key_parts.join("|");
     let instances_list = instances
         .read()
         .clone()
@@ -718,7 +720,7 @@ pub fn HqPlayer() -> Element {
                             "Tell Unified Hi-Fi Control which playback-zone name and HQPlayer instance describe the same existing signal path."
                         }
                     }
-                    div { key: "{zone_match_key}", class: "card overflow-hidden",
+                    div { key: "{_zone_match_key}", class: "card overflow-hidden",
                         ZoneLinkTable {
                             zones: zones_list,
                             links: links_list,

--- a/src/app/pages/hqplayer.rs
+++ b/src/app/pages/hqplayer.rs
@@ -718,9 +718,8 @@ pub fn HqPlayer() -> Element {
                             "Tell Unified Hi-Fi Control which playback-zone name and HQPlayer instance describe the same existing signal path."
                         }
                     }
-                    div { class: "card overflow-hidden",
+                    div { key: "{zone_match_key}", class: "card overflow-hidden",
                         ZoneLinkTable {
-                            key: "{zone_match_key}",
                             zones: zones_list,
                             links: links_list,
                             instances: instances_list,

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 /// Note: "lms-cli" is a companion to "lms" and shares its enabled state.
 pub const AVAILABLE_ADAPTERS: &[&str] = &[
     "roon",
+    "hqplayer",
     "lms",
     "lms-cli",
     "openhome",
@@ -92,6 +93,7 @@ impl AdapterCoordinator {
         for &name in AVAILABLE_ADAPTERS {
             let enabled = match name {
                 "roon" => settings.roon,
+                "hqplayer" => settings.hqplayer,
                 "lms" => settings.lms,
                 // lms-cli shares enabled state with lms (companion adapter)
                 "lms-cli" => settings.lms,

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -8,7 +8,7 @@
 //! For assets to be embedded, you must run `dx build` BEFORE `cargo build`:
 //!
 //! ```bash
-//! dx build --fullstack=false --release --platform web --no-default-features --features web
+//! dx build --fullstack=false --release @client --no-default-features --features web
 //! cargo build --release
 //! ```
 //!

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -8,7 +8,7 @@
 //! For assets to be embedded, you must run `dx build` BEFORE `cargo build`:
 //!
 //! ```bash
-//! dx build --fullstack --release @client --no-default-features --features web @server --features server
+//! dx build --fullstack=false --release --platform web --no-default-features --features web
 //! cargo build --release
 //! ```
 //!

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,142 @@
+//! Process-wide logging policy.
+//!
+//! Service managers that already own retention (journald and container log
+//! drivers) leave `UHC_LOG_DIR` unset and receive stdout. File-based packages
+//! set only the destination; rotation and retention remain identical across
+//! platforms.
+
+use anyhow::{Context, Result};
+use tracing_appender::{
+    non_blocking::WorkerGuard,
+    rolling::{RollingFileAppender, Rotation},
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+const DEFAULT_FILTER: &str = "unified_hifi_control=info,tower_http=info,roon_api=info";
+const DEFAULT_RETENTION_DAYS: usize = 7;
+const MAX_RETENTION_DAYS: usize = 365;
+
+/// Keeps the non-blocking file writer alive until server shutdown.
+pub struct LoggingGuard {
+    _file_writer: Option<WorkerGuard>,
+}
+
+pub fn initialize() -> Result<LoggingGuard> {
+    let filter = std::env::var("RUST_LOG")
+        .or_else(|_| std::env::var("LOG_LEVEL"))
+        .unwrap_or_else(|_| DEFAULT_FILTER.to_owned());
+    let directory = std::env::var_os("UHC_LOG_DIR").filter(|value| !value.is_empty());
+
+    if let Some(directory) = directory {
+        let retention_days =
+            retention_days(std::env::var("UHC_LOG_RETENTION_DAYS").ok().as_deref())?;
+        std::fs::create_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to create UHC log directory {}",
+                std::path::Path::new(&directory).display()
+            )
+        })?;
+        let appender = file_appender(&directory, retention_days)?;
+        let (writer, guard) = tracing_appender::non_blocking(appender);
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::EnvFilter::new(filter))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(writer),
+            )
+            .try_init()
+            .context("failed to initialize UHC file logging")?;
+        return Ok(LoggingGuard {
+            _file_writer: Some(guard),
+        });
+    }
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::new(filter))
+        .with(tracing_subscriber::fmt::layer())
+        .try_init()
+        .context("failed to initialize UHC stdout logging")?;
+    Ok(LoggingGuard { _file_writer: None })
+}
+
+fn file_appender(
+    directory: impl AsRef<std::path::Path>,
+    retention_days: usize,
+) -> Result<RollingFileAppender> {
+    RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("uhc-server")
+        .filename_suffix("log")
+        // Keep one spare because the appender documents that retention can
+        // briefly dip below its maximum during rollover.
+        .max_log_files(retention_days.saturating_add(1))
+        .build(directory)
+        .context("failed to initialize daily UHC log rotation")
+}
+
+fn retention_days(raw: Option<&str>) -> Result<usize> {
+    match raw {
+        None | Some("") => Ok(DEFAULT_RETENTION_DAYS),
+        Some(value) => {
+            let days = value
+                .parse::<usize>()
+                .context("UHC_LOG_RETENTION_DAYS must be an integer")?;
+            if !(1..=MAX_RETENTION_DAYS).contains(&days) {
+                anyhow::bail!("UHC_LOG_RETENTION_DAYS must be between 1 and 365");
+            }
+            Ok(days)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    #[test]
+    fn retention_is_bounded_and_defaults_to_seven_days() {
+        assert_eq!(retention_days(None).unwrap(), 7);
+        assert_eq!(retention_days(Some("")).unwrap(), 7);
+        assert_eq!(retention_days(Some("30")).unwrap(), 30);
+        assert!(retention_days(Some("0")).is_err());
+        assert!(retention_days(Some("366")).is_err());
+        assert!(retention_days(Some("daily")).is_err());
+    }
+
+    #[test]
+    fn daily_appender_removes_old_matching_files_and_writes_the_current_log() {
+        let directory = tempfile::tempdir().unwrap();
+        for day in 1..=12 {
+            std::fs::write(
+                directory
+                    .path()
+                    .join(format!("uhc-server.2026-01-{day:02}.log")),
+                b"old\n",
+            )
+            .unwrap();
+        }
+        // A similarly named launcher diagnostic is not owned by the core
+        // appender and must never be deleted by retention.
+        let launcher = directory.path().join("unified-hifi-control-launcher.log");
+        std::fs::write(&launcher, b"startup\n").unwrap();
+
+        let mut appender = file_appender(directory.path(), 7).unwrap();
+        writeln!(appender, "current").unwrap();
+        appender.flush().unwrap();
+
+        let owned = std::fs::read_dir(directory.path())
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("uhc-server.")
+            })
+            .count();
+        assert!(owned <= 8, "seven retained days plus the current file");
+        assert!(launcher.exists());
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -12,7 +12,7 @@ use tracing_appender::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-const DEFAULT_FILTER: &str = "unified_hifi_control=info,tower_http=info,roon_api=info";
+const DEFAULT_FILTER: &str = "info,unified_hifi_control=info,tower_http=info,roon_api=info";
 const DEFAULT_RETENTION_DAYS: usize = 7;
 const MAX_RETENTION_DAYS: usize = 365;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@
 //!
 //! A source-agnostic hi-fi control bridge for hardware surfaces and Home Assistant.
 
+#[cfg(feature = "server")]
+mod logging;
+
 // Server-only: full server implementation
 #[cfg(feature = "server")]
 mod server {
@@ -31,7 +34,6 @@ mod server {
         cors::{AllowOrigin, Any, CorsLayer},
         trace::TraceLayer,
     };
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     /// Same-origin browser requests do not need CORS. Cross-origin browser
     /// access is opt-in because this server also exposes playback, OAuth, and
@@ -175,16 +177,9 @@ mod server {
     }
 
     pub async fn run() -> Result<()> {
-        // Initialize logging
-        // Priority: RUST_LOG > LOG_LEVEL (legacy) > default
-        let log_filter = std::env::var("RUST_LOG")
-            .or_else(|_| std::env::var("LOG_LEVEL"))
-            .unwrap_or_else(|_| "unified_hifi_control=debug,tower_http=debug,roon_api=info".into());
-
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::EnvFilter::new(&log_filter))
-            .with(tracing_subscriber::fmt::layer())
-            .init();
+        // Keep the guard alive for the process lifetime so buffered file logs
+        // flush during graceful shutdown.
+        let _logging_guard = crate::logging::initialize()?;
 
         tracing::info!(
             "Starting Unified Hi-Fi Control (Rust) v{} ({})",
@@ -1354,6 +1349,8 @@ async fn main() -> anyhow::Result<()> {
         println!("    PORT             HTTP server port (default: 8088)");
         println!("    CONFIG_DIR       Configuration directory");
         println!("    LOG_LEVEL        Log level (debug, info, warn, error)");
+        println!("    UHC_LOG_DIR      Enable daily rotating files in this directory");
+        println!("    UHC_LOG_RETENTION_DAYS  Retained days (default: 7, maximum: 365)");
         println!("    LMS_HOST         LMS server host (auto-enables LMS backend)");
         println!("    LMS_PORT         LMS server port (default: 9000)");
         return Ok(());

--- a/tests/logging_policy.rs
+++ b/tests/logging_policy.rs
@@ -1,0 +1,40 @@
+//! Cross-platform contract for production logging and bounded file retention.
+
+const CARGO: &str = include_str!("../Cargo.toml");
+const MAIN: &str = include_str!("../src/main.rs");
+const LOGGING: &str = include_str!("../src/logging.rs");
+const QNAP: &str = include_str!("../build/qnap/shared/unified-hifi-control.sh");
+const SYNOLOGY: &str = include_str!("../build/synology/scripts/start-stop-status");
+const MACOS: &str = include_str!("../build/macos/com.cloudatlas.unified-hifi-control.plist");
+const LINUX: &str = include_str!("../build/linux/unified-hifi-control.service");
+const DOCKER: &str = include_str!("../Dockerfile");
+
+#[test]
+fn core_owns_one_daily_bounded_file_logging_policy() {
+    assert!(CARGO.contains("tracing-appender"));
+    assert!(MAIN.contains("logging::initialize"));
+    assert!(LOGGING.contains("Rotation::DAILY"));
+    assert!(LOGGING.contains("UHC_LOG_RETENTION_DAYS"));
+    assert!(LOGGING.contains("DEFAULT_RETENTION_DAYS: usize = 7"));
+    assert!(LOGGING.contains("max_log_files"));
+    assert!(LOGGING.contains("unified_hifi_control=info"));
+}
+
+#[test]
+fn file_based_packages_select_the_core_destination_without_own_rotators() {
+    for package in [QNAP, SYNOLOGY, MACOS] {
+        assert!(package.contains("UHC_LOG_DIR"));
+        assert!(!package.contains("UHC_LOG_CHECK_SECONDS"));
+        assert!(!package.contains("LOG_ROTATOR_PIDF"));
+    }
+    assert!(!QNAP.contains("unified-hifi-control\" >> \"$LOGF\""));
+    assert!(!SYNOLOGY.contains("nohup \"$BINARY\" >> \"$LOG_FILE\""));
+}
+
+#[test]
+fn supervisor_managed_platforms_keep_their_native_log_sink() {
+    assert!(LINUX.contains("StandardOutput=journal"));
+    assert!(LINUX.contains("Environment=RUST_LOG=info"));
+    assert!(DOCKER.contains("ENV RUST_LOG=info"));
+    assert!(!DOCKER.contains("UHC_LOG_DIR"));
+}

--- a/tests/logging_policy.rs
+++ b/tests/logging_policy.rs
@@ -18,6 +18,11 @@ fn core_owns_one_daily_bounded_file_logging_policy() {
     assert!(LOGGING.contains("DEFAULT_RETENTION_DAYS: usize = 7"));
     assert!(LOGGING.contains("max_log_files"));
     assert!(LOGGING.contains("unified_hifi_control=info"));
+    // A bare `info` default keeps unlisted targets (anything outside the
+    // explicit unified_hifi_control/tower_http/roon_api directives) at info
+    // instead of silently falling back to EnvFilter's implicit error level,
+    // matching the RUST_LOG=info policy set for Docker/systemd.
+    assert!(LOGGING.contains(r#"DEFAULT_FILTER: &str = "info,unified_hifi_control=info"#));
 }
 
 #[test]

--- a/tests/qnap_service_contract.rs
+++ b/tests/qnap_service_contract.rs
@@ -93,6 +93,58 @@ fn qnap_service_keeps_credentials_private_and_stops_only_its_recorded_process() 
 }
 
 #[test]
+fn qnap_service_bounds_and_reclaims_its_own_log() {
+    assert!(
+        SERVICE.contains("UHC_LOG_MAX_BYTES"),
+        "the package must expose a bounded log-size policy"
+    );
+    assert!(
+        SERVICE.contains("UHC_LOG_ARCHIVES"),
+        "the package must expose a bounded archive-retention policy"
+    );
+    assert!(
+        SERVICE.contains("UHC_LOG_CHECK_SECONDS"),
+        "the package must check log size while the service is running"
+    );
+    assert!(
+        SERVICE.contains("tail -c \"$LOG_MAX_BYTES\""),
+        "rotation must retain only a bounded tail instead of copying an oversized log"
+    );
+    assert!(
+        SERVICE.contains("rotate \"$SERVICE_PID\""),
+        "rotation must be package-owned rather than editing QNAP's global cron table"
+    );
+    assert!(
+        SERVICE.contains("RUST_LOG=${RUST_LOG:-unified_hifi_control=info"),
+        "QNAP must default to production-safe info logging"
+    );
+    assert!(
+        INSTALL.contains("chmod 600 \"${QPKG_ROOT}/unified-hifi-control.log\""),
+        "the retained service log must remain owner-only"
+    );
+}
+
+#[test]
+fn qnap_rotator_is_stopped_only_after_process_identity_validation() {
+    assert!(
+        SERVICE.contains("is_our_rotator_pid"),
+        "a stale rotator PID must not be trusted"
+    );
+    let stop = SERVICE
+        .split("  stop)")
+        .nth(1)
+        .and_then(|tail| tail.split("  restart)").next())
+        .expect("stop arm exists");
+    let kill = stop
+        .find("kill \"$ROTATOR_PID\"")
+        .expect("stop arm terminates the package rotator");
+    let validation = stop[..kill]
+        .rfind("is_our_rotator_pid \"$ROTATOR_PID\"")
+        .expect("rotator identity is checked before signaling");
+    assert!(validation < kill);
+}
+
+#[test]
 fn qnap_package_persists_and_loads_the_complete_hiphi_connector_configuration() {
     assert!(
         INSTALL.contains("touch \"${QPKG_ROOT}/config/hiphi.env\""),

--- a/tests/qnap_service_contract.rs
+++ b/tests/qnap_service_contract.rs
@@ -93,58 +93,6 @@ fn qnap_service_keeps_credentials_private_and_stops_only_its_recorded_process() 
 }
 
 #[test]
-fn qnap_service_bounds_and_reclaims_its_own_log() {
-    assert!(
-        SERVICE.contains("UHC_LOG_MAX_BYTES"),
-        "the package must expose a bounded log-size policy"
-    );
-    assert!(
-        SERVICE.contains("UHC_LOG_ARCHIVES"),
-        "the package must expose a bounded archive-retention policy"
-    );
-    assert!(
-        SERVICE.contains("UHC_LOG_CHECK_SECONDS"),
-        "the package must check log size while the service is running"
-    );
-    assert!(
-        SERVICE.contains("tail -c \"$LOG_MAX_BYTES\""),
-        "rotation must retain only a bounded tail instead of copying an oversized log"
-    );
-    assert!(
-        SERVICE.contains("rotate \"$SERVICE_PID\""),
-        "rotation must be package-owned rather than editing QNAP's global cron table"
-    );
-    assert!(
-        SERVICE.contains("RUST_LOG=${RUST_LOG:-unified_hifi_control=info"),
-        "QNAP must default to production-safe info logging"
-    );
-    assert!(
-        INSTALL.contains("chmod 600 \"${QPKG_ROOT}/unified-hifi-control.log\""),
-        "the retained service log must remain owner-only"
-    );
-}
-
-#[test]
-fn qnap_rotator_is_stopped_only_after_process_identity_validation() {
-    assert!(
-        SERVICE.contains("is_our_rotator_pid"),
-        "a stale rotator PID must not be trusted"
-    );
-    let stop = SERVICE
-        .split("  stop)")
-        .nth(1)
-        .and_then(|tail| tail.split("  restart)").next())
-        .expect("stop arm exists");
-    let kill = stop
-        .find("kill \"$ROTATOR_PID\"")
-        .expect("stop arm terminates the package rotator");
-    let validation = stop[..kill]
-        .rfind("is_our_rotator_pid \"$ROTATOR_PID\"")
-        .expect("rotator identity is checked before signaling");
-    assert!(validation < kill);
-}
-
-#[test]
 fn qnap_package_persists_and_loads_the_complete_hiphi_connector_configuration() {
     assert!(
         INSTALL.contains("touch \"${QPKG_ROOT}/config/hiphi.env\""),


### PR DESCRIPTION
Fixes #675

## What changed

- moves file rotation into the UHC Rust logging subsystem
- defaults UHC logging to `info` on every platform
- rotates file logs daily and retains seven completed days by default
- supports `UHC_LOG_RETENTION_DAYS=1..365`
- lets QNAP, Synology, and macOS packages select only `UHC_LOG_DIR`
- keeps Docker stdout and systemd journald as their native managed sinks
- truncates a separate launcher diagnostic on package restart so pre-initialization failures cannot grow forever
- updates owner-token guidance and logging documentation for the shared policy

The prior one-minute, size-based QNAP rotator has been reverted. No polling process or package-specific rotation policy remains.

The concurrent HiPhi `connecting` incident was independently traced to Cloud version validation and fixed/deployed in open-horizon-labs/hiphi-cloud#75.

## Verification

- `cargo test --test logging_policy` — 3/3 passed
- `cargo test --test qnap_service_contract` — 8/8 passed
- `sh tests/synology_package_contract.sh` — passed
- `cargo test --bin unified-hifi-control logging::tests` — 2/2 passed, including filesystem retention behavior
- `cargo clippy --features server --bin unified-hifi-control -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- local process smoke produced `uhc-server.2026-09-01.log` in a configured temporary directory

The Docker-backed Synology lifecycle test could not run locally because the local OrbStack daemon is unavailable; the non-Docker Synology package contract passed and CI owns the lifecycle run.

No public HTTP API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable application logging with daily rotation and retention controls.
  * Added `UHC_LOG_DIR` and `UHC_LOG_RETENTION_DAYS` environment variables.
  * Native packages now use dedicated log directories and separate launcher logs.
  * Added HQPlayer to the available audio adapter options.

* **Documentation**
  * Updated installation, troubleshooting, and bootstrap-token guidance across deployment methods.
  * Added instructions for locating rotated application logs.

* **Bug Fixes**
  * Separated startup failures from ongoing application logs.
  * Improved log-directory security with restricted ownership and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->