### PR TITLE
Recover expired Roon browse sessions

### DIFF
--- a/src/adapters/roon.rs
+++ b/src/adapters/roon.rs
@@ -2,7 +2,7 @@
 //!
 //! Connects to Roon Core via SOOD discovery and WebSocket protocol.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use roon_api::{
     browse::{
@@ -41,6 +41,7 @@ use crate::bus::{
 };
 use crate::config::get_config_file_path;
 use crate::knobs::KnobStore;
+use crate::mcp::collection_locations::{CollectionLocation, CollectionStep, RoonLocationOrigin};
 
 const ROON_STATE_FILE: &str = "roon_state.json";
 
@@ -2499,10 +2500,11 @@ impl RoonAdapter {
         zone_id: &str,
         session_key: &str,
         items: Vec<BrowseItem>,
+        raw_offset: usize,
         at_collection_root: bool,
         mapped: &mut Vec<Value>,
     ) -> Result<()> {
-        for item in items {
+        for (index, item) in items.into_iter().enumerate() {
             // #573 defect 3: the exact-title category filter
             // (`is_category`) was verified for *search result* levels only,
             // but the Library node's real children are titled exactly
@@ -2568,6 +2570,10 @@ impl RoonAdapter {
                 "item_key": item.item_key,
                 "navigable": navigable,
                 "playable": playable,
+                // Stable-location recovery uses the original raw row
+                // position only to disambiguate duplicate title/subtitle
+                // pairs. A unique semantic match wins even if rows reorder.
+                "position": raw_offset + index,
                 // #549: Roon's own image_key, resolved through the same
                 // `RoonAdapter::get_image` now-playing art already uses --
                 // `hifi_collections` mints an opaque ref over this rather
@@ -3193,6 +3199,131 @@ impl RoonAdapter {
         Ok((session_key, item_key))
     }
 
+    /// Resolve a durable Library location in a fresh Roon browse session.
+    /// A unique title+subtitle identity survives row reordering. The recorded
+    /// raw position is consulted only when Roon presents duplicate semantic
+    /// identities; if neither rule identifies exactly one row, recovery fails
+    /// instead of choosing plausible-but-wrong content.
+    pub(crate) async fn resolve_collection_location(
+        &self,
+        zone_id: &str,
+        location: &CollectionLocation,
+    ) -> Result<(String, String)> {
+        let CollectionLocation::Roon { origin, steps } = location else {
+            return Err(anyhow::anyhow!(
+                "collection location is not a Roon location"
+            ));
+        };
+        if steps.is_empty() {
+            return Err(anyhow::anyhow!(
+                "cannot resolve an empty collection location"
+            ));
+        }
+        let bare_zone_id = strip_roon_prefix(zone_id);
+        let session_key = match origin {
+            RoonLocationOrigin::BrowseRoot => {
+                let session_key = format!(
+                    "location_{}",
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_nanos()
+                );
+                self.browse(BrowseOpts {
+                    multi_session_key: Some(session_key.clone()),
+                    zone_or_output_id: Some(bare_zone_id.to_string()),
+                    pop_all: true,
+                    ..Default::default()
+                })
+                .await?;
+                session_key
+            }
+            RoonLocationOrigin::Search { query, source } => {
+                let source = match source.as_deref() {
+                    Some("tidal") => SearchSource::Tidal,
+                    Some("qobuz") => SearchSource::Qobuz,
+                    _ => SearchSource::Library,
+                };
+                let (session_key, _) = self
+                    .search_with_session(query, Some(zone_id), Some(TRAIL_PAGE_SIZE), source)
+                    .await?;
+                session_key
+            }
+        };
+
+        let mut found_key: Option<String> = None;
+        for (depth, step) in steps.iter().enumerate() {
+            if let Some(parent_key) = found_key.take() {
+                self.browse(BrowseOpts {
+                    multi_session_key: Some(session_key.clone()),
+                    item_key: Some(parent_key),
+                    zone_or_output_id: Some(bare_zone_id.to_string()),
+                    ..Default::default()
+                })
+                .await?;
+            }
+            found_key = Some(
+                self.find_location_row(
+                    &session_key,
+                    step,
+                    depth == 0 && matches!(origin, RoonLocationOrigin::BrowseRoot),
+                )
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "collection location lost row {:?} at depth {depth}",
+                        step.title
+                    )
+                })?,
+            );
+        }
+
+        let item_key = found_key.ok_or_else(|| {
+            anyhow::anyhow!("collection location resolution produced no final row")
+        })?;
+        Ok((session_key, item_key))
+    }
+
+    async fn find_location_row(
+        &self,
+        session_key: &str,
+        step: &CollectionStep,
+        at_root: bool,
+    ) -> Result<Option<String>> {
+        let mut offset = 0usize;
+        let mut matches = Vec::<(usize, String)>::new();
+        loop {
+            let page = self
+                .load(LoadOpts {
+                    multi_session_key: Some(session_key.to_string()),
+                    offset,
+                    count: Some(TRAIL_PAGE_SIZE),
+                    ..Default::default()
+                })
+                .await?;
+            let fetched = page.items.len();
+            for (index, item) in page.items.into_iter().enumerate() {
+                let shown_title = if at_root && item.title == "Library" {
+                    "Local Library".to_string()
+                } else {
+                    strip_roon_link_markup(&item.title)
+                };
+                let shown_subtitle = item.subtitle.as_deref().map(strip_roon_link_markup);
+                if shown_title == step.title && shown_subtitle == step.subtitle {
+                    if let Some(key) = item.item_key {
+                        matches.push((offset + index, key));
+                    }
+                }
+            }
+            offset += fetched;
+            if fetched == 0 || offset >= page.list.count.min(TRAIL_SCAN_LIMIT) {
+                break;
+            }
+        }
+
+        select_location_match(&matches, step)
+    }
+
     /// Page through the level `session_key` is currently on, looking for a
     /// row whose title matches `title`. `Ok(None)` means the level was read
     /// to its end (or to [`TRAIL_SCAN_LIMIT`]) without a match.
@@ -3518,6 +3649,33 @@ impl RoonAdapter {
     }
 }
 
+fn select_location_match(
+    matches: &[(usize, String)],
+    step: &CollectionStep,
+) -> Result<Option<String>> {
+    match matches {
+        [] => Ok(None),
+        [(_, key)] => Ok(Some(key.clone())),
+        many => {
+            if let Some(position) = step.position.map(|value| value as usize) {
+                let at_position = many
+                    .iter()
+                    .filter(|(candidate, _)| *candidate == position)
+                    .collect::<Vec<_>>();
+                if let [(_, key)] = at_position.as_slice() {
+                    return Ok(Some((*key).clone()));
+                }
+            }
+            Err(anyhow::anyhow!(
+                "collection location is ambiguous: {} rows match {:?} / {:?}",
+                many.len(),
+                step.title,
+                step.subtitle
+            ))
+        }
+    }
+}
+
 /// Content-library surface: the multiroom grouping operations (#509) and
 /// the `hifi_collections` browse operations (#531) are both implemented
 /// here. Roon's own search/play surfaces are reached through their
@@ -3529,8 +3687,8 @@ impl RoonAdapter {
 /// (pre-existing debt, unaffected by this registration). `content` is what
 /// lets the provider-neutral MCP registry (`AdapterRegistry::library_content`)
 /// dispatch `multiroom_status`, `multiroom_set_members`,
-/// `multiroom_ungroup`, `collections_browse` and `collections_playlists` to
-/// Roon the same way it already dispatches the multiroom operations to
+/// `multiroom_ungroup`, `collections_browse`, `collections_playlists`, and
+/// durable collection-location recovery to Roon the same way it already dispatches the multiroom operations to
 /// Music Assistant (`src/adapters/musicassistant.rs`).
 #[async_trait]
 impl LibraryAdapter for RoonAdapter {
@@ -3550,7 +3708,8 @@ impl LibraryAdapter for RoonAdapter {
     }
 
     /// `operation` is one of `multiroom_status`, `multiroom_set_members`,
-    /// `multiroom_ungroup`, `collections_browse` or `collections_playlists`
+    /// `multiroom_ungroup`, `collections_browse`, `collections_playlists`, or
+    /// `collections_resolve_location`
     /// (never `collections_favorites` -- Roon's favorites capability is not
     /// wired, see `crate::mcp::capabilities`). The collections response is
     /// this adapter's own shape, not `hifi_collections`' wire shape:
@@ -3637,6 +3796,7 @@ impl LibraryAdapter for RoonAdapter {
                     zone_id,
                     &session_key,
                     items,
+                    offset,
                     at_collection_root,
                     &mut mapped,
                 )
@@ -3665,11 +3825,13 @@ impl LibraryAdapter for RoonAdapter {
                         consumed = total;
                         break;
                     }
+                    let chunk_offset = consumed;
                     consumed = (consumed + chunk.items.len()).min(total);
                     self.map_collection_page(
                         zone_id,
                         &session_key,
                         chunk.items,
+                        chunk_offset,
                         at_collection_root,
                         &mut mapped,
                     )
@@ -3681,6 +3843,24 @@ impl LibraryAdapter for RoonAdapter {
                     "session_key": session_key,
                     "items": mapped,
                     "next_offset": next_offset,
+                }))
+            }
+            "collections_resolve_location" => {
+                let zone_id = params
+                    .get("zone_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("zone_id is required"))?;
+                let location = params
+                    .get("location")
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("location is required"))?;
+                let location: CollectionLocation =
+                    serde_json::from_value(location).context("decode Roon collection location")?;
+                let (session_key, item_key) =
+                    self.resolve_collection_location(zone_id, &location).await?;
+                Ok(serde_json::json!({
+                    "session_key": session_key,
+                    "item_key": item_key,
                 }))
             }
             _ => Err(anyhow::anyhow!(
@@ -4915,6 +5095,37 @@ mod defect_573_row_classification {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn durable_location_uses_unique_semantic_match_even_after_reorder() {
+        let step = CollectionStep::roon("Kind of Blue", Some("Miles Davis".to_string()), Some(0));
+        let matches = vec![(7, "correct-key".to_string())];
+
+        assert_eq!(
+            select_location_match(&matches, &step).unwrap(),
+            Some("correct-key".to_string())
+        );
+    }
+
+    #[test]
+    fn durable_location_uses_recorded_position_only_for_true_duplicates() {
+        let step = CollectionStep::roon("Greatest Hits", Some("Various".to_string()), Some(9));
+        let matches = vec![(3, "wrong-key".to_string()), (9, "right-key".to_string())];
+
+        assert_eq!(
+            select_location_match(&matches, &step).unwrap(),
+            Some("right-key".to_string())
+        );
+    }
+
+    #[test]
+    fn durable_location_refuses_ambiguous_duplicates_without_a_matching_position() {
+        let step = CollectionStep::roon("Greatest Hits", Some("Various".to_string()), Some(4));
+        let matches = vec![(3, "first-key".to_string()), (9, "second-key".to_string())];
+
+        let error = select_location_match(&matches, &step).unwrap_err();
+        assert!(error.to_string().contains("ambiguous"), "{error:#}");
+    }
 
     /// Create a test zone with specified volume parameters
     fn make_test_zone(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -302,6 +302,15 @@ pub struct AppState {
     /// `/library/<source>/<view>/loc_…` URLs. Unlike `mcp_refs`, these survive
     /// process and provider-session restarts.
     pub collection_locations: crate::mcp::collection_locations::CollectionLocationStore,
+    /// Bounded in-process cache from a durable collection location token to
+    /// the provider-session-scoped `(session_key, item_key)` pair that last
+    /// served it. Purely an optimisation for Roon browsing: it turns the
+    /// steady state (each level, each "Load more" page) into one browse call
+    /// instead of a full re-walk of the saved trail, and is evicted the moment
+    /// the provider rejects a pair. Deliberately not durable -- the pairs it
+    /// holds are only meaningful inside a live provider session.
+    pub collection_location_keys:
+        std::sync::Arc<crate::mcp::collection_locations::LocationKeyCache>,
     /// Opaque image refs (#549): what a `hifi_collections`/`/api/collections`
     /// item's `image` field resolves through, so a collection browse row can
     /// carry a per-item artwork reference without ever handing a client the
@@ -387,6 +396,9 @@ impl AppState {
             mcp_refs: crate::mcp::refs::RefTable::new(),
             collection_locations:
                 crate::mcp::collection_locations::CollectionLocationStore::default(),
+            collection_location_keys: std::sync::Arc::new(
+                crate::mcp::collection_locations::LocationKeyCache::new(),
+            ),
             image_refs: crate::mcp::refs::ImageRefTable::new(),
             eink_artwork_cache: crate::knobs::image::EinkArtworkCache::default(),
             listening_plans: crate::mcp::listening_plan::ListeningPlanStore::from_config(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -298,6 +298,10 @@ pub struct AppState {
     /// constructor parameter -- like `sse_connections` above -- so every
     /// existing `AppState::new` call site is untouched by this addition.
     pub mcp_refs: crate::mcp::refs::RefTable,
+    /// Durable provider-private collection identities behind canonical
+    /// `/library/<source>/<view>/loc_…` URLs. Unlike `mcp_refs`, these survive
+    /// process and provider-session restarts.
+    pub collection_locations: crate::mcp::collection_locations::CollectionLocationStore,
     /// Opaque image refs (#549): what a `hifi_collections`/`/api/collections`
     /// item's `image` field resolves through, so a collection browse row can
     /// carry a per-item artwork reference without ever handing a client the
@@ -381,6 +385,8 @@ impl AppState {
             shutdown,
             sse_connections: Arc::new(AtomicUsize::new(0)),
             mcp_refs: crate::mcp::refs::RefTable::new(),
+            collection_locations:
+                crate::mcp::collection_locations::CollectionLocationStore::default(),
             image_refs: crate::mcp::refs::ImageRefTable::new(),
             eink_artwork_cache: crate::knobs::image::EinkArtworkCache::default(),
             listening_plans: crate::mcp::listening_plan::ListeningPlanStore::from_config(),

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -822,8 +822,10 @@ pub struct NowPlaying {
 // deserialize away harmlessly.
 // =============================================================================
 
-/// One item from a `hifi_collections` page: either a folder (`path` set,
+/// One item from a `hifi_collections` page: either a folder (`location` set,
 /// browse only) or a playable entry (`r#ref` set, usable with `/api/play_ref`).
+/// `path` remains for non-web MCP clients that want a short-lived
+/// continuation; the web Library always navigates with `location`.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct CollectionItem {
     pub title: String,
@@ -831,6 +833,9 @@ pub struct CollectionItem {
     pub subtitle: Option<String>,
     #[serde(default)]
     pub path: Option<String>,
+    /// Durable provider-neutral identity used in canonical Library URLs.
+    #[serde(default)]
+    pub location: Option<String>,
     #[serde(rename = "ref", default)]
     pub item_ref: Option<String>,
     /// Artwork URL, used verbatim as an `<img src>`. The server sends the
@@ -847,7 +852,15 @@ pub struct CollectionPage {
     #[serde(default)]
     pub items: Vec<CollectionItem>,
     #[serde(default)]
+    pub breadcrumbs: Vec<CollectionBreadcrumb>,
+    #[serde(default)]
     pub next_offset: Option<u32>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct CollectionBreadcrumb {
+    pub title: String,
+    pub location: String,
 }
 
 /// The `reason`-tagged refusal shape from `crate::mcp::envelope::Refusal`.
@@ -894,6 +907,8 @@ pub struct CollectionsRequest {
     pub action: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub media_type: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -951,11 +966,14 @@ pub struct SearchResult {
     pub subtitle: Option<String>,
     #[serde(rename = "ref", default)]
     pub item_ref: Option<String>,
-    /// Opaque browse-continuation ref (#566), present when this result is
-    /// navigable -- same convention as `CollectionItem::path`, consumed the
-    /// same way (open into browse, push a breadcrumb).
+    /// Short-lived browse-continuation ref (#566), present when this result
+    /// is navigable. Retained for MCP compatibility; the web Library uses the
+    /// durable `location` below.
     #[serde(default)]
     pub path: Option<String>,
+    /// Durable collection location for navigable search hits.
+    #[serde(default)]
+    pub location: Option<String>,
     /// Artwork URL (#573 defect 10) -- same contract as
     /// `CollectionItem::image`: a complete same-origin path, used verbatim
     /// as an `<img src>`.

--- a/src/app/components/nav.rs
+++ b/src/app/components/nav.rs
@@ -67,7 +67,7 @@ pub fn Nav(props: NavProps) -> Element {
             div { class: "nav-inner",
                 // Logo / Brand
                 div { class: "flex items-center",
-                    Link { class: "nav-brand flex items-center", to: Route::Library { source: None, tab: None, path: None, zone: None },
+                    Link { class: "nav-brand flex items-center", to: Route::LibraryHome {},
                         img {
                             // base-path-ok: an inlined data: URL carries no path to map.
                             src: "{*LOGO_DATA_URL}",
@@ -81,7 +81,7 @@ pub fn Nav(props: NavProps) -> Element {
                 div { class: "hidden lg:flex items-center space-x-4",
                     Link {
                         class: nav_link_class("library"),
-                        to: Route::Library { source: None, tab: None, path: None, zone: None },
+                        to: Route::LibraryHome {},
                         "Library"
                     }
                     Link { class: nav_link_class("zones"), to: Route::Zones {}, "Zones" }
@@ -149,7 +149,7 @@ pub fn Nav(props: NavProps) -> Element {
                 div { class: "px-2 pt-2 pb-3 space-y-1",
                     Link {
                         class: nav_link_class("library"),
-                        to: Route::Library { source: None, tab: None, path: None, zone: None },
+                        to: Route::LibraryHome {},
                         onclick: move |_| menu_open.set(false),
                         "Library"
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,7 +16,10 @@ pub mod sse;
 pub mod theme;
 
 use components::BootstrapPrompt;
-use pages::{HqPlayer, Knobs, Library, Lms, Settings, Spotify, Zones};
+use pages::{
+    HqPlayer, Knobs, LibraryHome, LibraryLocation, LibrarySource, LibraryView, Lms, Settings,
+    Spotify, Zones,
+};
 use settings_context::use_settings_provider;
 use sse::use_sse_provider;
 use theme::use_theme_provider;
@@ -138,24 +141,23 @@ pub fn App() -> Element {
 
 /// Application routes.
 ///
-/// Library is the home page (#550): a full-page browse/search surface that
-/// replaced the old per-zone-card browse panel. Its state -- which
-/// provider/zone is being browsed, which tab, and the breadcrumb path -- is
-/// carried entirely in the query string so a level is refresh/back/share
-/// safe, per the issue's URL-addressability requirement. `path` is a
-/// base64url-encoded JSON breadcrumb stack (`Vec<(String, Option<String>)>`,
-/// see `pages::library::BreadcrumbEntry`) rather than raw path segments:
-/// provider browse paths are opaque tokens that may contain characters a URL
-/// path segment can't carry safely, and a flat list of segments would lose
-/// the breadcrumb titles on a fresh (deep-linked) load.
+/// Library is the home page (#550). Source, view, and durable collection
+/// location use one readable path grammar for every provider. The armed
+/// playback zone is client preference, not content identity, so it never
+/// appears in these URLs.
 #[derive(Clone, Routable, Debug, PartialEq)]
 pub enum Route {
-    #[route("/?:source&:tab&:path&:zone")]
-    Library {
-        source: Option<String>,
-        tab: Option<String>,
-        path: Option<String>,
-        zone: Option<String>,
+    #[route("/")]
+    LibraryHome {},
+    #[route("/library/:source")]
+    LibrarySource { source: String },
+    #[route("/library/:source/:view")]
+    LibraryView { source: String, view: String },
+    #[route("/library/:source/:view/:location")]
+    LibraryLocation {
+        source: String,
+        view: String,
+        location: String,
     },
     // #560: was `/zones`, which collides with the JSON protocol route
     // `GET /zones` (knobs::knob_zones_handler, registered in main.rs) --
@@ -178,7 +180,36 @@ pub enum Route {
 
 #[cfg(test)]
 mod tests {
-    use super::McpEndpoint;
+    use super::{McpEndpoint, Route};
+
+    #[test]
+    fn library_routes_are_canonical_and_provider_neutral() {
+        assert_eq!(Route::LibraryHome {}.to_string(), "/");
+        assert_eq!(
+            Route::LibrarySource {
+                source: "roon".to_string(),
+            }
+            .to_string(),
+            "/library/roon"
+        );
+        assert_eq!(
+            Route::LibraryView {
+                source: "lms".to_string(),
+                view: "playlists".to_string(),
+            }
+            .to_string(),
+            "/library/lms/playlists"
+        );
+        assert_eq!(
+            Route::LibraryLocation {
+                source: "musicassistant".to_string(),
+                view: "browse".to_string(),
+                location: "loc_4fNE3TqO1n0Yzg".to_string(),
+            }
+            .to_string(),
+            "/library/musicassistant/browse/loc_4fNE3TqO1n0Yzg"
+        );
+    }
 
     #[test]
     fn mcp_endpoint_uses_reachable_ipv4_address_in_agent_config() {

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -921,6 +921,11 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
                         class: "btn btn-ghost",
                         r#type: "button",
                         onclick: move |_| {
+                            // Same rule as `open_folder`: leaving for the root
+                            // ends the search, or the results view would stay
+                            // mounted over the level we just navigated to.
+                            let mut search_query = search_query;
+                            search_query.set(String::new());
                             navigate(selected_source(), Some(current_tab.as_str().to_string()), None);
                         },
                         "Back to library"

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -904,13 +904,27 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
             div { class: "library-provider-down",
                 p { "{heading}" }
                 p { class: "text-sm text-muted", "{detail}" }
-                button {
-                    class: "btn btn-outline",
-                    r#type: "button",
-                    onclick: move |_| {
-                        refresh(false);
-                    },
-                    "Retry"
+                div { class: "flex flex-wrap items-center justify-center gap-2",
+                    button {
+                        class: "btn btn-outline",
+                        r#type: "button",
+                        onclick: move |_| {
+                            refresh(false);
+                        },
+                        "Retry"
+                    }
+                    // Retrying in place is right for a level that is merely
+                    // stale -- the server re-walks the saved trail. A node
+                    // that is permanently gone would strand the user there,
+                    // so this is the deliberate way out, not an automatic one.
+                    button {
+                        class: "btn btn-ghost",
+                        r#type: "button",
+                        onclick: move |_| {
+                            navigate(selected_source(), Some(current_tab.as_str().to_string()), None);
+                        },
+                        "Back to library"
+                    }
                 }
             }
         }

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -10,22 +10,17 @@
 //!
 //! # URL-addressability
 //!
-//! Every piece of state a user would want to refresh, go back through, or
-//! share -- source, tab, breadcrumb path, armed zone -- lives in the route's
-//! query string (`Route::Library`). `path` is a base64url-encoded JSON
-//! breadcrumb stack rather than raw segments: a provider browse path is an
-//! opaque token (see `crate::app::api::CollectionItem::path`) that may not
-//! be a safe URL path segment, and a flat segment list would lose each
-//! breadcrumb's title on a fresh (deep-linked) load.
+//! Source, view, and the durable provider-neutral collection location use
+//! canonical path segments. Provider paths and Roon browse-session keys stay
+//! behind `/api/collections`; the browser sees only a short `loc_…` identity.
 
 use crate::app::api::{
-    self, source_label, CollectionItem, CollectionsRequest, NowPlaying, PlayRefRequest,
-    SearchRequest, SearchResult, Zone, ZonesResponse,
+    self, source_label, CollectionBreadcrumb, CollectionItem, CollectionsRequest, NowPlaying,
+    PlayRefRequest, SearchRequest, SearchResult, Zone, ZonesResponse,
 };
 use crate::app::components::{Layout, ZonesStrip};
 use crate::app::sse::{use_sse, SseEvent};
 use crate::app::Route;
-use base64::Engine;
 use dioxus::prelude::*;
 use std::collections::HashMap;
 
@@ -33,6 +28,22 @@ const PAGE_LIMIT: u32 = 30;
 const SEARCH_DEBOUNCE_MS: u64 = 300;
 #[cfg(target_arch = "wasm32")]
 const ARMED_ZONE_STORAGE_KEY: &str = "uhc.armed_zone";
+
+fn library_route(source: Option<String>, view: Option<String>, location: Option<String>) -> Route {
+    let Some(source) = source else {
+        return Route::LibraryHome {};
+    };
+    let view = view.filter(|value| !value.is_empty());
+    match (view, location) {
+        (Some(view), Some(location)) => Route::LibraryLocation {
+            source,
+            view,
+            location,
+        },
+        (Some(view), None) if view != "browse" => Route::LibraryView { source, view },
+        _ => Route::LibrarySource { source },
+    }
+}
 
 /// Control request body, mirrors `pages::zones`.
 #[derive(Clone, serde::Serialize)]
@@ -119,7 +130,7 @@ fn visible_tabs_for(library_tabs: &[String]) -> Vec<Tab> {
 }
 
 /// The tab actually shown: the route's tab when this provider serves it,
-/// otherwise Browse -- so a deep link to `?tab=favorites` on a Roon zone
+/// otherwise Browse -- so a deep link to `/library/roon/favorites`
 /// lands on a working tab instead of a permanent refusal page.
 fn effective_tab(requested: Tab, visible: &[Tab]) -> Tab {
     if visible.contains(&requested) {
@@ -145,34 +156,6 @@ fn image_src(image: &str) -> String {
     crate::app::base_path::href(image)
 }
 
-/// One breadcrumb: what the user picked, and the opaque path it opened.
-/// The root ("Library") is implicit and never stored -- an empty stack
-/// means "at the root of this tab".
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-struct BreadcrumbEntry {
-    title: String,
-    path: Option<String>,
-}
-
-fn encode_path(stack: &[BreadcrumbEntry]) -> Option<String> {
-    if stack.is_empty() {
-        return None;
-    }
-    let json = serde_json::to_string(stack).ok()?;
-    Some(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json))
-}
-
-fn decode_path(encoded: Option<&str>) -> Vec<BreadcrumbEntry> {
-    let Some(encoded) = encoded.filter(|s| !s.is_empty()) else {
-        return Vec::new();
-    };
-    base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .decode(encoded)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
-        .unwrap_or_default()
-}
-
 /// Last-used armed zone, read only from client-side effects (never as part
 /// of a signal's *initial* value) so SSR and the pre-hydration WASM render
 /// stay identical -- see this module's doc comment and the pattern already
@@ -192,28 +175,23 @@ fn load_last_zone() -> Option<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn save_last_zone(zone_id: &str) {
+pub(crate) fn save_last_zone(zone_id: &str) {
     if let Some(Ok(Some(storage))) = web_sys::window().map(|w| w.local_storage()) {
         let _ = storage.set_item(ARMED_ZONE_STORAGE_KEY, zone_id);
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn save_last_zone(_zone_id: &str) {}
+pub(crate) fn save_last_zone(_zone_id: &str) {}
 
-/// Resolve which zone is armed: the URL wins (deep link), then the last
-/// zone the user picked, then whichever zone is currently playing, then
-/// simply the first zone. Never `None` when `zones` is non-empty.
+/// Resolve which zone is armed: the last zone the user picked wins, then
+/// whichever zone is currently playing, then simply the first zone. Zone
+/// selection is client preference state and deliberately never enters the
+/// canonical library URL.
 fn resolve_armed_zone<'a>(
-    route_zone: Option<&str>,
     zones: &'a [Zone],
     now_playing: &HashMap<String, NowPlaying>,
 ) -> Option<&'a Zone> {
-    if let Some(id) = route_zone {
-        if let Some(zone) = zones.iter().find(|z| z.zone_id == id) {
-            return Some(zone);
-        }
-    }
     if let Some(last) = load_last_zone() {
         if let Some(zone) = zones.iter().find(|z| z.zone_id == last) {
             return Some(zone);
@@ -308,7 +286,7 @@ fn missing_now_playing_zones(
 ///
 /// `unreachable` is true only when the HTTP request itself failed -- the one
 /// case "«source» isn't reachable right now." is true of. A well-formed
-/// refusal envelope (a capability gap, an expired path, ...) reaches the
+/// refusal envelope (a capability gap, an unknown location, ...) reaches the
 /// server fine; rendering it under unreachability copy told users the
 /// provider was down when it wasn't.
 #[derive(Clone, Debug, PartialEq)]
@@ -317,23 +295,13 @@ struct LevelError {
     unreachable: bool,
 }
 
-/// Roon browse item keys belong to a Core-side session. A Core reconnect can
-/// invalidate that session while UHC is still running, leaving a bookmarked
-/// or already-open library URL pointing at keys Roon will reject. Keep that
-/// provider detail out of the UI; the page can return to a fresh root instead.
-fn is_expired_roon_browse(message: &str, source: Option<&str>) -> bool {
-    source == Some("roon")
-        && (message.contains("no longer valid in this browse session")
-            || message.contains("InvalidItemKey"))
-}
-
 /// Fetch one page of the current level and apply it.
 #[allow(clippy::too_many_arguments)]
 async fn load_page(
     zone_id: String,
     action: String,
     media_type: Option<String>,
-    path: Option<String>,
+    location: Option<String>,
     request_offset: u32,
     append: bool,
     mut items: Signal<Vec<CollectionItem>>,
@@ -341,13 +309,15 @@ async fn load_page(
     mut offset: Signal<u32>,
     mut loading: Signal<bool>,
     mut error: Signal<Option<LevelError>>,
+    mut breadcrumbs: Signal<Vec<CollectionBreadcrumb>>,
 ) {
     loading.set(true);
     error.set(None);
     let req = CollectionsRequest {
         zone_id,
         action,
-        path,
+        path: None,
+        location,
         media_type,
         limit: Some(PAGE_LIMIT),
         offset: Some(request_offset),
@@ -359,6 +329,7 @@ async fn load_page(
                 items.with_mut(|list| list.extend(page.items));
             } else {
                 items.set(page.items);
+                breadcrumbs.set(page.breadcrumbs);
             }
             next_offset.set(page.next_offset);
             offset.set(request_offset);
@@ -374,6 +345,7 @@ async fn load_page(
                 // under the error panel.
                 items.set(Vec::new());
                 next_offset.set(None);
+                breadcrumbs.set(Vec::new());
             }
         }
         Err(message) => {
@@ -384,6 +356,7 @@ async fn load_page(
             if !append {
                 items.set(Vec::new());
                 next_offset.set(None);
+                breadcrumbs.set(Vec::new());
             }
         }
     }
@@ -392,16 +365,10 @@ async fn load_page(
 
 /// The Library page.
 #[component]
-pub fn Library(
-    source: Option<String>,
-    tab: Option<String>,
-    path: Option<String>,
-    zone: Option<String>,
-) -> Element {
+fn Library(source: Option<String>, tab: Option<String>, location: Option<String>) -> Element {
     let route_source = source.clone();
     let route_tab = tab.clone().unwrap_or_default();
-    let route_path = path.clone();
-    let route_zone = zone.clone();
+    let route_location = location.clone();
 
     let sse = use_sse();
     let navigator = use_navigator();
@@ -512,37 +479,28 @@ pub fn Library(
         }
     });
 
-    // Armed target zone: resolved from the URL / last-used / now-playing,
-    // written back into the URL and localStorage so it survives a refresh
-    // and shows up in shared links.
-    //
-    // `use_reactive!` on `route_zone` is load-bearing, same hazard class as
-    // #566's breadcrumb resync: `zone` is a plain route prop, so an effect
-    // that merely captures it has no reactive dependency on it. A zone-strip
-    // click (`arm_zone`) pushes a new `zone` query param and re-renders this
-    // component, but without `use_reactive!` nothing this effect *tracks*
-    // changed -- it wouldn't rerun until some unrelated zones/now-playing
-    // update, so the click read as a no-op whenever nothing was playing.
-    let mut armed_zone_id = use_signal(|| route_zone.clone());
-    use_effect(use_reactive!(|route_zone| {
+    // Armed target zone is client preference state. Persist it locally so
+    // refreshes keep the user's target without polluting shareable URLs.
+    let mut armed_zone_id = use_signal(|| None::<String>);
+    use_effect(move || {
         let list = zones_list();
         if list.is_empty() {
             return;
         }
-        let resolved = resolve_armed_zone(route_zone.as_deref(), &list, &now_playing());
+        let resolved = resolve_armed_zone(&list, &now_playing());
         if let Some(zone) = resolved {
             if armed_zone_id.peek().as_deref() != Some(zone.zone_id.as_str()) {
                 armed_zone_id.set(Some(zone.zone_id.clone()));
             }
             save_last_zone(&zone.zone_id);
         }
-    }));
+    });
 
     // Selected browse source. `use_reactive!` on `route_source` is
-    // load-bearing (same class as the `route_zone` effect above): `source`
+    // load-bearing: `source`
     // is a plain route prop, so without it this memo recomputes only when
     // the zone list or armed zone changes. A source-picker click
-    // (`select_source`) changes only the `source` query param -- the memo
+    // (`select_source`) changes only the `source` route segment -- the memo
     // kept returning the old source and the click read as a no-op.
     let selected_source = use_memo(use_reactive!(|route_source| {
         let list = zones_list();
@@ -581,31 +539,9 @@ pub fn Library(
         visible_tabs_for(&tabs)
     });
     let current_tab = effective_tab(Tab::parse(&route_tab), &visible_tabs());
-    let breadcrumbs = use_signal(|| decode_path(route_path.as_deref()));
-
-    // Re-sync local breadcrumb signal when navigation (a row click's
-    // `navigator.push`, back/forward, or a deep link) changes the route's
-    // `path` out from under us.
-    //
-    // #566 (live probe): `use_reactive!` is load-bearing. `path` is a plain
-    // route prop, not a signal -- an effect that merely *captures* it has no
-    // tracked dependency and runs exactly once, at mount. In-app navigation
-    // keeps this component mounted, so every breadcrumb-changing click
-    // (browse rows and the new search-result chevrons alike) updated the URL
-    // while the visible level never changed -- the click read as a no-op.
-    // Deep links appeared to work only because a fresh mount seeds the
-    // signal's initial value. `use_reactive!` diffs the prop across renders
-    // and re-runs this effect when it actually changes.
-    {
-        let mut breadcrumbs = breadcrumbs;
-        let route_path_for_effect = path.clone();
-        use_effect(use_reactive!(|route_path_for_effect| {
-            let decoded = decode_path(route_path_for_effect.as_deref());
-            if *breadcrumbs.peek() != decoded {
-                breadcrumbs.set(decoded);
-            }
-        }));
-    }
+    // Breadcrumb labels are reconstructed by the server from the durable
+    // location. They are display data, not URL state.
+    let breadcrumbs = use_signal(Vec::<CollectionBreadcrumb>::new);
 
     let items = use_signal(Vec::<CollectionItem>::new);
     let offset = use_signal(|| 0u32);
@@ -616,19 +552,20 @@ pub fn Library(
     // Monotonic guard so a delayed auto-clear never erases a NEWER toast.
     let mut status_generation = use_signal(|| 0u64);
 
+    let route_location_for_refresh = route_location.clone();
     let refresh = use_callback(move |append: bool| {
         let Some(zone_id) = browse_zone_id() else {
             return;
         };
-        let path = breadcrumbs.read().last().and_then(|e| e.path.clone());
+        let location = route_location_for_refresh.clone();
         // #573 (visual pass V2b root cause): a tab's action ("playlists",
-        // "favorites") lists that tab's ROOT and ignores `path` -- so once
+        // "favorites") lists that tab's ROOT and ignores navigation state -- so once
         // the user opened a playlist, every reload re-listed the parent
         // under an advanced breadcrumb (an empty playlist looked like the
         // playlists list itself). Any level below a tab's root is reached
-        // by its opaque `path`, and the documented way to continue into a
-        // path is the `browse` action, whatever tab it started from.
-        let (action, media_type) = if path.is_some() {
+        // by its durable `location`, and continuing into one uses the
+        // `browse` action, whatever tab it started from.
+        let (action, media_type) = if location.is_some() {
             ("browse".to_string(), None)
         } else {
             (
@@ -641,7 +578,7 @@ pub fn Library(
             zone_id,
             action,
             media_type,
-            path,
+            location,
             request_offset,
             append,
             items,
@@ -649,24 +586,26 @@ pub fn Library(
             offset,
             loading,
             error,
+            breadcrumbs,
         ));
     });
 
-    // Reload the level whenever source, tab, browse zone, or breadcrumb
-    // path changes.
+    // Reload the level whenever source, tab, browse zone, or durable
+    // location changes.
     //
     // `use_reactive!` on `route_tab` is load-bearing (same class as the
-    // `route_zone` effect above): `tab` is a plain route prop, and the old
+    // source route effect above): `tab` is a plain route prop, and the old
     // `let _ = route_tab.clone();` captured it without tracking anything. A
     // tab switch at the breadcrumb root (e.g. Browse -> Playlists, stack
     // [] == [], source and zone unchanged) changed no tracked dependency,
     // so this effect never reran and the old tab's items stayed on screen
     // under the new tab's header.
-    use_effect(use_reactive!(|route_tab| {
+    let route_location_for_effect = route_location.clone();
+    use_effect(use_reactive!(|(route_tab, route_location_for_effect)| {
         let _ = selected_source();
         let _ = browse_zone_id();
         let _ = route_tab;
-        let _ = breadcrumbs.read().clone();
+        let _ = route_location_for_effect;
         // The play-status toast ("Playing", "Added to queue") describes an
         // action taken on the level the user was on -- it must not follow
         // them around the library (live report: a lone "Playing" haunting
@@ -681,19 +620,12 @@ pub fn Library(
         }
     }));
 
-    // Navigate helper: push a fresh URL for the given state, keeping the
-    // rest of the query intact.
-    let navigate = move |new_source: Option<String>,
-                         new_tab: Option<String>,
-                         new_path: Option<String>,
-                         new_zone: Option<String>| {
-        navigator.push(Route::Library {
-            source: new_source,
-            tab: new_tab,
-            path: new_path,
-            zone: new_zone,
-        });
-    };
+    // Navigate with canonical route state only. The armed zone remains a
+    // client-side preference and provider-native paths remain server-side.
+    let navigate =
+        move |new_source: Option<String>, new_tab: Option<String>, new_location: Option<String>| {
+            navigator.push(library_route(new_source, new_tab, new_location));
+        };
 
     // The search box's text. Declared before `open_folder` (its consumers --
     // the input binding and the search effect -- live in the "Unified search"
@@ -701,7 +633,7 @@ pub fn Library(
     let mut search_query = use_signal(String::new);
 
     let open_folder = {
-        move |(title, folder_path): (String, String)| {
+        move |(_title, location): (String, String)| {
             // #566 (live probe): a non-empty query keeps the search-results
             // view mounted, so opening a search hit navigated the route (URL
             // and breadcrumbs updated) while the visible page stayed on the
@@ -715,16 +647,10 @@ pub fn Library(
             // components' handler props don't accept.)
             let mut search_query = search_query;
             search_query.set(String::new());
-            let mut stack = breadcrumbs();
-            stack.push(BreadcrumbEntry {
-                title,
-                path: Some(folder_path),
-            });
             navigate(
                 selected_source(),
                 Some(current_tab.as_str().to_string()),
-                encode_path(&stack),
-                armed_zone_id(),
+                Some(location),
             );
         }
     };
@@ -736,31 +662,27 @@ pub fn Library(
     // stale crumbs afterwards desyncs from the provider's browse session.
     // Opening a search hit starts a FRESH trail rooted at the hit itself.
     let open_search_hit = {
-        move |(title, folder_path): (String, String)| {
+        move |(_title, location): (String, String)| {
             let mut search_query = search_query;
             search_query.set(String::new());
-            let stack = vec![BreadcrumbEntry {
-                title,
-                path: Some(folder_path),
-            }];
             navigate(
                 selected_source(),
                 Some(current_tab.as_str().to_string()),
-                encode_path(&stack),
-                armed_zone_id(),
+                Some(location),
             );
         }
     };
 
     let go_to_crumb = {
         move |index: usize| {
-            let mut stack = breadcrumbs();
-            stack.truncate(index);
+            let location = index
+                .checked_sub(1)
+                .and_then(|crumb_index| breadcrumbs().get(crumb_index).cloned())
+                .map(|crumb| crumb.location);
             navigate(
                 selected_source(),
                 Some(current_tab.as_str().to_string()),
-                encode_path(&stack),
-                armed_zone_id(),
+                location,
             );
         }
     };
@@ -771,19 +693,13 @@ pub fn Library(
                 Some(new_source),
                 Some(current_tab.as_str().to_string()),
                 None,
-                armed_zone_id(),
             );
         }
     };
 
     let select_tab = {
         move |new_tab: Tab| {
-            navigate(
-                selected_source(),
-                Some(new_tab.as_str().to_string()),
-                None,
-                armed_zone_id(),
-            );
+            navigate(selected_source(), Some(new_tab.as_str().to_string()), None);
         }
     };
 
@@ -799,12 +715,9 @@ pub fn Library(
             // type-check here -- the closure is required.
             #[allow(clippy::redundant_closure)]
             let source = zone_source.or_else(|| selected_source());
-            navigate(
-                source,
-                Some(current_tab.as_str().to_string()),
-                None,
-                Some(zone_id),
-            );
+            armed_zone_id.set(Some(zone_id.clone()));
+            save_last_zone(&zone_id);
+            navigate(source, Some(current_tab.as_str().to_string()), None);
         }
     };
 
@@ -974,15 +887,11 @@ pub fn Library(
             }
         }
     } else if let Some(level_error) = current_error.clone() {
-        let roon_session_expired =
-            is_expired_roon_browse(&level_error.message, current_source.as_deref());
         // #573 visual pass V3: unreachability copy is reserved for actual
-        // network failures; a genuine refusal (a capability gap, an expired
-        // path) renders its own reason instead of claiming the provider is
-        // down.
-        let heading = if roon_session_expired {
-            "Roon refreshed; this browse page expired.".to_string()
-        } else if level_error.unreachable {
+        // network failures; a genuine refusal renders its own reason instead
+        // of claiming the provider is down. Durable locations are retried in
+        // place; the UI never silently throws the user back to the root.
+        let heading = if level_error.unreachable {
             format!(
                 "{} isn't reachable right now.",
                 source_label(current_source.as_deref().unwrap_or("this source"))
@@ -990,11 +899,7 @@ pub fn Library(
         } else {
             "This view isn't available.".to_string()
         };
-        let detail = if roon_session_expired {
-            "Your library connection changed, so we’ll reload this from the beginning.".to_string()
-        } else {
-            level_error.message.clone()
-        };
+        let detail = level_error.message.clone();
         rsx! {
             div { class: "library-provider-down",
                 p { "{heading}" }
@@ -1005,7 +910,7 @@ pub fn Library(
                     onclick: move |_| {
                         refresh(false);
                     },
-                    if roon_session_expired { "Refresh library" } else { "Retry" }
+                    "Retry"
                 }
             }
         }
@@ -1055,11 +960,11 @@ pub fn Library(
                                     // row opens a navigable hit, same as
                                     // browse rows.
                                     onclick: {
-                                        let path = result.path.clone();
+                                        let location = result.location.clone();
                                         let title = result.title.clone();
                                         move |_| {
-                                            if let Some(path) = path.clone() {
-                                                open_search_hit((title.clone(), path.clone()));
+                                            if let Some(location) = location.clone() {
+                                                open_search_hit((title.clone(), location));
                                             }
                                         }
                                     },
@@ -1099,27 +1004,27 @@ pub fn Library(
                                         // #566: a navigable result (a real
                                         // hit like an artist, or a grouping
                                         // row like "Albums · 35 Results")
-                                        // carries a `path` -- open it the
+                                        // carries a durable `location` -- open it the
                                         // same way a browse row does: push a
                                         // breadcrumb and navigate into it,
                                         // rather than leaving the row a dead
                                         // end. Independent of the play
                                         // button above: a result can have
                                         // either, both, or neither.
-                                        if let Some(path) = result.path.clone() {
+                                        if let Some(location) = result.location.clone() {
                                             button {
                                                 class: "library-chevron-btn",
                                                 aria_label: "Open {result.title}",
                                                 r#type: "button",
                                                 onclick: {
                                                     let title = result.title.clone();
-                                                    let path = path.clone();
+                                                    let location = location.clone();
                                                     // stop_propagation: the row's
                                                     // own click does the same
                                                     // navigation.
                                                     move |evt: Event<MouseData>| {
                                                         evt.stop_propagation();
-                                                        open_search_hit((title.clone(), path.clone()));
+                                                        open_search_hit((title.clone(), location.clone()));
                                                     }
                                                 },
                                                 svg { class: "w-5 h-5", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
@@ -1256,6 +1161,26 @@ pub fn Library(
     }
 }
 
+#[component]
+pub fn LibraryHome() -> Element {
+    rsx! { Library { source: None, tab: None, location: None } }
+}
+
+#[component]
+pub fn LibrarySource(source: String) -> Element {
+    rsx! { Library { source: Some(source), tab: None, location: None } }
+}
+
+#[component]
+pub fn LibraryView(source: String, view: String) -> Element {
+    rsx! { Library { source: Some(source), tab: Some(view), location: None } }
+}
+
+#[component]
+pub fn LibraryLocation(source: String, view: String, location: String) -> Element {
+    rsx! { Library { source: Some(source), tab: Some(view), location: Some(location) } }
+}
+
 fn empty_state_heading(tab: Tab) -> &'static str {
     match tab {
         Tab::Browse => "Nothing here yet",
@@ -1279,9 +1204,9 @@ fn empty_state_body(tab: Tab) -> &'static str {
 /// Per-level layout follows the design brief's "art-first, list otherwise"
 /// split: a page made mostly of playable leaves (tracks/albums, `ref` set)
 /// renders as an artwork-forward grid; a page made mostly of folders
-/// (`path` set, no `ref`) renders as compact navigable rows. `CollectionItem`
-/// has no artwork field yet (that's the sibling companion issue, #549) so
-/// the grid tile falls back to a text placeholder until it does.
+/// (`location` set, no `ref`) renders as compact navigable rows. `CollectionItem`
+/// carries artwork when a provider has it; the grid tile falls back to a
+/// text placeholder for rows without art.
 #[component]
 fn LibraryRows(
     items: Vec<CollectionItem>,
@@ -1298,7 +1223,7 @@ fn LibraryRows(
             ul { class: "library-grid",
                 for (index , item) in items.iter().cloned().enumerate() {
                     LibraryTile {
-                        key: "{item.title}-{item.path.clone().unwrap_or_default()}-{item.item_ref.clone().unwrap_or_default()}",
+                        key: "{item.title}-{item.location.clone().unwrap_or_default()}-{item.item_ref.clone().unwrap_or_default()}",
                         item: item,
                         index: index,
                         tab: tab,
@@ -1314,7 +1239,7 @@ fn LibraryRows(
             ul { class: "library-list",
                 for (index , item) in items.iter().cloned().enumerate() {
                     LibraryRow {
-                        key: "{item.title}-{item.path.clone().unwrap_or_default()}-{item.item_ref.clone().unwrap_or_default()}",
+                        key: "{item.title}-{item.location.clone().unwrap_or_default()}-{item.item_ref.clone().unwrap_or_default()}",
                         item: item,
                         index: index,
                         tab: tab,
@@ -1350,11 +1275,11 @@ fn LibraryRow(
             // buttons stop propagation so their own actions stay separate
             // hit areas.
             onclick: {
-                let path = item.path.clone();
+                let location = item.location.clone();
                 let title = item.title.clone();
                 move |_| {
-                    if let Some(path) = path.clone() {
-                        on_open((title.clone(), path.clone()));
+                    if let Some(location) = location.clone() {
+                        on_open((title.clone(), location.clone()));
                     }
                 }
             },
@@ -1440,19 +1365,19 @@ fn LibraryRow(
                         }
                     }
                 }
-                if let Some(path) = item.path.clone() {
+                if let Some(location) = item.location.clone() {
                     button {
                         class: "library-chevron-btn",
                         aria_label: "Open {item.title}",
                         r#type: "button",
                         onclick: {
                             let title = item.title.clone();
-                            let path = path.clone();
+                            let location = location.clone();
                             // stop_propagation so the row's own click
                             // handler (same navigation) doesn't fire twice.
                             move |evt: Event<MouseData>| {
                                 evt.stop_propagation();
-                                on_open((title.clone(), path.clone()));
+                                on_open((title.clone(), location.clone()));
                             }
                         },
                         svg { class: "w-5 h-5", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
@@ -1476,7 +1401,7 @@ fn LibraryTile(
 ) -> Element {
     let stagger_style = format!("--library-stagger-index: {index};");
     let has_ref = item.item_ref.is_some();
-    let has_path = item.path.is_some();
+    let has_location = item.location.is_some();
 
     rsx! {
         li {
@@ -1486,11 +1411,11 @@ fn LibraryTile(
             // subtitle alike), not just the art block -- the play button
             // below stops propagation to stay its own hit area.
             onclick: {
-                let path = item.path.clone();
+                let location = item.location.clone();
                 let title = item.title.clone();
                 move |_| {
-                    if let Some(path) = path.clone() {
-                        on_open((title.clone(), path.clone()));
+                    if let Some(location) = location.clone() {
+                        on_open((title.clone(), location.clone()));
                     }
                 }
             },
@@ -1531,7 +1456,7 @@ fn LibraryTile(
                         "▶"
                     }
                 }
-                if has_path {
+                if has_location {
                     span { class: "library-tile-chevron",
                         svg { class: "w-4 h-4", fill: "none", view_box: "0 0 24 24", stroke: "currentColor", "stroke-width": "2",
                             path { "stroke-linecap": "round", "stroke-linejoin": "round", d: "M9 5l7 7-7 7" }
@@ -1688,19 +1613,6 @@ mod loop_regression_tests {
 #[cfg(test)]
 mod library_defect_pins {
     use super::*;
-
-    #[test]
-    fn roon_session_rejection_is_classified_for_recovery() {
-        assert!(is_expired_roon_browse(
-            "Roon Core rejected the item key: it is no longer valid in this browse session",
-            Some("roon")
-        ));
-        assert!(!is_expired_roon_browse("connection refused", Some("roon")));
-        assert!(!is_expired_roon_browse(
-            "Roon Core rejected the item key: it is no longer valid in this browse session",
-            Some("lms")
-        ));
-    }
 
     /// Defect 2 pin: the API's `image` field is the complete `<img src>`
     /// value. It must be used verbatim -- prefixing it again

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -317,6 +317,16 @@ struct LevelError {
     unreachable: bool,
 }
 
+/// Roon browse item keys belong to a Core-side session. A Core reconnect can
+/// invalidate that session while UHC is still running, leaving a bookmarked
+/// or already-open library URL pointing at keys Roon will reject. Keep that
+/// provider detail out of the UI; the page can return to a fresh root instead.
+fn is_expired_roon_browse(message: &str, source: Option<&str>) -> bool {
+    source == Some("roon")
+        && (message.contains("no longer valid in this browse session")
+            || message.contains("InvalidItemKey"))
+}
+
 /// Fetch one page of the current level and apply it.
 #[allow(clippy::too_many_arguments)]
 async fn load_page(
@@ -964,12 +974,15 @@ pub fn Library(
             }
         }
     } else if let Some(level_error) = current_error.clone() {
-        let retry_source = current_source.clone();
+        let roon_session_expired =
+            is_expired_roon_browse(&level_error.message, current_source.as_deref());
         // #573 visual pass V3: unreachability copy is reserved for actual
         // network failures; a genuine refusal (a capability gap, an expired
         // path) renders its own reason instead of claiming the provider is
         // down.
-        let heading = if level_error.unreachable {
+        let heading = if roon_session_expired {
+            "Roon refreshed; this browse page expired.".to_string()
+        } else if level_error.unreachable {
             format!(
                 "{} isn't reachable right now.",
                 source_label(current_source.as_deref().unwrap_or("this source"))
@@ -977,18 +990,22 @@ pub fn Library(
         } else {
             "This view isn't available.".to_string()
         };
+        let detail = if roon_session_expired {
+            "Your library connection changed, so we’ll reload this from the beginning.".to_string()
+        } else {
+            level_error.message.clone()
+        };
         rsx! {
             div { class: "library-provider-down",
                 p { "{heading}" }
-                p { class: "text-sm text-muted", "{level_error.message}" }
+                p { class: "text-sm text-muted", "{detail}" }
                 button {
                     class: "btn btn-outline",
                     r#type: "button",
                     onclick: move |_| {
-                        let _ = retry_source.clone();
                         refresh(false);
                     },
-                    "Retry"
+                    if roon_session_expired { "Refresh library" } else { "Retry" }
                 }
             }
         }
@@ -1671,6 +1688,19 @@ mod loop_regression_tests {
 #[cfg(test)]
 mod library_defect_pins {
     use super::*;
+
+    #[test]
+    fn roon_session_rejection_is_classified_for_recovery() {
+        assert!(is_expired_roon_browse(
+            "Roon Core rejected the item key: it is no longer valid in this browse session",
+            Some("roon")
+        ));
+        assert!(!is_expired_roon_browse("connection refused", Some("roon")));
+        assert!(!is_expired_roon_browse(
+            "Roon Core rejected the item key: it is no longer valid in this browse session",
+            Some("lms")
+        ));
+    }
 
     /// Defect 2 pin: the API's `image` field is the complete `<img src>`
     /// value. It must be used verbatim -- prefixing it again

--- a/src/app/pages/mod.rs
+++ b/src/app/pages/mod.rs
@@ -12,7 +12,7 @@ mod zones;
 
 pub use hqplayer::HqPlayer;
 pub use knobs::Knobs;
-pub use library::Library;
+pub use library::{LibraryHome, LibraryLocation, LibrarySource, LibraryView};
 pub use lms::Lms;
 pub use settings::Settings;
 pub use spotify::Spotify;

--- a/src/app/pages/zones.rs
+++ b/src/app/pages/zones.rs
@@ -506,16 +506,17 @@ fn ZoneCard(
             // actually implements this zone's provider -- so LMS and Roon
             // zones light up as their slices land without a web change.
             if zone.browse_supported {
-                div { class: "mt-3 border-t border-subtle pt-3",
-                    Link {
-                        class: "btn btn-ghost text-sm",
-                        to: Route::Library {
-                            source: zone.source.clone(),
-                            tab: None,
-                            path: None,
-                            zone: Some(zone.zone_id.clone()),
-                        },
-                        "Browse →"
+                if let Some(source) = zone.source.clone() {
+                    div { class: "mt-3 border-t border-subtle pt-3",
+                        Link {
+                            class: "btn btn-ghost text-sm",
+                            onclick: {
+                                let zone_id = zone.zone_id.clone();
+                                move |_| super::library::save_last_zone(&zone_id)
+                            },
+                            to: Route::LibrarySource { source },
+                            "Browse →"
+                        }
                     }
                 }
             }

--- a/src/mcp/collection_locations.rs
+++ b/src/mcp/collection_locations.rs
@@ -1,14 +1,29 @@
 //! Durable, provider-private collection locations used by canonical Library URLs.
+//!
+//! Two layers live here, with deliberately different lifetimes:
+//!
+//! - [`CollectionLocationStore`] is the durable, append-only token -> location
+//!   map behind every canonical `/library/<source>/<view>/loc_…` URL. It
+//!   survives restarts and provider sessions.
+//! - [`LocationKeyCache`] is the opposite: a small, bounded, in-process cache
+//!   from one of those tokens to the provider-session-scoped key pair
+//!   (`session_key`, `item_key`) that last served it. It exists so the steady
+//!   state of ordinary browsing -- every level, and every "Load more" page --
+//!   costs one provider browse instead of a full re-walk of the saved trail.
+//!   It is a cache, never a source of truth: it is populated for free when a
+//!   token is minted, re-populated after each re-walk, and dropped entirely on
+//!   restart, so the first request per location after a restart re-walks once
+//!   and every later one is cheap again.
 
 use anyhow::{Context, Result};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
 const LOCATION_FILE: &str = "collection-locations.jsonl";
 
@@ -244,6 +259,89 @@ impl CollectionLocationStore {
     }
 }
 
+/// How many location tokens [`LocationKeyCache`] remembers before it starts
+/// dropping the oldest. Browsing touches one token per level and reuses it for
+/// every page of that level, so a few thousand entries covers a very long
+/// session while keeping the memory cost trivial.
+const LOCATION_KEY_CACHE_CAPACITY: usize = 4096;
+
+/// Bounded in-process map from a durable location token to the
+/// provider-session-scoped `(session_key, item_key)` pair that last served it.
+///
+/// # Why a cache and not a second store
+///
+/// A location token is durable; the key pair behind it is not. Roon item keys
+/// only mean anything inside the Core-side browse session that minted them, so
+/// this pair can go stale at any moment (Core reconnect, session reset,
+/// process restart on the Core side) with no event this process can observe.
+/// That is exactly what makes a cache the right shape: the pair is *tried*,
+/// and the recoverable rejection that comes back when it has gone stale is the
+/// signal to evict it and re-walk the saved trail. Nothing here has to be
+/// correct for the system to be correct -- only useful.
+///
+/// Eviction is by insertion order (oldest first) rather than by access recency:
+/// the pairs are cheap to reconstruct and the capacity is far larger than any
+/// realistic working set, so the extra bookkeeping of an LRU would buy nothing.
+#[derive(Debug, Default)]
+pub struct LocationKeyCache {
+    inner: Mutex<LocationKeyCacheInner>,
+}
+
+#[derive(Debug, Default)]
+struct LocationKeyCacheInner {
+    keys: HashMap<String, (String, String)>,
+    order: VecDeque<String>,
+}
+
+impl LocationKeyCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The `(session_key, item_key)` last seen for this token, if any. A miss
+    /// is ordinary: it means "re-walk the trail", not "something is wrong".
+    pub fn get(&self, token: &str) -> Option<(String, String)> {
+        self.lock().keys.get(token).cloned()
+    }
+
+    /// Remember the pair currently serving `token`, evicting the oldest entry
+    /// when the cache is full. Re-inserting a known token refreshes its pair
+    /// without moving it in the eviction order.
+    pub fn insert(
+        &self,
+        token: impl Into<String>,
+        session_key: impl Into<String>,
+        item_key: impl Into<String>,
+    ) {
+        let token = token.into();
+        let pair = (session_key.into(), item_key.into());
+        let mut inner = self.lock();
+        if inner.keys.insert(token.clone(), pair).is_none() {
+            inner.order.push_back(token);
+            while inner.order.len() > LOCATION_KEY_CACHE_CAPACITY {
+                if let Some(oldest) = inner.order.pop_front() {
+                    inner.keys.remove(&oldest);
+                }
+            }
+        }
+    }
+
+    /// Forget this token's pair -- called when the provider rejects it, so the
+    /// next request re-walks instead of retrying a key known to be dead.
+    pub fn evict(&self, token: &str) {
+        let mut inner = self.lock();
+        if inner.keys.remove(token).is_some() {
+            inner.order.retain(|entry| entry != token);
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, LocationKeyCacheInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
 fn location_token(target: &CollectionLocation) -> Result<String> {
     let bytes = serde_json::to_vec(target).context("serialize collection location")?;
     let digest = Sha256::digest(bytes);
@@ -288,7 +386,7 @@ fn append_location(path: &Path, entry: &StoredLocation) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CollectionLocation, CollectionLocationStore, CollectionStep};
+    use super::{CollectionLocation, CollectionLocationStore, CollectionStep, LocationKeyCache};
 
     fn lms_album() -> CollectionLocation {
         CollectionLocation::Lms {
@@ -352,5 +450,69 @@ mod tests {
 
         let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn location_key_cache_returns_what_was_inserted_and_nothing_else() {
+        let cache = LocationKeyCache::new();
+        cache.insert("loc_a", "session_1", "item_1");
+
+        assert_eq!(
+            cache.get("loc_a"),
+            Some(("session_1".to_string(), "item_1".to_string()))
+        );
+        assert_eq!(cache.get("loc_b"), None);
+    }
+
+    #[test]
+    fn re_inserting_a_token_replaces_its_pair() {
+        let cache = LocationKeyCache::new();
+        cache.insert("loc_a", "session_1", "item_1");
+        cache.insert("loc_a", "session_2", "item_2");
+
+        assert_eq!(
+            cache.get("loc_a"),
+            Some(("session_2".to_string(), "item_2".to_string()))
+        );
+    }
+
+    #[test]
+    fn evicting_a_token_forces_the_next_request_to_re_walk() {
+        let cache = LocationKeyCache::new();
+        cache.insert("loc_a", "session_1", "item_1");
+        cache.evict("loc_a");
+
+        assert_eq!(cache.get("loc_a"), None);
+        // Evicting an unknown token is a no-op, not a panic.
+        cache.evict("loc_missing");
+    }
+
+    #[test]
+    fn the_cache_is_capacity_bounded_and_drops_the_oldest_first() {
+        let cache = LocationKeyCache::new();
+        for index in 0..super::LOCATION_KEY_CACHE_CAPACITY + 10 {
+            cache.insert(format!("loc_{index}"), "session", format!("item_{index}"));
+        }
+
+        assert_eq!(cache.lock().keys.len(), super::LOCATION_KEY_CACHE_CAPACITY);
+        assert_eq!(cache.lock().order.len(), super::LOCATION_KEY_CACHE_CAPACITY);
+        assert_eq!(cache.get("loc_0"), None, "oldest entry must be evicted");
+        assert_eq!(cache.get("loc_9"), None);
+        assert!(cache.get("loc_10").is_some(), "newer entries must survive");
+        assert!(cache
+            .get(&format!("loc_{}", super::LOCATION_KEY_CACHE_CAPACITY + 9))
+            .is_some());
+    }
+
+    /// Re-inserting a known token must not grow the eviction queue, or a page
+    /// refreshed often enough would evict live entries for no reason.
+    #[test]
+    fn refreshing_a_known_token_does_not_grow_the_eviction_queue() {
+        let cache = LocationKeyCache::new();
+        for _ in 0..10 {
+            cache.insert("loc_a", "session", "item");
+        }
+
+        assert_eq!(cache.lock().order.len(), 1);
     }
 }

--- a/src/mcp/collection_locations.rs
+++ b/src/mcp/collection_locations.rs
@@ -1,0 +1,356 @@
+//! Durable, provider-private collection locations used by canonical Library URLs.
+
+use anyhow::{Context, Result};
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+const LOCATION_FILE: &str = "collection-locations.jsonl";
+
+/// One human-visible step in a collection walk. `provider_path` never leaves
+/// the server; Roon uses `subtitle` + `position` to safely find the equivalent
+/// row in a fresh Core browse session.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CollectionStep {
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subtitle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<u32>,
+    #[serde(default = "visible_breadcrumb")]
+    pub breadcrumb: bool,
+}
+
+const fn visible_breadcrumb() -> bool {
+    true
+}
+
+impl CollectionStep {
+    pub fn new(title: impl Into<String>, provider_path: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            subtitle: None,
+            provider_path: Some(provider_path.into()),
+            position: None,
+            breadcrumb: true,
+        }
+    }
+
+    pub fn roon(title: impl Into<String>, subtitle: Option<String>, position: Option<u32>) -> Self {
+        Self {
+            title: title.into(),
+            subtitle,
+            provider_path: None,
+            position,
+            breadcrumb: true,
+        }
+    }
+
+    pub fn hidden_roon(title: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            subtitle: None,
+            provider_path: None,
+            position: None,
+            breadcrumb: false,
+        }
+    }
+}
+
+/// Provider-specific resolution material behind one provider-neutral URL
+/// token. The enum is persisted, but never serialized into a client response.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "provider", rename_all = "snake_case")]
+pub enum CollectionLocation {
+    Roon {
+        origin: RoonLocationOrigin,
+        steps: Vec<CollectionStep>,
+    },
+    Lms {
+        steps: Vec<CollectionStep>,
+    },
+    #[serde(rename = "musicassistant")]
+    MusicAssistant {
+        steps: Vec<CollectionStep>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RoonLocationOrigin {
+    BrowseRoot,
+    Search {
+        query: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
+}
+
+impl CollectionLocation {
+    pub fn provider(&self) -> &'static str {
+        match self {
+            Self::Roon { .. } => "roon",
+            Self::Lms { .. } => "lms",
+            Self::MusicAssistant { .. } => "musicassistant",
+        }
+    }
+
+    pub fn steps(&self) -> &[CollectionStep] {
+        match self {
+            Self::Roon { steps, .. } | Self::Lms { steps } | Self::MusicAssistant { steps } => {
+                steps
+            }
+        }
+    }
+
+    pub fn with_steps(&self, steps: Vec<CollectionStep>) -> Self {
+        match self {
+            Self::Roon { origin, .. } => Self::Roon {
+                origin: origin.clone(),
+                steps,
+            },
+            Self::Lms { .. } => Self::Lms { steps },
+            Self::MusicAssistant { .. } => Self::MusicAssistant { steps },
+        }
+    }
+
+    pub fn appended(&self, step: CollectionStep) -> Self {
+        let mut steps = self.steps().to_vec();
+        steps.push(step);
+        self.with_steps(steps)
+    }
+
+    pub fn last_provider_path(&self) -> Option<&str> {
+        self.steps().last()?.provider_path.as_deref()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct CollectionBreadcrumb {
+    pub title: String,
+    pub location: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct StoredLocation {
+    token: String,
+    target: CollectionLocation,
+}
+
+#[derive(Debug)]
+struct StoreInner {
+    path: PathBuf,
+    locations: RwLock<HashMap<String, CollectionLocation>>,
+}
+
+/// Append-only durable map from short URL tokens to provider-private browse
+/// identity. Clone is cheap because every request shares one in-process map.
+#[derive(Clone, Debug)]
+pub struct CollectionLocationStore {
+    inner: Arc<StoreInner>,
+}
+
+impl Default for CollectionLocationStore {
+    fn default() -> Self {
+        Self::at(crate::config::get_config_file_path(LOCATION_FILE))
+    }
+}
+
+impl CollectionLocationStore {
+    pub fn at(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let mut locations = HashMap::new();
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            for (index, line) in contents.lines().enumerate() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<StoredLocation>(line) {
+                    Ok(entry) => {
+                        locations.entry(entry.token).or_insert(entry.target);
+                    }
+                    Err(error) => tracing::warn!(
+                        path = %path.display(),
+                        line = index + 1,
+                        %error,
+                        "ignoring invalid collection-location journal entry"
+                    ),
+                }
+            }
+        }
+        Self {
+            inner: Arc::new(StoreInner {
+                path,
+                locations: RwLock::new(locations),
+            }),
+        }
+    }
+
+    pub fn mint(&self, target: CollectionLocation) -> Result<String> {
+        let token = location_token(&target)?;
+        let mut locations = self
+            .inner
+            .locations
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(existing) = locations.get(&token) {
+            anyhow::ensure!(
+                existing == &target,
+                "collection location token collision for {token}"
+            );
+            return Ok(token);
+        }
+
+        append_location(
+            &self.inner.path,
+            &StoredLocation {
+                token: token.clone(),
+                target: target.clone(),
+            },
+        )?;
+        locations.insert(token.clone(), target);
+        Ok(token)
+    }
+
+    pub fn resolve(&self, token: &str) -> Option<CollectionLocation> {
+        self.inner
+            .locations
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(token)
+            .cloned()
+    }
+
+    pub fn breadcrumbs(&self, target: &CollectionLocation) -> Result<Vec<CollectionBreadcrumb>> {
+        let mut breadcrumbs = Vec::with_capacity(target.steps().len());
+        for end in 1..=target.steps().len() {
+            if !target.steps()[end - 1].breadcrumb {
+                continue;
+            }
+            let prefix = target.with_steps(target.steps()[..end].to_vec());
+            breadcrumbs.push(CollectionBreadcrumb {
+                title: target.steps()[end - 1].title.clone(),
+                location: self.mint(prefix)?,
+            });
+        }
+        Ok(breadcrumbs)
+    }
+}
+
+fn location_token(target: &CollectionLocation) -> Result<String> {
+    let bytes = serde_json::to_vec(target).context("serialize collection location")?;
+    let digest = Sha256::digest(bytes);
+    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&digest[..16]);
+    Ok(format!("loc_{encoded}"))
+}
+
+fn append_location(path: &Path, entry: &StoredLocation) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!("create collection location directory {}", parent.display())
+        })?;
+    }
+
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("open collection location journal {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .with_context(|| {
+                format!(
+                    "restrict collection location journal permissions {}",
+                    path.display()
+                )
+            })?;
+    }
+    serde_json::to_writer(&mut file, entry)
+        .context("serialize collection location journal entry")?;
+    file.write_all(b"\n")
+        .context("append collection location journal entry")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CollectionLocation, CollectionLocationStore, CollectionStep};
+
+    fn lms_album() -> CollectionLocation {
+        CollectionLocation::Lms {
+            steps: vec![
+                CollectionStep::new("Albums", "albums"),
+                CollectionStep::new("Ambient 1", "album:42"),
+            ],
+        }
+    }
+
+    #[test]
+    fn location_tokens_are_short_deterministic_and_provider_private() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = CollectionLocationStore::at(directory.path().join("locations.jsonl"));
+
+        let first = store.mint(lms_album()).unwrap();
+        let second = store.mint(lms_album()).unwrap();
+
+        assert_eq!(first, second);
+        assert!(first.starts_with("loc_"));
+        assert!(first.len() <= 27, "canonical URL token grew: {first}");
+        assert!(!first.contains("album"));
+        assert!(!first.contains("Ambient"));
+    }
+
+    #[test]
+    fn locations_survive_a_new_store_instance() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("locations.jsonl");
+        let token = CollectionLocationStore::at(path.clone())
+            .mint(lms_album())
+            .unwrap();
+
+        let restarted = CollectionLocationStore::at(path);
+        assert_eq!(restarted.resolve(&token), Some(lms_album()));
+    }
+
+    #[test]
+    fn breadcrumb_locations_are_minted_for_every_prefix() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = CollectionLocationStore::at(directory.path().join("locations.jsonl"));
+
+        let breadcrumbs = store.breadcrumbs(&lms_album()).unwrap();
+
+        assert_eq!(breadcrumbs.len(), 2);
+        assert_eq!(breadcrumbs[0].title, "Albums");
+        assert_eq!(breadcrumbs[1].title, "Ambient 1");
+        assert_ne!(breadcrumbs[0].location, breadcrumbs[1].location);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn location_journal_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("locations.jsonl");
+        CollectionLocationStore::at(path.clone())
+            .mint(lms_album())
+            .unwrap();
+
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -34,6 +34,7 @@
 //! ```
 
 pub mod capabilities;
+pub mod collection_locations;
 pub mod envelope;
 pub mod feedback;
 pub mod handler;

--- a/src/mcp/refs.rs
+++ b/src/mcp/refs.rs
@@ -177,6 +177,7 @@ pub enum RefTarget {
     MusicAssistantBrowse {
         path: String,
         title: String,
+        location: crate::mcp::collection_locations::CollectionLocation,
     },
     /// An LMS browse continuation (#531): a server-side collection path
     /// (`"albums"`, `"album:<id>"`, ...), never a raw entity id handed to a
@@ -185,6 +186,7 @@ pub enum RefTarget {
     LmsBrowse {
         path: String,
         title: String,
+        location: crate::mcp::collection_locations::CollectionLocation,
     },
     /// A Roon browse continuation (#531): the `item_key` **and**
     /// `multi_session_key` a collection list was loaded under, so resuming it
@@ -194,6 +196,7 @@ pub enum RefTarget {
     RoonBrowse {
         target: RoonRefTarget,
         title: String,
+        location: crate::mcp::collection_locations::CollectionLocation,
     },
     /// An Apple Music catalog/library identifier resolved by the paired native
     /// companion. Clients only receive the opaque token.

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -1,8 +1,10 @@
 //! Provider-neutral read-only library collections.
 //!
-//! The wire contract deliberately speaks only of collections, paths, pages and
-//! opaque playable refs. Provider adapters translate those concepts to their
-//! native library APIs; no provider URI or identifier is returned to a client.
+//! The wire contract deliberately speaks only of collections, locations,
+//! pages, and opaque refs. Provider adapters translate those concepts to
+//! their native library APIs; no provider URI or identifier is returned to a
+//! client. `location` is durable canonical identity; legacy `path` refs remain
+//! short-lived MCP continuations.
 //!
 //! # #531: per-provider slices, not one blanket gate
 //!
@@ -18,8 +20,12 @@
 //! honestly: reachable through their own provider tools today, not yet wired
 //! to this one. See #531's PR body for what remains.
 
+use crate::adapters::roon::RoonBrowseError;
 use crate::api::AppState;
 use crate::mcp::capabilities::{support, Capability, Support};
+use crate::mcp::collection_locations::{
+    CollectionBreadcrumb, CollectionLocation, CollectionStep, RoonLocationOrigin,
+};
 use crate::mcp::envelope::{Envelope, Refusal, Scope};
 use crate::mcp::refs::{RefTarget, RoonRefTarget};
 use crate::mcp::routing::{LibraryRoute, ZoneTarget};
@@ -86,7 +92,7 @@ pub fn collections_tabs_for_zone(zone_id: &str) -> Vec<&'static str> {
 
 #[mcp_tool(
     name = "hifi_collections",
-    description = "Alpha capability: expect refinement across releases. Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection. Implemented for lms and roon zones; Music Assistant zones (see hifi_queue's provider notes); Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one."
+    description = "Alpha capability: expect refinement across releases. Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset. Navigable entries include a durable opaque location for canonical navigation and a short-lived path for MCP continuation; playable entries include a short-lived opaque ref for hifi_play_ref. Send location or path, never both. Implemented for Roon, LMS, and Music Assistant zones. Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one."
 )]
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct HifiCollectionsTool {
@@ -94,9 +100,12 @@ pub struct HifiCollectionsTool {
     pub zone_id: String,
     /// browse, playlists, or favorites.
     pub action: String,
-    /// Opaque collection path returned by a preceding browse call.
+    /// Short-lived collection continuation returned by a preceding browse call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    /// Durable provider-neutral collection location returned by a preceding browse call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
     /// Media type when listing favorites (tracks by default).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub media_type: Option<String>,
@@ -115,6 +124,8 @@ struct CollectionItem {
     subtitle: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    location: Option<String>,
     #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
     r#ref: Option<String>,
     /// Artwork URL (#549), present only when the provider has art for this
@@ -153,6 +164,7 @@ pub(crate) async fn mint_image(
 #[derive(Debug, Serialize)]
 struct CollectionPage {
     items: Vec<CollectionItem>,
+    breadcrumbs: Vec<CollectionBreadcrumb>,
     #[serde(skip_serializing_if = "Option::is_none")]
     next_offset: Option<u32>,
 }
@@ -177,6 +189,7 @@ pub async fn handle_collections(
         .param("zone_id", &*args.zone_id)
         .param("action", &*args.action)
         .param_opt("path", args.path.as_deref())
+        .param_opt("location", args.location.as_deref())
         .param_opt("media_type", args.media_type.as_deref())
         .param_opt("limit", args.limit)
         .param_opt("offset", args.offset)
@@ -184,6 +197,17 @@ pub async fn handle_collections(
     let route = target.for_library();
     if let LibraryRoute::Refused(_) = route {
         return env.failed("This zone has no library path");
+    }
+
+    if args.path.is_some() && args.location.is_some() {
+        return env.refused(
+            "path and location cannot be used together.",
+            Refusal::invalid_parameter(
+                "location",
+                &["a durable location without path"],
+                "Use location for canonical Library navigation or path for a short-lived MCP continuation, not both.",
+            ),
+        );
     }
 
     // A `path`'s provider-boundary check runs before anything else,
@@ -200,6 +224,19 @@ pub async fn handle_collections(
             }
             None => return refuse_unknown_path(env),
             Some(_) => {}
+        }
+    }
+    if let Some(token) = args.location.as_deref() {
+        let Some(location) = state.collection_locations.resolve(token) else {
+            return refuse_unknown_location(env);
+        };
+        if !matches!(
+            (location.provider(), target),
+            ("roon", ZoneTarget::Roon)
+                | ("lms", ZoneTarget::Lms)
+                | ("musicassistant", ZoneTarget::MusicAssistant)
+        ) {
+            return refuse_foreign_location(env);
         }
     }
 
@@ -312,14 +349,21 @@ async fn handle_music_assistant(
     // Browse paths are server-side refs, just like playable media refs. MA's
     // native `library://…` paths contain provider implementation details and
     // must not become MCP client input.
-    let provider_path = match args.path.as_deref() {
-        None => None,
-        Some(token) => match state.mcp_refs.resolve(token).await {
-            Some(RefTarget::MusicAssistantBrowse { path, .. }) => Some(path),
+    let parent_location = match (args.location.as_deref(), args.path.as_deref()) {
+        (Some(token), None) => match state.collection_locations.resolve(token) {
+            Some(location @ CollectionLocation::MusicAssistant { .. }) => location,
+            Some(_) => return refuse_foreign_location(env),
+            None => return refuse_unknown_location(env),
+        },
+        (None, Some(token)) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::MusicAssistantBrowse { location, .. }) => location,
             Some(_) => return refuse_foreign_path(env),
             None => return refuse_unknown_path(env),
         },
+        (None, None) => CollectionLocation::MusicAssistant { steps: Vec::new() },
+        (Some(_), Some(_)) => unreachable!("path/location exclusivity checked by caller"),
     };
+    let provider_path = parent_location.last_provider_path();
     let operation = format!("collections_{}", args.action);
     let response = match state
         .adapter_registry
@@ -359,17 +403,29 @@ async fn handle_music_assistant(
             .get("subtitle")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
-        let path = match item.get("path").and_then(Value::as_str) {
-            Some(path) => Some(
-                state
+        let (path, location) = match item.get("path").and_then(Value::as_str) {
+            Some(provider_path) => {
+                let target =
+                    parent_location.appended(CollectionStep::new(title.clone(), provider_path));
+                let location = match state.collection_locations.mint(target.clone()) {
+                    Ok(token) => token,
+                    Err(error) => {
+                        return env.failed(format!(
+                            "Collection error: could not preserve location: {error:#}"
+                        ))
+                    }
+                };
+                let path = state
                     .mcp_refs
                     .mint(RefTarget::MusicAssistantBrowse {
-                        path: path.to_string(),
+                        path: provider_path.to_string(),
                         title: title.clone(),
+                        location: target,
                     })
-                    .await,
-            ),
-            None => None,
+                    .await;
+                (Some(path), Some(location))
+            }
+            None => (None, None),
         };
         let r#ref = match item.get("uri").and_then(Value::as_str) {
             Some(uri) => Some(
@@ -393,11 +449,24 @@ async fn handle_music_assistant(
             title,
             subtitle,
             path,
+            location,
             r#ref,
             image,
         });
     }
-    Ok(env.json_result(&CollectionPage { items, next_offset }))
+    let breadcrumbs = match state.collection_locations.breadcrumbs(&parent_location) {
+        Ok(breadcrumbs) => breadcrumbs,
+        Err(error) => {
+            return env.failed(format!(
+                "Collection error: could not preserve breadcrumbs: {error:#}"
+            ))
+        }
+    };
+    Ok(env.json_result(&CollectionPage {
+        items,
+        breadcrumbs,
+        next_offset,
+    }))
 }
 
 // =============================================================================
@@ -415,14 +484,21 @@ async fn handle_lms(
     // Same opaque-path split as Music Assistant: the plain collection path
     // this adapter invents ("albums", "album:<id>", ...) never becomes
     // client-visible; only the ref token is.
-    let provider_path = match args.path.as_deref() {
-        None => None,
-        Some(token) => match state.mcp_refs.resolve(token).await {
-            Some(RefTarget::LmsBrowse { path, .. }) => Some(path),
+    let parent_location = match (args.location.as_deref(), args.path.as_deref()) {
+        (Some(token), None) => match state.collection_locations.resolve(token) {
+            Some(location @ CollectionLocation::Lms { .. }) => location,
+            Some(_) => return refuse_foreign_location(env),
+            None => return refuse_unknown_location(env),
+        },
+        (None, Some(token)) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::LmsBrowse { location, .. }) => location,
             Some(_) => return refuse_foreign_path(env),
             None => return refuse_unknown_path(env),
         },
+        (None, None) => CollectionLocation::Lms { steps: Vec::new() },
+        (Some(_), Some(_)) => unreachable!("path/location exclusivity checked by caller"),
     };
+    let provider_path = parent_location.last_provider_path();
     let operation = format!("collections_{}", args.action);
     let response = match state
         .adapter_registry
@@ -466,17 +542,29 @@ async fn handle_lms(
         // `LmsPlayTarget::Library`) or `url` (a favorite, which LMS gives no
         // durable id for -- `LmsPlayTarget::Url`). At most one of the three
         // is ever present on one row.
-        let path = match item.get("path").and_then(Value::as_str) {
-            Some(path) => Some(
-                state
+        let (path, location) = match item.get("path").and_then(Value::as_str) {
+            Some(provider_path) => {
+                let target =
+                    parent_location.appended(CollectionStep::new(title.clone(), provider_path));
+                let location = match state.collection_locations.mint(target.clone()) {
+                    Ok(token) => token,
+                    Err(error) => {
+                        return env.failed(format!(
+                            "Collection error: could not preserve location: {error:#}"
+                        ))
+                    }
+                };
+                let path = state
                     .mcp_refs
                     .mint(RefTarget::LmsBrowse {
-                        path: path.to_string(),
+                        path: provider_path.to_string(),
                         title: title.clone(),
+                        location: target,
                     })
-                    .await,
-            ),
-            None => None,
+                    .await;
+                (Some(path), Some(location))
+            }
+            None => (None, None),
         };
         let r#ref = match (
             item.get("kind").and_then(Value::as_str),
@@ -518,11 +606,24 @@ async fn handle_lms(
             title,
             subtitle,
             path,
+            location,
             r#ref,
             image,
         });
     }
-    Ok(env.json_result(&CollectionPage { items, next_offset }))
+    let breadcrumbs = match state.collection_locations.breadcrumbs(&parent_location) {
+        Ok(breadcrumbs) => breadcrumbs,
+        Err(error) => {
+            return env.failed(format!(
+                "Collection error: could not preserve breadcrumbs: {error:#}"
+            ))
+        }
+    };
+    Ok(env.json_result(&CollectionPage {
+        items,
+        breadcrumbs,
+        next_offset,
+    }))
 }
 
 // =============================================================================
@@ -540,13 +641,34 @@ async fn handle_roon(
     // Roon's continuation is a (item_key, multi_session_key) pair, not a flat
     // string -- resuming it must re-enter that exact session (same reasoning
     // as a playable Roon ref; see `RoonRefTarget`'s docs).
-    let resume = match args.path.as_deref() {
-        None => None,
-        Some(token) => match state.mcp_refs.resolve(token).await {
-            Some(RefTarget::RoonBrowse { target, .. }) => Some(target),
+    let (resume, parent_location) = match (args.location.as_deref(), args.path.as_deref()) {
+        (Some(token), None) => match state.collection_locations.resolve(token) {
+            Some(location @ CollectionLocation::Roon { .. }) => (None, location),
+            Some(_) => return refuse_foreign_location(env),
+            None => return refuse_unknown_location(env),
+        },
+        (None, Some(token)) => match state.mcp_refs.resolve(token).await {
+            Some(RefTarget::RoonBrowse {
+                target, location, ..
+            }) => (Some(target), location),
             Some(_) => return refuse_foreign_path(env),
             None => return refuse_unknown_path(env),
         },
+        (None, None) => {
+            let steps = if args.action == "playlists" {
+                vec![CollectionStep::hidden_roon("Playlists")]
+            } else {
+                Vec::new()
+            };
+            (
+                None,
+                CollectionLocation::Roon {
+                    origin: RoonLocationOrigin::BrowseRoot,
+                    steps,
+                },
+            )
+        }
+        (Some(_), Some(_)) => unreachable!("path/location exclusivity checked by caller"),
     };
 
     let mut params = json!({
@@ -554,7 +676,24 @@ async fn handle_roon(
         "limit": limit,
         "offset": offset,
     });
-    if let Some(RoonRefTarget {
+    if args.location.is_some() {
+        let (session_key, item_key) = match resolve_roon_location(
+            state,
+            &args.zone_id,
+            &parent_location,
+        )
+        .await
+        {
+            Ok(pair) => pair,
+            Err(error) => {
+                return env.failed(format!(
+                    "Collection error: this saved Roon location can no longer be resolved safely: {error:#}"
+                ))
+            }
+        };
+        params["item_key"] = json!(item_key);
+        params["session_key"] = json!(session_key);
+    } else if let Some(RoonRefTarget {
         item_key,
         multi_session_key,
         ..
@@ -566,23 +705,28 @@ async fn handle_roon(
     // #616: the trail this page hangs off. Children extend it by their own
     // title, so every ref minted below carries the full root-to-item walk
     // and can be re-resolved after its session is gone.
-    let parent_trail: Vec<String> = resume
-        .as_ref()
-        .map(|target| target.trail.clone())
-        .unwrap_or_default();
+    let parent_trail: Vec<String> = parent_location
+        .steps()
+        .iter()
+        .map(|step| step.title.clone())
+        .collect();
     // Roon has no separate playlists/favorites protocol feature: both arrive
     // as named nodes in the same browse hierarchy (see the capability
     // table's note on this). `favorites` never reaches here -- `support()`
     // reports it `not_implemented` for Roon and the shared check above
     // already refused it.
-    let operation = match args.action.as_str() {
-        "browse" => "collections_browse",
-        "playlists" => "collections_playlists",
-        other => {
-            return env.failed(format!(
-                "internal routing error: unexpected hifi_collections action {other:?} reached \
-                 Roon dispatch after the capability check. This is a UHC bug."
-            ))
+    let operation = if !parent_location.steps().is_empty() && args.location.is_some() {
+        "collections_browse"
+    } else {
+        match args.action.as_str() {
+            "browse" => "collections_browse",
+            "playlists" => "collections_playlists",
+            other => {
+                return env.failed(format!(
+                    "internal routing error: unexpected hifi_collections action {other:?} reached \
+                     Roon dispatch after the capability check. This is a UHC bug."
+                ))
+            }
         }
     };
     let response = match state
@@ -595,18 +739,25 @@ async fn handle_roon(
             if resume
                 .as_ref()
                 .is_some_and(|target| !target.trail.is_empty())
-                && (error
-                    .to_string()
-                    .contains("no longer valid in this browse session")
-                    || error.to_string().contains("InvalidItemKey")) =>
+                && RoonBrowseError::from_error(&error)
+                    .is_some_and(|rejection| rejection.kind.is_recoverable()) =>
         {
             // Roon item keys are scoped to a Core-side browse session. If the
             // Core reconnects, re-walk the saved breadcrumb trail and retry
             // the same node rather than making the user start at the root.
-            let target = resume.as_ref().expect("resume checked above");
-            let (session_key, item_key) = match state.roon.resolve_trail(&args.zone_id, &target.trail).await {
+            let (session_key, item_key) = match resolve_roon_location(
+                state,
+                &args.zone_id,
+                &parent_location,
+            )
+            .await
+            {
                 Ok(pair) => pair,
-                Err(_) => return env.failed("Collection error: Roon refreshed; this browse page expired. Refresh to continue."),
+                Err(error) => {
+                    return env.failed(format!(
+                        "Collection error: this saved Roon location can no longer be resolved safely: {error:#}"
+                    ))
+                }
             };
             params["item_key"] = json!(item_key);
             params["session_key"] = json!(session_key);
@@ -616,10 +767,10 @@ async fn handle_roon(
                 .await
             {
                 Ok(value) => value,
-                Err(_) => return env.failed("Collection error: Roon refreshed; this browse page expired. Refresh to continue."),
+                Err(error) => return env.failed(format!("Collection error: {error}")),
             }
         }
-        Err(_) => return env.failed("Collection error: Roon is unavailable right now. Try again."),
+        Err(error) => return env.failed(format!("Collection error: {error}")),
     };
 
     let Some(session_key) = response.get("session_key").and_then(Value::as_str) else {
@@ -659,8 +810,17 @@ async fn handle_roon(
             .get("playable")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let (path, r#ref) = match item_key {
-            None => (None, None),
+        let position = item
+            .get("position")
+            .and_then(Value::as_u64)
+            .map(|value| value as u32);
+        let child_location = parent_location.appended(CollectionStep::roon(
+            title.clone(),
+            subtitle.clone(),
+            position,
+        ));
+        let (path, location, r#ref) = match item_key {
+            None => (None, None, None),
             Some(item_key) => {
                 let mut trail = parent_trail.clone();
                 trail.push(title.clone());
@@ -676,9 +836,22 @@ async fn handle_roon(
                             .mint(RefTarget::RoonBrowse {
                                 target: target.clone(),
                                 title: title.clone(),
+                                location: child_location.clone(),
                             })
                             .await,
                     )
+                } else {
+                    None
+                };
+                let location = if navigable {
+                    match state.collection_locations.mint(child_location) {
+                        Ok(token) => Some(token),
+                        Err(error) => {
+                            return env.failed(format!(
+                                "Collection error: could not preserve location: {error:#}"
+                            ))
+                        }
+                    }
                 } else {
                     None
                 };
@@ -695,7 +868,7 @@ async fn handle_roon(
                 } else {
                     None
                 };
-                (path, r#ref)
+                (path, location, r#ref)
             }
         };
         let image = mint_image(
@@ -708,6 +881,7 @@ async fn handle_roon(
             title,
             subtitle,
             path,
+            location,
             r#ref,
             image,
         });
@@ -716,7 +890,46 @@ async fn handle_roon(
         .get("next_offset")
         .and_then(Value::as_u64)
         .map(|v| v as u32);
-    Ok(env.json_result(&CollectionPage { items, next_offset }))
+    let breadcrumbs = match state.collection_locations.breadcrumbs(&parent_location) {
+        Ok(breadcrumbs) => breadcrumbs,
+        Err(error) => {
+            return env.failed(format!(
+                "Collection error: could not preserve breadcrumbs: {error:#}"
+            ))
+        }
+    };
+    Ok(env.json_result(&CollectionPage {
+        items,
+        breadcrumbs,
+        next_offset,
+    }))
+}
+
+async fn resolve_roon_location(
+    state: &AppState,
+    zone_id: &str,
+    location: &CollectionLocation,
+) -> anyhow::Result<(String, String)> {
+    let resolved = state
+        .adapter_registry
+        .library_content(
+            "roon",
+            "collections_resolve_location",
+            &json!({
+                "zone_id": zone_id,
+                "location": location,
+            }),
+        )
+        .await?;
+    let session_key = resolved
+        .get("session_key")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("Roon adapter returned no session_key"))?;
+    let item_key = resolved
+        .get("item_key")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("Roon adapter returned no item_key"))?;
+    Ok((session_key.to_string(), item_key.to_string()))
 }
 
 // =============================================================================
@@ -731,6 +944,29 @@ fn refuse_foreign_path(env: Envelope) -> Result<CallToolResult, CallToolError> {
             &["a path returned by hifi_collections for this zone"],
             "Browse again from this zone and use that result's path.",
         ),
+    )
+}
+
+fn refuse_foreign_location(env: Envelope) -> Result<CallToolResult, CallToolError> {
+    env.refused(
+        "location does not name a collection for this zone.",
+        Refusal::invalid_parameter(
+            "location",
+            &["a location returned by hifi_collections for this provider"],
+            "Open the collection from the matching provider.",
+        ),
+    )
+}
+
+fn refuse_unknown_location(env: Envelope) -> Result<CallToolResult, CallToolError> {
+    env.refused(
+        "location is unknown.",
+        Refusal::UnknownTarget {
+            parameter: "location",
+            discover_with: "hifi_collections",
+            detail: "Open the collection from its provider root to create a durable location."
+                .to_string(),
+        },
     )
 }
 

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -631,6 +631,37 @@ async fn handle_lms(
 // drives (src/adapters/roon.rs), exposed as hierarchy walking.
 // =============================================================================
 
+/// Browse one Roon collection level.
+///
+/// # Cheap in the steady state, correct after a session loss
+///
+/// Roon's continuation is a `(item_key, multi_session_key)` pair, not a flat
+/// string, and both halves only mean anything inside the Core-side browse
+/// session that minted them (same reasoning as a playable Roon ref; see
+/// [`RoonRefTarget`]'s docs). A durable `location` therefore cannot carry that
+/// pair -- it names the walk, and the pair has to be reconstructed.
+///
+/// Reconstructing it means `collections_resolve_location`: a root browse plus
+/// a paged scan per trail step. That is far too expensive to pay on every
+/// request, and the Library page sends `location` for every level *and* every
+/// "Load more" page. So the pair is treated as a cache, not as something to
+/// recompute:
+///
+/// 1. Every navigable child minted below gets its `(session_key, item_key)`
+///    written into [`AppState::collection_location_keys`] alongside its
+///    location token -- free, since this response already holds both.
+/// 2. A `location` request looks that pair up and browses with it directly.
+///    A `path` request takes the same pair from its `RoonRefTarget`. From here
+///    the two branches are one code path.
+/// 3. If the Core rejects the pair *recoverably* (the session is gone), the
+///    stale entry is evicted, the saved trail is re-walked once, the fresh
+///    pair is cached, and the same node is retried -- rather than throwing the
+///    user back to the root. A cache miss (first request for a location after
+///    a restart, or an entry aged out) simply re-walks up front.
+///
+/// The cache is deliberately not durable: it holds live-session material, so
+/// the first request per location after a restart re-walks once and every
+/// later one is cheap again.
 async fn handle_roon(
     state: &AppState,
     env: Envelope,
@@ -638,69 +669,75 @@ async fn handle_roon(
     limit: u32,
     offset: u32,
 ) -> Result<CallToolResult, CallToolError> {
-    // Roon's continuation is a (item_key, multi_session_key) pair, not a flat
-    // string -- resuming it must re-enter that exact session (same reasoning
-    // as a playable Roon ref; see `RoonRefTarget`'s docs).
-    let (resume, parent_location) = match (args.location.as_deref(), args.path.as_deref()) {
-        (Some(token), None) => match state.collection_locations.resolve(token) {
-            Some(location @ CollectionLocation::Roon { .. }) => (None, location),
-            Some(_) => return refuse_foreign_location(env),
-            None => return refuse_unknown_location(env),
-        },
-        (None, Some(token)) => match state.mcp_refs.resolve(token).await {
-            Some(RefTarget::RoonBrowse {
-                target, location, ..
-            }) => (Some(target), location),
-            Some(_) => return refuse_foreign_path(env),
-            None => return refuse_unknown_path(env),
-        },
-        (None, None) => {
-            let steps = if args.action == "playlists" {
-                vec![CollectionStep::hidden_roon("Playlists")]
-            } else {
-                Vec::new()
-            };
-            (
-                None,
-                CollectionLocation::Roon {
-                    origin: RoonLocationOrigin::BrowseRoot,
-                    steps,
-                },
-            )
-        }
-        (Some(_), Some(_)) => unreachable!("path/location exclusivity checked by caller"),
-    };
+    // Both entry shapes reduce to the same thing: the parent trail this page
+    // hangs off, plus (maybe) a session-scoped key pair to resume it with.
+    // `can_rewalk` is whether that trail has anything to re-walk -- a root
+    // browse has no saved node to recover.
+    let (mut resume_pair, parent_location, can_rewalk) =
+        match (args.location.as_deref(), args.path.as_deref()) {
+            (Some(token), None) => match state.collection_locations.resolve(token) {
+                Some(location @ CollectionLocation::Roon { .. }) => {
+                    let cached = state.collection_location_keys.get(token);
+                    let can_rewalk = !location.steps().is_empty();
+                    (cached, location, can_rewalk)
+                }
+                Some(_) => return refuse_foreign_location(env),
+                None => return refuse_unknown_location(env),
+            },
+            (None, Some(token)) => match state.mcp_refs.resolve(token).await {
+                Some(RefTarget::RoonBrowse {
+                    target, location, ..
+                }) => {
+                    let can_rewalk = !target.trail.is_empty();
+                    let RoonRefTarget {
+                        item_key,
+                        multi_session_key,
+                        ..
+                    } = target;
+                    (Some((multi_session_key, item_key)), location, can_rewalk)
+                }
+                Some(_) => return refuse_foreign_path(env),
+                None => return refuse_unknown_path(env),
+            },
+            (None, None) => {
+                let steps = if args.action == "playlists" {
+                    vec![CollectionStep::hidden_roon("Playlists")]
+                } else {
+                    Vec::new()
+                };
+                (
+                    None,
+                    CollectionLocation::Roon {
+                        origin: RoonLocationOrigin::BrowseRoot,
+                        steps,
+                    },
+                    false,
+                )
+            }
+            (Some(_), Some(_)) => unreachable!("path/location exclusivity checked by caller"),
+        };
 
     let mut params = json!({
         "zone_id": args.zone_id,
         "limit": limit,
         "offset": offset,
     });
-    if args.location.is_some() {
-        let (session_key, item_key) = match resolve_roon_location(
-            state,
-            &args.zone_id,
-            &parent_location,
-        )
-        .await
+    // Cache miss on a saved location: nothing to try, so re-walk up front.
+    if resume_pair.is_none() && args.location.is_some() && can_rewalk {
+        match resolve_and_cache_roon_location(state, &args.zone_id, &parent_location, args.location.as_deref())
+            .await
         {
-            Ok(pair) => pair,
+            Ok(pair) => resume_pair = Some(pair),
             Err(error) => {
                 return env.failed(format!(
                     "Collection error: this saved Roon location can no longer be resolved safely: {error:#}"
                 ))
             }
-        };
+        }
+    }
+    if let Some((session_key, item_key)) = &resume_pair {
         params["item_key"] = json!(item_key);
         params["session_key"] = json!(session_key);
-    } else if let Some(RoonRefTarget {
-        item_key,
-        multi_session_key,
-        ..
-    }) = &resume
-    {
-        params["item_key"] = json!(item_key);
-        params["session_key"] = json!(multi_session_key);
     }
     // #616: the trail this page hangs off. Children extend it by their own
     // title, so every ref minted below carries the full root-to-item walk
@@ -736,19 +773,25 @@ async fn handle_roon(
     {
         Ok(value) => value,
         Err(error)
-            if resume
-                .as_ref()
-                .is_some_and(|target| !target.trail.is_empty())
+            if can_rewalk
+                && resume_pair.is_some()
                 && RoonBrowseError::from_error(&error)
                     .is_some_and(|rejection| rejection.kind.is_recoverable()) =>
         {
             // Roon item keys are scoped to a Core-side browse session. If the
-            // Core reconnects, re-walk the saved breadcrumb trail and retry
-            // the same node rather than making the user start at the root.
-            let (session_key, item_key) = match resolve_roon_location(
+            // Core reconnects, the cached pair is dead: drop it, re-walk the
+            // saved breadcrumb trail, and retry the same node rather than
+            // making the user start at the root. This arm is shared by
+            // `location` and `path` requests -- both arrive here holding a
+            // pair whose session may have expired.
+            if let Some(token) = args.location.as_deref() {
+                state.collection_location_keys.evict(token);
+            }
+            let (session_key, item_key) = match resolve_and_cache_roon_location(
                 state,
                 &args.zone_id,
                 &parent_location,
+                args.location.as_deref(),
             )
             .await
             {
@@ -845,7 +888,16 @@ async fn handle_roon(
                 };
                 let location = if navigable {
                     match state.collection_locations.mint(child_location) {
-                        Ok(token) => Some(token),
+                        Ok(token) => {
+                            // Free cache fill: this response already holds the
+                            // session-scoped pair behind the token we just
+                            // minted, so opening this row costs one browse
+                            // instead of a re-walk of its trail.
+                            state
+                                .collection_location_keys
+                                .insert(&token, session_key, item_key);
+                            Some(token)
+                        }
                         Err(error) => {
                             return env.failed(format!(
                                 "Collection error: could not preserve location: {error:#}"
@@ -903,6 +955,31 @@ async fn handle_roon(
         breadcrumbs,
         next_offset,
     }))
+}
+
+/// [`resolve_roon_location`] plus the cache write every caller wants: a fresh
+/// pair is only useful to the *next* request if it is remembered.
+///
+/// `token` is the location token this walk was performed for, when the request
+/// carried one. A `path`-driven re-walk has no token in hand, so it derives the
+/// canonical one for the same trail -- minting is deterministic and idempotent,
+/// and the breadcrumb pass below mints this very location anyway.
+async fn resolve_and_cache_roon_location(
+    state: &AppState,
+    zone_id: &str,
+    location: &CollectionLocation,
+    token: Option<&str>,
+) -> anyhow::Result<(String, String)> {
+    let (session_key, item_key) = resolve_roon_location(state, zone_id, location).await?;
+    let token = token
+        .map(ToOwned::to_owned)
+        .or_else(|| state.collection_locations.mint(location.clone()).ok());
+    if let Some(token) = token {
+        state
+            .collection_location_keys
+            .insert(token, &session_key, &item_key);
+    }
+    Ok((session_key, item_key))
 }
 
 async fn resolve_roon_location(

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -591,7 +591,35 @@ async fn handle_roon(
         .await
     {
         Ok(value) => value,
-        Err(error) => return env.failed(format!("Collection error: {error}")),
+        Err(error)
+            if resume
+                .as_ref()
+                .is_some_and(|target| !target.trail.is_empty())
+                && (error
+                    .to_string()
+                    .contains("no longer valid in this browse session")
+                    || error.to_string().contains("InvalidItemKey")) =>
+        {
+            // Roon item keys are scoped to a Core-side browse session. If the
+            // Core reconnects, re-walk the saved breadcrumb trail and retry
+            // the same node rather than making the user start at the root.
+            let target = resume.as_ref().expect("resume checked above");
+            let (session_key, item_key) = match state.roon.resolve_trail(&args.zone_id, &target.trail).await {
+                Ok(pair) => pair,
+                Err(_) => return env.failed("Collection error: Roon refreshed; this browse page expired. Refresh to continue."),
+            };
+            params["item_key"] = json!(item_key);
+            params["session_key"] = json!(session_key);
+            match state
+                .adapter_registry
+                .library_content("roon", operation, &params)
+                .await
+            {
+                Ok(value) => value,
+                Err(_) => return env.failed("Collection error: Roon refreshed; this browse page expired. Refresh to continue."),
+            }
+        }
+        Err(_) => return env.failed("Collection error: Roon is unavailable right now. Try again."),
     };
 
     let Some(session_key) = response.get("session_key").and_then(Value::as_str) else {

--- a/src/mcp/tools/library.rs
+++ b/src/mcp/tools/library.rs
@@ -48,6 +48,7 @@
 use super::spotify::refusal_for_spotify_error;
 use crate::api::AppState;
 use crate::mcp::capabilities::{support, Capability};
+use crate::mcp::collection_locations::{CollectionLocation, CollectionStep, RoonLocationOrigin};
 use crate::mcp::envelope::{Envelope, Observed, Provider, Refusal, Scope};
 use crate::mcp::refs::{RefTarget, RoonRefTarget};
 use crate::mcp::routing::{
@@ -220,6 +221,7 @@ pub async fn handle_search(
                             // grouping row or browsable container in its
                             // response shape to mint a path for.
                             path: None,
+                            location: None,
                             image: None,
                         });
                     }
@@ -252,6 +254,7 @@ pub async fn handle_search(
                             // (`LibrarySearchResult`) has no grouping or
                             // browse concept -- see #566's audit.
                             path: None,
+                            location: None,
                             image: None,
                         });
                     }
@@ -289,6 +292,7 @@ pub async fn handle_search(
                             // exposes MA's real browse hierarchy
                             // separately, via `MusicAssistantBrowse`.)
                             path: None,
+                            location: None,
                             image: None,
                         });
                     }
@@ -332,6 +336,7 @@ pub async fn handle_search(
                             // flat catalog/library hits -- no grouping or
                             // browse concept -- see #566's audit.
                             path: None,
+                            location: None,
                             image: None,
                         });
                     }
@@ -353,7 +358,7 @@ pub async fn handle_search(
             {
                 Ok((session_key, results)) => {
                     let mut mcp_results = Vec::with_capacity(results.len());
-                    for item in results {
+                    for (position, item) in results.into_iter().enumerate() {
                         // #573 defect 10: search hits carry artwork where
                         // Roon supplies it, resolved through the identical
                         // opaque-ref URL browse rows use.
@@ -378,6 +383,7 @@ pub async fn handle_search(
                                 subtitle,
                                 r#ref: None,
                                 path: None,
+                                location: None,
                                 image,
                             });
                             continue;
@@ -443,6 +449,17 @@ pub async fn handle_search(
                                 // claimed without a way to verify it.
                                 (false, true)
                             };
+                        let location_target = CollectionLocation::Roon {
+                            origin: RoonLocationOrigin::Search {
+                                query: args.query.clone(),
+                                source: args.source.clone(),
+                            },
+                            steps: vec![CollectionStep::roon(
+                                title.clone(),
+                                subtitle.clone(),
+                                Some(position as u32),
+                            )],
+                        };
                         let path = if navigable {
                             Some(
                                 state
@@ -450,9 +467,22 @@ pub async fn handle_search(
                                     .mint(RefTarget::RoonBrowse {
                                         target: target.clone(),
                                         title: item.title.clone(),
+                                        location: location_target.clone(),
                                     })
                                     .await,
                             )
+                        } else {
+                            None
+                        };
+                        let location = if navigable {
+                            match state.collection_locations.mint(location_target) {
+                                Ok(token) => Some(token),
+                                Err(error) => {
+                                    return env.failed(format!(
+                                        "Search error: could not preserve location: {error:#}"
+                                    ))
+                                }
+                            }
                         } else {
                             None
                         };
@@ -474,6 +504,7 @@ pub async fn handle_search(
                             subtitle,
                             r#ref: ref_token,
                             path,
+                            location,
                             image,
                         });
                     }

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -133,7 +133,15 @@ pub fn declared_params(tool: &str) -> &'static [&'static str] {
         "hifi_play" => &["query", "zone_id", "source", "action"],
         "hifi_play_ref" => &["ref", "zone_id", "action"],
         "hifi_queue" => &["zone_id", "action", "item_id", "position", "target_zone_id"],
-        "hifi_collections" => &["zone_id", "action", "path", "media_type", "limit", "offset"],
+        "hifi_collections" => &[
+            "zone_id",
+            "action",
+            "path",
+            "location",
+            "media_type",
+            "limit",
+            "offset",
+        ],
         "hifi_zone_group" => &[
             "action",
             "zone_id",

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -68,16 +68,13 @@ pub struct McpNowPlaying {
 /// anyway would trade "no ref" for "a ref that might play the wrong thing".
 /// `title`/`subtitle` are unchanged from before this issue.
 ///
-/// `path` (#566) is the same addition PR #533/#547 made for
-/// `hifi_collections`: a `RefTarget::RoonBrowse` token, present exactly when
-/// the result is navigable (a real hit that can be browsed into, or a
-/// grouping row like "Albums · 35 Results" that names a bucket in the
-/// search session). `path` and `ref` are independent — a result can carry
-/// either, both, or neither, never conflated into one slot. Only Roon mints
-/// it today: LMS's search drills straight to leaf results server-side and
-/// Spotify/Apple Music/Music Assistant's generic search has no grouping or
-/// browse concept, so they always leave this `None` (see
-/// `crate::mcp::tools::library::handle_search`'s per-route docs).
+/// `path` (#566) is a short-lived `RefTarget::RoonBrowse` continuation,
+/// present exactly when a Roon result is navigable. `location` is its durable,
+/// provider-neutral counterpart and is what canonical Library URLs consume.
+/// Both are independent from `ref`: a result may be navigable, playable,
+/// both, or neither. LMS search drills straight to leaves, while the generic
+/// Spotify/Apple Music/Music Assistant search mappings have no grouping
+/// concept, so only Roon search mints either navigation field today.
 /// `image` (#573 defect 10) follows `hifi_collections`' artwork convention
 /// exactly: a same-origin `/api/collections/image?ref=...` path over an
 /// opaque minted token, present only when the provider supplied art for the
@@ -91,6 +88,8 @@ pub struct McpSearchResult {
     pub r#ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
 }

--- a/tests/fixtures/mcp_tools.json
+++ b/tests/fixtures/mcp_tools.json
@@ -114,7 +114,7 @@
     }
   },
   "hifi_collections": {
-    "description": "Alpha capability: expect refinement across releases. Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset and playable entries include a short-lived opaque ref for hifi_play_ref. Use path from a browse entry to continue into that collection. Implemented for lms and roon zones; Music Assistant zones (see hifi_queue's provider notes); Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one.",
+    "description": "Alpha capability: expect refinement across releases. Browse a provider library or list saved playlists and favorites. Results are paged with limit/offset. Navigable entries include a durable opaque location for canonical navigation and a short-lived path for MCP continuation; playable entries include a short-lived opaque ref for hifi_play_ref. Send location or path, never both. Implemented for Roon, LMS, and Music Assistant zones. Spotify and Apple Music are reachable via hifi_spotify and the Apple Music tools today, not yet through this one.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -125,6 +125,11 @@
           "description": "Maximum entries to return (1-50; default 20).",
           "nullable": true,
           "type": "integer"
+        },
+        "location": {
+          "description": "Durable provider-neutral collection location returned by a preceding browse call.",
+          "nullable": true,
+          "type": "string"
         },
         "media_type": {
           "description": "Media type when listing favorites (tracks by default).",
@@ -137,7 +142,7 @@
           "type": "integer"
         },
         "path": {
-          "description": "Opaque collection path returned by a preceding browse call.",
+          "description": "Short-lived collection continuation returned by a preceding browse call.",
           "nullable": true,
           "type": "string"
         },

--- a/tests/mcp_contract.rs
+++ b/tests/mcp_contract.rs
@@ -869,6 +869,7 @@ const EXPECTED_TOOL_PARAMS: &[(&str, &[(&str, bool)])] = &[
             ("zone_id", true),
             ("action", true),
             ("path", false),
+            ("location", false),
             ("media_type", false),
             ("limit", false),
             ("offset", false),
@@ -2420,6 +2421,11 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
         .expect("browse folder must return an opaque continuation path");
     assert!(path.starts_with("ref_"));
     assert_ne!(path, "library://jazz", "MA path must stay server-side");
+    let location = root_page["items"][0]["location"]
+        .as_str()
+        .expect("browse folder must return a durable canonical location");
+    assert!(location.starts_with("loc_"));
+    assert!(!location.contains("jazz"));
     // #549: the folder-shaped root row has no MA image_url, so it must carry
     // no image field at all -- absent honestly, not a placeholder.
     assert!(
@@ -2445,12 +2451,14 @@ async fn musicassistant_collections_are_paged_and_mint_opaque_playable_refs() {
     let browse = app
         .call_tool(
             "hifi_collections",
-            json!({"zone_id": zone_id, "action": "browse", "path": path, "limit": 1, "offset": 1}),
+            json!({"zone_id": zone_id, "action": "browse", "location": location, "limit": 1, "offset": 1}),
         )
         .await;
     assert_eq!(browse["structuredContent"]["outcome"], "ok");
     let browse_page: Value = serde_json::from_str(&result_text(&browse)).expect("browse page JSON");
     assert_eq!(browse_page["items"][0]["title"], "So What");
+    assert_eq!(browse_page["breadcrumbs"][0]["title"], "Jazz");
+    assert_eq!(browse_page["breadcrumbs"][0]["location"], location);
     assert!(browse_page["items"][0]["ref"].as_str().is_some());
     assert!(
         browse_page["items"][0].get("uri").is_none(),
@@ -2584,18 +2592,25 @@ async fn lms_collections_browse_walks_albums_into_tracks() {
         .expect("root must list Albums");
     let albums_path = albums_entry["path"].as_str().expect("Albums has a path");
     assert!(albums_path.starts_with("ref_"));
+    let albums_location = albums_entry["location"]
+        .as_str()
+        .expect("Albums has a durable canonical location");
+    assert!(albums_location.starts_with("loc_"));
+    assert!(!albums_location.contains("albums"));
 
     let albums = h
         .app
         .call_tool(
             "hifi_collections",
-            json!({"zone_id": zone_id, "action": "browse", "path": albums_path}),
+            json!({"zone_id": zone_id, "action": "browse", "location": albums_location}),
         )
         .await;
     assert_eq!(albums["structuredContent"]["outcome"], "ok");
     let albums_page: Value = serde_json::from_str(&result_text(&albums)).expect("albums page JSON");
     assert_eq!(albums_page["items"][0]["title"], "Kind of Blue");
     assert_eq!(albums_page["items"][0]["subtitle"], "Album by Miles Davis");
+    assert_eq!(albums_page["breadcrumbs"][0]["title"], "Albums");
+    assert_eq!(albums_page["breadcrumbs"][0]["location"], albums_location);
     let album_image = albums_page["items"][0]["image"]
         .as_str()
         .expect("an album with a seeded coverid must carry an image field");
@@ -2610,17 +2625,24 @@ async fn lms_collections_browse_walks_albums_into_tracks() {
     let album_path = albums_page["items"][0]["path"]
         .as_str()
         .expect("an album is itself browsable, into its tracks");
+    let album_location = albums_page["items"][0]["location"]
+        .as_str()
+        .expect("a browsable album has a durable canonical location");
+    assert!(album_path.starts_with("ref_"));
+    assert!(album_location.starts_with("loc_"));
 
     let tracks = h
         .app
         .call_tool(
             "hifi_collections",
-            json!({"zone_id": zone_id, "action": "browse", "path": album_path}),
+            json!({"zone_id": zone_id, "action": "browse", "location": album_location}),
         )
         .await;
     assert_eq!(tracks["structuredContent"]["outcome"], "ok");
     let tracks_page: Value = serde_json::from_str(&result_text(&tracks)).expect("tracks page JSON");
     assert_eq!(tracks_page["items"][0]["title"], "So What");
+    assert_eq!(tracks_page["breadcrumbs"][0]["title"], "Albums");
+    assert_eq!(tracks_page["breadcrumbs"][1]["title"], "Kind of Blue");
     let track_ref = tracks_page["items"][0]["ref"]
         .as_str()
         .expect("a track is playable, not a browsable path");
@@ -2743,12 +2765,12 @@ async fn lms_collections_playlists_and_favorites() {
     h.stop().await;
 }
 
-/// #531: an opaque path minted for one zone's provider must never resolve
-/// against a different provider's zone -- same safety property #492 already
-/// pins for Music Assistant, now proven for LMS.
+/// #531: opaque collection handles minted for one zone's provider must never
+/// resolve against a different provider's zone -- same safety property #492
+/// already pins for Music Assistant, now proven for LMS.
 #[tokio::test]
 #[serial_test::serial(uhc_config_dir)]
-async fn lms_collections_path_does_not_cross_provider_boundaries() {
+async fn lms_collection_handles_do_not_cross_provider_boundaries() {
     let h = LmsHarness::start().await;
     let zone_id = h.zone_id();
     h.mock
@@ -2767,16 +2789,61 @@ async fn lms_collections_path_does_not_cross_provider_boundaries() {
         .as_str()
         .expect("root item has a path")
         .to_string();
+    let location = root_page["items"][0]["location"]
+        .as_str()
+        .expect("root item has a durable location")
+        .to_string();
 
     let cross = h
         .app
         .call_tool(
             "hifi_collections",
-            json!({"zone_id": "roon:not-lms", "action": "browse", "path": path}),
+            json!({"zone_id": "roon:not-lms", "action": "browse", "path": &path}),
         )
         .await;
     assert_eq!(cross["structuredContent"]["outcome"], "invalid", "{cross}");
     assert_eq!(cross["structuredContent"]["refusal"]["parameter"], "path");
+
+    let cross_location = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({
+                "zone_id": "roon:not-lms",
+                "action": "browse",
+                "location": &location,
+            }),
+        )
+        .await;
+    assert_eq!(
+        cross_location["structuredContent"]["outcome"], "invalid",
+        "{cross_location}"
+    );
+    assert_eq!(
+        cross_location["structuredContent"]["refusal"]["parameter"],
+        "location"
+    );
+
+    let conflicting_handles = h
+        .app
+        .call_tool(
+            "hifi_collections",
+            json!({
+                "zone_id": zone_id,
+                "action": "browse",
+                "path": &path,
+                "location": &location,
+            }),
+        )
+        .await;
+    assert_eq!(
+        conflicting_handles["structuredContent"]["outcome"], "invalid",
+        "{conflicting_handles}"
+    );
+    assert_eq!(
+        conflicting_handles["structuredContent"]["refusal"]["parameter"],
+        "location"
+    );
 
     let stale = h
         .app
@@ -3422,6 +3489,30 @@ const FIELD_ROLES: &[(&str, FieldRole)] = &[
         ),
     ),
     (
+        "location",
+        Consumed(
+            "hifi_collections.location — the durable provider-neutral collection identity used by canonical Library URLs. Navigable collection and Roon search rows return it; clients pass it back to hifi_collections instead of depending on the short-lived path cursor.",
+        ),
+    ),
+    (
+        "breadcrumbs",
+        DisplayOnly(
+            "server-reconstructed labels and durable locations for the current collection lineage; the web Library renders them and navigates using each entry's location.",
+        ),
+    ),
+    (
+        "items",
+        DisplayOnly(
+            "collection page wrapper; actionable child fields close their own loops through location, path, and ref.",
+        ),
+    ),
+    (
+        "next_offset",
+        Consumed(
+            "hifi_collections.offset — the continuation position for the next page of the same collection location.",
+        ),
+    ),
+    (
         "image",
         DisplayOnly(
             "artwork URL (#549 for hifi_collections rows, #573 for hifi_search hits): a \
@@ -3817,11 +3908,22 @@ async fn no_tool_returns_an_unclassified_field() {
             // #566: same reasoning as `ref` above -- `Some` so `path` is
             // collected and must be classified below too.
             path: Some(String::new()),
+            // Durable canonical Library location, separate from the
+            // short-lived MCP browse continuation above.
+            location: Some(String::new()),
             // #573 defect 10: same again -- `Some` so `image` is collected
             // and must be classified below.
             image: Some(String::new()),
         })
         .expect("McpSearchResult must serialize"),
+        &mut returned,
+    );
+    // Collection pages are not otherwise exercised in this inventory test.
+    // Serialize the web API's exact mirror so its page wrappers and durable
+    // breadcrumb field remain classified.
+    collect_keys(
+        &serde_json::to_value(unified_hifi_control::app::api::CollectionPage::default())
+            .expect("CollectionPage must serialize"),
         &mut returned,
     );
     collect_keys(

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -53,6 +53,7 @@ use unified_hifi_control::api::AppState;
 use unified_hifi_control::bus::create_bus;
 use unified_hifi_control::coordinator::AdapterCoordinator;
 use unified_hifi_control::knobs::KnobStore;
+use unified_hifi_control::mcp::tools::collections::{handle_collections, HifiCollectionsTool};
 use unified_hifi_control::mcp::tools::library::{
     handle_play_ref, handle_search, HifiPlayRefTool, HifiSearchTool,
 };
@@ -116,6 +117,13 @@ fn search_results_of(result: &ToolResult) -> Vec<Value> {
         .unwrap_or_default()
 }
 
+fn collection_page_of(result: &ToolResult) -> Value {
+    structured_of(result)
+        .get("data")
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
 // =============================================================================
 // Roon: FakeRoonCore-backed AppState
 // =============================================================================
@@ -177,8 +185,8 @@ async fn app_state_with_roon(roon: Arc<RoonAdapter>) -> AppState {
     let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
     let startable: Vec<Arc<dyn Startable>> = vec![roon.clone()];
 
-    AppState::new(
-        roon,
+    let state = AppState::new(
+        roon.clone(),
         hqplayer,
         hqp_instances,
         hqp_zone_links,
@@ -192,7 +200,9 @@ async fn app_state_with_roon(roon: Arc<RoonAdapter>) -> AppState {
         startable,
         Instant::now(),
         CancellationToken::new(),
-    )
+    );
+    state.adapter_registry.register_library("roon", roon).await;
+    state
 }
 
 /// Same shape, but with a real (connected) LMS adapter and disconnected Roon
@@ -498,6 +508,79 @@ async fn roon_search_result_with_zone_context_mints_both_ref_and_path() {
         ref_token, path_token,
         "the play ref and the browse path are minted from the same target but are \
          distinct tokens"
+    );
+
+    core.stop().await;
+}
+
+/// A canonical Roon Library URL holds a durable `location`, not the Core's
+/// session-scoped browse key. Losing every Core session between mint and
+/// refresh must therefore reconstruct the page and its breadcrumbs.
+#[tokio::test]
+async fn roon_collection_location_survives_core_session_loss() {
+    let core = FakeRoonCore::start().await;
+    core.set_item_key_scope(ItemKeyScope::PerSessionSilentRootReset)
+        .await;
+    let adapter = connected_roon(&core).await;
+    let state = app_state_with_roon(adapter).await;
+
+    let root = handle_collections(
+        &state,
+        HifiCollectionsTool {
+            zone_id: "roon:zone_fake_1".to_string(),
+            action: "browse".to_string(),
+            path: None,
+            location: None,
+            media_type: None,
+            limit: Some(20),
+            offset: Some(0),
+        },
+    )
+    .await;
+    assert_eq!(outcome_of(&root), "ok", "{}", text_of(&root));
+    let root_page = collection_page_of(&root);
+    let local_library = root_page["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["title"] == "Local Library")
+        .expect("root must expose Local Library");
+    let location = local_library["location"]
+        .as_str()
+        .expect("navigable row must carry a durable location")
+        .to_string();
+    assert!(location.starts_with("loc_"));
+    assert!(
+        location.len() <= 27,
+        "location leaked URL noise: {location}"
+    );
+
+    core.drop_all_sessions().await;
+
+    let refreshed = handle_collections(
+        &state,
+        HifiCollectionsTool {
+            zone_id: "roon:zone_fake_1".to_string(),
+            action: "browse".to_string(),
+            path: None,
+            location: Some(location.clone()),
+            media_type: None,
+            limit: Some(20),
+            offset: Some(0),
+        },
+    )
+    .await;
+    assert_eq!(outcome_of(&refreshed), "ok", "{}", text_of(&refreshed));
+    let page = collection_page_of(&refreshed);
+    assert_eq!(page["breadcrumbs"][0]["title"], "Local Library");
+    assert_eq!(page["breadcrumbs"][0]["location"], location);
+    assert!(
+        page["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item["title"] == "Artists"),
+        "freshly resolved page must contain the Library children: {page}"
     );
 
     core.stop().await;

--- a/tests/mcp_refs.rs
+++ b/tests/mcp_refs.rs
@@ -1160,3 +1160,276 @@ async fn lms_a_valid_ref_beyond_the_validation_search_limit_still_resolves() {
 async fn lms_stop(state: &AppState) {
     state.lms.stop().await;
 }
+
+// =============================================================================
+// Roon: the location -> (session_key, item_key) cache (#677 review)
+// =============================================================================
+//
+// `FakeRoonCore` proves the *protocol*; these tests prove the *call shape* --
+// how many `collections_resolve_location` walks `handle_collections` pays for
+// an ordinary browse, and when it pays for one. That is invisible at the
+// protocol layer (a re-walk is just more browse traffic), so they drive a
+// counting `LibraryAdapter` registered under the `roon` prefix, exactly where
+// production registers `RoonAdapter`. The counter is the assertion.
+
+/// A `LibraryAdapter` that answers Roon's collections operations from a tiny
+/// canned hierarchy and counts what it was asked to do.
+///
+/// `poison` arms one recoverable Core rejection for a specific
+/// `(session_key, item_key)` pair -- the exact failure a browse session that
+/// expired between requests produces.
+#[derive(Default)]
+struct CountingRoonLibrary {
+    resolve_calls: std::sync::atomic::AtomicUsize,
+    browse_calls: std::sync::atomic::AtomicUsize,
+    session: std::sync::Mutex<String>,
+    poison: std::sync::Mutex<Option<(String, String)>>,
+}
+
+impl CountingRoonLibrary {
+    fn new() -> Self {
+        Self {
+            session: std::sync::Mutex::new("session_1".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn resolve_calls(&self) -> usize {
+        self.resolve_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn browse_calls(&self) -> usize {
+        self.browse_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn session(&self) -> String {
+        self.session.lock().unwrap().clone()
+    }
+
+    /// Arm exactly one recoverable rejection for this pair, as a Core that
+    /// dropped the session would produce.
+    fn expire(&self, session_key: &str, item_key: &str) {
+        *self.poison.lock().unwrap() = Some((session_key.to_string(), item_key.to_string()));
+    }
+
+    fn page(&self, item_key: Option<&str>) -> Value {
+        let items = match item_key {
+            // Root: one navigable child, so a browse response mints a
+            // location token (and, with it, a cache entry).
+            None => vec![serde_json::json!({
+                "title": "Local Library",
+                "item_key": "key_library",
+                "navigable": true,
+                "playable": false,
+                "position": 0,
+            })],
+            Some(_) => vec![serde_json::json!({
+                "title": "Artists",
+                "item_key": "key_artists",
+                "navigable": true,
+                "playable": false,
+                "position": 0,
+            })],
+        };
+        serde_json::json!({ "session_key": self.session(), "items": items })
+    }
+}
+
+#[async_trait::async_trait]
+impl unified_hifi_control::adapters::traits::LibraryAdapter for CountingRoonLibrary {
+    async fn search(
+        &self,
+        _query: &str,
+        _limit: usize,
+    ) -> anyhow::Result<Vec<unified_hifi_control::adapters::traits::LibrarySearchResult>> {
+        Ok(Vec::new())
+    }
+
+    async fn play_uri(&self, _zone_id: &str, _uri: &str) -> anyhow::Result<String> {
+        Err(anyhow::anyhow!("not used by these tests"))
+    }
+
+    async fn content(&self, operation: &str, params: &Value) -> anyhow::Result<Value> {
+        match operation {
+            "collections_browse" | "collections_playlists" => {
+                self.browse_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let session_key = params.get("session_key").and_then(Value::as_str);
+                let item_key = params.get("item_key").and_then(Value::as_str);
+                let armed = self.poison.lock().unwrap().clone();
+                if let (Some(session_key), Some(item_key), Some((bad_session, bad_item))) =
+                    (session_key, item_key, armed)
+                {
+                    if session_key == bad_session && item_key == bad_item {
+                        // One-shot, and the Core comes back on a new session:
+                        // the re-walk must produce a *different* pair or the
+                        // retry would fail the same way.
+                        *self.poison.lock().unwrap() = None;
+                        *self.session.lock().unwrap() = "session_2".to_string();
+                        return Err(anyhow::Error::new(
+                            unified_hifi_control::adapters::roon::RoonBrowseError {
+                                kind: unified_hifi_control::adapters::roon::RoonBrowseErrorKind::InvalidItemKey,
+                                session_key: Some(session_key.to_string()),
+                            },
+                        ));
+                    }
+                }
+                Ok(self.page(item_key))
+            }
+            "collections_resolve_location" => {
+                self.resolve_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(serde_json::json!({
+                    "session_key": self.session(),
+                    "item_key": "key_library",
+                }))
+            }
+            other => Err(anyhow::anyhow!("unexpected operation {other}")),
+        }
+    }
+}
+
+/// `AppState` whose `roon` library route is the counting fake above.
+async fn app_state_with_counting_roon(library: Arc<CountingRoonLibrary>) -> AppState {
+    let _ = isolate_config_dir();
+    let bus = create_bus();
+    let roon = Arc::new(RoonAdapter::new_disconnected(bus.clone()));
+    let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
+    let hqplayer = hqp_instances.get_default().await;
+    let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
+    let lms = Arc::new(LmsAdapter::new(bus.clone()));
+    let openhome = Arc::new(OpenHomeAdapter::new(bus.clone()));
+    let upnp = Arc::new(UPnPAdapter::new(bus.clone()));
+
+    let state = AppState::new(
+        roon,
+        hqplayer,
+        hqp_instances,
+        hqp_zone_links,
+        lms,
+        openhome,
+        upnp,
+        KnobStore::new(),
+        bus.clone(),
+        Arc::new(ZoneAggregator::new(bus.clone())),
+        Arc::new(AdapterCoordinator::new(bus)),
+        Vec::new(),
+        Instant::now(),
+        CancellationToken::new(),
+    );
+    state
+        .adapter_registry
+        .register_library("roon", library)
+        .await;
+    state
+}
+
+fn collections_args(location: Option<&str>, offset: u32) -> HifiCollectionsTool {
+    HifiCollectionsTool {
+        zone_id: "roon:zone_fake_1".to_string(),
+        action: "browse".to_string(),
+        path: None,
+        location: location.map(ToOwned::to_owned),
+        media_type: None,
+        limit: Some(20),
+        offset: Some(offset),
+    }
+}
+
+/// Browse the root and return the durable location its one navigable child
+/// carries -- the token the UI puts in the canonical URL.
+async fn browse_root_for_location(state: &AppState) -> String {
+    let root = handle_collections(state, collections_args(None, 0)).await;
+    assert_eq!(outcome_of(&root), "ok", "{}", text_of(&root));
+    collection_page_of(&root)["items"][0]["location"]
+        .as_str()
+        .expect("a navigable row must carry a durable location")
+        .to_string()
+}
+
+/// The steady state. A location token minted by a browse response already has
+/// its `(session_key, item_key)` pair in hand, so opening it costs one browse
+/// and no trail re-walk at all.
+#[tokio::test]
+async fn opening_a_freshly_minted_location_never_re_walks_the_trail() {
+    let library = Arc::new(CountingRoonLibrary::new());
+    let state = app_state_with_counting_roon(library.clone()).await;
+
+    let location = browse_root_for_location(&state).await;
+    assert_eq!(library.resolve_calls(), 0, "the root browse walks nothing");
+
+    let level = handle_collections(&state, collections_args(Some(&location), 0)).await;
+
+    assert_eq!(outcome_of(&level), "ok", "{}", text_of(&level));
+    assert_eq!(
+        library.resolve_calls(),
+        0,
+        "a cached location must be browsed directly, not re-resolved"
+    );
+    assert_eq!(library.browse_calls(), 2, "root browse + one level browse");
+    assert_eq!(
+        collection_page_of(&level)["items"][0]["title"],
+        Value::from("Artists")
+    );
+}
+
+/// Paging is the same location again. "Load more" must not turn into a re-walk
+/// per page -- that was the whole cost this cache exists to remove.
+#[tokio::test]
+async fn paging_the_same_location_costs_no_extra_trail_walks() {
+    let library = Arc::new(CountingRoonLibrary::new());
+    let state = app_state_with_counting_roon(library.clone()).await;
+
+    let location = browse_root_for_location(&state).await;
+    for offset in [0, 20] {
+        let page = handle_collections(&state, collections_args(Some(&location), offset)).await;
+        assert_eq!(outcome_of(&page), "ok", "{}", text_of(&page));
+    }
+
+    assert_eq!(
+        library.resolve_calls(),
+        0,
+        "neither page may re-walk the saved trail"
+    );
+}
+
+/// The recovery arm, now reachable for `location` requests too: the cached pair
+/// is tried first, the Core's recoverable rejection evicts it, the trail is
+/// re-walked exactly once, and the same node is retried and served.
+#[tokio::test]
+async fn a_rejected_cached_pair_re_walks_once_and_retries_in_place() {
+    let library = Arc::new(CountingRoonLibrary::new());
+    let state = app_state_with_counting_roon(library.clone()).await;
+
+    let location = browse_root_for_location(&state).await;
+    let minting_session = library.session();
+    library.expire(&minting_session, "key_library");
+
+    let level = handle_collections(&state, collections_args(Some(&location), 0)).await;
+
+    assert_eq!(
+        outcome_of(&level),
+        "ok",
+        "a recoverable rejection must be recovered in place, not surfaced: {}",
+        text_of(&level)
+    );
+    assert_eq!(
+        library.resolve_calls(),
+        1,
+        "exactly one re-walk, triggered by the rejection"
+    );
+    assert_eq!(
+        collection_page_of(&level)["items"][0]["title"],
+        Value::from("Artists"),
+        "the retry must serve the node the user asked for"
+    );
+
+    // The re-walk repopulated the cache, so the next request is cheap again.
+    let again = handle_collections(&state, collections_args(Some(&location), 0)).await;
+    assert_eq!(outcome_of(&again), "ok", "{}", text_of(&again));
+    assert_eq!(
+        library.resolve_calls(),
+        1,
+        "the fresh pair must have been cached by the re-walk"
+    );
+}


### PR DESCRIPTION
When Roon Core reconnects, browse item keys from the prior session become invalid while UHC URLs still point at them.

This re-walks the saved breadcrumb trail and retries the same node, so users stay where they were instead of seeing provider internals. If recovery cannot find the node, the UI shows a concise refresh message rather than the raw item-key/session error.

Validation:
- cargo fmt --all -- --check
- git diff --check
- Full cargo check/test is blocked in this clean worktree because generated public/tailwind.css is absent; CI generates it before compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Library navigation now uses stable, shareable URLs for sources, views, and locations.
  * Added breadcrumbs for easier navigation through collection hierarchies.
  * Collection browsing supports durable location references alongside temporary continuation paths.
  * Roon collection locations can be restored after sessions expire, including search-based browsing.
  * Library navigation now preserves context across collection browsing and search results.
* **Bug Fixes**
  * Improved validation when navigating between providers and location references.
  * Improved collection refresh and recovery reliability.
  * Error views now offer retry and navigation back to the Library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->