### PR TITLE
Point the LMS beta feed at v4 and unskip release follow-up jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2199,7 +2199,8 @@ jobs:
           commit-message: "chore: Update LMS plugin to v${{ steps.version.outputs.version }}"
           title: "chore: Update LMS plugin to v${{ steps.version.outputs.version }}"
           body: "Auto-generated PR to update LMS plugin metadata for release v${{ steps.version.outputs.version }}."
-          branch: chore/lms-update-${{ steps.version.outputs.version }}
+          # Fixed branch for the same reason as the beta feed job below.
+          branch: chore/lms-update
           base: v4
           add-paths: |
             lms-plugin/repo.xml
@@ -2265,7 +2266,10 @@ jobs:
           commit-message: "chore: Point LMS beta feed at v${{ needs.plan.outputs.version }}"
           title: "chore: Point LMS beta feed at v${{ needs.plan.outputs.version }}"
           body: "Auto-generated. Updates `lms-plugin/repo-beta.xml` so the beta repository URL serves v${{ needs.plan.outputs.version }}."
-          branch: chore/lms-beta-feed-${{ needs.plan.outputs.version }}
+          # One fixed branch, not one per version: create-pull-request then updates
+          # the existing PR in place, so two prerelease tags in quick succession
+          # cannot race two PRs into a conflict over the same file.
+          branch: chore/lms-beta-feed
           base: v4
           add-paths: lms-plugin/repo-beta.xml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2120,7 +2120,15 @@ jobs:
   update-repo-xml:
     name: Update LMS repo.xml
     needs: [plan, upload-release]
-    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_beta != 'true'
+    # `!cancelled()`: `upload-release` runs under `always()` because the Synology
+    # build is skipped on prerelease tags. Without it, GitHub applies the implicit
+    # success() check transitively and skips this job on every such tag -- which is
+    # how the beta feed stayed at 3.6.1-beta through the v4 alphas.
+    if: |
+      !cancelled() &&
+      needs.plan.outputs.is_release == 'true' &&
+      needs.plan.outputs.is_beta != 'true' &&
+      needs.upload-release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2219,7 +2227,12 @@ jobs:
   update-beta-repo-xml:
     name: Update LMS beta repo.xml
     needs: [plan, upload-release]
-    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_beta == 'true'
+    # See update-repo-xml for why `!cancelled()` is required here.
+    if: |
+      !cancelled() &&
+      needs.plan.outputs.is_release == 'true' &&
+      needs.plan.outputs.is_beta == 'true' &&
+      needs.upload-release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2265,7 +2278,15 @@ jobs:
   publish-aur:
     name: Publish to AUR
     needs: [plan, upload-release]
-    if: needs.plan.outputs.is_release == 'true' && needs.plan.outputs.is_beta != 'true'
+    # `!cancelled()`: `upload-release` runs under `always()` because the Synology
+    # build is skipped on prerelease tags. Without it, GitHub applies the implicit
+    # success() check transitively and skips this job on every such tag -- which is
+    # how the beta feed stayed at 3.6.1-beta through the v4 alphas.
+    if: |
+      !cancelled() &&
+      needs.plan.outputs.is_release == 'true' &&
+      needs.plan.outputs.is_beta != 'true' &&
+      needs.upload-release.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2129,6 +2129,12 @@ jobs:
       needs.plan.outputs.is_release == 'true' &&
       needs.plan.outputs.is_beta != 'true' &&
       needs.upload-release.result == 'success'
+    # Serialize across tag runs: the workflow group is per-ref, so two tags can
+    # run at once, and both jobs push the same fixed PR branch. Queue, never
+    # cancel, so the newest release metadata is what lands last.
+    concurrency:
+      group: lms-repo-feed-update
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -2234,6 +2240,12 @@ jobs:
       needs.plan.outputs.is_release == 'true' &&
       needs.plan.outputs.is_beta == 'true' &&
       needs.upload-release.result == 'success'
+    # Serialize across tag runs: the workflow group is per-ref, so two tags can
+    # run at once, and both jobs push the same fixed PR branch. Queue, never
+    # cancel, so the newest release metadata is what lands last.
+    concurrency:
+      group: lms-beta-feed-update
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/lms-plugin/repo-beta.xml
+++ b/lms-plugin/repo-beta.xml
@@ -2,15 +2,15 @@
 <extensions>
   <plugins>
     <plugin name="UnifiedHiFi"
-            version="3.6.1-beta"
+            version="4.0.0-alpha.2"
             minTarget="8.0"
             maxTarget="*">
       <title lang="EN">Unified Hi-Fi Control (Beta)</title>
       <desc lang="EN">Beta builds of Unified Hi-Fi Control for testing.</desc>
-      <url>https://github.com/open-horizon-labs/unified-hifi-control/releases/download/v3.6.1-beta/lms-unified-hifi-control-3.6.1-beta.zip</url>
-      <sha>4cb7a34410ec30f1c243d0024644a95af3ffdbe4</sha>
+      <url>https://github.com/open-horizon-labs/unified-hifi-control/releases/download/v4.0.0-alpha.2/lms-unified-hifi-control-4.0.0-alpha.2.zip</url>
+      <sha>20d46fe66a0dec51ebf383d661b404bf98ee9270</sha>
       <creator>Muness Castle</creator>
-      <link>https://github.com/open-horizon-labs/unified-hifi-control/releases/tag/v3.6.1-beta</link>
+      <link>https://github.com/open-horizon-labs/unified-hifi-control/releases/tag/v4.0.0-alpha.2</link>
     </plugin>
   </plugins>
 </extensions>


### PR DESCRIPTION
## Problem

An LMS user on "alpha.2" could not find the new Library UI. LMS *is* wired for collections; the user was not on v4 at all.

- README and the alpha.2 release notes point LMS testers at the raw v4 `lms-plugin/repo-beta.xml`.
- That file still advertised **3.6.1-beta**, so following the instructions installs the v3 plugin, which has no Library page.
- The tag run generated a correct `lms-beta.xml` release asset, but the **Update LMS beta repo.xml** job was skipped on every prerelease tag (alpha.2, the v3.7.0 alphas). `upload-release` runs under `always()` because the Synology SPK build is skipped on prerelease versions; GitHub then applies the implicit `success()` check transitively and skips every job that needs `upload-release`.

## Change

- `lms-plugin/repo-beta.xml`: replaced with the alpha.2 release asset content, so the documented URL serves v4 immediately.
- `.github/workflows/build.yml`: the repo.xml, beta repo.xml, and AUR follow-up jobs now gate on `!cancelled()` plus an explicit `needs.upload-release.result == 'success'`, matching how `upload-release` itself is gated.

## Verification

- YAML parses.
- The gating fix can only be exercised by a tag run; the next `v4.0.0-alpha.3` tag should produce a `chore: Point LMS beta feed at v4.0.0-alpha.3` PR against `v4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated the UnifiedHiFi plugin’s beta repository metadata to version 4.0.0-alpha.2.
  - Updated the associated download information, checksum, and release link.

- **Release Process**
  - Stable and beta repository updates are now limited to their respective release types.
  - Release updates now proceed only after required publishing steps complete successfully and are not cancelled.
  - Successive release updates are coordinated to prevent conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->