### PR TITLE
LMS plugin: read knob devices same-origin so bridge status is correct on v4

### DIFF
--- a/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
+++ b/lms-plugin/HTML/EN/plugins/UnifiedHiFi/settings/basic.html
@@ -51,7 +51,9 @@
     [% title = "PLUGIN_UNIFIED_HIFI" %]
 
     <script TYPE="text/javascript" language="JavaScript">
-        const knobDevicesUrl = '[% webUrl %]/knob/devices';
+        // Same-origin relay (see Plugin.pm knobDevices); the bridge's own URL
+        // is cross-origin from this page and the bridge does not serve CORS.
+        const knobDevicesUrl = '/plugins/UnifiedHiFi/knobs.json';
         const charging = '[% "PLUGIN_UNIFIED_HIFI_KNOB_BATTERY_CHARGING" | string %]';
         const playerIdNameMap = JSON.parse('[% playerIdNameMap | replace("'", "\\'") %]');
 

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -11,6 +11,8 @@ use base qw(Slim::Plugin::Base);
 use Slim::Utils::Prefs;
 use Slim::Utils::Log;
 use Slim::Utils::Strings qw(string);
+use Slim::Networking::SimpleAsyncHTTP;
+use HTTP::Status qw(RC_OK RC_SERVICE_UNAVAILABLE);
 
 use Plugins::UnifiedHiFi::Helper;
 use Plugins::UnifiedHiFi::Settings;
@@ -37,6 +39,18 @@ sub initPlugin {
     Plugins::UnifiedHiFi::Settings->new;
     Plugins::UnifiedHiFi::Helper->init;
 
+    # The settings page polls the bridge for knob devices. It used to call the
+    # bridge's own URL from the browser, which is a cross-origin request: the
+    # page is served by LMS, the bridge by a different port. v4 of the bridge
+    # no longer answers cross-origin browser requests unless an operator opts
+    # in (UHC_ALLOWED_ORIGINS), so that call failed and the page reported the
+    # bridge as not running while it was. Serve the data from LMS's own origin
+    # instead: this handler fetches it server-side over loopback and relays it.
+    Slim::Web::Pages->addPageFunction(
+        qr{^plugins/UnifiedHiFi/knobs\.json},
+        \&knobDevices,
+    );
+
     # Start the helper if autorun is enabled
     if ($prefs->get('autorun')) {
         Plugins::UnifiedHiFi::Helper->start;
@@ -50,6 +64,39 @@ sub initPlugin {
 sub shutdownPlugin {
     Plugins::UnifiedHiFi::Helper->stop;
     $log->info("Unified Hi-Fi Control plugin shutdown");
+}
+
+# GET plugins/UnifiedHiFi/knobs.json -- same-origin relay of the bridge's
+# /knob/devices. Responds asynchronously: returns undef now and completes the
+# HTTP response from the SimpleAsyncHTTP callback. A bridge that is down or
+# not answering yields 503 with a small JSON error body, so the page's failure
+# path still means "bridge not running".
+sub knobDevices {
+    my ($client, $params, $callback, $httpClient, $response) = @_;
+
+    my $port = $prefs->get('port') || 8088;
+    my $url  = "http://127.0.0.1:$port/knob/devices";
+
+    Slim::Networking::SimpleAsyncHTTP->new(
+        sub {
+            my $http = shift;
+            my $body = $http->content;
+            $response->code(RC_OK);
+            $response->content_type('application/json');
+            $callback->($client, $params, \$body, $httpClient, $response);
+        },
+        sub {
+            my ($http, $error) = @_;
+            $log->debug("Bridge not reachable at $url: $error");
+            my $body = '{"error":"bridge unreachable"}';
+            $response->code(RC_SERVICE_UNAVAILABLE);
+            $response->content_type('application/json');
+            $callback->($client, $params, \$body, $httpClient, $response);
+        },
+        { timeout => 3, cache => 0 },
+    )->get($url);
+
+    return;
 }
 
 sub getDisplayName {

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -77,25 +77,36 @@ sub knobDevices {
     my $port = $prefs->get('port') || 8088;
     my $url  = "http://127.0.0.1:$port/knob/devices";
 
+    # One failure shape for "down", "not answering", and "answered with an
+    # error": 503 plus a small JSON body the page can treat as not running.
+    my $unavailable = sub {
+        my $body = '{"error":"bridge unavailable"}';
+        $response->code(RC_SERVICE_UNAVAILABLE);
+        $response->content_type('application/json');
+        $callback->($client, $params, \$body, $httpClient, $response);
+    };
+
     Slim::Networking::SimpleAsyncHTTP->new(
         sub {
             my $http = shift;
-            my $body = $http->content;
             # SimpleAsyncHTTP calls this for any HTTP response, 4xx and 5xx
-            # included; only a 2xx is a healthy bridge. Pass the bridge's own
-            # status through so the page's failure path still fires.
-            my $code = $http->code || RC_OK;
-            $response->code($code =~ /^2\d\d$/ ? RC_OK : $code);
+            # included; only a 2xx is a healthy bridge. Anything else takes
+            # the same 503 path as an unreachable bridge, so the page never
+            # relays a bridge error body as if it were knob data.
+            my $code = $http->code;
+            if (!$code || $code !~ /^2\d\d$/) {
+                $log->debug("Bridge answered $url with status " . ($code // 'none'));
+                return $unavailable->();
+            }
+            my $body = $http->content;
+            $response->code(RC_OK);
             $response->content_type('application/json');
             $callback->($client, $params, \$body, $httpClient, $response);
         },
         sub {
             my ($http, $error) = @_;
             $log->debug("Bridge not reachable at $url: $error");
-            my $body = '{"error":"bridge unreachable"}';
-            $response->code(RC_SERVICE_UNAVAILABLE);
-            $response->content_type('application/json');
-            $callback->($client, $params, \$body, $httpClient, $response);
+            $unavailable->();
         },
         { timeout => 3, cache => 0 },
     )->get($url);

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -108,7 +108,7 @@ sub knobDevices {
             $log->debug("Bridge not reachable at $url: $error");
             $unavailable->();
         },
-        { timeout => 3, cache => 0 },
+        { timeout => 3, cache => 0, maxRedirect => 0 },
     )->get($url);
 
     return;

--- a/lms-plugin/Plugin.pm
+++ b/lms-plugin/Plugin.pm
@@ -81,7 +81,11 @@ sub knobDevices {
         sub {
             my $http = shift;
             my $body = $http->content;
-            $response->code(RC_OK);
+            # SimpleAsyncHTTP calls this for any HTTP response, 4xx and 5xx
+            # included; only a 2xx is a healthy bridge. Pass the bridge's own
+            # status through so the page's failure path still fires.
+            my $code = $http->code || RC_OK;
+            $response->code($code =~ /^2\d\d$/ ? RC_OK : $code);
             $response->content_type('application/json');
             $callback->($client, $params, \$body, $httpClient, $response);
         },


### PR DESCRIPTION
## Problem

An LMS tester on v4.0.0-alpha.3 reports the plugin says the bridge is not running while it is.

The settings page's JavaScript polls the bridge directly at `http://<lms-host>:<bridge-port>/knob/devices`. That is cross-origin from the LMS page. The v4 bridge only answers cross-origin browser requests when `UHC_ALLOWED_ORIGINS` is set (#542 withdrew the permissive CORS layer because the server exposes playback, OAuth, and companion authority). The alpha.3 binary returns 200 with no `Access-Control-Allow-Origin`, the browser blocks it, and the page takes its failure path: "Stopped".

## Change

- `Plugin.pm`: register `plugins/UnifiedHiFi/knobs.json`, a same-origin relay that fetches `/knob/devices` over loopback via `SimpleAsyncHTTP` and completes the HTTP response asynchronously. Bridge down or silent yields 503 with a small JSON body, so the failure path still means "not running".
- `basic.html`: poll the relay instead of the bridge URL. `webUrl` is still used for "Open Web UI".

No change to the bridge's CORS policy.

## Verification

Lyrion Music Server 9.1.2 in Docker with the alpha.3 plugin binaries:

| Plugin | Bridge | Page shows | Request |
|---|---|---|---|
| unpatched alpha.3 | running | Stopped | direct bridge call fails in browser |
| patched | running | Running | `knobs.json` 200 |
| patched | killed | Stopped | `knobs.json` 503 |

The bridge itself, probed with `curl -H 'Origin: ...'`, confirms no CORS headers on `/knob/devices`, so the cross-origin path cannot work without an operator opt-in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a same-origin endpoint for retrieving knob-device data through the configured bridge.
  * Successful requests now relay device information to the settings interface.
  * Unavailable or unsuccessful bridge requests return a clear service-unavailable response.

* **Bug Fixes**
  * Updated the settings interface to use the local endpoint, improving compatibility with browser security restrictions and local bridge configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->