### PR TITLE
LMS collections: fix browse, favorites, and wire internet radio

### DIFF
--- a/docs/lyrion.md
+++ b/docs/lyrion.md
@@ -164,3 +164,27 @@ LMS supports HTTP Basic Auth. Include credentials in requests:
 const auth = Buffer.from(`${username}:${password}`).toString('base64');
 headers['Authorization'] = `Basic ${auth}`;
 ```
+
+## Internet radio
+
+`radios <start> <count>` is the top of the radio hierarchy; on a stock server the
+rows come from the bundled TuneIn plugin. Each row names a menu in `cmd`
+(`presets`, `local`, `music`, `search`, …) and the loop is `radioss_loop` — the
+doubled `s` the command name produces.
+
+Walk a menu with `<cmd> items <start> <count> [item_id:<id>] want_url:1`:
+
+- **It needs a player.** A server-level `<cmd> items` is the bad-params failure —
+  a closed socket, no body. Every library query in the adapter is server-level;
+  this one is not.
+- **`want_url:1` is required for playback.** A station's stream url is a
+  requested field and its only handle; LMS gives radio rows no durable entity id.
+- **`hasitems` and `isaudio` are independent.** Categories are navigable and play
+  nothing, stations play and contain nothing, and a category still carries a
+  `Browse.ashx` url when `want_url` is on — so a url does not mean playable.
+- **Item ids are per-request.** They carry a session prefix (`4f1345bf.0`, then
+  `755cb784.0` for the same row) and cannot outlive a server restart.
+
+Saved favorites are a different surface: a flat `favorites items` list that may
+contain streams. The Library page's Radio tab serves this hierarchy and its
+Favorites tab serves that list; see `LmsAdapter::collections_content`.

--- a/docs/lyrion.md
+++ b/docs/lyrion.md
@@ -103,6 +103,13 @@ are the `ALBUM_DISPLAY_TAGS` / `TRACK_DISPLAY_TAGS` constants in
 `src/adapters/lms.rs`, and `tests/lms_collection_tags.rs` fails if either drops a
 field it reads.
 
+The same rule reaches beyond `tags:`. `favorites items` omits `url` unless the
+request asks `want_url:1`, and a favorite has no durable entity id, so the url is
+its only playback handle — without the flag every favorite row is unplayable and
+UHC drops it. Recorded both ways in
+`tests/fixtures/lms/collections_favorites_without_want_url.json` and
+`collections_favorites_with_want_url.json`.
+
 | Tag | Key in the response | Value |
 |-----|--------------------|-------|
 | `a` | `artist` | Track artist name |

--- a/docs/lyrion.md
+++ b/docs/lyrion.md
@@ -91,6 +91,18 @@ table below is read from LMS's own `%tagMap` in
 `Slim/Control/Queries.pm` at 9.1.2 and confirmed against a live server; the recorded
 response is `tests/fixtures/lms/status_tags_aAdltKc.json`.
 
+**A `tags:` parameter replaces the query's default tag set, it does not extend it.**
+Every field a caller reads has to be named in the string, including ones the same
+query returns by default when no `tags:` is sent at all. This bit
+`hifi_collections`: `albums` sends `album` by default, and adding `tags:cJ` for
+artwork alone removed it, so every album row arrived with no title and the whole
+Albums level came back empty. Recorded both ways in
+`tests/fixtures/lms/collections_albums_artwork_only.json` and
+`collections_albums_with_display_tags.json`; the adapter's collection tag strings
+are the `ALBUM_DISPLAY_TAGS` / `TRACK_DISPLAY_TAGS` constants in
+`src/adapters/lms.rs`, and `tests/lms_collection_tags.rs` fails if either drops a
+field it reads.
+
 | Tag | Key in the response | Value |
 |-----|--------------------|-------|
 | `a` | `artist` | Track artist name |

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -160,6 +160,9 @@ fn loop_entity_id(row: &Value, entity: &str) -> Option<i64> {
     lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id"))).filter(|id| *id > 0)
 }
 
+/// The collection path for the top of LMS's internet-radio hierarchy.
+pub(crate) const RADIO_ROOT_PATH: &str = "radio";
+
 /// Tags the `albums` query must request for a browsable album row.
 ///
 /// **A `tags:` parameter replaces the default tag set, it does not extend it.**
@@ -2140,13 +2143,29 @@ impl LmsAdapter {
             .unwrap_or(20)
             .clamp(1, 50) as usize;
         let offset = params.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize;
+        // Radio is player-scoped: LMS's XMLBrowser `<cmd> items` queries close the
+        // socket on a server-level request (the documented bad-params failure),
+        // unlike every library query above them.
+        let player = params
+            .get("zone_id")
+            .and_then(Value::as_str)
+            .map(strip_lms_prefix);
         match operation {
             "collections_browse" => {
                 let path = params.get("path").and_then(Value::as_str).unwrap_or("root");
-                self.browse_collections(path, offset, limit).await
+                self.browse_collections(path, player, offset, limit).await
             }
             "collections_playlists" => self.list_playlists(offset, limit).await,
-            "collections_favorites" => self.list_favorites(offset, limit).await,
+            // The Library page's Favorites and Radio tabs are the same action
+            // told apart by `media_type` (`crate::app::pages::library`). LMS
+            // keeps them in two unrelated places: saved favorites are a flat
+            // list, while radio is TuneIn's own browse hierarchy behind
+            // `radios`. Serving the favorites list for both -- which is what
+            // ignoring `media_type` did -- made the two tabs identical.
+            "collections_favorites" => match params.get("media_type").and_then(Value::as_str) {
+                Some("radio") => self.list_radio_root(player, offset, limit).await,
+                _ => self.list_favorites(offset, limit).await,
+            },
             _ => Err(anyhow!("unsupported LMS collection operation {operation}")),
         }
     }
@@ -2156,7 +2175,13 @@ impl LmsAdapter {
     /// playlist's tracks. Every navigable path is a plain string this adapter
     /// invented (`"albums"`, `"album:<id>"`, ...) -- never a raw LMS id handed
     /// back to a client uninterpreted.
-    async fn browse_collections(&self, path: &str, offset: usize, limit: usize) -> Result<Value> {
+    async fn browse_collections(
+        &self,
+        path: &str,
+        player: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Value> {
         if path == "root" {
             // The root menu is invented by this adapter, not read from LMS --
             // but a caller with no LMS host configured (or one that is
@@ -2207,6 +2232,21 @@ impl LmsAdapter {
             .and_then(|s| s.parse::<i64>().ok())
         {
             return self.query_playlist_tracks(offset, limit, id).await;
+        }
+        if path == RADIO_ROOT_PATH {
+            return self.list_radio_root(player, offset, limit).await;
+        }
+        if let Some(rest) = path.strip_prefix("radio:") {
+            // `radio:<cmd>` is a menu named by `radios`; `radio:<cmd>:<item_id>`
+            // is a level inside it. The item id is XMLBrowser's own, and only
+            // its owning menu can interpret it.
+            let (menu, item_id) = match rest.split_once(':') {
+                Some((menu, item)) => (menu, Some(item)),
+                None => (rest, None),
+            };
+            return self
+                .browse_radio(menu, item_id, player, offset, limit)
+                .await;
         }
         Err(anyhow!("unknown LMS collection path {path:?}"))
     }
@@ -2392,6 +2432,123 @@ impl LmsAdapter {
                     "id": id,
                     "image_key": row_image_key(row),
                 }))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `radios <start> <count>` -- the top of LMS's internet-radio hierarchy.
+    ///
+    /// Each row names a menu (`cmd`: `local`, `music`, `news`, `search`, ...)
+    /// served by whichever radio plugin is installed; on a stock server that is
+    /// TuneIn. The rows are navigable only -- nothing at this level plays --
+    /// so each becomes a `radio:<cmd>` collection path.
+    ///
+    /// Distinct from [`Self::list_favorites`] on purpose: a saved favorite that
+    /// happens to be a stream lives in the favorites list, while this is the
+    /// provider's own station directory. See `collections_content` on why the
+    /// Radio tab reaches this and the Favorites tab does not.
+    async fn list_radio_root(
+        &self,
+        player: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Value> {
+        let raw = self
+            .rpc
+            .execute(player, vec![json!("radios"), json!(offset), json!(limit)])
+            .await?;
+        // LMS spells this loop with the doubled `s` its command name produces.
+        let items: Vec<Value> = raw
+            .get("radioss_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let title = row.get("name").and_then(Value::as_str)?.to_string();
+                let menu = row.get("cmd").and_then(Value::as_str)?;
+                Some(json!({"title": title, "path": format!("radio:{menu}")}))
+            })
+            .collect();
+        let next_offset = next_offset(&raw, offset, limit, items.len());
+        Ok(json!({"items": items, "next_offset": next_offset}))
+    }
+
+    /// `<menu> items <start> <count> [item_id:<id>] want_url:1` -- one level of
+    /// a radio menu.
+    ///
+    /// # Two things this level needs that it must ask for
+    ///
+    /// `want_url:1` for the same reason [`Self::list_favorites`] sends it: a
+    /// station's stream url is a requested field, and it is the only playback
+    /// handle a station has. And the query needs a **player**, unlike every
+    /// library query in this file -- a server-level XMLBrowser request is the
+    /// bad-params failure that closes the socket (`tests/fixtures/lms/PROVENANCE.md`).
+    ///
+    /// # Why the ids are not durable
+    ///
+    /// XMLBrowser item ids are minted per request (`4f1345bf.0` one call,
+    /// `755cb784.0` the next) and mean nothing outside the feed LMS cached for
+    /// them. They resolve for as long as that cache lives -- which is how LMS's
+    /// own web UI walks this tree -- but they cannot outlive a server restart,
+    /// so a bookmarked deep radio location can go stale where a library one
+    /// cannot. The location this path hangs off records each step's **title**
+    /// as well, so re-walking the trail by name is possible later without
+    /// changing any token already handed out.
+    async fn browse_radio(
+        &self,
+        menu: &str,
+        item_id: Option<&str>,
+        player: Option<&str>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Value> {
+        let player = player.ok_or_else(|| {
+            anyhow!("LMS radio browsing needs a zone: XMLBrowser refuses a server-level request")
+        })?;
+        let mut params = vec![
+            json!(menu),
+            json!("items"),
+            json!(offset),
+            json!(limit),
+            json!("want_url:1"),
+        ];
+        if let Some(id) = item_id {
+            params.push(json!(format!("item_id:{id}")));
+        }
+        let raw = self.rpc.execute(Some(player), params).await?;
+        let items: Vec<Value> = raw
+            .get("loop_loop")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|row| {
+                let title = row
+                    .get("name")
+                    .or_else(|| row.get("title"))
+                    .and_then(Value::as_str)?
+                    .to_string();
+                let id = row.get("id").and_then(Value::as_str);
+                // `hasitems` and `isaudio` are independent: a station can be
+                // playable with nothing inside it, a genre is navigable and
+                // plays nothing, and TuneIn serves rows that are both.
+                let navigable = lms_flag(row.get("hasitems"));
+                let playable = lms_flag(row.get("isaudio"));
+                let mut item = json!({"title": title});
+                if navigable {
+                    if let Some(id) = id {
+                        item["path"] = json!(format!("radio:{menu}:{id}"));
+                    }
+                }
+                if playable {
+                    if let Some(url) = row.get("url").and_then(Value::as_str) {
+                        item["url"] = json!(url);
+                    }
+                }
+                // A row with neither is a label or a dead end; listing it would
+                // be a row that does nothing when tapped.
+                (item.get("path").is_some() || item.get("url").is_some()).then_some(item)
             })
             .collect();
         let next_offset = next_offset(&raw, offset, limit, items.len());

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -2413,6 +2413,15 @@ impl LmsAdapter {
                     json!("items"),
                     json!(offset),
                     json!(limit),
+                    // `favorites items` omits `url` unless the request asks for
+                    // it, and a favorite has no other playback handle -- LMS
+                    // gives them no durable entity id. Without this every row
+                    // failed the `url` guard below and the Favorites and Radio
+                    // tabs came back empty. Same rule as the `tags:` constants
+                    // above: a field that is not requested is simply absent.
+                    // Recorded both ways in
+                    // `tests/fixtures/lms/collections_favorites_*.json`.
+                    json!("want_url:1"),
                 ],
             )
             .await?;

--- a/src/adapters/lms.rs
+++ b/src/adapters/lms.rs
@@ -160,6 +160,25 @@ fn loop_entity_id(row: &Value, entity: &str) -> Option<i64> {
     lms_i64(row.get(format!("{}_id", entity)).or_else(|| row.get("id"))).filter(|id| *id > 0)
 }
 
+/// Tags the `albums` query must request for a browsable album row.
+///
+/// **A `tags:` parameter replaces the default tag set, it does not extend it.**
+/// LMS returns exactly the fields the letters name, so anything the caller
+/// reads has to appear here. `l` album title, `a` artist, `c` coverid,
+/// `J` artwork_track_id (see docs/lyrion.md's tag table).
+///
+/// Recorded proof of both halves, from live Lyrion 9.1.2:
+/// `tests/fixtures/lms/collections_albums_artwork_only.json` (what `tags:cJ`
+/// returns -- no `album` key at all) and
+/// `collections_albums_with_display_tags.json`.
+pub(crate) const ALBUM_DISPLAY_TAGS: &str = "tags:lacJ";
+
+/// Tags the `titles` and `playlists tracks` queries must request.
+///
+/// Both always return `title`, but the artist subtitle is a tagged field like
+/// any other: `tags:cJ` drops it. See [`ALBUM_DISPLAY_TAGS`].
+pub(crate) const TRACK_DISPLAY_TAGS: &str = "tags:acJ";
+
 /// This row's artwork handle, for `hifi_collections`' image ref (#549), or
 /// `None` when LMS has none for it (an artist row, or a track/album LMS
 /// never assigned art to) -- absent honestly, not a placeholder.
@@ -2200,14 +2219,19 @@ impl LmsAdapter {
         limit: usize,
         artist_id: Option<i64>,
     ) -> Result<Value> {
-        // #549: `tags:cJ` requests coverid and artwork_track_id (docs/lyrion.md)
-        // so `row_image_key` has something to read; neither tag changes any
-        // field this method already used.
+        // A `tags:` parameter REPLACES the query's default tag set rather than
+        // adding to it, so every field this method reads has to be named here.
+        // #549 added `tags:cJ` for artwork alone, which dropped `album` from
+        // every row -- the title this method requires -- so `filter_map` below
+        // discarded the whole page and the Albums level (and every artist's
+        // album list) went empty against a real server. `l` album title,
+        // `a` artist, `c` coverid, `J` artwork_track_id; see docs/lyrion.md's
+        // tag table and `tests/lms_collection_tags.rs`.
         let mut params = vec![
             json!("albums"),
             json!(offset),
             json!(limit),
-            json!("tags:cJ"),
+            json!(ALBUM_DISPLAY_TAGS),
         ];
         if let Some(id) = artist_id {
             params.push(json!(format!("artist_id:{id}")));
@@ -2273,8 +2297,10 @@ impl LmsAdapter {
                     json!(offset),
                     json!(limit),
                     json!(format!("{filter_key}:{filter_id}")),
-                    // #549: see `row_image_key`'s docs.
-                    json!("tags:cJ"),
+                    // `a` for the artist subtitle alongside the artwork tags --
+                    // see `ALBUM_DISPLAY_TAGS` on why the artwork tags alone
+                    // silently drop it.
+                    json!(TRACK_DISPLAY_TAGS),
                 ],
             )
             .await?;
@@ -2341,8 +2367,8 @@ impl LmsAdapter {
                     json!(offset),
                     json!(limit),
                     json!(format!("playlist_id:{playlist_id}")),
-                    // #549: see `row_image_key`'s docs.
-                    json!("tags:cJ"),
+                    // Same tag rule as `query_tracks`; see `ALBUM_DISPLAY_TAGS`.
+                    json!(TRACK_DISPLAY_TAGS),
                 ],
             )
             .await?;

--- a/src/mcp/tools/collections.rs
+++ b/src/mcp/tools/collections.rs
@@ -508,6 +508,11 @@ async fn handle_lms(
             &json!({
                 "path": provider_path,
                 "media_type": args.media_type,
+                // LMS radio is XMLBrowser, which refuses a server-level
+                // request, so the zone has to reach the adapter (see
+                // `LmsAdapter::browse_radio`). Every other LMS collection
+                // query is server-level and ignores this.
+                "zone_id": args.zone_id,
                 "limit": limit,
                 "offset": offset,
             }),

--- a/tests/fixtures/lms/PROVENANCE.md
+++ b/tests/fixtures/lms/PROVENANCE.md
@@ -49,6 +49,8 @@ network if you need a player.
 | `collections_titles_with_display_tags.json` | The same query as `tags:acJ`; `artist` restored. |
 | `collections_playlisttracks_artwork_only.json` | `playlists tracks 0 3 playlist_id:<id> tags:cJ` — same subtitle loss as `titles`, and shows the loop is named `playlisttracks_loop`. |
 | `collections_playlisttracks_with_display_tags.json` | The same query as `tags:acJ`; `artist` restored. |
+| `collections_favorites_without_want_url.json` | **The favorites defect.** `favorites items 0 20` — the query the adapter shipped. Rows carry `id`, `name`, `type`, `image`, `isaudio`, `hasitems` and **no `url`**. A favorite has no durable entity id, so `list_favorites`' url guard dropped every row and the Favorites and Radio tabs were empty. Also shows the artwork field is `image` (a server-relative icon path like `html/images/radio.png`), **not** the `icon` absolute URL the adapter reads — so favorites carry no artwork either way. |
+| `collections_favorites_with_want_url.json` | The same query plus `want_url:1`: every non-folder row gains `url` (`http://…` for a stream, `db:track.titlesearch=…` for a library favorite). The folder row (`hasitems: 1`) still has none, which is why it is dropped rather than listed as a dead end. |
 | `status_tags_aAdltKc.json` | **Defect 4.** The adapter's exact `tags:aAdltKc` string. `l` yields `"album": "Ember Light"` (album **title**, not `album_id`); `A` yields per-role `albumartist`/`trackartist`; `a` yields `artist`; `d` `duration`; `t` `tracknum`. Also shows `artwork_track_id` is **absent**, because that field is tag `J` which this string does not request. |
 
 ## Mute is immediate; the negated volume lags it (no fixture file — this is timing)

--- a/tests/fixtures/lms/PROVENANCE.md
+++ b/tests/fixtures/lms/PROVENANCE.md
@@ -51,6 +51,10 @@ network if you need a player.
 | `collections_playlisttracks_with_display_tags.json` | The same query as `tags:acJ`; `artist` restored. |
 | `collections_favorites_without_want_url.json` | **The favorites defect.** `favorites items 0 20` — the query the adapter shipped. Rows carry `id`, `name`, `type`, `image`, `isaudio`, `hasitems` and **no `url`**. A favorite has no durable entity id, so `list_favorites`' url guard dropped every row and the Favorites and Radio tabs were empty. Also shows the artwork field is `image` (a server-relative icon path like `html/images/radio.png`), **not** the `icon` absolute URL the adapter reads — so favorites carry no artwork either way. |
 | `collections_favorites_with_want_url.json` | The same query plus `want_url:1`: every non-folder row gains `url` (`http://…` for a stream, `db:track.titlesearch=…` for a library favorite). The folder row (`hasitems: 1`) still has none, which is why it is dropped rather than listed as a dead end. |
+| `collections_radios_root.json` | `radios 0 20` — the top of LMS's internet-radio hierarchy on a stock server (TuneIn): My Presets, Local Radio, Music, Sports, News, Talk, By Location, By Language, Podcasts, Search TuneIn. Each row is a menu named by `cmd`, with **no `id` and no `url`** — nothing here plays. Note the loop is `radioss_loop`, with the doubled `s` the command name produces. |
+| `collections_radio_menu_items.json` | `music items 0 6 want_url:1` — one menu's top level. Rows are categories (`hasitems: 1`, `isaudio: 0`) that **also carry a `Browse.ashx` url**, which is why "has a url" cannot mean "is playable": treating it that way puts a play button on a genre. |
+| `collections_radio_stations_with_want_url.json` | `music items 0 6 item_id:<id> want_url:1` — a station level. Rows are `isaudio: 1`, `hasitems: 0`, each with a `Tune.ashx` stream url, the only playback handle a station has. |
+| `collections_radio_stations_without_want_url.json` | The same query with the flag dropped: identical rows, **no `url` on any of them**. Third recorded instance of the rule that a field LMS is not asked for is simply absent (see the `tags:` and favorites entries above). |
 | `status_tags_aAdltKc.json` | **Defect 4.** The adapter's exact `tags:aAdltKc` string. `l` yields `"album": "Ember Light"` (album **title**, not `album_id`); `A` yields per-role `albumartist`/`trackartist`; `a` yields `artist`; `d` `duration`; `t` `tracknum`. Also shows `artwork_track_id` is **absent**, because that field is tag `J` which this string does not request. |
 
 ## Mute is immediate; the negated volume lags it (no fixture file — this is timing)
@@ -106,3 +110,19 @@ Source: `Slim::Web::JSONRPC::requestMethod` calls `closeHTTPSocket()` on any
 Because there is nothing to record, `tests/lms_transport.rs` reproduces this
 behaviour with a local TCP listener that accepts, reads the request, and closes
 without writing — the exact wire behaviour in the table above.
+
+## Radio item ids are per-request, and radio needs a player
+
+`radios` answers a server-level request, but every `<menu> items` query below it
+does not: addressed to `""` it is the bad-params failure above — 9 bytes and a
+closed socket. It must carry a player id, unlike every library query in
+`lms.rs`.
+
+XMLBrowser item ids are also minted per request. Two `music items 0 1` calls a
+second apart returned `4f1345bf.0` and `755cb784.0` for the same row. An older
+id still resolved after unrelated traffic, so they are not single-use — LMS is
+addressing the feed it cached — but they carry a session prefix and cannot
+outlive a server restart. That is why a deep radio location can go stale where a
+library one (`album:42`) cannot. The collection location records each step's
+title as well as its path, so re-walking a radio trail by name is possible later
+without changing any token already handed out.

--- a/tests/fixtures/lms/PROVENANCE.md
+++ b/tests/fixtures/lms/PROVENANCE.md
@@ -43,6 +43,12 @@ network if you need a player.
 | `players_no_playerprefs.json` | The same `players` query **without** `playerprefs:` — no `mute` key on any player. Proves the tag is what adds it, and that the old call could not have known mute. |
 | `mixer_muting_query_muted.json` / `..._unmuted.json` | `mixer muting ?` → `{"_muting": 1}` / `{"_muting": 0}`. The per-player query, kept as the documented alternative to the batched one. |
 | `status_squeezelite_muted.json` | `status` on a **muted** real squeezelite player carries **no mute key at all**, and reports `"mixer volume": -42` — LMS **negates** the volume once its mute fade completes. Both halves matter: `status` cannot report mute directly, and the raw value it does report goes negative, which the adapter used to hand straight to a `VolumeControl` declared `min: 0.0`. See the timing table below. |
+| `collections_albums_artwork_only.json` | **The collection tag defect.** `albums 0 3 tags:cJ` — the artwork-only string #549 shipped. Rows carry `id`, `performance`, `favorites_url`, and a **null** `favorites_title`, and **no `album` key at all**, so `query_albums`' title guard dropped every row and the Albums level (plus every artist's album list) was empty against a real server, at any library size. |
+| `collections_albums_with_display_tags.json` | The same query as `tags:lacJ`: `album` and `artist` are back alongside the artwork tags. Proves the fields are absent because they were not requested, not because the album lacks them. |
+| `collections_titles_artwork_only.json` | `titles 0 3 album_id:2 tags:cJ` — `title` survives (it is not tag-gated) but `artist` is gone, so track rows lost their subtitle. |
+| `collections_titles_with_display_tags.json` | The same query as `tags:acJ`; `artist` restored. |
+| `collections_playlisttracks_artwork_only.json` | `playlists tracks 0 3 playlist_id:<id> tags:cJ` — same subtitle loss as `titles`, and shows the loop is named `playlisttracks_loop`. |
+| `collections_playlisttracks_with_display_tags.json` | The same query as `tags:acJ`; `artist` restored. |
 | `status_tags_aAdltKc.json` | **Defect 4.** The adapter's exact `tags:aAdltKc` string. `l` yields `"album": "Ember Light"` (album **title**, not `album_id`); `A` yields per-role `albumartist`/`trackartist`; `a` yields `artist`; `d` `duration`; `t` `tracknum`. Also shows `artwork_track_id` is **absent**, because that field is tag `J` which this string does not request. |
 
 ## Mute is immediate; the negated volume lags it (no fixture file — this is timing)

--- a/tests/fixtures/lms/collections_albums_artwork_only.json
+++ b/tests/fixtures/lms/collections_albums_artwork_only.json
@@ -1,0 +1,36 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "albums",
+      "0",
+      3,
+      "tags:cJ"
+    ]
+  ],
+  "result": {
+    "albums_loop": [
+      {
+        "id": 1,
+        "performance": "",
+        "favorites_url": "db:album.title=&contributor.name=Aurora%20Fields",
+        "favorites_title": null
+      },
+      {
+        "id": 4,
+        "performance": "",
+        "favorites_url": "db:album.title=&contributor.name=Cosmic%20Drift",
+        "favorites_title": null
+      },
+      {
+        "id": 166,
+        "performance": "",
+        "favorites_url": "db:album.title=&contributor.name=Various%20Artists",
+        "favorites_title": null
+      }
+    ],
+    "count": 166
+  }
+}

--- a/tests/fixtures/lms/collections_albums_with_display_tags.json
+++ b/tests/fixtures/lms/collections_albums_with_display_tags.json
@@ -1,0 +1,42 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "albums",
+      "0",
+      3,
+      "tags:lacJ"
+    ]
+  ],
+  "result": {
+    "albums_loop": [
+      {
+        "id": 1,
+        "performance": "",
+        "favorites_url": "db:album.title=Greatest%20Hits&contributor.name=Aurora%20Fields",
+        "favorites_title": "Greatest Hits",
+        "album": "Greatest Hits",
+        "artist": "Aurora Fields"
+      },
+      {
+        "id": 4,
+        "performance": "",
+        "favorites_url": "db:album.title=Greatest%20Hits&contributor.name=Cosmic%20Drift",
+        "favorites_title": "Greatest Hits",
+        "album": "Greatest Hits",
+        "artist": "Cosmic Drift"
+      },
+      {
+        "id": 166,
+        "performance": "",
+        "favorites_url": "db:album.title=Label%20Sampler%20Vol.%201&contributor.name=Various%20Artists",
+        "favorites_title": "Label Sampler Vol. 1",
+        "album": "Label Sampler Vol. 1",
+        "artist": "Various Artists"
+      }
+    ],
+    "count": 166
+  }
+}

--- a/tests/fixtures/lms/collections_favorites_with_want_url.json
+++ b/tests/fixtures/lms/collections_favorites_with_want_url.json
@@ -1,0 +1,54 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "favorites",
+      "items",
+      "0",
+      20,
+      "want_url:1"
+    ]
+  ],
+  "result": {
+    "title": "Favorites",
+    "loop_loop": [
+      {
+        "id": "4f437447.0",
+        "name": "Groove Salad",
+        "type": "audio",
+        "image": "html/images/radio.png",
+        "url": "http://ice1.somafm.com/groovesalad-128-mp3",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "4f437447.1",
+        "name": "Drone Zone",
+        "type": "audio",
+        "image": "html/images/radio.png",
+        "url": "http://ice1.somafm.com/dronezone-128-mp3",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "4f437447.2",
+        "name": "First Light Fav",
+        "type": "audio",
+        "image": "html/images/favorites.png",
+        "url": "db:track.titlesearch=FIRST LIGHT",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "4f437447.3",
+        "name": "Test Folder",
+        "image": "html/images/favorites.png",
+        "isaudio": 0,
+        "hasitems": 1
+      }
+    ],
+    "count": 4
+  }
+}

--- a/tests/fixtures/lms/collections_favorites_without_want_url.json
+++ b/tests/fixtures/lms/collections_favorites_without_want_url.json
@@ -1,0 +1,50 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "favorites",
+      "items",
+      "0",
+      "20"
+    ]
+  ],
+  "result": {
+    "title": "Favorites",
+    "loop_loop": [
+      {
+        "id": "b2bb7a02.0",
+        "name": "Groove Salad",
+        "type": "audio",
+        "image": "html/images/radio.png",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b2bb7a02.1",
+        "name": "Drone Zone",
+        "type": "audio",
+        "image": "html/images/radio.png",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b2bb7a02.2",
+        "name": "First Light Fav",
+        "type": "audio",
+        "image": "html/images/favorites.png",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b2bb7a02.3",
+        "name": "Test Folder",
+        "image": "html/images/favorites.png",
+        "isaudio": 0,
+        "hasitems": 1
+      }
+    ],
+    "count": 4
+  }
+}

--- a/tests/fixtures/lms/collections_playlisttracks_artwork_only.json
+++ b/tests/fixtures/lms/collections_playlisttracks_artwork_only.json
@@ -1,0 +1,36 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "playlists",
+      "tracks",
+      "0",
+      3,
+      "playlist_id:482",
+      "tags:cJ"
+    ]
+  ],
+  "result": {
+    "__playlistTitle": "Mixed Test",
+    "playlisttracks_loop": [
+      {
+        "playlist index": "0",
+        "id": 1,
+        "title": "Best Of One"
+      },
+      {
+        "playlist index": 1,
+        "id": 2,
+        "title": "Best Of Two"
+      },
+      {
+        "playlist index": 2,
+        "id": 3,
+        "title": "Best Of Three"
+      }
+    ],
+    "count": 14
+  }
+}

--- a/tests/fixtures/lms/collections_playlisttracks_with_display_tags.json
+++ b/tests/fixtures/lms/collections_playlisttracks_with_display_tags.json
@@ -1,0 +1,39 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "playlists",
+      "tracks",
+      "0",
+      3,
+      "playlist_id:482",
+      "tags:acJ"
+    ]
+  ],
+  "result": {
+    "__playlistTitle": "Mixed Test",
+    "playlisttracks_loop": [
+      {
+        "playlist index": "0",
+        "id": 1,
+        "title": "Best Of One",
+        "artist": "Aurora Fields"
+      },
+      {
+        "playlist index": 1,
+        "id": 2,
+        "title": "Best Of Two",
+        "artist": "Aurora Fields"
+      },
+      {
+        "playlist index": 2,
+        "id": 3,
+        "title": "Best Of Three",
+        "artist": "Aurora Fields"
+      }
+    ],
+    "count": 14
+  }
+}

--- a/tests/fixtures/lms/collections_radio_menu_items.json
+++ b/tests/fixtures/lms/collections_radio_menu_items.json
@@ -1,0 +1,68 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:01",
+    [
+      "music",
+      "items",
+      "0",
+      6,
+      "want_url:1"
+    ]
+  ],
+  "result": {
+    "title": "Music",
+    "loop_loop": [
+      {
+        "id": "167b1b35.0",
+        "name": "Country",
+        "type": "link",
+        "url": "http://opml.radiotime.com/Browse.ashx?id=c57940&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 0,
+        "hasitems": 1
+      },
+      {
+        "id": "167b1b35.1",
+        "name": "Powerhitz",
+        "type": "link",
+        "url": "http://opml.radiotime.com/Browse.ashx?id=c100035612&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 0,
+        "hasitems": 1
+      },
+      {
+        "id": "167b1b35.2",
+        "name": "World Music",
+        "type": "link",
+        "url": "http://opml.radiotime.com/Browse.ashx?id=g22&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 0,
+        "hasitems": 1
+      },
+      {
+        "id": "167b1b35.3",
+        "name": "Top 40 & Pop Music",
+        "type": "link",
+        "url": "http://opml.radiotime.com/Browse.ashx?id=c57943&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 0,
+        "hasitems": 1
+      },
+      {
+        "id": "167b1b35.4",
+        "name": "Soul & R&B",
+        "type": "link",
+        "url": "http://opml.radiotime.com/Browse.ashx?id=c1367173&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 0,
+        "hasitems": 1
+      },
+      {
+        "id": "167b1b35.5",
+        "name": "Rock Music",
+        "type": "link",
+        "url": "http://opml.radiotime.com/Browse.ashx?id=c57951&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 0,
+        "hasitems": 1
+      }
+    ],
+    "count": 25
+  }
+}

--- a/tests/fixtures/lms/collections_radio_stations_with_want_url.json
+++ b/tests/fixtures/lms/collections_radio_stations_with_want_url.json
@@ -1,0 +1,75 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:01",
+    [
+      "music",
+      "items",
+      "0",
+      6,
+      "item_id:b4426ee5.0.1",
+      "want_url:1"
+    ]
+  ],
+  "result": {
+    "title": "Stations",
+    "loop_loop": [
+      {
+        "id": "b4426ee5.0.1.0",
+        "name": "CountryLine Radio (UK)",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-profiles.tunein.com%2Fs196675%2Fimages%2Flogoq.jpg%3Ft%3D1/image.jpg",
+        "url": "http://opml.radiotime.com/Tune.ashx?id=s196675&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.1",
+        "name": "America's Country",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-radiotime-logos.tunein.com%2Fs126270q.png/image.png",
+        "url": "http://opml.radiotime.com/Tune.ashx?id=s126270&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.2",
+        "name": "KX 94.7 (Hamilton, Canada)",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-radiotime-logos.tunein.com%2Fs7723q.png/image.png",
+        "url": "http://opml.radiotime.com/Tune.ashx?id=s7723&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.3",
+        "name": "Highway 65 Radio",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-radiotime-logos.tunein.com%2Fs174864q.png/image.png",
+        "url": "http://opml.radiotime.com/Tune.ashx?id=s174864&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.4",
+        "name": "100.9/107.1 The Cat (Albany, NY)",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-profiles.tunein.com%2Fs30267%2Fimages%2Flogoq.png%3Ft%3D2/image.png",
+        "url": "http://opml.radiotime.com/Tune.ashx?id=s30267&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.5",
+        "name": "The Ranch - Classic Country",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-profiles.tunein.com%2Fs135419%2Fimages%2Flogoq.png%3Ft%3D4/image.png",
+        "url": "http://opml.radiotime.com/Tune.ashx?id=s135419&formats=aac,ogg,mp3,wmpro,wma,wmvoice&partnerId=15&serial=664af1a949e673a78e2e548696f69cd8",
+        "isaudio": 1,
+        "hasitems": 0
+      }
+    ],
+    "count": 23
+  }
+}

--- a/tests/fixtures/lms/collections_radio_stations_without_want_url.json
+++ b/tests/fixtures/lms/collections_radio_stations_without_want_url.json
@@ -1,0 +1,68 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:01",
+    [
+      "music",
+      "items",
+      "0",
+      6,
+      "item_id:b4426ee5.0.1"
+    ]
+  ],
+  "result": {
+    "title": "Stations",
+    "loop_loop": [
+      {
+        "id": "b4426ee5.0.1.0",
+        "name": "CountryLine Radio (UK)",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-profiles.tunein.com%2Fs196675%2Fimages%2Flogoq.jpg%3Ft%3D1/image.jpg",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.1",
+        "name": "America's Country",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-radiotime-logos.tunein.com%2Fs126270q.png/image.png",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.2",
+        "name": "KX 94.7 (Hamilton, Canada)",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-radiotime-logos.tunein.com%2Fs7723q.png/image.png",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.3",
+        "name": "Highway 65 Radio",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-radiotime-logos.tunein.com%2Fs174864q.png/image.png",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.4",
+        "name": "100.9/107.1 The Cat (Albany, NY)",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-profiles.tunein.com%2Fs30267%2Fimages%2Flogoq.png%3Ft%3D2/image.png",
+        "isaudio": 1,
+        "hasitems": 0
+      },
+      {
+        "id": "b4426ee5.0.1.5",
+        "name": "The Ranch - Classic Country",
+        "type": "audio",
+        "image": "/imageproxy/http%3A%2F%2Fcdn-profiles.tunein.com%2Fs135419%2Fimages%2Flogoq.png%3Ft%3D4/image.png",
+        "isaudio": 1,
+        "hasitems": 0
+      }
+    ],
+    "count": 23
+  }
+}

--- a/tests/fixtures/lms/collections_radios_root.json
+++ b/tests/fixtures/lms/collections_radios_root.json
@@ -1,0 +1,87 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "02:00:00:00:00:01",
+    [
+      "radios",
+      "0",
+      "20"
+    ]
+  ],
+  "result": {
+    "count": 10,
+    "radioss_loop": [
+      {
+        "weight": 5,
+        "icon": "/plugins/TuneIn/html/images/radiopresets.png",
+        "name": "My Presets",
+        "type": "xmlbrowser",
+        "cmd": "presets"
+      },
+      {
+        "cmd": "local",
+        "weight": 20,
+        "icon": "/plugins/TuneIn/html/images/radiolocal.png",
+        "type": "xmlbrowser",
+        "name": "Local Radio"
+      },
+      {
+        "weight": 30,
+        "icon": "/plugins/TuneIn/html/images/radiomusic.png",
+        "type": "xmlbrowser",
+        "name": "Music",
+        "cmd": "music"
+      },
+      {
+        "cmd": "sports",
+        "weight": 40,
+        "icon": "/plugins/TuneIn/html/images/radiosports.png",
+        "type": "xmlbrowser",
+        "name": "Sports"
+      },
+      {
+        "cmd": "news",
+        "weight": 45,
+        "icon": "/plugins/TuneIn/html/images/radionews.png",
+        "name": "News",
+        "type": "xmlbrowser"
+      },
+      {
+        "icon": "/plugins/TuneIn/html/images/radiotalk.png",
+        "weight": 50,
+        "type": "xmlbrowser",
+        "name": "Talk",
+        "cmd": "talk"
+      },
+      {
+        "cmd": "location",
+        "type": "xmlbrowser",
+        "name": "By Location",
+        "weight": 55,
+        "icon": "/plugins/TuneIn/html/images/radioworld.png"
+      },
+      {
+        "cmd": "language",
+        "weight": 56,
+        "icon": "/plugins/TuneIn/html/images/radioworld.png",
+        "name": "By Language",
+        "type": "xmlbrowser"
+      },
+      {
+        "cmd": "podcast",
+        "weight": 70,
+        "icon": "/plugins/TuneIn/html/images/podcasts.png",
+        "type": "xmlbrowser",
+        "name": "Podcasts"
+      },
+      {
+        "weight": 110,
+        "icon": "/plugins/TuneIn/html/images/radiosearch.png",
+        "type": "xmlbrowser_search",
+        "name": "Search TuneIn",
+        "cmd": "search"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/lms/collections_titles_artwork_only.json
+++ b/tests/fixtures/lms/collections_titles_artwork_only.json
@@ -1,0 +1,31 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "titles",
+      "0",
+      3,
+      "album_id:2",
+      "tags:cJ"
+    ]
+  ],
+  "result": {
+    "titles_loop": [
+      {
+        "id": 4,
+        "title": "First Light"
+      },
+      {
+        "id": 6,
+        "title": "Glass Meadow"
+      },
+      {
+        "id": 7,
+        "title": "Nightfall"
+      }
+    ],
+    "count": 5
+  }
+}

--- a/tests/fixtures/lms/collections_titles_with_display_tags.json
+++ b/tests/fixtures/lms/collections_titles_with_display_tags.json
@@ -1,0 +1,34 @@
+{
+  "id": 217,
+  "method": "slim.request",
+  "params": [
+    "",
+    [
+      "titles",
+      "0",
+      3,
+      "album_id:2",
+      "tags:acJ"
+    ]
+  ],
+  "result": {
+    "titles_loop": [
+      {
+        "id": 4,
+        "title": "First Light",
+        "artist": "Aurora Fields"
+      },
+      {
+        "id": 6,
+        "title": "Glass Meadow",
+        "artist": "Aurora Fields"
+      },
+      {
+        "id": 7,
+        "title": "Nightfall",
+        "artist": "Aurora Fields"
+      }
+    ],
+    "count": 5
+  }
+}

--- a/tests/lms_collection_tags.rs
+++ b/tests/lms_collection_tags.rs
@@ -1,0 +1,325 @@
+//! Regression tests for the LMS collection tag set.
+//!
+//! Every response here is replayed verbatim from a recording of a live Lyrion
+//! Music Server 9.1.2 (`tests/fixtures/lms/`, see that directory's
+//! `PROVENANCE.md`). Nothing guesses at LMS's shape.
+//!
+//! # The defect these exist for
+//!
+//! An LMS `tags:` parameter **replaces** the query's default tag set; it does
+//! not extend it. #549 added `tags:cJ` to the `albums`, `titles` and
+//! `playlists tracks` queries so artwork had a handle to read, which silently
+//! dropped the fields those queries return by default. For `albums` that
+//! included `album` -- the title `query_albums` requires -- so its `filter_map`
+//! discarded every row and the Albums level, plus every artist's album list,
+//! came back empty from a real server at any library size. Tracks and playlist
+//! tracks kept their titles but lost the artist subtitle.
+//!
+//! # Why the replay server is tag-aware
+//!
+//! A fixture server that always returns the fully tagged response would pass
+//! just as happily with the broken `tags:cJ` request, which is exactly the
+//! mock-agrees-with-the-code trap `lms_adapter_defects.rs` was written to
+//! avoid. So this server picks its fixture the way LMS itself does: from the
+//! tags the request actually asked for. Ask for artwork alone and you get the
+//! stripped rows a real server sends, and these tests fail.
+
+use axum::{extract::State, routing::post, Json, Router};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use unified_hifi_control::adapters::lms::LmsAdapter;
+use unified_hifi_control::bus::create_bus;
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+fn fixture_result(name: &str) -> Value {
+    let path = format!(
+        "{}/tests/fixtures/lms/{}.json",
+        env!("CARGO_MANIFEST_DIR"),
+        name
+    );
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) => panic!("recorded fixture {path} is missing: {e}"),
+    };
+    let parsed: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => panic!("recorded fixture {path} is not valid JSON: {e}"),
+    };
+    match parsed.get("result") {
+        Some(r) => r.clone(),
+        None => panic!("recorded fixture {path} has no `result` member"),
+    }
+}
+
+/// The letters of the request's `tags:` parameter, or `None` when it sent none.
+fn requested_tags(cmd: &Value) -> Option<String> {
+    cmd.as_array()?.iter().find_map(|part| {
+        part.as_str()
+            .and_then(|s| s.strip_prefix("tags:"))
+            .map(str::to_string)
+    })
+}
+
+// =============================================================================
+// Tag-aware replay server
+// =============================================================================
+
+#[derive(Clone)]
+struct ReplayState {
+    requests: Arc<Mutex<Vec<Value>>>,
+}
+
+struct TagReplayServer {
+    addr: SocketAddr,
+    requests: Arc<Mutex<Vec<Value>>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl TagReplayServer {
+    async fn start() -> Self {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let state = ReplayState {
+            requests: Arc::clone(&requests),
+        };
+        let app = Router::new()
+            .route("/jsonrpc.js", post(replay))
+            .with_state(state);
+        let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(l) => l,
+            Err(e) => panic!("bind replay server: {e}"),
+        };
+        let addr = match listener.local_addr() {
+            Ok(a) => a,
+            Err(e) => panic!("local_addr: {e}"),
+        };
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            addr,
+            requests,
+            handle,
+        }
+    }
+
+    fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    fn commands(&self) -> Vec<Value> {
+        match self.requests.lock() {
+            Ok(g) => g.clone(),
+            Err(e) => panic!("request log poisoned: {e}"),
+        }
+    }
+
+    fn stop(self) {
+        self.handle.abort();
+    }
+}
+
+/// Serve the recording that matches the request's own tags, as LMS does.
+async fn replay(State(state): State<ReplayState>, Json(body): Json<Value>) -> Json<Value> {
+    let cmd = body["params"][1].clone();
+    if let Ok(mut log) = state.requests.lock() {
+        log.push(cmd.clone());
+    }
+
+    let verb = cmd
+        .get(0)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let sub = cmd.get(1).and_then(Value::as_str).unwrap_or_default();
+    let tags = requested_tags(&cmd).unwrap_or_default();
+
+    let result = match (verb.as_str(), sub) {
+        // `l` is the album title. Without it a real server sends no `album`.
+        ("albums", _) => {
+            if tags.contains('l') {
+                fixture_result("collections_albums_with_display_tags")
+            } else {
+                fixture_result("collections_albums_artwork_only")
+            }
+        }
+        // `a` is the artist. Without it a real server sends no `artist`.
+        ("titles", _) => {
+            if tags.contains('a') {
+                fixture_result("collections_titles_with_display_tags")
+            } else {
+                fixture_result("collections_titles_artwork_only")
+            }
+        }
+        ("playlists", "tracks") => {
+            if tags.contains('a') {
+                fixture_result("collections_playlisttracks_with_display_tags")
+            } else {
+                fixture_result("collections_playlisttracks_artwork_only")
+            }
+        }
+        other => panic!("replay server got an unexpected command: {other:?} ({cmd})"),
+    };
+
+    Json(json!({"result": result}))
+}
+
+async fn adapter_for(addr: SocketAddr) -> LmsAdapter {
+    let adapter = LmsAdapter::new(create_bus());
+    adapter
+        .configure(addr.ip().to_string(), Some(addr.port()), None, None)
+        .await;
+    adapter
+}
+
+async fn browse(adapter: &LmsAdapter, path: &str) -> Value {
+    match adapter
+        .collections_content(
+            "collections_browse",
+            &json!({"path": path, "limit": 3, "offset": 0}),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => panic!("collections_browse {path:?} failed: {e:#}"),
+    }
+}
+
+fn rows(page: &Value) -> Vec<Value> {
+    page.get("items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// The Albums level, and every artist's album list
+// =============================================================================
+
+/// The load-bearing test: with artwork-only tags this page is empty, which is
+/// what a real server produced for every album row.
+#[tokio::test]
+async fn browsing_albums_returns_titled_rows() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let page = browse(&adapter, "albums").await;
+    let items = rows(&page);
+
+    assert!(
+        !items.is_empty(),
+        "the Albums level came back empty; LMS sends no `album` key unless the \
+         query asks for the album-title tag (see this file's module docs)"
+    );
+    for item in &items {
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(!title.is_empty(), "album row has no title: {item}");
+        let path = item.get("path").and_then(Value::as_str).unwrap_or_default();
+        assert!(
+            path.starts_with("album:"),
+            "album row is not navigable: {item}"
+        );
+    }
+    server.stop();
+}
+
+/// One artist's albums take the same query, so the same tags have to reach it.
+#[tokio::test]
+async fn browsing_one_artists_albums_returns_titled_rows() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let page = browse(&adapter, "artist:2").await;
+
+    assert!(
+        !rows(&page).is_empty(),
+        "an artist's album list came back empty"
+    );
+    let asked = server.commands().iter().any(|cmd| {
+        cmd.as_array()
+            .is_some_and(|a| a.iter().any(|p| p.as_str() == Some("artist_id:2")))
+    });
+    assert!(
+        asked,
+        "the artist filter never reached LMS: {:?}",
+        server.commands()
+    );
+    server.stop();
+}
+
+/// The request itself is the defect, so assert on it directly: a future edit
+/// that drops a display tag for artwork's sake fails here even if some mock
+/// would still hand back full rows.
+#[tokio::test]
+async fn album_query_asks_for_title_artist_and_artwork_tags() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    browse(&adapter, "albums").await;
+
+    let tags = server
+        .commands()
+        .iter()
+        .find_map(requested_tags)
+        .unwrap_or_else(|| panic!("no tags: parameter was sent: {:?}", server.commands()));
+    for (letter, field) in [
+        ('l', "album title"),
+        ('a', "artist"),
+        ('c', "coverid"),
+        ('J', "artwork_track_id"),
+    ] {
+        assert!(
+            tags.contains(letter),
+            "tags:{tags} omits `{letter}` ({field}); a tags: parameter replaces \
+             the default set, so an omitted field is simply absent from the rows"
+        );
+    }
+    server.stop();
+}
+
+// =============================================================================
+// Tracks and playlist tracks keep their subtitles
+// =============================================================================
+
+#[tokio::test]
+async fn album_tracks_keep_their_artist_subtitle() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let page = browse(&adapter, "album:2").await;
+    let items = rows(&page);
+
+    assert!(!items.is_empty(), "an album's track list came back empty");
+    assert!(
+        items
+            .iter()
+            .all(|i| i.get("subtitle").and_then(Value::as_str).is_some()),
+        "track rows lost their artist subtitle: {items:?}"
+    );
+    server.stop();
+}
+
+#[tokio::test]
+async fn playlist_tracks_keep_their_artist_subtitle() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let page = browse(&adapter, "playlist:482").await;
+    let items = rows(&page);
+
+    assert!(!items.is_empty(), "a playlist's track list came back empty");
+    assert!(
+        items
+            .iter()
+            .all(|i| i.get("subtitle").and_then(Value::as_str).is_some()),
+        "playlist track rows lost their artist subtitle: {items:?}"
+    );
+    server.stop();
+}

--- a/tests/lms_collection_tags.rs
+++ b/tests/lms_collection_tags.rs
@@ -15,6 +15,11 @@
 //! came back empty from a real server at any library size. Tracks and playlist
 //! tracks kept their titles but lost the artist subtitle.
 //!
+//! `favorites items` is the same rule wearing different clothes: it omits `url`
+//! unless the request asks `want_url:1`, and a favorite has no other playback
+//! handle, so the `url` guard in `list_favorites` discarded every row and the
+//! Favorites and Radio tabs came back empty too.
+//!
 //! # Why the replay server is tag-aware
 //!
 //! A fixture server that always returns the fully tagged response would pass
@@ -153,6 +158,18 @@ async fn replay(State(state): State<ReplayState>, Json(body): Json<Value>) -> Js
                 fixture_result("collections_titles_with_display_tags")
             } else {
                 fixture_result("collections_titles_artwork_only")
+            }
+        }
+        // `favorites items` sends `url` only when asked, and a favorite has no
+        // other handle to play.
+        ("favorites", "items") => {
+            let asked_for_url = cmd
+                .as_array()
+                .is_some_and(|a| a.iter().any(|p| p.as_str() == Some("want_url:1")));
+            if asked_for_url {
+                fixture_result("collections_favorites_with_want_url")
+            } else {
+                fixture_result("collections_favorites_without_want_url")
             }
         }
         ("playlists", "tracks") => {
@@ -320,6 +337,87 @@ async fn playlist_tracks_keep_their_artist_subtitle() {
             .iter()
             .all(|i| i.get("subtitle").and_then(Value::as_str).is_some()),
         "playlist track rows lost their artist subtitle: {items:?}"
+    );
+    server.stop();
+}
+
+// =============================================================================
+// Favorites (and the Radio tab, which is the same query)
+// =============================================================================
+
+async fn favorites(adapter: &LmsAdapter) -> Value {
+    match adapter
+        .collections_content("collections_favorites", &json!({"limit": 20, "offset": 0}))
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => panic!("collections_favorites failed: {e:#}"),
+    }
+}
+
+/// Favorites must arrive playable. A favorite carries no durable entity id, so
+/// the url is its only handle -- and LMS withholds it unless asked.
+#[tokio::test]
+async fn favorites_arrive_with_a_playback_url() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let page = favorites(&adapter).await;
+    let items = rows(&page);
+
+    assert!(
+        !items.is_empty(),
+        "the Favorites level came back empty; LMS omits `url` unless the request \
+         asks `want_url:1`, and `list_favorites` drops any row without one"
+    );
+    for item in &items {
+        assert!(
+            item.get("url")
+                .and_then(Value::as_str)
+                .is_some_and(|u| !u.is_empty()),
+            "favorite row has no playback url, so nothing can play it: {item}"
+        );
+    }
+    server.stop();
+}
+
+/// Assert on the request as well: the url is a *requested* field, and a future
+/// edit that drops the flag would empty both tabs again.
+#[tokio::test]
+async fn favorites_query_asks_for_the_url() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    favorites(&adapter).await;
+
+    let asked = server.commands().iter().any(|cmd| {
+        cmd.as_array()
+            .is_some_and(|a| a.iter().any(|p| p.as_str() == Some("want_url:1")))
+    });
+    assert!(
+        asked,
+        "the favorites query never asked for `want_url:1`: {:?}",
+        server.commands()
+    );
+    server.stop();
+}
+
+/// A folder-shaped favorite (`hasitems: 1`) has no url of its own. It is
+/// deliberately not browsable in this slice, so it must be dropped rather than
+/// listed as a dead end -- the recorded fixture contains one.
+#[tokio::test]
+async fn folder_shaped_favorites_are_not_listed_as_dead_ends() {
+    let server = TagReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let items = rows(&favorites(&adapter).await);
+
+    assert!(
+        !items.iter().any(|i| i
+            .get("title")
+            .and_then(Value::as_str)
+            .is_some_and(|t| t == "Test Folder")),
+        "a folder favorite was listed with no url and no way in: {items:?}"
     );
     server.stop();
 }

--- a/tests/lms_live_smoke.rs
+++ b/tests/lms_live_smoke.rs
@@ -236,3 +236,105 @@ async fn set_mute_on_server(player: &str, muted: bool) {
         Err(e) => panic!("mixer muting failed: {e}"),
     }
 }
+
+// =============================================================================
+// hifi_collections browse, against a real library
+// =============================================================================
+
+/// The Albums level must not be empty on a server that has albums.
+///
+/// This is the shape of defect the `tags:` rule produces: the adapter asked for
+/// artwork alone, LMS replaced the default tag set with it, and every album row
+/// arrived with no title to show. Unit tests passed throughout -- a fixture that
+/// carried the titles agreed with the broken request -- so the tag-keyed replay
+/// in `tests/lms_collection_tags.rs` and this live walk are what hold it down.
+#[tokio::test]
+#[ignore = "requires a live LMS; see module docs"]
+async fn live_albums_level_has_titled_rows() {
+    let adapter = live_adapter().await;
+
+    let page = match adapter
+        .collections_content(
+            "collections_browse",
+            &serde_json::json!({"path": "albums", "limit": 10, "offset": 0}),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => panic!("collections_browse albums failed: {e:#}"),
+    };
+    let items = page
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    println!("albums level returned {} rows:", items.len());
+    for item in &items {
+        println!("  {item}");
+    }
+    assert!(
+        !items.is_empty(),
+        "the Albums level is empty. If this server has albums, the query is \
+         dropping them -- check the tag string against docs/lyrion.md."
+    );
+    for item in &items {
+        assert!(
+            item.get("title")
+                .and_then(|v| v.as_str())
+                .is_some_and(|t| !t.is_empty()),
+            "album row has no title: {item}"
+        );
+    }
+}
+
+/// Walk one artist to its albums to its tracks, the path a Library click makes.
+#[tokio::test]
+#[ignore = "requires a live LMS; see module docs"]
+async fn live_artist_walk_reaches_tracks_with_subtitles() {
+    let adapter = live_adapter().await;
+    let browse = |path: String| {
+        let adapter = &adapter;
+        async move {
+            match adapter
+                .collections_content(
+                    "collections_browse",
+                    &serde_json::json!({"path": path, "limit": 10, "offset": 0}),
+                )
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => panic!("collections_browse {path:?} failed: {e:#}"),
+            }
+        }
+    };
+    let first_path = |page: &serde_json::Value| -> String {
+        page.get("items")
+            .and_then(|v| v.as_array())
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("path"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| panic!("no navigable row in {page}"))
+    };
+
+    let artists = browse("artists".to_string()).await;
+    let artist_path = first_path(&artists);
+    let albums = browse(artist_path.clone()).await;
+    println!("{artist_path} -> {albums}");
+    let album_path = first_path(&albums);
+    let tracks = browse(album_path.clone()).await;
+    println!("{album_path} -> {tracks}");
+
+    let rows = tracks
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(!rows.is_empty(), "an album's track list is empty: {tracks}");
+    assert!(
+        rows.iter()
+            .all(|r| r.get("subtitle").and_then(|v| v.as_str()).is_some()),
+        "track rows lost their artist subtitle, so the artist tag is missing: {rows:?}"
+    );
+}

--- a/tests/lms_live_smoke.rs
+++ b/tests/lms_live_smoke.rs
@@ -338,3 +338,68 @@ async fn live_artist_walk_reaches_tracks_with_subtitles() {
         "track rows lost their artist subtitle, so the artist tag is missing: {rows:?}"
     );
 }
+
+/// Walk the radio hierarchy on a real server: menus, then a level inside one.
+///
+/// Skips itself when the server has no radio plugin (a bare `radios` with no
+/// rows), so it cannot fail for a reason that is not UHC's.
+#[tokio::test]
+#[ignore = "requires a live LMS with a radio plugin; see module docs"]
+async fn live_radio_hierarchy_walks_into_a_menu() {
+    let adapter = live_adapter().await;
+    let zone = std::env::var("LMS_LIVE_PLAYER").unwrap_or_default();
+    if zone.is_empty() {
+        println!("set LMS_LIVE_PLAYER to a player id to run this");
+        return;
+    }
+
+    let root = match adapter
+        .collections_content(
+            "collections_favorites",
+            &serde_json::json!({"media_type": "radio", "zone_id": zone, "limit": 20, "offset": 0}),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => panic!("radio root failed: {e:#}"),
+    };
+    let menus = root
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if menus.is_empty() {
+        println!("no radio menus on this server; skipping");
+        return;
+    }
+    println!("radio menus: {menus:?}");
+
+    let path = menus
+        .iter()
+        .find_map(|m| m.get("path").and_then(|v| v.as_str()))
+        .unwrap_or_else(|| panic!("no navigable radio menu in {menus:?}"))
+        .to_string();
+    let level = match adapter
+        .collections_content(
+            "collections_browse",
+            &serde_json::json!({"path": path, "zone_id": zone, "limit": 20, "offset": 0}),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => panic!("radio menu {path:?} failed: {e:#}"),
+    };
+    let rows = level
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    println!("{path} -> {} rows", rows.len());
+    assert!(!rows.is_empty(), "radio menu {path:?} came back empty");
+    for row in &rows {
+        assert!(
+            row.get("path").is_some() || row.get("url").is_some(),
+            "radio row is neither navigable nor playable, so it does nothing: {row}"
+        );
+    }
+}

--- a/tests/lms_radio.rs
+++ b/tests/lms_radio.rs
@@ -1,0 +1,385 @@
+//! LMS internet radio, the Library page's Radio tab.
+//!
+//! Every response is replayed verbatim from a recording of a live Lyrion Music
+//! Server 9.1.2 with the stock TuneIn plugin (`tests/fixtures/lms/`, see that
+//! directory's `PROVENANCE.md`).
+//!
+//! # What this surface is, and what it is not
+//!
+//! The Library page derives its Favorites and Radio tabs from the one
+//! `Favorites` capability and tells them apart by `media_type`. LMS keeps the
+//! two in unrelated places: saved favorites are a flat list, while radio is the
+//! radio plugin's own browse hierarchy behind `radios`. The adapter ignored
+//! `media_type` and served favorites for both, so the two tabs showed identical
+//! lists while LMS's station directory was never called at all.
+//!
+//! # Three things this hierarchy demands that the library queries do not
+//!
+//! 1. **A player.** `<menu> items` closes the socket on a server-level request
+//!    (LMS's documented bad-params failure), so the zone has to reach the
+//!    adapter. Every library query in `lms.rs` is server-level.
+//! 2. **`want_url:1`.** A station's stream url is a requested field and its only
+//!    playback handle -- the same rule that emptied Favorites. Recorded both
+//!    ways in `collections_radio_stations_with_want_url.json` and
+//!    `..._without_want_url.json`.
+//! 3. **`hasitems` and `isaudio` read independently.** A category is navigable
+//!    and plays nothing; a station plays and contains nothing. A category also
+//!    carries a `Browse.ashx` url when `want_url` is on, so treating "has a url"
+//!    as "is playable" would offer a play button that browses.
+
+use axum::{extract::State, routing::post, Json, Router};
+use serde_json::{json, Value};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use unified_hifi_control::adapters::lms::LmsAdapter;
+use unified_hifi_control::bus::create_bus;
+
+const ZONE: &str = "lms:02:00:00:00:00:01";
+
+fn fixture_result(name: &str) -> Value {
+    let path = format!(
+        "{}/tests/fixtures/lms/{}.json",
+        env!("CARGO_MANIFEST_DIR"),
+        name
+    );
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(e) => panic!("recorded fixture {path} is missing: {e}"),
+    };
+    let parsed: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => panic!("recorded fixture {path} is not valid JSON: {e}"),
+    };
+    match parsed.get("result") {
+        Some(r) => r.clone(),
+        None => panic!("recorded fixture {path} has no `result` member"),
+    }
+}
+
+fn has_param(cmd: &Value, prefix: &str) -> bool {
+    cmd.as_array().is_some_and(|a| {
+        a.iter()
+            .any(|p| p.as_str().is_some_and(|s| s.starts_with(prefix)))
+    })
+}
+
+// =============================================================================
+// Replay server
+// =============================================================================
+
+#[derive(Clone)]
+struct ReplayState {
+    requests: Arc<Mutex<Vec<Value>>>,
+    players: Arc<Mutex<Vec<String>>>,
+}
+
+struct RadioReplayServer {
+    addr: SocketAddr,
+    requests: Arc<Mutex<Vec<Value>>>,
+    players: Arc<Mutex<Vec<String>>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl RadioReplayServer {
+    async fn start() -> Self {
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let players = Arc::new(Mutex::new(Vec::new()));
+        let state = ReplayState {
+            requests: Arc::clone(&requests),
+            players: Arc::clone(&players),
+        };
+        let app = Router::new()
+            .route("/jsonrpc.js", post(replay))
+            .with_state(state);
+        let listener = match tokio::net::TcpListener::bind("127.0.0.1:0").await {
+            Ok(l) => l,
+            Err(e) => panic!("bind replay server: {e}"),
+        };
+        let addr = match listener.local_addr() {
+            Ok(a) => a,
+            Err(e) => panic!("local_addr: {e}"),
+        };
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            addr,
+            requests,
+            players,
+            handle,
+        }
+    }
+
+    fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    fn commands(&self) -> Vec<Value> {
+        match self.requests.lock() {
+            Ok(g) => g.clone(),
+            Err(e) => panic!("request log poisoned: {e}"),
+        }
+    }
+
+    /// The player id each request was addressed to; `""` is server-level.
+    fn players(&self) -> Vec<String> {
+        match self.players.lock() {
+            Ok(g) => g.clone(),
+            Err(e) => panic!("player log poisoned: {e}"),
+        }
+    }
+
+    fn stop(self) {
+        self.handle.abort();
+    }
+}
+
+async fn replay(State(state): State<ReplayState>, Json(body): Json<Value>) -> Json<Value> {
+    let player = body["params"][0].as_str().unwrap_or_default().to_string();
+    let cmd = body["params"][1].clone();
+    if let Ok(mut log) = state.requests.lock() {
+        log.push(cmd.clone());
+    }
+    if let Ok(mut log) = state.players.lock() {
+        log.push(player);
+    }
+
+    let verb = cmd.get(0).and_then(Value::as_str).unwrap_or_default();
+    let sub = cmd.get(1).and_then(Value::as_str).unwrap_or_default();
+
+    let result = match (verb, sub) {
+        ("radios", _) => fixture_result("collections_radios_root"),
+        // Inside a menu: an `item_id` means a level below its top.
+        (_, "items") => {
+            if has_param(&cmd, "item_id:") {
+                if has_param(&cmd, "want_url:") {
+                    fixture_result("collections_radio_stations_with_want_url")
+                } else {
+                    fixture_result("collections_radio_stations_without_want_url")
+                }
+            } else {
+                fixture_result("collections_radio_menu_items")
+            }
+        }
+        other => panic!("replay server got an unexpected command: {other:?} ({cmd})"),
+    };
+    Json(json!({"result": result}))
+}
+
+async fn adapter_for(addr: SocketAddr) -> LmsAdapter {
+    let adapter = LmsAdapter::new(create_bus());
+    adapter
+        .configure(addr.ip().to_string(), Some(addr.port()), None, None)
+        .await;
+    adapter
+}
+
+/// The Radio tab's request: the favorites action, told apart by `media_type`.
+async fn radio_tab(adapter: &LmsAdapter) -> Value {
+    match adapter
+        .collections_content(
+            "collections_favorites",
+            &json!({"media_type": "radio", "zone_id": ZONE, "limit": 20, "offset": 0}),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => panic!("radio tab failed: {e:#}"),
+    }
+}
+
+async fn browse(adapter: &LmsAdapter, path: &str, zone: Option<&str>) -> anyhow::Result<Value> {
+    let mut params = json!({"path": path, "limit": 20, "offset": 0});
+    if let Some(zone) = zone {
+        params["zone_id"] = json!(zone);
+    }
+    adapter
+        .collections_content("collections_browse", &params)
+        .await
+}
+
+fn rows(page: &Value) -> Vec<Value> {
+    page.get("items")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// The tab, and the top of the hierarchy
+// =============================================================================
+
+/// The Radio tab must reach the station directory, not the favorites list.
+#[tokio::test]
+async fn radio_tab_serves_the_station_directory() {
+    let server = RadioReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let items = rows(&radio_tab(&adapter).await);
+
+    assert!(!items.is_empty(), "the Radio tab came back empty");
+    let titles: Vec<&str> = items
+        .iter()
+        .filter_map(|i| i.get("title").and_then(Value::as_str))
+        .collect();
+    assert!(
+        titles.contains(&"Local Radio") && titles.contains(&"Search TuneIn"),
+        "these are not the radio menus LMS serves: {titles:?}"
+    );
+    assert!(
+        server
+            .commands()
+            .iter()
+            .any(|cmd| cmd.get(0).and_then(Value::as_str) == Some("radios")),
+        "the Radio tab never called `radios`: {:?}",
+        server.commands()
+    );
+    server.stop();
+}
+
+/// Nothing at the top level plays; every row is a menu to walk into.
+#[tokio::test]
+async fn radio_menus_are_navigable_and_never_playable() {
+    let server = RadioReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    for item in rows(&radio_tab(&adapter).await) {
+        let path = item.get("path").and_then(Value::as_str).unwrap_or_default();
+        assert!(
+            path.starts_with("radio:"),
+            "radio menu row is not navigable: {item}"
+        );
+        assert!(
+            item.get("url").is_none(),
+            "a radio menu is not playable, but this row carries a url: {item}"
+        );
+    }
+    server.stop();
+}
+
+// =============================================================================
+// Inside a menu
+// =============================================================================
+
+/// A category is navigable only -- even though LMS hands it a `Browse.ashx` url
+/// once `want_url` is on. Reading "has a url" as "plays" would put a play
+/// button on a genre.
+#[tokio::test]
+async fn categories_inside_a_menu_are_navigable_only() {
+    let server = RadioReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let page = match browse(&adapter, "radio:music", Some(ZONE)).await {
+        Ok(p) => p,
+        Err(e) => panic!("browsing a radio menu failed: {e:#}"),
+    };
+    let items = rows(&page);
+    assert!(!items.is_empty(), "a radio menu's level is empty: {page}");
+    for item in &items {
+        assert!(
+            item.get("path")
+                .and_then(Value::as_str)
+                .is_some_and(|p| p.starts_with("radio:music:")),
+            "category row is not navigable within its own menu: {item}"
+        );
+        assert!(
+            item.get("url").is_none(),
+            "category row was made playable by its Browse.ashx url: {item}"
+        );
+    }
+    server.stop();
+}
+
+/// Stations must arrive playable, which means the stream url has to be asked for.
+#[tokio::test]
+async fn stations_are_playable_with_a_stream_url() {
+    let server = RadioReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let page = match browse(&adapter, "radio:music:b4426ee5.0.1", Some(ZONE)).await {
+        Ok(p) => p,
+        Err(e) => panic!("browsing a radio station level failed: {e:#}"),
+    };
+    let items = rows(&page);
+
+    assert!(!items.is_empty(), "a station level is empty: {page}");
+    for item in &items {
+        assert!(
+            item.get("url")
+                .and_then(Value::as_str)
+                .is_some_and(|u| u.starts_with("http")),
+            "station row has no stream url, so nothing can play it: {item}"
+        );
+        assert!(
+            item.get("path").is_none(),
+            "a station contains nothing, so it must not be navigable: {item}"
+        );
+    }
+    server.stop();
+}
+
+/// Assert on the request too: without the flag LMS omits the url and every
+/// station becomes unplayable.
+#[tokio::test]
+async fn station_query_asks_for_the_stream_url() {
+    let server = RadioReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let _ = browse(&adapter, "radio:music:b4426ee5.0.1", Some(ZONE)).await;
+
+    assert!(
+        server.commands().iter().any(|cmd| cmd
+            .as_array()
+            .is_some_and(|a| a.iter().any(|p| p.as_str() == Some("want_url:1")))),
+        "the station query never asked for `want_url:1`: {:?}",
+        server.commands()
+    );
+    server.stop();
+}
+
+// =============================================================================
+// The player requirement
+// =============================================================================
+
+/// XMLBrowser refuses a server-level request by closing the socket, so a radio
+/// browse with no zone must fail loudly here rather than reach LMS and come
+/// back as an empty level.
+#[tokio::test]
+async fn radio_browse_without_a_zone_is_refused_before_the_request() {
+    let server = RadioReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let error = match browse(&adapter, "radio:music", None).await {
+        Ok(page) => panic!("a zoneless radio browse should not have succeeded: {page}"),
+        Err(e) => format!("{e:#}"),
+    };
+
+    assert!(
+        error.contains("zone"),
+        "the refusal should say a zone is required, got: {error}"
+    );
+    assert!(
+        server.commands().is_empty(),
+        "nothing should have been sent to LMS: {:?}",
+        server.commands()
+    );
+    server.stop();
+}
+
+/// The level queries must be addressed to the zone's own player.
+#[tokio::test]
+async fn radio_level_queries_are_addressed_to_the_zone_player() {
+    let server = RadioReplayServer::start().await;
+    let adapter = adapter_for(server.addr()).await;
+
+    let _ = browse(&adapter, "radio:music", Some(ZONE)).await;
+
+    assert_eq!(
+        server.players(),
+        vec!["02:00:00:00:00:01".to_string()],
+        "the radio level query was not addressed to the zone's player (and the \
+         `lms:` prefix must be stripped)"
+    );
+    server.stop();
+}


### PR DESCRIPTION
## Problem

A tester reported the v4 Library "does not work" against their LMS and wondered whether their large library was the cause. It is not size — LMS library browse is broken at any size, and I reproduced it on a generated library.

The Albums level and **every artist's album list** come back **empty**, while `next_offset` still reports LMS's real total. Track and playlist rows lose their artist subtitle.

**Cause.** An LMS `tags:` parameter *replaces* the query's default tag set, it does not extend it. #549 added `tags:cJ` to `albums`, `titles` and `playlists tracks` so artwork had a handle to read, which silently removed the fields those queries return by default. For `albums` that included `album` — the title `query_albums` requires — so its `filter_map` discarded every row.

Recorded from live Lyrion 9.1.2:

```
albums 0 3            -> {"id":1,...,"album":"Greatest Hits"}
albums 0 3 tags:cJ    -> {"id":1,"performance":"","favorites_title":null}   # no `album` at all
albums 0 3 tags:lacJ  -> {"id":1,...,"album":"Greatest Hits","artist":"Aurora Fields"}
```

## Change

- `src/adapters/lms.rs`: two documented constants — `ALBUM_DISPLAY_TAGS = "tags:lacJ"` (album title, artist, coverid, artwork_track_id) and `TRACK_DISPLAY_TAGS = "tags:acJ"` — replacing the three bare `tags:cJ` strings.
- `docs/lyrion.md`: the replace-not-extend rule stated next to the existing tag table, which already carries a warning about a previous tag mistake.
- `tests/fixtures/lms/`: six new recordings from live 9.1.2 (each query with artwork-only tags and with display tags), plus `PROVENANCE.md` rows.
- `tests/lms_collection_tags.rs`: five regression tests.
- `tests/lms_live_smoke.rs`: two opt-in live walks.

## Why the new tests actually hold this down

A replay server that always returned fully tagged rows would pass just as happily with the broken request — the exact mock-agrees-with-the-code trap `lms_adapter_defects.rs` was written after. So this server picks its fixture **from the tags the request asked for**, the way LMS does. Ask for artwork alone and you get the stripped rows a real server sends.

Confirmed adversarially: reverting both constants to `tags:cJ` fails all five.

| | shipped `tags:cJ` | this PR |
|---|---|---|
| `browsing_albums_returns_titled_rows` | FAILED | ok |
| `browsing_one_artists_albums_returns_titled_rows` | FAILED | ok |
| `album_query_asks_for_title_artist_and_artwork_tags` | FAILED | ok |
| `album_tracks_keep_their_artist_subtitle` | FAILED | ok |
| `playlist_tracks_keep_their_artist_subtitle` | FAILED | ok |

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --workspace` all clean (the previously failing `fixtures_are_recorded_not_authored` guard passes — the fixtures are recorded through the repo's request id 217).

End to end against Lyrion 9.1.2 in Docker with a real squeezelite player and an ffmpeg-generated library (480 tracks, 126 artists, 166 albums, a 220-track album, a playlist), following the convention in `tests/fixtures/lms/PROVENANCE.md` and **not** publishing 3483:

- Albums, Artists, artist → albums → tracks, and playlist → tracks all return rows with titles, subtitles and playable refs
- breadcrumbs correct at each level
- paging on the 220-track album at offsets 0/50/200 returns 50/50/20 with the right `next_offset`

## Not in scope

The Favorites and Radio tabs return empty on my rig because the library has no favorites configured, so I could not exercise them. `list_favorites` sends no `tags:` and reads `name`/`url`, so it is not affected by this defect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added LMS Internet radio browsing, including radio categories and playable stations.
  - Added player- and zone-specific routing for radio requests.
  - Radio and Favorites entries now provide playback URLs when requested.

- **Bug Fixes**
  - Preserved navigation and display metadata across album, artist, track, playlist, Favorites, and radio views.
  - Excluded non-playable folder-style Favorites from playable results.

- **Documentation**
  - Clarified LMS radio hierarchy, player requirements, playback URLs, and item behavior.
  - Documented `want_url:1` requirements and collection tag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->