### PR TITLE
test(hqplayer): stop the profile-lane request budget racing the assertion

### DIFF
--- a/tests/hqplayer_conformance.rs
+++ b/tests/hqplayer_conformance.rs
@@ -8475,9 +8475,27 @@ async fn a_profile_form_post_without_native_confirmation_never_reports_success()
         },
     )
     .await;
+    // Only the *settle* deadline is load-bearing here, and it is the one budget that cannot be
+    // raced: `FakeConfigWeb` never changes the daemon's native active configuration, so
+    // `ConfigurationGet` can never name `semantic-z` and `wait_for_active_configuration` must
+    // reach its deadline however fast or slow the runner is. Both of its exit paths — the deadline
+    // elapsing between polls and a single poll outliving the remaining budget — produce the same
+    // `profile load is indeterminate ... active configuration became "semantic-z"` refusal this
+    // test asserts on.
+    //
+    // The *request* budget, by contrast, must never fire: a loopback round trip to the fake web
+    // server is not the behaviour under test, and when it expired first the refusal became
+    // "profile web request timed out", failing the assertion for a harness reason (seen in CI, GHA
+    // run 33655532768). It was 100ms, which measures at ~1ms locally even with 24 spinners on 12
+    // cores — the sweep only starts failing at 1ms — yet CI blew through 100ms under concurrent
+    // load, so no value derived from local latency is safe. It is therefore set well outside the
+    // range any localhost round trip can reach: at 5s it can only fire if the fake lane is
+    // genuinely broken, while still failing fast rather than hanging the suite. The sibling
+    // profile-lane tests in `hqplayer_operation_lease.rs` already pair whole-second request
+    // budgets with sub-second settle deadlines for the same reason.
     h.adapter
         .set_profile_timeouts(HqpProfileTimeouts {
-            request: Duration::from_millis(100),
+            request: Duration::from_secs(5),
             settle_deadline: Duration::from_millis(100),
             poll_interval: Duration::from_millis(10),
         })


### PR DESCRIPTION
## Problem

`a_profile_form_post_without_native_confirmation_never_reports_success` (tests/hqplayer_conformance.rs) flaked in GitHub Actions run 33655532768 (job 100333029050):

```
panicked at tests/hqplayer_conformance.rs:8523:
the refusal must identify the failed native verification:
HQPlayer profile web request timed out after 100ms
```

The test set **both** profile budgets to 100ms. Only one of them is the behaviour under test:

- **`settle_deadline` is load-bearing and cannot be raced.** `FakeConfigWeb` never changes the daemon's native active configuration, so `ConfigurationGet` can never name `semantic-z` and `wait_for_active_configuration` must reach its deadline however fast or slow the runner is. Both of its exit paths — the deadline elapsing between polls, and a single poll outliving the remaining budget — produce the same `profile load is indeterminate ... active configuration became "semantic-z"` refusal the assertion checks.
- **`request` was never load-bearing.** It bounds one loopback HTTP round trip to the in-process fake. When it expired first, `load_profile`'s opening `fetch_profiles_under_profile_operation` returned a transport-timeout error before the code path under test ran at all — a harness fault surfacing as an assertion failure.

## Fix

Raise only the request budget, to 5s, and document why in the test.

This is not "raise the number until it stops": the point is that the budget can no longer participate in the test's logic. 5s is ~5000x the measured round trip and 50x the worst round trip CI has been observed to produce, so it can only fire if the fake lane is genuinely broken — while still failing fast rather than hanging the suite. The asserted failure still comes from a deadline that is guaranteed to expire.

Considered and rejected: deriving a value from measured latency. The round trip measures **~1ms locally** and a swept budget only starts failing at **1ms** even with 24 spinners on 12 cores, yet CI blew past 100ms — a >100x dilation. Any number scaled from local latency would have been a guess.

## Sibling tests

Only three call sites set profile budgets, and the other two are the precedent for this shape:

| test | request | settle_deadline |
|---|---|---|
| `hqplayer_operation_lease.rs` · `profile_post_can_outlive_the_fast_web_deadline` | 5s | 2s |
| `hqplayer_operation_lease.rs` · `profile_that_never_settles_times_out_at_the_absolute_deadline` | 1s | 120ms |
| `hqplayer_conformance.rs` (this one) | ~~100ms~~ → **5s** | 100ms |

Both already pair a whole-second request budget with a sub-second settle deadline. This test was the only sub-second request budget in the tree, so no other test flakes this way. Every other `FakeConfigWeb` test in the conformance file goes through the ordinary web client, whose bound is a fixed 3s.

**Residual, not changed here:** this test also overrides `max_attempts: 1` over `fast_timeouts()`'s native `response: 300ms`. That budget is shared by ~300 tests in the file and was not the observed failure; flagging it rather than making a suite-wide timing change inside a flake fix.

## Verification

- `cargo test --test hqplayer_conformance` — 309 passed
- `cargo test --test hqplayer_operation_lease` — 56 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -- -D warnings` — clean
- Stress, 24 busy-loops on 12 cores: fixed test 0/30 failures; both siblings 0/20 and 0/10; full conformance binary 5/5 clean runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated profile-load conformance testing to allow up to 5 seconds for profile requests.
  * Retained the 100-millisecond deadline for verifying native configuration settlement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->