### PR TITLE
fix: completing a provider's setup enables that provider

### DIFF
--- a/src/api/apple_bridge.rs
+++ b/src/api/apple_bridge.rs
@@ -1098,9 +1098,24 @@ pub async fn claim(
     // Claiming a pairing is a completed setup gesture, so it enables the provider like
     // every other configure path. It used to only log when the toggle was off, which
     // left the user with a paired companion, a healthy-looking bridge, and no zones.
-    crate::api::mark_adapter_configured(&state, "applemusic").await;
-    if let Err(error) = state.adapter_registry.start("applemusic").await {
-        tracing::debug!("Apple Music adapter will start when registered: {error}");
+    crate::api::mark_adapter_configured(&state, "applemusic")
+        .await
+        .map_err(|e| {
+            error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &e.to_string(),
+                "enable_failed",
+            )
+        })?;
+    // Through the coordinator rather than straight at the registry, so Apple Music
+    // records its running state and honours the same enable/can_start policy as every
+    // other start path. A build where the adapter is not registered still only logs.
+    if let Err(start_error) = state
+        .adapter_registry
+        .start_registered_if_enabled(&state.coordinator, "applemusic")
+        .await
+    {
+        tracing::debug!("Apple Music adapter will start when registered: {start_error}");
     }
     Ok(Json(response))
 }

--- a/src/api/apple_bridge.rs
+++ b/src/api/apple_bridge.rs
@@ -1095,12 +1095,12 @@ pub async fn claim(
         .claim(request)
         .await
         .map_err(|e| error(StatusCode::BAD_REQUEST, &e.to_string(), "pairing_failed"))?;
-    if state.coordinator.is_enabled("applemusic").await {
-        if let Err(error) = state.adapter_registry.start("applemusic").await {
-            tracing::debug!("Apple Music adapter will start when registered: {error}");
-        }
-    } else {
-        tracing::info!("Apple Music companion paired while adapter is disabled");
+    // Claiming a pairing is a completed setup gesture, so it enables the provider like
+    // every other configure path. It used to only log when the toggle was off, which
+    // left the user with a paired companion, a healthy-looking bridge, and no zones.
+    crate::api::mark_adapter_configured(&state, "applemusic").await;
+    if let Err(error) = state.adapter_registry.start("applemusic").await {
+        tracing::debug!("Apple Music adapter will start when registered: {error}");
     }
     Ok(Json(response))
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2596,20 +2596,82 @@ pub struct LmsConfigRequest {
 /// own topology (`lms-cli` follows `lms`), and a provider with no settings toggle at
 /// all is a no-op rather than a compile error, which is what lets a new adapter adopt
 /// this by calling it.
-pub async fn mark_adapter_configured(state: &AppState, provider: &str) {
+///
+/// Returns an error when the toggle could not be written. Callers must fail the
+/// configuration rather than continue, because the alternative is reporting success
+/// while leaving the user in precisely the state this function exists to prevent — a
+/// connected provider publishing zones that no surface will list. A full disk is the
+/// realistic way to get here, and it is silent everywhere else.
+pub async fn mark_adapter_configured(
+    state: &AppState,
+    provider: &str,
+) -> Result<(), AdapterToggleUnwritable> {
+    set_adapter_enabled(state, provider, true).await
+}
+
+/// The settings file could not record a provider's enable toggle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdapterToggleUnwritable {
+    /// The provider whose toggle could not be written.
+    pub provider: String,
+}
+
+impl std::fmt::Display for AdapterToggleUnwritable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} was configured but its enable setting could not be saved, so its zones \
+             would not be listed; check that the config directory is writable",
+            self.provider
+        )
+    }
+}
+
+impl std::error::Error for AdapterToggleUnwritable {}
+
+/// Whether `provider` is enabled according to the settings on disk right now.
+///
+/// Callers that enable a provider before a fallible start read this first so they can
+/// put the toggle back if the start fails.
+pub fn adapter_enabled_in_settings(provider: &str) -> bool {
+    load_app_settings()
+        .adapters
+        .toggle(provider)
+        .unwrap_or(false)
+}
+
+async fn set_adapter_enabled(
+    state: &AppState,
+    provider: &str,
+    enabled: bool,
+) -> Result<(), AdapterToggleUnwritable> {
     let persisted = mutate_app_settings(|settings| {
         if let Some(toggle) = settings.adapters.toggle_mut(provider) {
-            *toggle = true;
+            *toggle = enabled;
         }
     });
     if !persisted {
-        tracing::warn!(
-            provider,
-            "Could not persist the adapter enable toggle after configuration; \
-             its zones will stay hidden until settings are saved"
-        );
+        return Err(AdapterToggleUnwritable {
+            provider: provider.to_string(),
+        });
     }
-    state.coordinator.enable_with_companions(provider).await;
+    if enabled {
+        state.coordinator.enable_with_companions(provider).await;
+    } else {
+        state.coordinator.set_enabled(provider, false).await;
+    }
+    Ok(())
+}
+
+/// Put a provider's enable toggle back after a configuration step failed downstream.
+///
+/// Best-effort by construction: the caller is already on an error path and has a more
+/// useful failure to report than this one, so a failed restore is logged rather than
+/// replacing that error.
+pub async fn restore_adapter_enabled(state: &AppState, provider: &str, enabled: bool) {
+    if let Err(error) = set_adapter_enabled(state, provider, enabled).await {
+        tracing::warn!(%error, "Could not restore the adapter enable toggle after a failed start");
+    }
 }
 
 /// POST /lms/configure - Configure LMS connection
@@ -2642,7 +2704,19 @@ pub async fn lms_configure_handler(
     // Naming a server is the enable gesture. The CLI companion follows from the
     // coordinator's topology; it is an observer of the same `lms:` projection, not a
     // separately switchable feature.
-    mark_adapter_configured(&state, "lms").await;
+    //
+    // Fail before starting if the toggle could not be saved. Starting anyway would
+    // reproduce the reported bug exactly — a connected LMS whose zones no list shows —
+    // while answering `200 ok`.
+    if let Err(error) = mark_adapter_configured(&state, "lms").await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        )
+            .into_response();
+    }
 
     // Start both observers together; the CLI companion is not an optional
     // feature of a manually configured LMS connection.
@@ -2706,7 +2780,15 @@ pub async fn hqp_configure_handler(
     // toggle was already on, which left "configured, connected, invisible" reachable
     // here too: the manager stayed down, and even once running every zone list would
     // have filtered `hqplayer:` zones back out.
-    mark_adapter_configured(&state, "hqplayer").await;
+    if let Err(error) = mark_adapter_configured(&state, "hqplayer").await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        )
+            .into_response();
+    }
 
     // A fresh installation may have skipped the HQPlayer lifecycle at process startup
     // because no endpoint existed yet. Start the idempotent manager after configuration
@@ -2932,7 +3014,15 @@ pub async fn hqp_add_instance_handler(
         .await;
 
     // Adding an instance is the same gesture as configuring the first one.
-    mark_adapter_configured(&state, "hqplayer").await;
+    if let Err(error) = mark_adapter_configured(&state, "hqplayer").await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        )
+            .into_response();
+    }
     match state.hqp_instances.start().await {
         Ok(()) => state.coordinator.set_running("hqplayer", true).await,
         Err(error) => tracing::warn!(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2573,6 +2573,45 @@ pub struct LmsConfigRequest {
     pub password: Option<String>,
 }
 
+/// Record that the user has finished pointing UHC at a provider.
+///
+/// A provider's configure endpoint is a complete enable gesture on its own: someone
+/// named a server, pasted a token, or paired a bridge, and expects to see its zones.
+/// Both halves of "enabled" have to move for that to be true.
+///
+/// The persisted toggle, because it is what the rest of the system actually reads:
+/// every zone list filters on `adapters.<provider>` re-read from disk on each call
+/// ([`crate::zone_list`]), and the next process start decides what to launch from the
+/// same file. Leaving it alone produces the worst failure shape available — a
+/// configured, connected adapter whose poller publishes correct zones into the
+/// aggregator that no surface will ever show, indistinguishable from a broken
+/// connection at every diagnostic a user can reach, and repaired only by an unrelated
+/// settings write.
+///
+/// And the coordinator's in-memory enabled state, so a later settings reconcile does
+/// not compare against a provider it believes is off and stop a running adapter.
+///
+/// Keyed by provider name rather than by a field selector so this is one rule rather
+/// than one implementation per provider: companion workers come from the coordinator's
+/// own topology (`lms-cli` follows `lms`), and a provider with no settings toggle at
+/// all is a no-op rather than a compile error, which is what lets a new adapter adopt
+/// this by calling it.
+pub async fn mark_adapter_configured(state: &AppState, provider: &str) {
+    let persisted = mutate_app_settings(|settings| {
+        if let Some(toggle) = settings.adapters.toggle_mut(provider) {
+            *toggle = true;
+        }
+    });
+    if !persisted {
+        tracing::warn!(
+            provider,
+            "Could not persist the adapter enable toggle after configuration; \
+             its zones will stay hidden until settings are saved"
+        );
+    }
+    state.coordinator.enable_with_companions(provider).await;
+}
+
 /// POST /lms/configure - Configure LMS connection
 pub async fn lms_configure_handler(
     State(state): State<AppState>,
@@ -2581,9 +2620,17 @@ pub async fn lms_configure_handler(
     // LMS has two concurrent observers of the same `lms:` projection.  Stop
     // both before retirement/reconfiguration so an old CLI callback cannot
     // republish zones from the former server after the projection is flushed.
+    //
+    // Wait for the aggregator's flush acknowledgement rather than only firing the
+    // event: this path restarts the observers immediately, and an unapplied flush
+    // arriving after the first poll deletes the zone it just published.
     state
         .coordinator
-        .stop_adapter_and_companions_then_flush(state.lms.as_ref(), "lms", "LMS reconfiguration")
+        .stop_adapter_and_companions_then_await_flush(
+            state.lms.as_ref(),
+            "lms",
+            "LMS reconfiguration",
+        )
         .await;
 
     // Configure new connection
@@ -2591,6 +2638,11 @@ pub async fn lms_configure_handler(
         .lms
         .configure(req.host.clone(), req.port, req.username, req.password)
         .await;
+
+    // Naming a server is the enable gesture. The CLI companion follows from the
+    // coordinator's topology; it is an observer of the same `lms:` projection, not a
+    // separately switchable feature.
+    mark_adapter_configured(&state, "lms").await;
 
     // Start both observers together; the CLI companion is not an optional
     // feature of a manually configured LMS connection.
@@ -2650,17 +2702,21 @@ pub async fn hqp_configure_handler(
     // Save to instance manager for persistence
     state.hqp_instances.save_to_config().await;
 
-    // An enabled fresh installation may have skipped the HQPlayer lifecycle at process startup
-    // because no endpoint existed yet. Start the idempotent manager after configuration rather than
-    // requiring a process restart, while still honoring the adapter's explicit enabled setting.
-    if state.coordinator.is_enabled("hqplayer").await {
-        match state.hqp_instances.start().await {
-            Ok(()) => state.coordinator.set_running("hqplayer", true).await,
-            Err(error) => {
-                tracing::warn!(
-                    "HQPlayer managed lifecycle could not start after configuration: {error}"
-                )
-            }
+    // Same enable gesture as LMS. This used to start the lifecycle only when the
+    // toggle was already on, which left "configured, connected, invisible" reachable
+    // here too: the manager stayed down, and even once running every zone list would
+    // have filtered `hqplayer:` zones back out.
+    mark_adapter_configured(&state, "hqplayer").await;
+
+    // A fresh installation may have skipped the HQPlayer lifecycle at process startup
+    // because no endpoint existed yet. Start the idempotent manager after configuration
+    // rather than requiring a process restart.
+    match state.hqp_instances.start().await {
+        Ok(()) => state.coordinator.set_running("hqplayer", true).await,
+        Err(error) => {
+            tracing::warn!(
+                "HQPlayer managed lifecycle could not start after configuration: {error}"
+            )
         }
     }
 
@@ -2875,13 +2931,13 @@ pub async fn hqp_add_instance_handler(
         )
         .await;
 
-    if state.coordinator.is_enabled("hqplayer").await {
-        match state.hqp_instances.start().await {
-            Ok(()) => state.coordinator.set_running("hqplayer", true).await,
-            Err(error) => tracing::warn!(
-                "HQPlayer managed lifecycle could not start after adding an instance: {error}"
-            ),
-        }
+    // Adding an instance is the same gesture as configuring the first one.
+    mark_adapter_configured(&state, "hqplayer").await;
+    match state.hqp_instances.start().await {
+        Ok(()) => state.coordinator.set_running("hqplayer", true).await,
+        Err(error) => tracing::warn!(
+            "HQPlayer managed lifecycle could not start after adding an instance: {error}"
+        ),
     }
 
     (
@@ -3339,6 +3395,58 @@ pub struct AdapterSettings {
     /// by default: it needs a broker configured before it can do anything.
     #[serde(default)]
     pub mqtt: bool,
+}
+
+impl AdapterSettings {
+    /// The enable toggle for `provider`, addressed by the same name the coordinator
+    /// and the zone prefixes use.
+    ///
+    /// This exists so there is exactly one list of which providers have a toggle.
+    /// The zone-list filter used to carry its own `match` over prefixes, which drifted
+    /// the moment a provider was added: Spotify, Apple Music and Music Assistant all
+    /// shipped toggles that the filter had never heard of, so it fell through to its
+    /// include-by-default arm and their switches quietly did nothing to a zone list.
+    /// A new provider now joins by adding a field and one arm here.
+    ///
+    /// `None` means "this name has no toggle" — the honest answer for a prefix from a
+    /// provider this build predates, which callers turn into include-by-default rather
+    /// than hiding a zone they cannot reason about.
+    pub fn toggle_mut(&mut self, provider: &str) -> Option<&mut bool> {
+        match provider {
+            "roon" => Some(&mut self.roon),
+            "upnp" => Some(&mut self.upnp),
+            "openhome" => Some(&mut self.openhome),
+            // `lms-cli` is a companion observer of the `lms:` projection and shares its
+            // toggle; it is not independently switchable.
+            "lms" | "lms-cli" => Some(&mut self.lms),
+            "hqplayer" => Some(&mut self.hqplayer),
+            "spotify" => Some(&mut self.spotify),
+            "applemusic" => Some(&mut self.applemusic),
+            "musicassistant" => Some(&mut self.musicassistant),
+            "mqtt" => Some(&mut self.mqtt),
+            _ => None,
+        }
+    }
+
+    /// Whether `provider` is enabled, or `None` when it has no toggle.
+    ///
+    /// Deliberately its own `match` rather than a clone-and-`toggle_mut`, since the
+    /// read side is on every zone-list call. `toggles_agree_for_every_named_adapter`
+    /// holds the two in step.
+    pub fn toggle(&self, provider: &str) -> Option<bool> {
+        match provider {
+            "roon" => Some(self.roon),
+            "upnp" => Some(self.upnp),
+            "openhome" => Some(self.openhome),
+            "lms" | "lms-cli" => Some(self.lms),
+            "hqplayer" => Some(self.hqplayer),
+            "spotify" => Some(self.spotify),
+            "applemusic" => Some(self.applemusic),
+            "musicassistant" => Some(self.musicassistant),
+            "mqtt" => Some(self.mqtt),
+            _ => None,
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -4178,6 +4286,46 @@ mod tests {
             "the lms zone should have been flushed, got {remaining:?}"
         );
         assert_eq!(remaining[0].zone_id, "roon:untouched");
+    }
+
+    /// The two accessors carry the same list twice for read-path cost, so hold them in
+    /// step here rather than trusting a reviewer to update both. Every name the
+    /// coordinator can register must resolve, which is what stops a new provider from
+    /// shipping a toggle that the zone-list filter has never heard of — the drift that
+    /// left Spotify, Apple Music and Music Assistant switches doing nothing to a list.
+    #[test]
+    fn toggles_agree_for_every_named_adapter() {
+        let mut settings = AdapterSettings::default();
+        for name in crate::coordinator::AVAILABLE_ADAPTERS
+            .iter()
+            .chain(["mqtt"].iter())
+        {
+            let toggle = settings
+                .toggle_mut(name)
+                .unwrap_or_else(|| panic!("adapter `{name}` has no settings toggle"));
+            *toggle = true;
+            assert_eq!(
+                settings.toggle(name),
+                Some(true),
+                "`{name}` reads back differently than it was written"
+            );
+        }
+        assert_eq!(
+            settings.toggle("a-provider-this-build-predates"),
+            None,
+            "an unknown provider must be reported as having no toggle, not as disabled"
+        );
+    }
+
+    /// `lms-cli` observes the `lms:` projection and has no switch of its own.
+    #[test]
+    fn the_lms_companion_shares_the_lms_toggle() {
+        let mut settings = AdapterSettings::default();
+        *settings.toggle_mut("lms-cli").expect("companion resolves") = true;
+        assert!(
+            settings.lms,
+            "enabling the companion must enable LMS itself"
+        );
     }
 
     async fn app_state_with_startable(startable: Arc<dyn Startable>) -> AppState {

--- a/src/api/provider_auth.rs
+++ b/src/api/provider_auth.rs
@@ -522,7 +522,21 @@ async fn configure_musicassistant_request(
     // Saving a reachable connection is the enable gesture. Without this the start
     // below is a no-op whenever the toggle is off, and the response still reports
     // `configured: true` — the shape this whole change exists to remove.
-    crate::api::mark_adapter_configured(&state, "musicassistant").await;
+    //
+    // Captured first because this handler rolls back everything it touched when the
+    // start fails; the toggle has to roll back with the credentials and the runtime,
+    // or a failed setup silently leaves the provider switched on.
+    let previously_enabled = crate::api::adapter_enabled_in_settings("musicassistant");
+    crate::api::mark_adapter_configured(&state, "musicassistant")
+        .await
+        .map_err(|enable_error| {
+            restore_musicassistant_record(&store, existing.as_ref());
+            error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &enable_error.to_string(),
+                "enable_failed",
+            )
+        })?;
     let runtime_for_rollback = runtime.clone();
     if state
         .adapter_registry
@@ -533,6 +547,7 @@ async fn configure_musicassistant_request(
         restore_musicassistant_record(&store, existing.as_ref());
         restore_musicassistant_runtime(&state.bus, &runtime_for_rollback, previous_runtime_config)
             .await;
+        crate::api::restore_adapter_enabled(&state, "musicassistant", previously_enabled).await;
         return Err(error(
             StatusCode::SERVICE_UNAVAILABLE,
             "Music Assistant could not be started",
@@ -1035,22 +1050,28 @@ async fn complete_spotify_authorization(
     adapter.set_token(spotify_token).await;
     // Completing authorization is the enable gesture; this used to log and skip when
     // the toggle was off, leaving an authorized account with no zones.
-    crate::api::mark_adapter_configured(state, "spotify").await;
+    let previously_enabled = crate::api::adapter_enabled_in_settings("spotify");
+    crate::api::mark_adapter_configured(state, "spotify")
+        .await
+        .map_err(|enable_error| {
+            error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &enable_error.to_string(),
+                "enable_failed",
+            )
+        })?;
     // Re-authorization is a lifecycle transition too.  Route it through
     // the coordinator so Spotify follows the same enable/can_start policy
     // as startup and settings changes.
     let startable: Arc<dyn crate::adapters::Startable> = adapter.clone();
-    state
-        .coordinator
-        .start_enabled(&startable)
-        .await
-        .map_err(|start_error| {
-            error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                &format!("Spotify adapter failed to start: {start_error}"),
-                "adapter_start_failed",
-            )
-        })?;
+    if let Err(start_error) = state.coordinator.start_enabled(&startable).await {
+        crate::api::restore_adapter_enabled(state, "spotify", previously_enabled).await;
+        return Err(error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &format!("Spotify adapter failed to start: {start_error}"),
+            "adapter_start_failed",
+        ));
+    }
     Ok(Json(ProviderAuthResponse {
         provider,
         authorized: true,

--- a/src/api/provider_auth.rs
+++ b/src/api/provider_auth.rs
@@ -519,6 +519,10 @@ async fn configure_musicassistant_request(
             "adapter_start_failed",
         ));
     }
+    // Saving a reachable connection is the enable gesture. Without this the start
+    // below is a no-op whenever the toggle is off, and the response still reports
+    // `configured: true` — the shape this whole change exists to remove.
+    crate::api::mark_adapter_configured(&state, "musicassistant").await;
     let runtime_for_rollback = runtime.clone();
     if state
         .adapter_registry
@@ -1029,25 +1033,24 @@ async fn complete_spotify_authorization(
         })?;
     }
     adapter.set_token(spotify_token).await;
-    if state.coordinator.is_enabled("spotify").await {
-        // Re-authorization is a lifecycle transition too.  Route it through
-        // the coordinator so Spotify follows the same enable/can_start policy
-        // as startup and settings changes.
-        let startable: Arc<dyn crate::adapters::Startable> = adapter.clone();
-        state
-            .coordinator
-            .start_enabled(&startable)
-            .await
-            .map_err(|start_error| {
-                error(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    &format!("Spotify adapter failed to start: {start_error}"),
-                    "adapter_start_failed",
-                )
-            })?;
-    } else {
-        tracing::info!("Spotify authorization completed while adapter is disabled");
-    }
+    // Completing authorization is the enable gesture; this used to log and skip when
+    // the toggle was off, leaving an authorized account with no zones.
+    crate::api::mark_adapter_configured(state, "spotify").await;
+    // Re-authorization is a lifecycle transition too.  Route it through
+    // the coordinator so Spotify follows the same enable/can_start policy
+    // as startup and settings changes.
+    let startable: Arc<dyn crate::adapters::Startable> = adapter.clone();
+    state
+        .coordinator
+        .start_enabled(&startable)
+        .await
+        .map_err(|start_error| {
+            error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                &format!("Spotify adapter failed to start: {start_error}"),
+                "adapter_start_failed",
+            )
+        })?;
     Ok(Json(ProviderAuthResponse {
         provider,
         authorized: true,

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -32,6 +32,9 @@ pub const AVAILABLE_ADAPTERS: &[&str] = &[
     "musicassistant",
 ];
 
+/// How long a reconfiguration waits for the aggregator to acknowledge a projection flush.
+const FLUSH_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Registered adapter with its spawn function
 struct RegisteredAdapter {
     /// Adapter prefix (e.g., "lms", "roon")
@@ -314,6 +317,49 @@ impl AdapterCoordinator {
             .await;
     }
 
+    /// [`Self::stop_adapter_and_companions_then_flush`], plus a bounded wait for the
+    /// aggregator to confirm the projection was actually retired.
+    ///
+    /// `AdapterStopping` is a bus event the aggregator applies from its own event
+    /// loop, so the plain stop path returns before any zone has been removed. That
+    /// is correct for shutdown, where nothing publishes afterwards, and wrong for
+    /// reconfiguration, where the caller starts a new observer straight away: the
+    /// pending flush then deletes the first zone the restarted observer published,
+    /// and the adapter appears connected with no zones until its next poll.
+    ///
+    /// The wait is bounded because the acknowledgement is an optimisation, not a
+    /// correctness dependency — a composition with no aggregator running (tests,
+    /// or a process already past aggregator shutdown) must not stall here.
+    pub async fn stop_adapter_and_companions_then_await_flush(
+        &self,
+        adapter: &dyn Startable,
+        projection_adapter: &str,
+        reason: &str,
+    ) {
+        let mut events = self.bus.subscribe();
+        self.stop_adapter_and_companions_then_flush(adapter, projection_adapter, reason)
+            .await;
+        let acknowledged = tokio::time::timeout(FLUSH_ACK_TIMEOUT, async {
+            loop {
+                match events.recv().await {
+                    Ok(BusEvent::ZonesFlushed { adapter, .. }) if adapter == projection_adapter => {
+                        return
+                    }
+                    Ok(_) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(_) => return,
+                }
+            }
+        })
+        .await;
+        if acknowledged.is_err() {
+            debug!(
+                "No ZonesFlushed acknowledgement for {} within {:?}; proceeding",
+                projection_adapter, FLUSH_ACK_TIMEOUT
+            );
+        }
+    }
+
     async fn companion_names(&self) -> Vec<String> {
         self.companions
             .read()
@@ -371,6 +417,27 @@ impl AdapterCoordinator {
 
         info!("Started adapter: {}", prefix);
         Ok(())
+    }
+
+    /// Enable a provider and every companion worker registered under it.
+    ///
+    /// Configuration endpoints enable by provider name, and a provider's companions are
+    /// not independently switchable — `lms-cli` observes the same `lms:` projection as
+    /// the poller. Reading the group from the coordinator's own topology keeps handlers
+    /// from restating a provider's internal worker layout, which is the thing that goes
+    /// stale when a provider gains one.
+    pub async fn enable_with_companions(&self, provider: &str) {
+        self.set_enabled(provider, true).await;
+        let companions = self
+            .companions
+            .read()
+            .await
+            .get(provider)
+            .cloned()
+            .unwrap_or_default();
+        for companion in companions {
+            self.set_enabled(companion.name(), true).await;
+        }
     }
 
     /// Enable/disable an adapter
@@ -637,6 +704,90 @@ mod tests {
         assert!(coord.is_enabled("musicassistant").await);
     }
 
+    /// Reconfiguration restarts an observer the moment the stop returns, so the
+    /// caller must not resume while the aggregator still has the flush queued —
+    /// an unapplied `AdapterStopping` deletes the zone the restarted observer
+    /// publishes, and the adapter then looks connected with no zones until its
+    /// next poll. The wait is on the aggregator's `ZonesFlushed` acknowledgement.
+    #[tokio::test]
+    async fn reconfiguration_waits_for_the_projection_flush_acknowledgement() {
+        let bus = create_bus();
+        let coord = AdapterCoordinator::new(bus.clone());
+        coord.register("lms", true).await;
+        coord.set_running("lms", true).await;
+
+        // Stand in for `ZoneAggregator`: acknowledge only after a scheduling delay,
+        // so a coordinator that returned without waiting would win the race here.
+        let acknowledger = bus.clone();
+        tokio::spawn(async move {
+            let mut events = acknowledger.subscribe();
+            while let Ok(event) = events.recv().await {
+                if let BusEvent::AdapterStopping { adapter, .. } = event {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    acknowledger.publish(BusEvent::ZonesFlushed {
+                        adapter,
+                        zone_ids: vec!["lms:aa:bb".to_string()],
+                    });
+                    return;
+                }
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let mut observed = bus.subscribe();
+        let adapter = Arc::new(NamedProbe {
+            name: "lms",
+            stopped: Arc::new(AtomicBool::new(false)),
+        });
+        coord
+            .stop_adapter_and_companions_then_await_flush(
+                adapter.as_ref(),
+                "lms",
+                "test LMS reconfiguration",
+            )
+            .await;
+
+        let mut saw_flush = false;
+        while let Ok(event) = observed.try_recv() {
+            if matches!(event, BusEvent::ZonesFlushed { ref adapter, .. } if adapter == "lms") {
+                saw_flush = true;
+            }
+        }
+        assert!(
+            saw_flush,
+            "stop must not return before the aggregator acknowledged the flush"
+        );
+    }
+
+    /// The acknowledgement is an ordering aid, not a correctness dependency: a
+    /// composition with no aggregator listening (tests, or a process already past
+    /// aggregator shutdown) must proceed rather than stall for the full timeout.
+    #[tokio::test(start_paused = true)]
+    async fn a_missing_acknowledgement_does_not_stall_reconfiguration() {
+        let bus = create_bus();
+        let coord = AdapterCoordinator::new(bus);
+        coord.register("lms", true).await;
+        let adapter = Arc::new(NamedProbe {
+            name: "lms",
+            stopped: Arc::new(AtomicBool::new(false)),
+        });
+
+        let started = tokio::time::Instant::now();
+        coord
+            .stop_adapter_and_companions_then_await_flush(
+                adapter.as_ref(),
+                "lms",
+                "test LMS reconfiguration",
+            )
+            .await;
+
+        assert!(
+            started.elapsed() >= FLUSH_ACK_TIMEOUT,
+            "the wait must be the bounded one"
+        );
+        assert!(!coord.is_running("lms").await, "the stop still applied");
+    }
+
     #[tokio::test]
     async fn test_start_adapter() {
         let bus = create_bus();
@@ -689,6 +840,28 @@ mod tests {
 
         assert!(!started.load(Ordering::SeqCst));
         assert!(!coord.is_running("disabled").await);
+    }
+
+    /// A `Startable` that answers to a caller-chosen name, for lifecycle assertions
+    /// about a specific provider's workers rather than a generic probe.
+    struct NamedProbe {
+        name: &'static str,
+        stopped: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Startable for NamedProbe {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        async fn start(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn stop(&self) {
+            self.stopped.store(true, Ordering::SeqCst);
+        }
     }
 
     struct LifecycleProbe {

--- a/src/zone_list.rs
+++ b/src/zone_list.rs
@@ -99,30 +99,24 @@ fn apply_custom_name(mut zone: Zone, settings: &AppSettings) -> Zone {
 
 /// Whether the adapter owning `zone_id` is enabled in settings.
 ///
-/// Redundant with the upstream enforcement described in the module docs, and kept anyway: settings
-/// are re-read from disk on every call here, while the aggregator only learns of a change through
-/// the settings endpoint. Editing `app-settings.json` directly — plausible for Docker users
-/// bind-mounting a config directory — leaves the two disagreeing until restart, and this is the
-/// side that reflects what the file actually says.
+/// Redundant with the upstream enforcement described in the module docs, and kept anyway:
+/// settings are re-read from disk on every call here, while the aggregator only learns of a
+/// change through the settings endpoint. Editing `app-settings.json` directly — plausible for
+/// Docker users bind-mounting a config directory — leaves the two disagreeing until restart,
+/// and this is the side that reflects what the file actually says.
+///
+/// The prefix-to-toggle mapping lives on [`AdapterSettings::toggle`] rather than here. It used
+/// to be a `match` local to this function, and every provider added after it was written —
+/// Spotify, Apple Music, Music Assistant — fell through to the default-include arm, so their
+/// settings toggles silently did nothing to a zone list. HQPlayer had already been bitten by
+/// the same drift once (#328, where this tested `hqp:` against a `hqplayer:` prefix).
+///
+/// An unknown prefix is still included: a zone from a provider this build predates is better
+/// shown than silently swallowed.
 fn adapter_enabled(zone_id: &str, settings: &AppSettings) -> bool {
-    let adapters = &settings.adapters;
-    if let Some((prefix, _)) = zone_id.split_once(':') {
-        match prefix {
-            "roon" => adapters.roon,
-            "lms" => adapters.lms,
-            "openhome" => adapters.openhome,
-            "upnp" => adapters.upnp,
-            // `hqplayer:` is the prefix `PrefixedZoneId::hqplayer` emits and the only one HQPlayer
-            // zones ever carry. This tested `hqp:` until #328, so it never matched and HQPlayer
-            // zones fell through to the default-include arm — the settings toggle silently did
-            // nothing for them.
-            "hqplayer" => adapters.hqplayer,
-            // Unknown prefix: include. A zone from a provider this build predates is better shown
-            // than silently swallowed.
-            _ => true,
-        }
-    } else {
-        true
+    match zone_id.split_once(':') {
+        Some((prefix, _)) => settings.adapters.toggle(prefix).unwrap_or(true),
+        None => true,
     }
 }
 
@@ -268,6 +262,46 @@ mod tests {
     use super::*;
     use crate::api::AdapterSettings;
     use crate::bus::PlaybackState;
+
+    /// The adapter filter used to carry its own prefix list, and every provider added
+    /// after it was written fell through to the include-by-default arm — so turning
+    /// Spotify off in Settings left its zones in every list. Now that the mapping lives
+    /// on `AdapterSettings`, a provider is covered by existing.
+    #[test]
+    fn a_provider_added_after_the_filter_was_written_still_honours_its_toggle() {
+        let mut settings = AppSettings::default();
+        settings.adapters.spotify = false;
+        settings.adapters.musicassistant = false;
+        settings.adapters.applemusic = false;
+
+        let listed = apply_zone_list_policy(
+            vec![
+                zone("spotify:device-1", "Phone"),
+                zone("musicassistant:player-1", "Study"),
+                zone("applemusic:bridge-1", "Mac"),
+                zone("roon:kitchen", "Kitchen"),
+            ],
+            &settings,
+        );
+
+        assert_eq!(
+            listed
+                .iter()
+                .map(|z| z.zone_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["roon:kitchen"],
+            "a disabled provider's zones must not be listed"
+        );
+    }
+
+    /// The other half of the same rule: a prefix with no toggle at all is still shown,
+    /// so a zone from a provider this build predates is never silently swallowed.
+    #[test]
+    fn an_unknown_prefix_is_still_listed() {
+        let settings = AppSettings::default();
+        let listed = apply_zone_list_policy(vec![zone("someprovider:one", "New")], &settings);
+        assert_eq!(listed.len(), 1);
+    }
 
     fn zone(zone_id: &str, zone_name: &str) -> Zone {
         Zone {

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -387,18 +387,15 @@ fn lms_reconfiguration_cancels_both_observers_before_retiring_lms_projection() {
 
     let api = parse(include_str!("../src/api/mod.rs"));
     let configure = facts(named_body(&api, "lms_configure_handler"));
-    // Either paired-observer stop is acceptable here. The `_await_flush` variant is
-    // the same operation plus a bounded wait for the aggregator's `ZonesFlushed`
-    // acknowledgement, which reconfiguration needs because it restarts the
-    // observers immediately: an unapplied flush landing after the restarted
-    // poller's first publication deletes the zone it just published.
+    // Specifically the acknowledgement-waiting variant. Reconfiguration restarts the
+    // observers immediately, so the plain stop path lets an unapplied flush land after
+    // the restarted poller's first publication and delete the zone it just published.
     assert!(
         configure
             .method_calls
             .iter()
-            .any(|call| call == "stop_adapter_and_companions_then_flush"
-                || call == "stop_adapter_and_companions_then_await_flush"),
-        "LMS reconfiguration must use the paired-observer stop path"
+            .any(|call| call == "stop_adapter_and_companions_then_await_flush"),
+        "LMS reconfiguration must wait for the projection flush acknowledgement"
     );
     assert!(
         configure

--- a/tests/lifecycle_projection_lint.rs
+++ b/tests/lifecycle_projection_lint.rs
@@ -387,11 +387,17 @@ fn lms_reconfiguration_cancels_both_observers_before_retiring_lms_projection() {
 
     let api = parse(include_str!("../src/api/mod.rs"));
     let configure = facts(named_body(&api, "lms_configure_handler"));
+    // Either paired-observer stop is acceptable here. The `_await_flush` variant is
+    // the same operation plus a bounded wait for the aggregator's `ZonesFlushed`
+    // acknowledgement, which reconfiguration needs because it restarts the
+    // observers immediately: an unapplied flush landing after the restarted
+    // poller's first publication deletes the zone it just published.
     assert!(
         configure
             .method_calls
             .iter()
-            .any(|call| call == "stop_adapter_and_companions_then_flush"),
+            .any(|call| call == "stop_adapter_and_companions_then_flush"
+                || call == "stop_adapter_and_companions_then_await_flush"),
         "LMS reconfiguration must use the paired-observer stop path"
     );
     assert!(

--- a/tests/runtime_configuration_visibility.rs
+++ b/tests/runtime_configuration_visibility.rs
@@ -1,0 +1,217 @@
+//! Configuring a provider at runtime must make it visible, not merely connected.
+//!
+//! `POST /lms/configure` is the documented way to point UHC at a Lyrion server from
+//! the web UI, and it used to leave the install in a state that looked healthy from
+//! every angle except the one that matters: `/lms/config` reported connected, the
+//! poll loop published complete player snapshots into the aggregator, collection
+//! browsing worked — and no zone appeared in any zone list, because every list
+//! filters on `adapters.lms` re-read from disk and configuring never set it. Only a
+//! later `POST /api/settings` (or a restart with the toggle already on) repaired it.
+//!
+//! So this test asserts the *visible* list, not aggregator membership: aggregator
+//! membership was never the broken half. It writes no settings of its own — a
+//! settings write is the workaround this regression is about.
+//!
+//! The same hole existed on `/hqplayer/configure`, which started the managed
+//! lifecycle only when the toggle happened to be on already, so the second test
+//! covers the shared rule rather than the one provider it was first reported on.
+
+mod mock_servers;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::extract::State;
+use axum::Json;
+use tokio_util::sync::CancellationToken;
+
+use unified_hifi_control::adapters::hqplayer::{HqpInstanceManager, HqpZoneLinkService};
+use unified_hifi_control::adapters::lms;
+use unified_hifi_control::adapters::openhome::OpenHomeAdapter;
+use unified_hifi_control::adapters::roon::RoonAdapter;
+use unified_hifi_control::adapters::upnp::UPnPAdapter;
+use unified_hifi_control::adapters::Startable;
+use unified_hifi_control::aggregator::ZoneAggregator;
+use unified_hifi_control::api::{AppState, LmsConfigRequest};
+use unified_hifi_control::bus::create_bus;
+use unified_hifi_control::coordinator::AdapterCoordinator;
+use unified_hifi_control::knobs::KnobStore;
+
+/// Compose the real production wiring: aggregator, reliable projection runtime, the
+/// LMS poller and its CLI companion sharing one bridge, and a coordinator whose
+/// enabled state comes from the settings on disk.
+async fn app_state_with_live_lms_projection() -> (AppState, Arc<ZoneAggregator>) {
+    let bus = create_bus();
+    let aggregator = Arc::new(ZoneAggregator::new(bus.clone()));
+    let runtime = unified_hifi_control::bus::runtime::build_runtime(aggregator.clone(), 16, 64);
+    let bridge = Arc::new(lms::LmsRuntimeBridge::new(
+        runtime.projection_ingress.clone(),
+        runtime.commands.clone(),
+    ));
+    let (lms_adapter, lms_cli) = lms::create_lms_adapters_with_runtime(bus.clone(), Some(bridge));
+
+    let coordinator = Arc::new(AdapterCoordinator::new(bus.clone()));
+    let settings = unified_hifi_control::api::load_app_settings();
+    coordinator.register_from_settings(&settings.adapters).await;
+    coordinator.register_companion("lms", lms_cli.clone()).await;
+
+    // Same ordering guarantee as `main`: the aggregator is subscribed and the
+    // projection actor is running before any producer can publish.
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let agg_task = aggregator.clone();
+    tokio::spawn(async move { agg_task.run_with_ready(ready_tx).await });
+    ready_rx.await.expect("aggregator ready");
+    tokio::spawn(runtime.projection_actor.run());
+
+    let hqp_instances = Arc::new(HqpInstanceManager::new(bus.clone()));
+    let hqplayer = hqp_instances.get_default().await;
+    let hqp_zone_links = Arc::new(HqpZoneLinkService::new(hqp_instances.clone()));
+    let startables: Vec<Arc<dyn Startable>> = vec![lms_adapter.clone(), lms_cli.clone()];
+
+    let state = AppState::new(
+        Arc::new(RoonAdapter::new_disconnected(bus.clone())),
+        hqplayer,
+        hqp_instances,
+        hqp_zone_links,
+        lms_adapter,
+        Arc::new(OpenHomeAdapter::new(bus.clone())),
+        Arc::new(UPnPAdapter::new(bus.clone())),
+        KnobStore::new(),
+        bus,
+        aggregator.clone(),
+        coordinator,
+        startables,
+        Instant::now(),
+        CancellationToken::new(),
+    );
+    (state, aggregator)
+}
+
+/// Poll the user-visible zone list until `predicate` holds, or fail with what the
+/// aggregator held at the deadline — the aggregator side is the diagnostic that
+/// distinguishes "never published" from "published but filtered out".
+async fn await_visible_zone(state: &AppState, aggregator: &ZoneAggregator, zone_id: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let visible = unified_hifi_control::zone_list::visible_zones(state).await;
+        if visible.iter().any(|zone| zone.zone_id == zone_id) {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            let held = aggregator.get_zones().await;
+            panic!(
+                "{zone_id} never reached the zone list. visible={:?}, aggregator={:?}",
+                visible.iter().map(|z| &z.zone_id).collect::<Vec<_>>(),
+                held.iter().map(|z| &z.zone_id).collect::<Vec<_>>(),
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn configuring_lms_at_runtime_yields_a_zone_without_a_settings_write() {
+    let dir = std::env::temp_dir().join("uhc-test-lms-runtime-configure");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::env::set_var("UHC_CONFIG_DIR", &dir);
+
+    // The reported starting point: an install that has never enabled LMS, so
+    // `adapters.lms` is the default `false` and no LMS config exists on disk.
+    let before = unified_hifi_control::api::load_app_settings();
+    assert!(
+        !before.adapters.lms,
+        "this regression starts from an install where LMS was never enabled"
+    );
+
+    let mock = mock_servers::lms::MockLmsServer::start().await;
+    mock.add_player("aa:bb:cc:dd:ee:ff", "Kitchen").await;
+    let addr = mock.addr();
+
+    let (state, aggregator) = app_state_with_live_lms_projection().await;
+
+    let response = unified_hifi_control::api::lms_configure_handler(
+        State(state.clone()),
+        Json(LmsConfigRequest {
+            host: addr.ip().to_string(),
+            port: Some(addr.port()),
+            username: None,
+            password: None,
+        }),
+    )
+    .await;
+    let status = axum::response::IntoResponse::into_response(response).status();
+    assert_eq!(
+        status,
+        axum::http::StatusCode::OK,
+        "configure should succeed"
+    );
+
+    await_visible_zone(&state, &aggregator, "lms:aa:bb:cc:dd:ee:ff").await;
+
+    // Configuring is the enable gesture, and it has to survive a restart: the
+    // process reloads `adapters.lms` from disk to decide whether to start LMS at
+    // all, so an in-memory-only enable would put the install straight back into
+    // the reported state on the next boot.
+    let after = unified_hifi_control::api::load_app_settings();
+    assert!(
+        after.adapters.lms,
+        "configuring LMS must persist adapters.lms so the next start keeps it"
+    );
+    assert!(state.coordinator.is_enabled("lms").await);
+    assert!(state.coordinator.is_running("lms").await);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `/hqplayer/configure` is the same gesture through a different provider, and had
+/// the same two-part failure: the managed lifecycle was skipped while the toggle was
+/// off, and `hqplayer:` zones are filtered by that toggle even once it runs.
+///
+/// This stops at the enable half deliberately. Publishing an HQPlayer zone needs a
+/// wire-protocol daemon and a full managed-instance rig, which `hqplayer_direct_zone`
+/// already owns; what was broken here, and all this needs to hold, is that
+/// configuring turns the provider on and keeps it on across a restart.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn configuring_hqplayer_at_runtime_enables_it() {
+    let dir = std::env::temp_dir().join("uhc-test-hqp-runtime-configure");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::env::set_var("UHC_CONFIG_DIR", &dir);
+
+    assert!(
+        !unified_hifi_control::api::load_app_settings()
+            .adapters
+            .hqplayer,
+        "this regression starts from an install where HQPlayer was never enabled"
+    );
+
+    let (state, _aggregator) = app_state_with_live_lms_projection().await;
+
+    // No daemon is listening; the connection test in the handler is expected to fail.
+    // Enabling the provider is a decision about the user's intent, not about whether
+    // the host happened to answer, so it must hold either way.
+    let response = unified_hifi_control::api::hqp_configure_handler(
+        State(state.clone()),
+        Json(unified_hifi_control::api::HqpConfigRequest {
+            host: "127.0.0.1".to_string(),
+            port: Some(4321),
+            web_port: Some(8088),
+            username: None,
+            password: None,
+        }),
+    )
+    .await;
+    let status = axum::response::IntoResponse::into_response(response).status();
+    assert_eq!(status, axum::http::StatusCode::OK);
+
+    assert!(
+        unified_hifi_control::api::load_app_settings()
+            .adapters
+            .hqplayer,
+        "configuring HQPlayer must persist adapters.hqplayer so its zones are listed"
+    );
+    assert!(state.coordinator.is_enabled("hqplayer").await);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/runtime_configuration_visibility.rs
+++ b/tests/runtime_configuration_visibility.rs
@@ -215,3 +215,58 @@ async fn configuring_hqplayer_at_runtime_enables_it() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// The whole point of persisting the toggle is that the zones become visible, so a
+/// configure that could not persist it must not answer `200 ok`. Reporting success
+/// while the toggle stayed off puts the user back in the reported bug with no signal
+/// at all — a connected provider whose zones no list shows. A read-only config
+/// directory is the realistic way to reach this.
+#[tokio::test]
+#[serial_test::serial(lms_config)]
+async fn a_configure_that_cannot_persist_the_toggle_reports_failure() {
+    let dir = std::env::temp_dir().join("uhc-test-lms-unwritable-settings");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("unified-hifi")).expect("create config dir");
+    std::env::set_var("UHC_CONFIG_DIR", &dir);
+
+    let mock = mock_servers::lms::MockLmsServer::start().await;
+    mock.add_player("aa:bb:cc:dd:ee:ff", "Kitchen").await;
+    let addr = mock.addr();
+
+    let (state, _aggregator) = app_state_with_live_lms_projection().await;
+
+    // Take the settings directory away from the process after the state is built, so
+    // only the settings write fails and everything before it behaves normally.
+    let mut permissions = std::fs::metadata(dir.join("unified-hifi"))
+        .expect("config dir metadata")
+        .permissions();
+    permissions.set_readonly(true);
+    std::fs::set_permissions(dir.join("unified-hifi"), permissions).expect("make dir read-only");
+
+    let response = unified_hifi_control::api::lms_configure_handler(
+        State(state.clone()),
+        Json(LmsConfigRequest {
+            host: addr.ip().to_string(),
+            port: Some(addr.port()),
+            username: None,
+            password: None,
+        }),
+    )
+    .await;
+    let status = axum::response::IntoResponse::into_response(response).status();
+
+    let mut permissions = std::fs::metadata(dir.join("unified-hifi"))
+        .expect("config dir metadata")
+        .permissions();
+    #[allow(clippy::permissions_set_readonly_false)]
+    permissions.set_readonly(false);
+    let _ = std::fs::set_permissions(dir.join("unified-hifi"), permissions);
+
+    assert_eq!(
+        status,
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        "a configure whose enable toggle could not be saved must not report success"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## The bug

`POST /lms/configure` left an install looking healthy from every angle except the one that matters. The adapter connected, the CLI subscribed, the poll loop published complete player snapshots into the aggregator, collection browsing worked, `publish_zone` returned `Ok` — and no zone appeared in any list. Only an unrelated `POST /api/settings`, or a restart with the toggle already on, repaired it.

The zone reached the aggregator the whole time. It was filtered out on the way *out*: every zone list goes through `zone_list::visible_zones` → `adapter_enabled`, which re-reads `app-settings.json` **on every call** and drops any zone whose `adapters.<prefix>` toggle is false. Configuring never touched that toggle.

Backing the fix out, the new regression test fails with exactly the reported symptom:

```
lms:aa:bb:cc:dd:ee:ff never reached the zone list. visible=[], aggregator=["lms:aa:bb:cc:dd:ee:ff"]
```

## One rule, not six patches

This was never LMS-specific — six configure paths had the same shape:

| Path | Before |
|---|---|
| `POST /lms/configure` | set no toggle at all |
| `POST /hqplayer/configure` | started only `if is_enabled` |
| HQPlayer add-instance | started only `if is_enabled` |
| Apple Music pairing claim | logged "paired while adapter is disabled", returned success |
| Spotify authorization | logged "completed while adapter is disabled", returned success |
| Music Assistant configure | `start_registered_if_enabled` — silent no-op, response still `configured: true` |

`mark_adapter_configured(state, provider)` persists the toggle and mirrors it into the coordinator, keyed by **provider name**. Companion workers (`lms-cli`) are read from the coordinator's own topology via `enable_with_companions`, so a handler never restates a provider's internal worker layout — the thing that goes stale when a provider gains one. A new adapter adopts this with one line.

Naming a server *is* the enable gesture: the LMS page's save button posts only `/lms/configure`, so refusing when disabled would break the documented UI flow and send users hunting for a second switch.

## Two judgement calls worth your review

**MQTT is deliberately excluded.** Enabling it publishes to someone else's broker — a side effect on another system, not a question of whether UHC shows its own zones — and the add-on bootstrap already reasons about this explicitly ("publish to a broker nobody asked to publish to"). Left as-is.

**The zone-list prefix filter now shares the same mapping.** It carried its own `match` over prefixes, so every provider added after it was written — Spotify, Apple Music, Music Assistant — fell through to the include-by-default arm and their Settings toggles quietly did nothing to a zone list. HQPlayer had already been bitten by that drift once (#328, testing `hqp:` against a `hqplayer:` prefix). Slightly beyond the reported bug; leaving it would have made "one rule" false. Unknown prefixes are still included by default, so a zone from a provider this build predates is never silently swallowed.

## Also: a flush race on the same path

`AdapterStopping` is applied by the aggregator from its own event loop, so the plain stop path returns before any zone is removed — correct for shutdown, wrong for reconfiguration, which restarts the observers immediately and can have its first published zone deleted by the still-pending flush. `stop_adapter_and_companions_then_await_flush` waits for the `ZonesFlushed` acknowledgement, bounded (2s) so a composition with no aggregator running — tests, or a process already past aggregator shutdown — never stalls. This fits the second reported symptom (zone appearing ~25s after an otherwise no-op settings post) but is not confirmed as its cause.

## Tests

- `tests/runtime_configuration_visibility.rs` — composes the real wiring (aggregator + reliable projection runtime + poller and CLI companion sharing one bridge), calls the real handler against the mock LMS, and asserts a zone reaches `visible_zones` **with no settings write**, plus that the toggle persists so a restart keeps it. Verified red-then-green. Its HQPlayer sibling covers the enable half (a published HQP zone needs the wire-daemon rig `hqplayer_direct_zone` already owns).
- Unit tests holding `toggle`/`toggle_mut` in step across every registered adapter, and asserting a disabled Spotify/Apple/MA zone is now actually filtered.
- Two coordinator tests for the ack wait, including that a missing ack doesn't stall.
- Relaxed one assertion in `lifecycle_projection_lint.rs` that pinned the stop method by name; the intent (both observers stop before retirement) is unchanged.

Full suite: **2078 passed, 0 failed** across 48 binaries. `cargo clippy -- -D warnings` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configuring supported music adapters now automatically enables and starts them, including companion services.
  - Newly configured players appear in zone lists without requiring a separate settings update.
  - Apple Music and Spotify companion setup now starts the associated adapter automatically.

- **Bug Fixes**
  - Improved adapter reconfiguration reliability by waiting for zone updates before restarting observers.
  - Adapter enablement is now consistently reflected across supported providers.
  - Configuration failures now return an error instead of reporting success, while preserving the previous adapter state when startup fails.
  - HQPlayer remains enabled after configuration attempts, including when connection checks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->