### PR TITLE
Stop heartbeat echo loops and ramp cloud heartbeat to 15 minutes

### DIFF
--- a/src/cloud_connector/mod.rs
+++ b/src/cloud_connector/mod.rs
@@ -10,6 +10,7 @@ pub mod identity;
 pub mod pairing;
 pub mod protocol;
 pub mod runtime;
+mod safety;
 pub mod session;
 pub mod state;
 pub mod transport;

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -222,6 +222,13 @@ async fn run(
             .await;
         let delay = backoff.next_delay();
         tokio::select! { _ = shutdown.cancelled() => break, _ = tokio::time::sleep(delay) => {} }
+        match super::safety::admit_reconnect(&config.epoch_path, now_ms() as u64) {
+            Ok(true) => {}
+            result => {
+                tracing::error!(event = "cloud_cost_quarantined", "HiPhi remote access stopped: reconnect budget or persisted safety state unavailable; inspect connector safety files before recovery ({result:?})");
+                break;
+            }
+        }
         let grant = match tokio::select! {
             biased;
             _ = shutdown.cancelled() => break,
@@ -300,6 +307,9 @@ async fn run(
                     }
                     Ok(ConnectionExit::Shutdown) => break,
                     Err(error) => {
+                        if error.is::<SafetyPersistenceFailure>() {
+                            break;
+                        }
                         supervisor
                             .set_phase(generation, ConnectorPhase::Offline)
                             .await;
@@ -500,7 +510,11 @@ where
         std::sync::Arc::new(Semaphore::new(ARTWORK_QUEUE_CAPACITY + ARTWORK_CONCURRENCY));
     let artwork_active = std::sync::Arc::new(Semaphore::new(ARTWORK_CONCURRENCY));
     let mut refresh = tokio::time::interval(std::time::Duration::from_secs(20));
-    let mut heartbeat_check = tokio::time::interval(PEER_HEARTBEAT_CHECK_INTERVAL);
+    let mut watchdog_check = tokio::time::interval(PEER_HEARTBEAT_CHECK_INTERVAL);
+    let mut heartbeat_step = 0u32;
+    let heartbeat_check = tokio::time::sleep(super::safety::heartbeat_delay(heartbeat_step));
+    tokio::pin!(heartbeat_check);
+    let mut traffic = super::safety::TrafficBudget::default();
     let mut peer_watchdog = PeerWatchdog::new(now_ms() as u64, PEER_HEARTBEAT_TIMEOUT);
     refresh.tick().await;
     loop {
@@ -510,16 +524,22 @@ where
                 close_socket_for_shutdown(&mut socket).await;
                 return Ok(ConnectionExit::Shutdown);
             }
-            message = socket.next() => {
-                let Some(message) = message else { break; };
-                message?
+            _ = watchdog_check.tick() => {
+                if peer_watchdog.expired(now_ms() as u64) { anyhow::bail!("relay heartbeat timed out"); }
+                continue;
             }
-            _ = heartbeat_check.tick() => {
+            _ = &mut heartbeat_check => {
                 if peer_watchdog.expired(now_ms() as u64) {
                     anyhow::bail!("relay heartbeat timed out");
                 }
                 send_json(&mut socket, &ConnectorMessage::Heartbeat { epoch, sent_at: now_ms() }).await?;
+                heartbeat_step = heartbeat_step.saturating_add(1);
+                heartbeat_check.as_mut().reset(tokio::time::Instant::now() + super::safety::heartbeat_delay(heartbeat_step));
                 continue;
+            }
+            message = socket.next() => {
+                let Some(message) = message else { break; };
+                message?
             }
             _ = refresh.tick() => {
                 let projection = snapshot_from_aggregator(state, store, config.installation_id.clone(), epoch, store.latest().map_or(1, |p| p.revision.saturating_add(1)), now_ms() as u64).await?;
@@ -539,6 +559,10 @@ where
             close_socket_for_shutdown(&mut socket).await;
             return Ok(ConnectionExit::Shutdown);
         }
+        if !traffic.admit(now_ms() as u64, message.len()) {
+            quarantine_connection(&mut socket, &config.epoch_path).await?;
+            return Ok(ConnectionExit::Disconnected);
+        }
         match message {
             Message::Text(text) if text.len() > MAX_COMMAND_BYTES => {
                 anyhow::bail!("relay command frame exceeds the command bound");
@@ -551,14 +575,6 @@ where
                     ..
                 } if message_epoch == epoch => {
                     peer_watchdog.observe(now_ms() as u64);
-                    send_json(
-                        &mut socket,
-                        &ConnectorMessage::Heartbeat {
-                            epoch,
-                            sent_at: now_ms(),
-                        },
-                    )
-                    .await?;
                 }
                 RelayMessage::Command(command) => {
                     let request_id = command.request_id;
@@ -629,6 +645,10 @@ where
                     .await?;
                 }
                 RelayMessage::ArtworkRequest(request) => {
+                    if !traffic.artwork() {
+                        quarantine_connection(&mut socket, &config.epoch_path).await?;
+                        return Ok(ConnectionExit::Disconnected);
+                    }
                     schedule_artwork(
                         state,
                         store,
@@ -656,6 +676,10 @@ where
             },
             Message::Ping(bytes) => {
                 send_message(&mut socket, Message::Pong(bytes)).await?;
+            }
+            Message::Close(Some(ref frame)) if u16::from(frame.code) == 4008 => {
+                quarantine_connection(&mut socket, &config.epoch_path).await?;
+                return Ok(ConnectionExit::Disconnected);
             }
             Message::Close(_) => break,
             Message::Binary(_) | Message::Pong(_) | Message::Frame(_) => {}
@@ -758,6 +782,35 @@ where
         })??;
     Ok(())
 }
+async fn quarantine_connection<S>(
+    socket: &mut tokio_tungstenite::WebSocketStream<S>,
+    epoch_path: &std::path::Path,
+) -> anyhow::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let persisted = super::safety::quarantine(epoch_path);
+    tracing::error!(event = "cloud_cost_quarantined", "HiPhi remote traffic stopped; local playback remains available. Inspect the relay before removing the quarantine file.");
+    let _ = tokio::time::timeout(
+        SHUTDOWN_CLOSE_TIMEOUT,
+        socket.send(Message::Close(Some(CloseFrame {
+            code: CloseCode::Library(4008),
+            reason: "cloud cost guard".into(),
+        }))),
+    )
+    .await;
+    // Failure to persist must still stop reconnects in this process.
+    if let Err(error) = persisted {
+        tracing::error!("Unable to persist cloud quarantine: {error}");
+        anyhow::bail!(SafetyPersistenceFailure);
+    }
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("cloud quarantine persistence failed")]
+struct SafetyPersistenceFailure;
+
 async fn send_json<S, T: serde::Serialize>(
     socket: &mut tokio_tungstenite::WebSocketStream<S>,
     value: &T,
@@ -1712,6 +1765,295 @@ mod tests {
         .unwrap();
         assert_eq!(exit, ConnectionExit::Revoked);
         assert_eq!(ledger.len(), 1, "the command authority grant was accepted");
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn received_heartbeat_does_not_create_an_echo_loop() {
+        let installation_id = Uuid::new_v4().to_string();
+        let identity = InstallationIdentity::generate(installation_id.clone()).unwrap();
+        let previous_session_issuer = SigningKey::from_bytes(&[28; 32]);
+        let session_issuer = SigningKey::from_bytes(&[30; 32]);
+        let previous_command_issuer = SigningKey::from_bytes(&[29; 32]);
+        let command_issuer = SigningKey::from_bytes(&[31; 32]);
+        let temp = tempfile::tempdir().unwrap();
+        let endpoint = "wss://cloud.invalid/v1/relay/connect";
+        let config = CloudConnectorConfig {
+            endpoint: RelayEndpoint::parse(endpoint).unwrap(),
+            installation_id: installation_id.clone(),
+            key_path: temp.path().join("installation.key"),
+            epoch_path: temp.path().join("epoch"),
+            session_issuer_keys: IssuerVerifyingKeyRing::from_entries([
+                (
+                    "session-issuer-1".into(),
+                    previous_session_issuer.verifying_key(),
+                ),
+                ("session-issuer-2".into(), session_issuer.verifying_key()),
+            ])
+            .unwrap(),
+            command_issuer_keys: IssuerVerifyingKeyRing::from_entries([
+                (
+                    "command-issuer-1".into(),
+                    previous_command_issuer.verifying_key(),
+                ),
+                ("command-issuer-2".into(), command_issuer.verifying_key()),
+            ])
+            .unwrap(),
+        };
+        let state = empty_app_state().await;
+        let (client_io, server_io) = tokio::io::duplex(128 * 1024);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let now = super::now_ms();
+        let challenge = RelayMessage::Challenge(SessionChallengeMessage {
+            protocol_version: PROTOCOL_VERSION,
+            challenge_id: Uuid::new_v4(),
+            endpoint: endpoint.into(),
+            nonce: "nonce_012345678901234567890123456789".into(),
+            expires_at: now + 30_000,
+        });
+        let epoch = u64::try_from(now).unwrap();
+        let command = signed_command(
+            "command-issuer-2",
+            &command_issuer,
+            &installation_id,
+            epoch,
+            0,
+            now,
+        );
+        let server_task = tokio::spawn(async move {
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&challenge).unwrap().into(),
+                ))
+                .await
+                .unwrap();
+            let Message::Text(proof) = server.next().await.unwrap().unwrap() else {
+                panic!("expected installation proof")
+            };
+            let proof: InstallationSessionProof = serde_json::from_str(&proof).unwrap();
+            assert_eq!(proof.grant, "test.session.grant");
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::SessionEstablished { epoch })
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            let Message::Text(hello) = server.next().await.unwrap().unwrap() else {
+                panic!("expected connector hello")
+            };
+            let hello: ConnectorMessage = serde_json::from_str(&hello).unwrap();
+            assert!(matches!(hello, ConnectorMessage::Hello(ref value)
+                if value.installation_id == installation_id
+                    && value.connector_version == env!("UHC_VERSION")));
+            let Message::Text(snapshot) = server.next().await.unwrap().unwrap() else {
+                panic!("expected initial snapshot")
+            };
+            let snapshot: ConnectorMessage = serde_json::from_str(&snapshot).unwrap();
+            assert!(matches!(snapshot, ConnectorMessage::Snapshot(ref value)
+                if value.installation_id == installation_id && value.epoch == epoch));
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::Heartbeat {
+                        epoch,
+                        sent_at: super::now_ms(),
+                    })
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), server.next())
+                    .await
+                    .is_err(),
+                "receiving a heartbeat must not immediately echo another heartbeat"
+            );
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::Command(command))
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            let Message::Text(result) = server.next().await.unwrap().unwrap() else {
+                panic!("expected command result")
+            };
+            let result: ConnectorMessage = serde_json::from_str(&result).unwrap();
+            assert!(matches!(result, ConnectorMessage::CommandResult(_)));
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::Revoke {
+                        reason_code: "owner_revoked".into(),
+                    })
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        });
+        let mut store = StateStore::default();
+        let mut epoch_guard = SessionEpochGuard::load(&config.epoch_path).unwrap();
+        let mut ledger = CommandLedger::default();
+        let supervisor = ConnectorSupervisor::default();
+        let exit = run_connection(
+            &state,
+            &config,
+            &identity,
+            "test.session.grant",
+            0,
+            &mut store,
+            &mut epoch_guard,
+            &mut ledger,
+            ConnectionLifecycle {
+                supervisor: &supervisor,
+                generation: 1,
+            },
+            client,
+        )
+        .await
+        .unwrap();
+        assert_eq!(exit, ConnectionExit::Revoked);
+        assert_eq!(ledger.len(), 1, "the command authority grant was accepted");
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn relay_flood_is_quarantined_before_processing_unbounded_messages() {
+        let installation_id = Uuid::new_v4().to_string();
+        let identity = InstallationIdentity::generate(installation_id.clone()).unwrap();
+        let previous_session_issuer = SigningKey::from_bytes(&[28; 32]);
+        let session_issuer = SigningKey::from_bytes(&[30; 32]);
+        let previous_command_issuer = SigningKey::from_bytes(&[29; 32]);
+        let command_issuer = SigningKey::from_bytes(&[31; 32]);
+        let temp = tempfile::tempdir().unwrap();
+        let endpoint = "wss://cloud.invalid/v1/relay/connect";
+        let config = CloudConnectorConfig {
+            endpoint: RelayEndpoint::parse(endpoint).unwrap(),
+            installation_id: installation_id.clone(),
+            key_path: temp.path().join("installation.key"),
+            epoch_path: temp.path().join("epoch"),
+            session_issuer_keys: IssuerVerifyingKeyRing::from_entries([
+                (
+                    "session-issuer-1".into(),
+                    previous_session_issuer.verifying_key(),
+                ),
+                ("session-issuer-2".into(), session_issuer.verifying_key()),
+            ])
+            .unwrap(),
+            command_issuer_keys: IssuerVerifyingKeyRing::from_entries([
+                (
+                    "command-issuer-1".into(),
+                    previous_command_issuer.verifying_key(),
+                ),
+                ("command-issuer-2".into(), command_issuer.verifying_key()),
+            ])
+            .unwrap(),
+        };
+        let state = empty_app_state().await;
+        let (client_io, server_io) = tokio::io::duplex(128 * 1024);
+        let client = WebSocketStream::from_raw_socket(client_io, Role::Client, None).await;
+        let mut server = WebSocketStream::from_raw_socket(server_io, Role::Server, None).await;
+        let now = super::now_ms();
+        let challenge = RelayMessage::Challenge(SessionChallengeMessage {
+            protocol_version: PROTOCOL_VERSION,
+            challenge_id: Uuid::new_v4(),
+            endpoint: endpoint.into(),
+            nonce: "nonce_012345678901234567890123456789".into(),
+            expires_at: now + 30_000,
+        });
+        let epoch = u64::try_from(now).unwrap();
+        let _command = signed_command(
+            "command-issuer-2",
+            &command_issuer,
+            &installation_id,
+            epoch,
+            0,
+            now,
+        );
+        let server_task = tokio::spawn(async move {
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&challenge).unwrap().into(),
+                ))
+                .await
+                .unwrap();
+            let Message::Text(proof) = server.next().await.unwrap().unwrap() else {
+                panic!("expected installation proof")
+            };
+            let proof: InstallationSessionProof = serde_json::from_str(&proof).unwrap();
+            assert_eq!(proof.grant, "test.session.grant");
+            server
+                .send(Message::Text(
+                    serde_json::to_string(&RelayMessage::SessionEstablished { epoch })
+                        .unwrap()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            let Message::Text(hello) = server.next().await.unwrap().unwrap() else {
+                panic!("expected connector hello")
+            };
+            let hello: ConnectorMessage = serde_json::from_str(&hello).unwrap();
+            assert!(matches!(hello, ConnectorMessage::Hello(ref value)
+                if value.installation_id == installation_id
+                    && value.connector_version == env!("UHC_VERSION")));
+            let Message::Text(snapshot) = server.next().await.unwrap().unwrap() else {
+                panic!("expected initial snapshot")
+            };
+            let snapshot: ConnectorMessage = serde_json::from_str(&snapshot).unwrap();
+            assert!(matches!(snapshot, ConnectorMessage::Snapshot(ref value)
+                if value.installation_id == installation_id && value.epoch == epoch));
+            for _ in 0..200 {
+                server
+                    .send(Message::Text(
+                        serde_json::to_string(&RelayMessage::Heartbeat {
+                            epoch,
+                            sent_at: super::now_ms(),
+                        })
+                        .unwrap()
+                        .into(),
+                    ))
+                    .await
+                    .unwrap();
+            }
+            let reply = tokio::time::timeout(std::time::Duration::from_secs(1), server.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            assert!(
+                matches!(reply, Message::Close(Some(ref frame)) if u16::from(frame.code) == 4008),
+                "a flood must close and quarantine the session, got {reply:?}"
+            );
+        });
+        let mut store = StateStore::default();
+        let mut epoch_guard = SessionEpochGuard::load(&config.epoch_path).unwrap();
+        let mut ledger = CommandLedger::default();
+        let supervisor = ConnectorSupervisor::default();
+        let exit = run_connection(
+            &state,
+            &config,
+            &identity,
+            "test.session.grant",
+            0,
+            &mut store,
+            &mut epoch_guard,
+            &mut ledger,
+            ConnectionLifecycle {
+                supervisor: &supervisor,
+                generation: 1,
+            },
+            client,
+        )
+        .await
+        .unwrap();
+        assert!(config.epoch_path.with_extension("quarantine").exists());
+        assert_eq!(exit, ConnectionExit::Disconnected);
+        assert_eq!(ledger.len(), 0);
         server_task.await.unwrap();
     }
 

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -2007,9 +2007,10 @@ mod tests {
             let snapshot: ConnectorMessage = serde_json::from_str(&snapshot).unwrap();
             assert!(matches!(snapshot, ConnectorMessage::Snapshot(ref value)
                 if value.installation_id == installation_id && value.epoch == epoch));
+            // Buffer one burst before flushing; closure during the burst is the expected outcome.
             for _ in 0..200 {
                 server
-                    .send(Message::Text(
+                    .feed(Message::Text(
                         serde_json::to_string(&RelayMessage::Heartbeat {
                             epoch,
                             sent_at: super::now_ms(),
@@ -2020,6 +2021,7 @@ mod tests {
                     .await
                     .unwrap();
             }
+            server.flush().await.unwrap();
             let reply = tokio::time::timeout(std::time::Duration::from_secs(1), server.next())
                 .await
                 .unwrap()

--- a/src/cloud_connector/safety.rs
+++ b/src/cloud_connector/safety.rs
@@ -1,0 +1,149 @@
+//! Local containment remains independent of cloud availability and remote identity.
+//!
+//! Recovery is deliberately manual: stop UHC, resolve the incident, then remove
+//! `hiphi-relay-epoch.quarantine` in the configuration directory. Wait for the
+//! reconnect window to expire or explicitly remove `hiphi-relay-epoch.attempts`
+//! during the same recovery. Never remove the epoch replay ledger or identity key.
+//! The cloud relay needs compatible 45-minute liveness before installing a
+//! connector with 15-minute steady heartbeats. State snapshots keep their own
+//! 20-second schedule; playback commands do not wait for a heartbeat.
+use std::{path::Path, time::Duration};
+
+pub fn heartbeat_delay(step: u32) -> Duration {
+    Duration::from_secs(match step {
+        0 => 5,
+        1 => 30,
+        2 => 120,
+        3 => 300,
+        _ => 900,
+    })
+}
+
+#[derive(Default)]
+pub struct TrafficBudget {
+    minute: u64,
+    hour: u64,
+    messages: u32,
+    bytes: usize,
+    hourly_messages: u32,
+    artwork: u32,
+}
+impl TrafficBudget {
+    pub fn admit(&mut self, now: u64, bytes: usize) -> bool {
+        if now.saturating_sub(self.minute) >= 60_000 {
+            self.minute = now;
+            self.messages = 0;
+            self.bytes = 0;
+        }
+        if now.saturating_sub(self.hour) >= 3_600_000 {
+            self.hour = now;
+            self.hourly_messages = 0;
+            self.artwork = 0;
+        }
+        self.messages = self.messages.saturating_add(1);
+        self.hourly_messages = self.hourly_messages.saturating_add(1);
+        self.bytes = self.bytes.saturating_add(bytes);
+        self.messages <= 120 && self.hourly_messages <= 6_000 && self.bytes <= 8 * 1024 * 1024
+    }
+    pub fn artwork(&mut self) -> bool {
+        self.artwork = self.artwork.saturating_add(1);
+        self.artwork <= 60
+    }
+}
+
+pub fn quarantine(epoch_path: &Path) -> std::io::Result<()> {
+    use std::io::Write;
+    let path = epoch_path.with_extension("quarantine");
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    match options.open(path) {
+        Ok(mut f) => {
+            f.write_all(
+                b"Cloud traffic limit exceeded. Inspect the relay before removing this file.\n",
+            )?;
+            f.sync_all()
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Reserve each attempt on disk before doing network work. Restart is not a refill.
+pub fn admit_reconnect(epoch_path: &Path, now: u64) -> std::io::Result<bool> {
+    use std::io::Write;
+    if epoch_path.with_extension("quarantine").try_exists()? {
+        return Ok(false);
+    }
+    let path = epoch_path.with_extension("attempts");
+    let (mut start, mut attempts): (u64, u32) = match std::fs::read_to_string(&path) {
+        Ok(s) => serde_json::from_str(&s).map_err(std::io::Error::other)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (now, 0),
+        Err(e) => return Err(e),
+    };
+    if now.saturating_sub(start) >= 3_600_000 {
+        start = now;
+        attempts = 0;
+    }
+    if attempts >= 32 {
+        quarantine(epoch_path)?;
+        return Ok(false);
+    }
+    attempts += 1;
+    let temporary = path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    file.write_all(serde_json::to_string(&(start, attempts))?.as_bytes())?;
+    file.sync_all()?;
+    std::fs::rename(temporary, path)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn heartbeat_cadence_slows_and_stays_bounded() {
+        assert_eq!(
+            (0..6)
+                .map(|i| heartbeat_delay(i).as_secs())
+                .collect::<Vec<_>>(),
+            vec![5, 30, 120, 300, 900, 900]
+        );
+        assert!(heartbeat_delay(u32::MAX) < super::super::transport::PEER_HEARTBEAT_TIMEOUT);
+    }
+    #[test]
+    fn flood_bytes_and_artwork_are_independently_bounded() {
+        let mut b = TrafficBudget::default();
+        for _ in 0..120 {
+            assert!(b.admit(10_000_000, 100));
+        }
+        assert!(!b.admit(10_000_000, 100));
+        let mut b = TrafficBudget::default();
+        assert!(!b.admit(10_000_000, 9 * 1024 * 1024));
+        for _ in 0..60 {
+            assert!(b.artwork());
+        }
+        assert!(!b.artwork());
+    }
+    #[test]
+    fn reconnect_budget_survives_restart_and_time_does_not_clear_quarantine() {
+        let dir = tempfile::tempdir().unwrap();
+        let epoch = dir.path().join("epoch");
+        for _ in 0..32 {
+            assert!(admit_reconnect(&epoch, 10_000).unwrap());
+        }
+        assert!(!admit_reconnect(&epoch, 10_000).unwrap());
+        assert!(!admit_reconnect(&epoch, 10_000_000).unwrap());
+    }
+}

--- a/src/cloud_connector/transport.rs
+++ b/src/cloud_connector/transport.rs
@@ -95,7 +95,7 @@ impl SessionEpochGuard {
 /// command execute, but it must eventually release a black-holed session.
 pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const SOCKET_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
-pub const PEER_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(90);
+pub const PEER_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(45 * 60);
 pub const PEER_HEARTBEAT_CHECK_INTERVAL: Duration = Duration::from_secs(15);
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/tests/cloud_connector.rs
+++ b/tests/cloud_connector.rs
@@ -1127,10 +1127,11 @@ fn peer_watchdog_expires_only_after_bounded_silence() {
         10_000,
         cloud_connector::transport::PEER_HEARTBEAT_TIMEOUT,
     );
-    assert!(!watchdog.expired(10_000 + 89_999));
-    watchdog.observe(100_000);
-    assert!(!watchdog.expired(100_000 + 89_999));
-    assert!(watchdog.expired(100_000 + 90_000));
+    // Sparse steady heartbeats must survive; silence is bounded at 45 minutes.
+    assert!(!watchdog.expired(10_000 + 15 * 60_000));
+    watchdog.observe(1_000_000);
+    assert!(!watchdog.expired(1_000_000 + 45 * 60_000 - 1));
+    assert!(watchdog.expired(1_000_000 + 45 * 60_000));
 }
 
 #[test]


### PR DESCRIPTION
Receiving a relay heartbeat immediately sent another heartbeat, creating a feedback loop when the relay also replied. The connector now observes received heartbeats without echoing them and sends its own at successive delays of 5 seconds, 30 seconds, 2 minutes, 5 minutes, then **15 minutes**. Peer timeout is 45 minutes; command delivery and existing snapshot refresh remain independent.

Fixes #691.

Inbound message/byte/artwork budgets quarantine a runaway session. Reconnect attempts are reserved on disk before network work, so restart cannot refill the attempt budget. Quarantine persists until explicit operator recovery; inability to persist safety state stops retries. A local `cloud_cost_quarantined` error identifies the stop. Local playback and public API schemas are unchanged.

Validation:
- Echo-loop and flood regression tests failed before the fix and now pass.
- `cargo test --lib cloud_connector:: --features server`: 18 passed.
- API contract: 2 passed; client harness: 83 passed.
- `dx build --release --platform web --features web`: completed successfully (installed CLI emits a Dioxus version compatibility warning).
- Formatting and diff checks passed.

Recovery instructions are in the safety module documentation: preserve the installation key and epoch ledger; clear only quarantine/attempt state after resolving the incident.

Deploy the compatible cloud relay first so it tolerates 15-minute heartbeats and contains old echoing connectors. Production rollout and observation of declining usage are still pending. No release or production deployment has occurred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud connection stability with controlled reconnect attempts and heartbeat scheduling.
  * Added protections against excessive traffic, artwork requests, and relay flooding.
  * Connections that exceed safety limits are quarantined and closed with an appropriate status.
  * Reconnect limits now persist across restarts, expire after one hour, and block quarantined connections until cleared.
  * Relay heartbeat messages no longer trigger unnecessary immediate responses.
  * Increased the peer heartbeat timeout to 45 minutes to reduce unnecessary disconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->