### PR TITLE
fix: explain Cloud cost pauses and allow safe resume from Settings

### DIFF
--- a/docs/hiphi-cloud-recovery.md
+++ b/docs/hiphi-cloud-recovery.md
@@ -1,0 +1,56 @@
+# Recovering paused HiPhi Cloud access
+
+Starting with the next alpha after v4.0.0-alpha.6, Settings distinguishes a
+stopped Cloud connector from one that is connecting. A cost stop appears as
+**Cloud paused · cost protection**. Local playback continues.
+
+After the Cloud incident is resolved, choose **Resume Cloud connection** in
+local UHC Settings. This resets the local cost stop and connection-attempt
+window, then starts one connector task. It does not re-pair the installation,
+change its key, reset the replay ledger, or disable traffic limits. Cloud can
+still refuse the connection while its own safety stop is active.
+
+Recovery attempts are limited to one every 15 minutes. That cooldown is saved
+on disk and survives restarting UHC. Repeated clicks cannot start parallel
+connectors. If the original problem continues, cost protection can stop the
+connector again.
+
+If Settings reports that safety state needs attention, inspect the UHC logs
+and configuration storage. The recovery action will not erase invalid replay
+or reconnect state. An ordinary restart deliberately does not clear a cost
+quarantine.
+
+## Local API
+
+The owner approved these additions for #694:
+
+- `POST /api/hiphi/connection/resume`: no required request body. Returns the
+  pairing status after scheduling startup; this does not claim the remote
+  connection is online. A refused or failed attempt returns HTTP 409 with
+  `code: "cloud_resume_failed"` and a `message`.
+- `GET /api/hiphi/pairing/status`: retains existing fields and adds
+  `pause_reason` (null, `cost_limit`, or `safety_state_unavailable`) and
+  `can_resume` (boolean). `connector_state` now includes `paused`.
+
+Recovery follows the existing controller-auth policy: when enabled, the
+controller session and same-origin CSRF checks apply, just as for pairing.
+Authenticated Home Assistant ingress uses the existing ingress boundary.
+Controller authentication remains opt-in.
+
+## Recovery design review
+
+The objective is recovery from a local cost stop without filesystem surgery.
+This does not assume that every offline installation is quarantined: the
+persisted state is checked before offering resume. Restart was observed not to
+restore the incident NAS, but its actual quarantine file was not inspected.
+
+The main failure modes are another traffic storm, duplicate connector tasks,
+and accidentally resetting replay protection. A persisted cooldown, serialized
+startup/recovery, validation before file changes, and preservation tests address
+those risks. The cooldown is committed before counter reset; the stop flag is
+removed last. Partial file-update failures therefore keep the connector stopped.
+
+The alternative of clearing quarantine on every restart was rejected because
+package restart loops would defeat containment. Automatic recovery of corrupt
+state was rejected because it could erase evidence or replay protection. The
+manual action is limited to a cost stop and leaves the Cloud safety lease intact.

--- a/src/api/controller_auth.rs
+++ b/src/api/controller_auth.rs
@@ -331,7 +331,7 @@ fn is_native_bridge(path: &str) -> bool {
 }
 
 fn is_protected(path: &str, method: &axum::http::Method) -> bool {
-    if path.starts_with("/api/hiphi/pairing/") {
+    if path.starts_with("/api/hiphi/pairing/") || path.starts_with("/api/hiphi/connection/") {
         return true;
     }
     if path.starts_with("/api/providers/") && path != "/api/providers/spotify/oauth/callback"
@@ -509,6 +509,10 @@ mod tests {
 
     #[test]
     fn protected_surface_keeps_read_only_lan_pages_available() {
+        assert!(is_protected(
+            "/api/hiphi/connection/resume",
+            &axum::http::Method::POST
+        ));
         assert!(is_protected(
             "/api/providers/spotify/account",
             &axum::http::Method::GET

--- a/src/api/hiphi_pairing.rs
+++ b/src/api/hiphi_pairing.rs
@@ -84,6 +84,8 @@ pub struct PairingStatusResponse {
     pub paired: bool,
     pub installation_id: Option<String>,
     pub connector_state: &'static str,
+    pub pause_reason: Option<&'static str>,
+    pub can_resume: bool,
 }
 
 fn helper_path() -> anyhow::Result<PathBuf> {
@@ -274,11 +276,29 @@ pub async fn status(State(state): State<crate::api::AppState>) -> axum::response
             paired: status.configured,
             installation_id: status.installation_id,
             connector_state: status.phase.as_str(),
+            pause_reason: status.pause_reason,
+            can_resume: status.can_resume,
         })
         .into_response(),
         Err(error_value) => error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "pairing_status_failed",
+            error_value.to_string(),
+        ),
+    }
+}
+
+/// Explicit local recovery; controller auth and CSRF use the same policy as pairing.
+pub async fn resume(State(state): State<crate::api::AppState>) -> axum::response::Response {
+    match state
+        .hiphi_connector
+        .resume_from_runtime(state.clone(), crate::config::get_config_dir())
+        .await
+    {
+        Ok(_) => status(State(state)).await,
+        Err(error_value) => error(
+            StatusCode::CONFLICT,
+            "cloud_resume_failed",
             error_value.to_string(),
         ),
     }

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -150,6 +150,10 @@ pub struct HiphiPairingStatus {
     pub paired: bool,
     pub installation_id: Option<String>,
     pub connector_state: String,
+    #[serde(default)]
+    pub pause_reason: Option<String>,
+    #[serde(default)]
+    pub can_resume: bool,
 }
 
 impl HiphiPairingStatus {
@@ -157,7 +161,11 @@ impl HiphiPairingStatus {
         match self.connector_state.as_str() {
             "online" => "Connected to HiPhi Cloud",
             "connecting" => "Paired · connecting",
-            "offline" => "Paired · reconnecting",
+            "offline" => "Paired · offline",
+            "paused" if self.pause_reason.as_deref() == Some("cost_limit") => {
+                "Cloud paused · cost protection"
+            }
+            "paused" => "Cloud paused · safety state needs attention",
             "revoked" => "Cloud access revoked",
             _ => "Not paired",
         }

--- a/src/app/pages/settings.rs
+++ b/src/app/pages/settings.rs
@@ -225,6 +225,29 @@ fn HiphiCloudPairing() -> Element {
         });
     };
 
+    let resume_cloud = move |_| {
+        if matches!(action(), ProviderActionState::Loading) {
+            return;
+        }
+        action.set(ProviderActionState::Loading);
+        error.set(None);
+        spawn(async move {
+            match crate::app::api::post_json::<serde_json::Value, HiphiPairingStatus>(
+                "/api/hiphi/connection/resume",
+                &serde_json::json!({}),
+            )
+            .await
+            {
+                Ok(_) => action.set(ProviderActionState::Success),
+                Err(message) => {
+                    action.set(ProviderActionState::Failed);
+                    error.set(crate::app::api::suppress_controller_unauthorized(message));
+                }
+            }
+            pairing_status.restart();
+        });
+    };
+
     let status_snapshot = pairing_status.read().as_ref().cloned();
     let status_pending = status_snapshot.is_none();
     let paired_status = status_snapshot
@@ -244,9 +267,23 @@ fn HiphiCloudPairing() -> Element {
                 if status_pending {
                     p { class: "text-sm text-secondary", "Checking this installation’s HiPhi Cloud connection…" }
                 } else if let Some(status) = paired_status {
-                    div { class: "status-ok", role: "status",
+                    div { class: if status.connector_state == "online" { "status-ok" } else { "text-secondary" }, role: "status",
                         p { class: "font-medium", "This UHC installation is paired." }
                         p { class: "mt-1", "{status.display_state()}" }
+                        if status.pause_reason.as_deref() == Some("cost_limit") {
+                            p { class: "mt-2 text-sm", "Cloud traffic or repeated connection attempts reached a safety limit. Local playback is unaffected. Resume after the Cloud issue is resolved; cost protection stays enabled." }
+                            button {
+                                r#type: "button", class: "btn-primary mt-3",
+                                disabled: !status.can_resume || matches!(action(), ProviderActionState::Loading),
+                                onclick: resume_cloud,
+                                "Resume Cloud connection"
+                            }
+                            if !status.can_resume {
+                                p { class: "mt-2 text-sm", "Recovery attempts are limited to once every 15 minutes. If this persists, the saved recovery state needs attention." }
+                            }
+                        } else if status.pause_reason.is_some() {
+                            p { class: "mt-2 text-sm", "Cloud safety or replay state could not be read or saved. Check the UHC logs and configuration storage before resuming. Pairing and local playback are preserved." }
+                        }
                         if let Some(installation_id) = status.installation_id {
                             p { class: "mt-2 text-xs text-muted break-all", "Installation ID: {installation_id}" }
                         }
@@ -345,8 +382,8 @@ fn HiphiCloudPairing() -> Element {
                     }
                 }
 
-                if let Some(message) = error() { p { class: "status-err", role: "alert", "{message}" } }
                 }
+                if let Some(message) = error() { p { class: "status-err", role: "alert", "{message}" } }
             }
         }
     }

--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -68,6 +68,8 @@ pub enum ConnectorPhase {
     Connecting,
     Online,
     Revoked,
+    Paused,
+    SafetyError,
 }
 
 impl ConnectorPhase {
@@ -78,6 +80,7 @@ impl ConnectorPhase {
             Self::Connecting => "connecting",
             Self::Online => "online",
             Self::Revoked => "revoked",
+            Self::Paused | Self::SafetyError => "paused",
         }
     }
 }
@@ -87,6 +90,8 @@ pub struct ConnectorStatus {
     pub configured: bool,
     pub installation_id: Option<String>,
     pub phase: ConnectorPhase,
+    pub pause_reason: Option<&'static str>,
+    pub can_resume: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -110,6 +115,7 @@ struct SupervisorState {
 #[derive(Clone, Default)]
 pub struct ConnectorSupervisor {
     inner: std::sync::Arc<Mutex<SupervisorState>>,
+    operation: std::sync::Arc<Mutex<()>>,
 }
 
 #[derive(Clone, Copy)]
@@ -124,6 +130,7 @@ impl ConnectorSupervisor {
         state: crate::api::AppState,
         config_dir: impl Into<std::path::PathBuf>,
     ) -> anyhow::Result<ConnectorStart> {
+        let _operation = self.operation.lock().await;
         let Some(config) = CloudConnectorConfig::from_runtime(config_dir)? else {
             return Ok(ConnectorStart::NotConfigured);
         };
@@ -132,6 +139,36 @@ impl ConnectorSupervisor {
                 anyhow::anyhow!("paired HiPhi installation key is unavailable: {error}")
             })?;
 
+        self.start_config(state, config, identity).await
+    }
+
+    pub async fn resume_from_runtime(
+        &self,
+        state: crate::api::AppState,
+        config_dir: impl Into<std::path::PathBuf>,
+    ) -> anyhow::Result<ConnectorStart> {
+        let _operation = self.operation.lock().await;
+        anyhow::ensure!(
+            !self.inner.lock().await.active,
+            "Cloud connector is already running."
+        );
+        anyhow::ensure!(!state.shutdown.is_cancelled(), "UHC is shutting down.");
+        let config = CloudConnectorConfig::from_runtime(config_dir)?
+            .ok_or_else(|| anyhow::anyhow!("This installation is not paired."))?;
+        // Validate identity and replay protection before changing containment.
+        let identity =
+            InstallationIdentity::load(&config.key_path, config.installation_id.clone())?;
+        SessionEpochGuard::load(&config.epoch_path)?;
+        super::safety::resume(&config.epoch_path, now_ms() as u64)?;
+        self.start_config(state, config, identity).await
+    }
+
+    async fn start_config(
+        &self,
+        state: crate::api::AppState,
+        config: CloudConnectorConfig,
+        identity: InstallationIdentity,
+    ) -> anyhow::Result<ConnectorStart> {
         let generation = {
             let mut inner = self.inner.lock().await;
             if inner.active {
@@ -164,20 +201,41 @@ impl ConnectorSupervisor {
                 configured: false,
                 installation_id: None,
                 phase: ConnectorPhase::Unconfigured,
+                pause_reason: None,
+                can_resume: false,
             });
         };
         let inner = self.inner.lock().await;
-        let phase = if inner.active
-            && inner.installation_id.as_deref() == Some(config.installation_id.as_str())
-        {
+        let same_installation =
+            inner.installation_id.as_deref() == Some(config.installation_id.as_str());
+        let active = inner.active && same_installation;
+        let mut phase = if same_installation {
             inner.phase.unwrap_or(ConnectorPhase::Offline)
         } else {
             ConnectorPhase::Offline
         };
+        let mut pause_reason = if active {
+            None
+        } else if phase == ConnectorPhase::SafetyError {
+            Some("safety_state_unavailable")
+        } else {
+            super::safety::pause_reason(&config.epoch_path)
+        };
+        if !active && SessionEpochGuard::load(&config.epoch_path).is_err() {
+            pause_reason = Some("safety_state_unavailable");
+        }
+        if pause_reason.is_some() {
+            phase = ConnectorPhase::Paused;
+        }
+        let can_resume = !active
+            && pause_reason == Some("cost_limit")
+            && super::safety::can_resume(&config.epoch_path, now_ms() as u64);
         Ok(ConnectorStatus {
             configured: true,
             installation_id: Some(config.installation_id),
             phase,
+            pause_reason,
+            can_resume,
         })
     }
 
@@ -211,7 +269,7 @@ async fn run(
         Ok(guard) => guard,
         Err(error) => {
             tracing::error!("HiPhi Cloud epoch state is unavailable: {error}");
-            return ConnectorPhase::Offline;
+            return ConnectorPhase::SafetyError;
         }
     };
     let mut ledger = CommandLedger::default();
@@ -226,6 +284,11 @@ async fn run(
             Ok(true) => {}
             result => {
                 tracing::error!(event = "cloud_cost_quarantined", "HiPhi remote access stopped: reconnect budget or persisted safety state unavailable; inspect connector safety files before recovery ({result:?})");
+                final_phase = if result.is_err() {
+                    ConnectorPhase::SafetyError
+                } else {
+                    ConnectorPhase::Paused
+                };
                 break;
             }
         }
@@ -308,6 +371,7 @@ async fn run(
                     Ok(ConnectionExit::Shutdown) => break,
                     Err(error) => {
                         if error.is::<SafetyPersistenceFailure>() {
+                            final_phase = ConnectorPhase::SafetyError;
                             break;
                         }
                         supervisor
@@ -1208,8 +1272,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn persisted_pairing_survives_restart_and_supervisor_is_duplicate_safe() {
+    fn paired_directory() -> (tempfile::TempDir, String) {
         use std::os::unix::fs::PermissionsExt as _;
 
         let directory = tempfile::tempdir().unwrap();
@@ -1246,6 +1309,13 @@ mod tests {
         std::fs::set_permissions(&environment_path, std::fs::Permissions::from_mode(0o600))
             .unwrap();
 
+        (directory, installation_id)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn persisted_pairing_survives_restart_and_supervisor_is_duplicate_safe() {
+        let (directory, installation_id) = paired_directory();
         let supervisor = ConnectorSupervisor::default();
         let status = supervisor
             .status_from_runtime(directory.path())
@@ -1297,6 +1367,97 @@ mod tests {
         })
         .await
         .expect("connector should stop on process shutdown");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn recovery_serializes_clicks_preserves_identity_and_exposes_terminal_pause() {
+        let (directory, installation_id) = paired_directory();
+        let key_path = directory.path().join("hiphi-installation.key");
+        InstallationIdentity::generate(installation_id)
+            .unwrap()
+            .save(&key_path)
+            .unwrap();
+        let key_before = std::fs::read(&key_path).unwrap();
+        let epoch = directory.path().join("hiphi-relay-epoch");
+        let now = super::now_ms() as u64;
+        super::SessionEpochGuard::load(&epoch)
+            .unwrap()
+            .accept_at(now, now)
+            .unwrap();
+        super::super::safety::quarantine(&epoch).unwrap();
+        let supervisor = ConnectorSupervisor::default();
+        let status = supervisor
+            .status_from_runtime(directory.path())
+            .await
+            .unwrap();
+        assert_eq!(status.phase.as_str(), "paused");
+        assert_eq!(status.pause_reason, Some("cost_limit"));
+        assert!(status.can_resume);
+        let state = empty_app_state().await;
+        supervisor
+            .start_from_runtime(state.clone(), directory.path())
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            while supervisor.inner.lock().await.active {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        let stopped = supervisor
+            .status_from_runtime(directory.path())
+            .await
+            .unwrap();
+        assert_eq!(stopped.phase.as_str(), "paused");
+        assert_eq!(stopped.pause_reason, Some("cost_limit"));
+        let (first, second) = tokio::join!(
+            supervisor.resume_from_runtime(state.clone(), directory.path()),
+            supervisor.resume_from_runtime(state.clone(), directory.path()),
+        );
+        assert_ne!(
+            first.is_ok(),
+            second.is_ok(),
+            "only one click may reset the budget"
+        );
+        assert_eq!(supervisor.inner.lock().await.generation, 2);
+        assert_eq!(std::fs::read(&key_path).unwrap(), key_before);
+        assert!(
+            !state.shutdown.is_cancelled(),
+            "recovery must not stop local playback"
+        );
+        assert!(supervisor.inner.lock().await.active);
+        let mut replay = super::SessionEpochGuard::load(&epoch).unwrap();
+        assert_eq!(replay.last(), now);
+        assert!(
+            replay.accept_at(now, now).is_err(),
+            "resume must not allow replay"
+        );
+        state.shutdown.cancel();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn recovery_rejects_damaged_replay_state_without_clearing_quarantine() {
+        let (directory, installation_id) = paired_directory();
+        InstallationIdentity::generate(installation_id)
+            .unwrap()
+            .save(&directory.path().join("hiphi-installation.key"))
+            .unwrap();
+        let epoch = directory.path().join("hiphi-relay-epoch");
+        std::fs::write(&epoch, "invalid replay state").unwrap();
+        super::super::safety::quarantine(&epoch).unwrap();
+        let supervisor = ConnectorSupervisor::default();
+        let state = empty_app_state().await;
+        assert!(supervisor
+            .resume_from_runtime(state.clone(), directory.path())
+            .await
+            .is_err());
+        assert!(epoch.with_extension("quarantine").exists());
+        assert!(!epoch.with_extension("resume").exists());
+        assert!(!supervisor.inner.lock().await.active);
+        state.shutdown.cancel();
     }
 
     #[derive(Default)]

--- a/src/cloud_connector/safety.rs
+++ b/src/cloud_connector/safety.rs
@@ -1,6 +1,7 @@
 //! Local containment remains independent of cloud availability and remote identity.
 //!
-//! Recovery is deliberately manual: stop UHC, resolve the incident, then remove
+//! Prefer Settings → Resume Cloud connection after resolving the incident.
+//! For manual recovery, stop UHC, resolve the incident, then remove
 //! `hiphi-relay-epoch.quarantine` in the configuration directory. Wait for the
 //! reconnect window to expire or explicitly remove `hiphi-relay-epoch.attempts`
 //! during the same recovery. Never remove the epoch replay ledger or identity key.
@@ -73,6 +74,99 @@ pub fn quarantine(epoch_path: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Inspect persisted containment without making a network attempt. Invalid
+/// state is not a cost quarantine and must not be erased by the resume action.
+pub fn pause_reason(epoch_path: &Path) -> Option<&'static str> {
+    match inspect(epoch_path) {
+        Ok(true) => Some("cost_limit"),
+        Ok(false) => None,
+        Err(_) => Some("safety_state_unavailable"),
+    }
+}
+
+fn read_regular(path: &Path) -> std::io::Result<Option<String>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => std::fs::read_to_string(path).map(Some),
+        Ok(_) => Err(std::io::Error::other("safety state is not a regular file")),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn inspect(epoch_path: &Path) -> std::io::Result<bool> {
+    if let Some(previous) = read_regular(&epoch_path.with_extension("resume"))? {
+        previous.parse::<u64>().map_err(std::io::Error::other)?;
+    }
+    if let Some(attempts) = read_regular(&epoch_path.with_extension("attempts"))? {
+        serde_json::from_str::<(u64, u32)>(&attempts).map_err(std::io::Error::other)?;
+    }
+    Ok(read_regular(&epoch_path.with_extension("quarantine"))?.is_some())
+}
+
+const RESUME_COOLDOWN_MS: u64 = 15 * 60 * 1000;
+
+fn check_resume_cooldown(epoch_path: &Path, now: u64) -> std::io::Result<()> {
+    if let Some(previous) = read_regular(&epoch_path.with_extension("resume"))? {
+        let previous: u64 = previous.parse().map_err(std::io::Error::other)?;
+        if now.saturating_sub(previous) < RESUME_COOLDOWN_MS {
+            return Err(std::io::Error::other(
+                "Wait 15 minutes between Cloud recovery attempts.",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn can_resume(epoch_path: &Path, now: u64) -> bool {
+    pause_reason(epoch_path) == Some("cost_limit") && check_resume_cooldown(epoch_path, now).is_ok()
+}
+
+/// Called only while the supervisor excludes startup and the connector is
+/// stopped. Commit the cooldown before clearing counters; remove the stop flag
+/// last, so failed writes/removals never accidentally release containment.
+pub fn resume(epoch_path: &Path, now: u64) -> std::io::Result<()> {
+    if !inspect(epoch_path)? {
+        return Err(std::io::Error::other(
+            "Cloud is not paused by a cost limit.",
+        ));
+    }
+    check_resume_cooldown(epoch_path, now)?;
+    let path = epoch_path.with_extension("resume");
+    let temporary = epoch_path.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+    let result = (|| {
+        use std::io::Write;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary)?;
+        file.write_all(now.to_string().as_bytes())?;
+        file.sync_all()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        std::fs::rename(&temporary, path)?;
+        #[cfg(unix)]
+        if let Some(parent) = epoch_path.parent() {
+            std::fs::File::open(parent)?.sync_all()?;
+        }
+        match std::fs::remove_file(epoch_path.with_extension("attempts")) {
+            Err(error) if error.kind() != std::io::ErrorKind::NotFound => return Err(error),
+            _ => {}
+        }
+        std::fs::remove_file(epoch_path.with_extension("quarantine"))
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(temporary);
+    }
+    result
+}
+
 /// Reserve each attempt on disk before doing network work. Restart is not a refill.
 pub fn admit_reconnect(epoch_path: &Path, now: u64) -> std::io::Result<bool> {
     use std::io::Write;
@@ -112,6 +206,47 @@ pub fn admit_reconnect(epoch_path: &Path, now: u64) -> std::io::Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn deliberate_resume_preserves_replay_and_retrips_with_persistent_cooldown() {
+        let dir = tempfile::tempdir().unwrap();
+        let epoch = dir.path().join("hiphi-relay-epoch");
+        std::fs::write(&epoch, "replay ledger must survive").unwrap();
+        let now = 1_000_000;
+        for _ in 0..32 {
+            assert!(admit_reconnect(&epoch, now).unwrap());
+        }
+        assert!(!admit_reconnect(&epoch, now).unwrap());
+        assert_eq!(pause_reason(&epoch), Some("cost_limit"));
+        resume(&epoch, now).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&epoch).unwrap(),
+            "replay ledger must survive"
+        );
+        assert_eq!(pause_reason(&epoch), None);
+        for _ in 0..32 {
+            assert!(admit_reconnect(&epoch, now).unwrap());
+        }
+        assert!(!admit_reconnect(&epoch, now).unwrap());
+        assert!(resume(&epoch, now + 1).is_err());
+        assert_eq!(pause_reason(&epoch), Some("cost_limit"));
+        resume(&epoch, now + 900_000).unwrap();
+    }
+
+    #[test]
+    fn resume_does_not_hide_corrupt_state_or_failed_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let epoch = dir.path().join("hiphi-relay-epoch");
+        quarantine(&epoch).unwrap();
+        std::fs::write(epoch.with_extension("attempts"), "broken").unwrap();
+        assert_eq!(pause_reason(&epoch), Some("safety_state_unavailable"));
+        assert!(resume(&epoch, 1_000_000).is_err());
+        assert!(epoch.with_extension("quarantine").exists());
+        std::fs::remove_file(epoch.with_extension("attempts")).unwrap();
+        std::fs::create_dir(epoch.with_extension("resume")).unwrap();
+        assert!(resume(&epoch, 1_000_000).is_err());
+        assert!(epoch.with_extension("quarantine").exists());
+    }
+
     #[test]
     fn heartbeat_cadence_slows_and_stays_bounded() {
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -880,6 +880,7 @@ mod server {
             .route("/api/controller/bootstrap", post(controller_bootstrap))
             .route("/api/controller/status", get(controller_status))
             .route("/api/hiphi/pairing/status", get(api::hiphi_pairing::status))
+            .route("/api/hiphi/connection/resume", post(api::hiphi_pairing::resume))
             .route("/api/hiphi/pairing/prepare", post(api::hiphi_pairing::prepare))
             .route("/api/hiphi/pairing/initiate", post(api::hiphi_pairing::initiate))
             .route("/api/hiphi/pairing/complete", post(api::hiphi_pairing::complete))

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -86,6 +86,7 @@ POST /api/bridges/applemusic/revoke
 POST /api/bridges/applemusic/state
 POST /api/collections
 POST /api/controller/bootstrap
+POST /api/hiphi/connection/resume
 POST /api/hiphi/pairing/complete
 POST /api/hiphi/pairing/initiate
 POST /api/hiphi/pairing/prepare

--- a/tests/hiphi_pairing_ui_contract.rs
+++ b/tests/hiphi_pairing_ui_contract.rs
@@ -80,3 +80,13 @@ fn browser_handoff_explicitly_clears_inherited_group_and_other_permissions() {
         "the QNAP config volume may inherit ACL mode bits despite create mode 0600"
     );
 }
+
+#[test]
+fn recovery_is_reachable_and_uses_the_controller_gate() {
+    let route = "/api/hiphi/connection/resume";
+    assert!(MAIN.contains(route));
+    assert!(SETTINGS.contains(route));
+    assert!(SETTINGS.contains("Resume Cloud connection"));
+    let auth = include_str!("../src/api/controller_auth.rs");
+    assert!(auth.contains("path.starts_with(\"/api/hiphi/connection/\")"));
+}

--- a/tests/hiphi_recovery.rs
+++ b/tests/hiphi_recovery.rs
@@ -1,0 +1,20 @@
+use unified_hifi_control::app::api::HiphiPairingStatus;
+
+#[test]
+fn stopped_connector_does_not_promise_retries() {
+    let status: HiphiPairingStatus = serde_json::from_value(serde_json::json!({
+        "paired": true, "installation_id": "test", "connector_state": "offline"
+    }))
+    .unwrap();
+    assert_eq!(status.display_state(), "Paired · offline");
+}
+
+#[test]
+fn quarantined_connector_explains_pause() {
+    let status: HiphiPairingStatus = serde_json::from_value(serde_json::json!({
+        "paired": true, "installation_id": "test", "connector_state": "paused",
+        "pause_reason": "cost_limit", "can_resume": true
+    }))
+    .unwrap();
+    assert_eq!(status.display_state(), "Cloud paused · cost protection");
+}


### PR DESCRIPTION
A Cloud cost stop in alpha.6 leaves Settings saying “Paired · reconnecting” after the connector has stopped, and recovery requires editing NAS configuration files. Settings now reports the pause and offers **Resume Cloud connection** after the underlying incident is resolved.

Recovery clears only the local cost quarantine and reconnect-attempt window. It validates the installation identity and replay ledger first, serializes recovery with startup, and persists a 15-minute cooldown before changing containment. Pairing, replay protection, progressive heartbeats, traffic limits, and Cloud-side safety remain in force. Failed recovery is shown in the paired UI; unreadable or corrupt safety state remains blocked.

The owner approved `POST /api/hiphi/connection/resume` and additive `pause_reason`/`can_resume` pairing-status fields in the task; approval is recorded on #694. The endpoint follows existing opt-in controller authentication, CSRF, and HA ingress policy. **Owner action: add `api-change-approved`; the agent has not added it.**

Validation: reproduced both misleading status tests failing before implementation; connector tests cover terminal pause after restart, concurrent clicks, cooldown persistence, repeat quarantine, unchanged identity/replay state, and corrupt state rejection. UI/API contract tests and the WASM frontend check pass. Existing flood and heartbeat protections still pass. This has not been installed on the incident NAS; end-to-end NAS recovery belongs to the next alpha validation.

Fixes #694

OH: 80222d6d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to resume paused HiPhi Cloud connections from Settings.
  * Added connection status details for paused states, including pause reasons and resume availability.
  * Added a protected endpoint for manually resuming cloud connections.
  * Added a 15-minute retry cooldown and clearer recovery guidance.

* **Bug Fixes**
  * Improved status messaging for offline, cost-limited, and safety-related connection states.
  * Preserved replay and traffic protections during recovery attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->