### PR TITLE
Use isolated Tart VM for trusted macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -918,7 +918,8 @@ jobs:
     name: Build macOS (x86_64)
     needs: [plan, build-wasm]
     if: needs.plan.outputs.build_macos == 'true'
-    runs-on: macos-latest
+    # Persistent self-hosted runners must not execute code from forks.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","artium-codex"]') || 'macos-15' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -976,7 +977,7 @@ jobs:
     name: Build macOS (arm64)
     needs: [plan, build-wasm]
     if: needs.plan.outputs.build_macos == 'true'
-    runs-on: macos-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","artium-codex"]') || 'macos-15' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -1038,7 +1039,7 @@ jobs:
       needs.plan.outputs.build_macos == 'true' &&
       needs.build-macos-x64.result == 'success' &&
       needs.build-macos-arm64.result == 'success'
-    runs-on: macos-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","artium-codex"]') || 'macos-15' }}
     steps:
       - name: Download x86_64 binary
         uses: actions/download-artifact@v8
@@ -1077,7 +1078,7 @@ jobs:
     name: Build Apple Music Companion DMG (macOS arm64)
     needs: [plan]
     if: needs.plan.outputs.build_applemusic_macos == 'true'
-    runs-on: macos-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","artium-codex"]') || 'macos-15' }}
     # `secrets` isn't allowed directly in step `if:` conditions, so surface
     # presence checks as job-level env vars instead.
     env:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,7 +19,8 @@ permissions:
 
 jobs:
   uhckit:
-    runs-on: macos-15
+    # Persistent self-hosted runners must not execute code from forks.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","artium-codex"]') || 'macos-15' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,7 +46,7 @@ jobs:
           swift build --package-path "$RUNNER_TEMP/uhc-remote" --target UHCKit
 
   apple-companion:
-    runs-on: macos-15
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","artium-codex"]') || 'macos-15' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The macOS jobs currently consume GitHub-hosted runners even though the isolated Tart VM is available for trusted CI. This routes macOS build, Swift package, and Apple companion jobs to `artium-codex-vm` for pushes, manual runs, and same-repository PRs.

Fork PRs continue on `macos-15`, so the repository's defined jobs do not execute fork code on the persistent worker. The runner is registered at repository scope with `self-hosted`, `macOS`, `ARM64`, and `artium-codex` labels.

Validation:
- `actionlint .github/workflows/swift.yml .github/workflows/build.yml`
- PR Swift jobs passed on `artium-codex-vm`, including the unsigned iOS companion build
- Manual build run 33942740983 passed macOS arm64, x86_64 cross-build, and universal assembly on `artium-codex-vm`
- Runner reports online and idle through the GitHub Actions API

The PR's Linux `Test` failure is inherited from `v4`: run 33829641167 on the base branch fails the same `await_in_lock_lint` check at `src/cloud_connector/runtime.rs`. This workflow-only change does not touch that source.

Fixes #696

OH: 80222d6d
