### PR TITLE
Fix cloud connector lifecycle lock lint

### DIFF
--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -130,7 +130,7 @@ impl ConnectorSupervisor {
         state: crate::api::AppState,
         config_dir: impl Into<std::path::PathBuf>,
     ) -> anyhow::Result<ConnectorStart> {
-        let _operation = self.operation.lock().await;
+        let _operation_guard = self.operation.lock().await;
         let Some(config) = CloudConnectorConfig::from_runtime(config_dir)? else {
             return Ok(ConnectorStart::NotConfigured);
         };
@@ -147,7 +147,7 @@ impl ConnectorSupervisor {
         state: crate::api::AppState,
         config_dir: impl Into<std::path::PathBuf>,
     ) -> anyhow::Result<ConnectorStart> {
-        let _operation = self.operation.lock().await;
+        let _operation_guard = self.operation.lock().await;
         anyhow::ensure!(
             !self.inner.lock().await.active,
             "Cloud connector is already running."

--- a/tests/await_in_lock_lint.rs
+++ b/tests/await_in_lock_lint.rs
@@ -230,6 +230,14 @@ fn allows_explicit_drop_before_await() {
 /// Allowlist for known-correct patterns where holding locks across awaits is intentional.
 /// Format: (file suffix, guard name, reason)
 const ALLOWLIST: &[(&str, &str, &str)] = &[
+    // Starting or resuming is one lifecycle transaction. The lease spans runtime identity and
+    // replay-state validation, safety-budget reset and task activation so concurrent resume
+    // requests cannot both reset containment before either marks the connector active.
+    (
+        "cloud_connector/runtime.rs",
+        "_operation_guard",
+        "Cloud connector start and resume transactions must be serialized",
+    ),
     // HQPlayer protocol requires exclusive connection access during entire command/response cycle.
     // Releasing the lock between send and receive would allow interleaving from other tasks.
     (


### PR DESCRIPTION
The `v4` Linux job fails because the cloud connector's deliberate lifecycle mutex was added after the await-in-lock allowlist. Concurrent resume requests must hold this guard through replay validation, safety-budget reset, and connector activation; releasing it early would let both requests reset containment.

This names the guard explicitly and documents the exact file/guard exception while retaining the existing concurrency regression coverage.

Closes #699.

Validation:

- `cargo test --test await_in_lock_lint -- --nocapture`
- `cargo test recovery_serializes_clicks_preserves_identity_and_exposes_terminal_pause -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal naming for cloud connector operation guards without changing behavior.

* **Tests**
  * Updated validation to allow required asynchronous operations during serialized cloud connector start and resume transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->