### PR TITLE
Stop Library pagination responses from resetting the first page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -681,8 +681,13 @@ jobs:
     name: Smoke Test Binary
     needs: [plan, build-linux-x64]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -682,6 +682,19 @@ jobs:
     needs: [plan, build-linux-x64]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Download binary
         uses: actions/download-artifact@v8
         with:
@@ -807,6 +820,24 @@ jobs:
 
           echo ""
           echo "All smoke tests passed!"
+
+      - name: Run library pagination browser regression
+        env:
+          UHC_URL: http://127.0.0.1:8088
+        run: |
+          npx playwright test e2e/library_pagination.spec.ts \
+            --project='Desktop Chrome' \
+            --reporter=line \
+            --output="$RUNNER_TEMP/playwright-test-results"
+
+      - name: Upload browser regression diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-test-playwright-diagnostics
+          path: ${{ runner.temp }}/playwright-test-results/
+          if-no-files-found: ignore
+          retention-days: 5
 
       - name: Stop server
         if: always()

--- a/e2e/library_pagination.spec.ts
+++ b/e2e/library_pagination.spec.ts
@@ -1,13 +1,15 @@
 import { expect, test } from '@playwright/test';
+import { join } from 'node:path';
+import { readdirSync } from 'node:fs';
 
 const baseUrl = process.env.UHC_URL || 'http://192.168.1.2:8088';
-const initialLocation = 'loc_WFoj90WCkO8tsIQmgM8rKA';
+const initialLocation = 'loc_test_root';
 
 function collectionPage(offset: number, location: string) {
   const items = Array.from({ length: offset < 60 ? 30 : 7 }, (_, index) => {
     const number = offset + index + 1;
     return {
-      title: `Folder ${number}`,
+      title: location === initialLocation ? `Folder ${number}` : `Child ${number}`,
       location: `loc_folder_${number}`,
     };
   });
@@ -23,6 +25,17 @@ function collectionPage(offset: number, location: string) {
 
 async function installLibraryMocks(page: import('@playwright/test').Page) {
   const collectionRequests: Array<{ offset: number; location: string | null }> = [];
+
+  const assetDir = process.env.UHC_CLIENT_ASSET_DIR;
+  if (assetDir) {
+    const mainJs = readdirSync(assetDir).find((name) => /^unified-hifi-control-dx.*\.js$/.test(name));
+    const wasm = readdirSync(assetDir).find((name) => /^unified-hifi-control_bg-.*\.wasm$/.test(name));
+    if (!mainJs || !wasm) throw new Error(`UHC_CLIENT_ASSET_DIR lacks the main JS/WASM pair: ${assetDir}`);
+    await page.route('**/assets/unified-hifi-control*.js', (route) =>
+      route.fulfill({ path: join(assetDir, mainJs), contentType: 'text/javascript' }));
+    await page.route('**/assets/unified-hifi-control*.wasm', (route) =>
+      route.fulfill({ path: join(assetDir, wasm), contentType: 'application/wasm' }));
+  }
 
   await page.route('**/zones', (route) => route.fulfill({
     contentType: 'application/json',
@@ -45,6 +58,11 @@ async function installLibraryMocks(page: import('@playwright/test').Page) {
     const offset = body.offset ?? 0;
     const location = body.location ?? null;
     collectionRequests.push({ offset, location });
+    if (collectionRequests.length > 100) {
+      await route.abort('failed');
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify(collectionPage(offset, location ?? initialLocation)),
@@ -60,19 +78,26 @@ test('Library pagination settles, advances offsets, retains rows, and refetches 
 
   const more = page.getByRole('button', { name: 'Load more', exact: true });
   await expect(page.getByText('Folder 1', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await page.waitForTimeout(250);
   await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0]);
 
   await more.click();
+  await expect(page.getByText('Folder 31', { exact: true })).toBeVisible();
   await expect(page.getByText('Folder 30', { exact: true })).toBeVisible();
   await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30]);
 
   await more.click();
+  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 31', { exact: true })).toBeVisible();
   await expect(page.getByText('Folder 60', { exact: true })).toBeVisible();
   await expect(page.getByText('Folder 67', { exact: true })).toBeVisible();
+  await expect(page.locator('.library-row')).toHaveCount(67);
+  await expect(more).toBeHidden();
   await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30, 60]);
 
   await page.getByRole('button', { name: 'Open Folder 1', exact: true }).click();
   await expect(page).toHaveURL(/\/library\/roon\/browse\/loc_folder_1$/);
   await expect.poll(() => collectionRequests.at(-1)).toEqual({ offset: 0, location: 'loc_folder_1' });
-  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Child 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 67', { exact: true })).toHaveCount(0);
 });

--- a/e2e/library_pagination.spec.ts
+++ b/e2e/library_pagination.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+const baseUrl = process.env.UHC_URL || 'http://192.168.1.2:8088';
+const initialLocation = 'loc_WFoj90WCkO8tsIQmgM8rKA';
+
+function collectionPage(offset: number, location: string) {
+  const items = Array.from({ length: offset < 60 ? 30 : 7 }, (_, index) => {
+    const number = offset + index + 1;
+    return {
+      title: `Folder ${number}`,
+      location: `loc_folder_${number}`,
+    };
+  });
+  return {
+    outcome: 'ok',
+    data: {
+      items,
+      breadcrumbs: [{ title: 'Library', location }],
+      next_offset: offset < 60 ? offset + 30 : null,
+    },
+  };
+}
+
+async function installLibraryMocks(page: import('@playwright/test').Page) {
+  const collectionRequests: Array<{ offset: number; location: string | null }> = [];
+
+  await page.route('**/zones', (route) => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      zones: [{
+        zone_id: 'roon:mock-zone',
+        zone_name: 'Mock Roon Zone',
+        source: 'roon',
+        browse_supported: true,
+        library_tabs: ['browse'],
+      }],
+    }),
+  }));
+  await page.route('**/now_playing**', (route) => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ line1: 'Idle', is_playing: false }),
+  }));
+  await page.route('**/api/collections', async (route) => {
+    const body = route.request().postDataJSON() as { offset?: number; location?: string };
+    const offset = body.offset ?? 0;
+    const location = body.location ?? null;
+    collectionRequests.push({ offset, location });
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(collectionPage(offset, location ?? initialLocation)),
+    });
+  });
+
+  return collectionRequests;
+}
+
+test('Library pagination settles, advances offsets, retains rows, and refetches after navigation', async ({ page }) => {
+  const collectionRequests = await installLibraryMocks(page);
+  await page.goto(`${baseUrl}/library/roon/browse/${initialLocation}`, { waitUntil: 'domcontentloaded' });
+
+  const more = page.getByRole('button', { name: 'Load more', exact: true });
+  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0]);
+
+  await more.click();
+  await expect(page.getByText('Folder 30', { exact: true })).toBeVisible();
+  await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30]);
+
+  await more.click();
+  await expect(page.getByText('Folder 60', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 67', { exact: true })).toBeVisible();
+  await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30, 60]);
+
+  await page.getByRole('button', { name: 'Open Folder 1', exact: true }).click();
+  await expect(page).toHaveURL(/\/library\/roon\/browse\/loc_folder_1$/);
+  await expect.poll(() => collectionRequests.at(-1)).toEqual({ offset: 0, location: 'loc_folder_1' });
+  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible();
+});

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -581,7 +581,13 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
                 current_tab.media_type().map(ToOwned::to_owned),
             )
         };
-        let Some(request_offset) = next_request_offset(append, next_offset()) else {
+        // A fresh route load must not subscribe this callback/effect to the
+        // pagination cursor: load_page updates `next_offset`, and that update
+        // would otherwise retrigger the route effect and erase appended rows
+        // with a new offset-0 request. The append path is an event handler, so
+        // it may read the cursor without creating that subscription.
+        let continuation = if append { *next_offset.peek() } else { None };
+        let Some(request_offset) = next_request_offset(append, continuation) else {
             // A stale click can arrive after the previous page has completed
             // and cleared the continuation. Never turn that into offset zero,
             // which would append the first page a second time.


### PR DESCRIPTION
On alpha.7, Library **Load more** sent the correct next offset and received the next page, but the UI immediately reloaded offset zero and erased the appended rows. Reading `next_offset()` in the shared refresh callback subscribed the route-loading effect to the pagination cursor; every response then retriggered that effect.

Fresh loads now avoid reading the cursor, and append clicks inspect it without a reactive subscription. The existing next-offset handling remains intact. No API changes.

Fixes #706. Follow-up to #703.

Validation:
- Reproduced in the installed alpha.7 browser: repeated offset-zero loads before clicking, then offset 30 followed by offset zero.
- Hydrated browser regression fails on alpha.7 and passes with the patched JS/WASM: initial load settles, offsets advance `0 → 30 → 60`, all 67 fixture rows remain, the final page hides Load more, and folder navigation starts a fresh load.
- Against the user's live Roon Artists location, the patched client requests exactly `0 → 30 → 60`, receives different artist pages, and retains earlier artists. Browser asset overrides were used; the installed bridge was not modified.
- Library unit tests (5), reactive-loop lint tests (15), formatting and diff checks passed.
- Dioxus release client build passed.

Browser command: build the client, then run `npx playwright test e2e/library_pagination.spec.ts --project='Desktop Chrome'` with `UHC_URL` pointing to a running Bridge and optional `UHC_CLIENT_ASSET_DIR` pointing to the generated main JS/WASM assets. Collection responses are mocked in this test.

OH: 80222d6d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed library pagination so loading additional pages no longer resets the list to the first page.
  * Preserved previously loaded items while advancing through subsequent pages.
  * Improved folder navigation so child content refreshes correctly.
  * Prevented excessive pagination requests during library browsing.
* **Tests**
  * Added end-to-end coverage for pagination, navigation, completion states, and request limits.
  * Added automated browser regression checks to help ensure reliable library loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->