### PR TITLE
Add persistent List and Cards library views

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -681,8 +681,13 @@ jobs:
     name: Smoke Test Binary
     needs: [plan, build-linux-x64]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -682,6 +682,19 @@ jobs:
     needs: [plan, build-linux-x64]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
       - name: Download binary
         uses: actions/download-artifact@v8
         with:
@@ -807,6 +820,24 @@ jobs:
 
           echo ""
           echo "All smoke tests passed!"
+
+      - name: Run library pagination browser regression
+        env:
+          UHC_URL: http://127.0.0.1:8088
+        run: |
+          npx playwright test e2e/library_pagination.spec.ts \
+            --project='Desktop Chrome' \
+            --reporter=line \
+            --output="$RUNNER_TEMP/playwright-test-results"
+
+      - name: Upload browser regression diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: smoke-test-playwright-diagnostics
+          path: ${{ runner.temp }}/playwright-test-results/
+          if-no-files-found: ignore
+          retention-days: 5
 
       - name: Stop server
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -826,11 +826,11 @@ jobs:
           echo ""
           echo "All smoke tests passed!"
 
-      - name: Run library pagination browser regression
+      - name: Run library browser regressions
         env:
           UHC_URL: http://127.0.0.1:8088
         run: |
-          npx playwright test e2e/library_pagination.spec.ts \
+          npx playwright test e2e/library_pagination.spec.ts e2e/library_view_toggle.spec.ts \
             --project='Desktop Chrome' \
             --reporter=line \
             --output="$RUNNER_TEMP/playwright-test-results"

--- a/e2e/library_pagination.spec.ts
+++ b/e2e/library_pagination.spec.ts
@@ -1,13 +1,15 @@
 import { expect, test } from '@playwright/test';
+import { join } from 'node:path';
+import { readdirSync } from 'node:fs';
 
 const baseUrl = process.env.UHC_URL || 'http://192.168.1.2:8088';
-const initialLocation = 'loc_WFoj90WCkO8tsIQmgM8rKA';
+const initialLocation = 'loc_test_root';
 
 function collectionPage(offset: number, location: string) {
   const items = Array.from({ length: offset < 60 ? 30 : 7 }, (_, index) => {
     const number = offset + index + 1;
     return {
-      title: `Folder ${number}`,
+      title: location === initialLocation ? `Folder ${number}` : `Child ${number}`,
       location: `loc_folder_${number}`,
     };
   });
@@ -23,6 +25,17 @@ function collectionPage(offset: number, location: string) {
 
 async function installLibraryMocks(page: import('@playwright/test').Page) {
   const collectionRequests: Array<{ offset: number; location: string | null }> = [];
+
+  const assetDir = process.env.UHC_CLIENT_ASSET_DIR;
+  if (assetDir) {
+    const mainJs = readdirSync(assetDir).find((name) => /^unified-hifi-control-dx.*\.js$/.test(name));
+    const wasm = readdirSync(assetDir).find((name) => /^unified-hifi-control_bg-.*\.wasm$/.test(name));
+    if (!mainJs || !wasm) throw new Error(`UHC_CLIENT_ASSET_DIR lacks the main JS/WASM pair: ${assetDir}`);
+    await page.route('**/assets/unified-hifi-control*.js', (route) =>
+      route.fulfill({ path: join(assetDir, mainJs), contentType: 'text/javascript' }));
+    await page.route('**/assets/unified-hifi-control*.wasm', (route) =>
+      route.fulfill({ path: join(assetDir, wasm), contentType: 'application/wasm' }));
+  }
 
   await page.route('**/zones', (route) => route.fulfill({
     contentType: 'application/json',
@@ -45,6 +58,11 @@ async function installLibraryMocks(page: import('@playwright/test').Page) {
     const offset = body.offset ?? 0;
     const location = body.location ?? null;
     collectionRequests.push({ offset, location });
+    if (collectionRequests.length > 100) {
+      await route.abort('failed');
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify(collectionPage(offset, location ?? initialLocation)),
@@ -60,19 +78,26 @@ test('Library pagination settles, advances offsets, retains rows, and refetches 
 
   const more = page.getByRole('button', { name: 'Load more', exact: true });
   await expect(page.getByText('Folder 1', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await page.waitForTimeout(250);
   await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0]);
 
   await more.click();
+  await expect(page.getByText('Folder 31', { exact: true })).toBeVisible();
   await expect(page.getByText('Folder 30', { exact: true })).toBeVisible();
   await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30]);
 
   await more.click();
+  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 31', { exact: true })).toBeVisible();
   await expect(page.getByText('Folder 60', { exact: true })).toBeVisible();
   await expect(page.getByText('Folder 67', { exact: true })).toBeVisible();
+  await expect(page.locator('.library-row')).toHaveCount(67);
+  await expect(more).toBeHidden();
   await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30, 60]);
 
   await page.getByRole('button', { name: 'Open Folder 1', exact: true }).click();
   await expect(page).toHaveURL(/\/library\/roon\/browse\/loc_folder_1$/);
   await expect.poll(() => collectionRequests.at(-1)).toEqual({ offset: 0, location: 'loc_folder_1' });
-  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Child 1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 67', { exact: true })).toHaveCount(0);
 });

--- a/e2e/library_pagination.spec.ts
+++ b/e2e/library_pagination.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+const baseUrl = process.env.UHC_URL || 'http://192.168.1.2:8088';
+const initialLocation = 'loc_WFoj90WCkO8tsIQmgM8rKA';
+
+function collectionPage(offset: number, location: string) {
+  const items = Array.from({ length: offset < 60 ? 30 : 7 }, (_, index) => {
+    const number = offset + index + 1;
+    return {
+      title: `Folder ${number}`,
+      location: `loc_folder_${number}`,
+    };
+  });
+  return {
+    outcome: 'ok',
+    data: {
+      items,
+      breadcrumbs: [{ title: 'Library', location }],
+      next_offset: offset < 60 ? offset + 30 : null,
+    },
+  };
+}
+
+async function installLibraryMocks(page: import('@playwright/test').Page) {
+  const collectionRequests: Array<{ offset: number; location: string | null }> = [];
+
+  await page.route('**/zones', (route) => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({
+      zones: [{
+        zone_id: 'roon:mock-zone',
+        zone_name: 'Mock Roon Zone',
+        source: 'roon',
+        browse_supported: true,
+        library_tabs: ['browse'],
+      }],
+    }),
+  }));
+  await page.route('**/now_playing**', (route) => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ line1: 'Idle', is_playing: false }),
+  }));
+  await page.route('**/api/collections', async (route) => {
+    const body = route.request().postDataJSON() as { offset?: number; location?: string };
+    const offset = body.offset ?? 0;
+    const location = body.location ?? null;
+    collectionRequests.push({ offset, location });
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(collectionPage(offset, location ?? initialLocation)),
+    });
+  });
+
+  return collectionRequests;
+}
+
+test('Library pagination settles, advances offsets, retains rows, and refetches after navigation', async ({ page }) => {
+  const collectionRequests = await installLibraryMocks(page);
+  await page.goto(`${baseUrl}/library/roon/browse/${initialLocation}`, { waitUntil: 'domcontentloaded' });
+
+  const more = page.getByRole('button', { name: 'Load more', exact: true });
+  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible({ timeout: 10_000 });
+  await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0]);
+
+  await more.click();
+  await expect(page.getByText('Folder 30', { exact: true })).toBeVisible();
+  await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30]);
+
+  await more.click();
+  await expect(page.getByText('Folder 60', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 67', { exact: true })).toBeVisible();
+  await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30, 60]);
+
+  await page.getByRole('button', { name: 'Open Folder 1', exact: true }).click();
+  await expect(page).toHaveURL(/\/library\/roon\/browse\/loc_folder_1$/);
+  await expect.poll(() => collectionRequests.at(-1)).toEqual({ offset: 0, location: 'loc_folder_1' });
+  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible();
+});

--- a/e2e/library_view_toggle.spec.ts
+++ b/e2e/library_view_toggle.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test';
+import { join } from 'node:path';
+import { readdirSync } from 'node:fs';
+
+const baseUrl = process.env.UHC_URL || 'http://192.168.1.2:8088';
+const location = 'loc_test_root';
+
+async function installLibraryMocks(page: import('@playwright/test').Page) {
+  const assetDir = process.env.UHC_CLIENT_ASSET_DIR;
+  if (assetDir) {
+    const mainJs = readdirSync(assetDir).find((name) => /^unified-hifi-control-dx.*\.js$/.test(name));
+    const wasm = readdirSync(assetDir).find((name) => /^unified-hifi-control_bg-.*\.wasm$/.test(name));
+    if (!mainJs || !wasm) throw new Error(`UHC_CLIENT_ASSET_DIR lacks the main JS/WASM pair: ${assetDir}`);
+    await page.route('**/assets/unified-hifi-control*.js', (route) =>
+      route.fulfill({ path: join(assetDir, mainJs), contentType: 'text/javascript' }));
+    await page.route('**/assets/unified-hifi-control*.wasm', (route) =>
+      route.fulfill({ path: join(assetDir, wasm), contentType: 'application/wasm' }));
+  }
+
+  await page.route('**/zones', (route) => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify({ zones: [{
+      zone_id: 'roon:mock-zone', zone_name: 'Mock Roon Zone', source: 'roon',
+      browse_supported: true, library_tabs: ['browse'],
+    }] }),
+  }));
+  await page.route('**/now_playing**', (route) => route.fulfill({
+    contentType: 'application/json', body: JSON.stringify({ line1: 'Idle', is_playing: false }),
+  }));
+  const collectionRequests: Array<{ offset: number; location: string | null }> = [];
+  await page.route('**/api/collections', async (route) => {
+    const body = route.request().postDataJSON() as { offset?: number; location?: string };
+    const offset = body.offset ?? 0;
+    const requestedLocation = body.location ?? null;
+    collectionRequests.push({ offset, location: requestedLocation });
+    const child = requestedLocation === 'loc_folder_1';
+    const start = child ? 1 : offset === 30 ? 31 : 1;
+    const end = child ? 3 : offset === 30 ? 35 : 30;
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ outcome: 'ok', data: {
+        items: Array.from({ length: end - start + 1 }, (_, index) => ({
+          title: child ? `Child ${start + index}` : `Folder ${start + index}`,
+          location: child ? `loc_child_${start + index}` : `loc_folder_${start + index}`,
+        })),
+        breadcrumbs: [{ title: 'Library', location: requestedLocation ?? location }],
+        next_offset: child || offset === 30 ? null : 30,
+      } }),
+    });
+  });
+  return collectionRequests;
+}
+
+test('Library lets the user choose and persist List or Cards without refetching', async ({ page }) => {
+  const collectionRequests = await installLibraryMocks(page);
+
+  await page.goto(`${baseUrl}/library/roon/browse/${location}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByText('Folder 1', { exact: true })).toBeVisible({ timeout: 10_000 });
+  const listView = page.getByRole('button', { name: 'List view', exact: true });
+  const cardsView = page.getByRole('button', { name: 'Cards view', exact: true });
+  await expect(listView).toHaveAttribute('aria-pressed', 'true');
+  await expect(cardsView).toHaveAttribute('aria-pressed', 'false');
+
+  const loadMore = page.getByRole('button', { name: 'Load more', exact: true });
+  await expect(loadMore).toBeVisible();
+  await loadMore.click();
+  await expect(page.getByText('Folder 31', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 35', { exact: true })).toBeVisible();
+  await expect(page.locator('.library-row')).toHaveCount(35);
+  await expect(loadMore).toBeHidden();
+  await expect.poll(() => collectionRequests.map(({ offset }) => offset)).toEqual([0, 30]);
+
+  const requestsBeforeToggle = collectionRequests.length;
+  await cardsView.click();
+  await expect(page.locator('.library-grid')).toBeVisible();
+  await expect(page.getByText('Folder 31', { exact: true })).toBeVisible();
+  await expect(page.getByText('Folder 35', { exact: true })).toBeVisible();
+  await expect(cardsView).toHaveAttribute('aria-pressed', 'true');
+  await expect(listView).toHaveAttribute('aria-pressed', 'false');
+  await page.waitForTimeout(250);
+  expect(collectionRequests.length).toBe(requestsBeforeToggle);
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('uhc.library.view'))).toBe('cards');
+
+  await listView.click();
+  await expect(page.locator('.library-list')).toBeVisible();
+  await expect(page.getByText('Folder 35', { exact: true })).toBeVisible();
+  await page.waitForTimeout(250);
+  expect(collectionRequests.length).toBe(requestsBeforeToggle);
+
+  await cardsView.click();
+  await expect(page.getByText('Folder 35', { exact: true })).toBeVisible();
+  await page.waitForTimeout(250);
+  expect(collectionRequests.length).toBe(requestsBeforeToggle);
+  await page.locator('.library-tile').filter({
+    has: page.getByText('Folder 1', { exact: true }),
+  }).click();
+  await expect(page).toHaveURL(/\/library\/roon\/browse\/loc_folder_1$/);
+  await expect(page.getByText('Child 1', { exact: true })).toBeVisible();
+  await expect(page.locator('.library-grid')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Cards view', exact: true })).toHaveAttribute('aria-pressed', 'true');
+  await expect.poll(() => collectionRequests.at(-1)).toEqual({ offset: 0, location: 'loc_folder_1' });
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(page.locator('.library-grid')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Cards view', exact: true })).toHaveAttribute('aria-pressed', 'true');
+
+  await page.evaluate(() => localStorage.setItem('uhc.library.view', 'invalid'));
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('button', { name: 'List view', exact: true })).toHaveAttribute('aria-pressed', 'true');
+});

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -581,7 +581,13 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
                 current_tab.media_type().map(ToOwned::to_owned),
             )
         };
-        let Some(request_offset) = next_request_offset(append, next_offset()) else {
+        // A fresh route load must not subscribe this callback/effect to the
+        // pagination cursor: load_page updates `next_offset`, and that update
+        // would otherwise retrigger the route effect and erase appended rows
+        // with a new offset-0 request. The append path is an event handler, so
+        // it may read the cursor without creating that subscription.
+        let continuation = if append { *next_offset.peek() } else { None };
+        let Some(request_offset) = next_request_offset(append, continuation) else {
             // A stale click can arrive after the previous page has completed
             // and cleared the continuation. Never turn that into offset zero,
             // which would append the first page a second time.

--- a/src/app/pages/library.rs
+++ b/src/app/pages/library.rs
@@ -27,6 +27,8 @@ use std::collections::HashMap;
 const PAGE_LIMIT: u32 = 30;
 const SEARCH_DEBOUNCE_MS: u64 = 300;
 #[cfg(target_arch = "wasm32")]
+const LIBRARY_LAYOUT_STORAGE_KEY: &str = "uhc.library.view";
+#[cfg(target_arch = "wasm32")]
 const ARMED_ZONE_STORAGE_KEY: &str = "uhc.armed_zone";
 
 fn library_route(source: Option<String>, view: Option<String>, location: Option<String>) -> Route {
@@ -61,6 +63,53 @@ enum Tab {
     Favorites,
     Radio,
 }
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum LibraryLayout {
+    #[default]
+    Auto,
+    List,
+    Cards,
+}
+
+impl LibraryLayout {
+    #[cfg(target_arch = "wasm32")]
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::List => "list",
+            Self::Cards => "cards",
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn parse(value: &str) -> Self {
+        match value {
+            "list" => Self::List,
+            "cards" => Self::Cards,
+            _ => Self::Auto,
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn load_library_layout() -> LibraryLayout {
+    web_sys::window()
+        .and_then(|window| window.local_storage().ok().flatten())
+        .and_then(|storage| storage.get_item(LIBRARY_LAYOUT_STORAGE_KEY).ok().flatten())
+        .map(|value| LibraryLayout::parse(&value))
+        .unwrap_or_default()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn save_library_layout(layout: LibraryLayout) {
+    if let Some(Ok(Some(storage))) = web_sys::window().map(|window| window.local_storage()) {
+        let _ = storage.set_item(LIBRARY_LAYOUT_STORAGE_KEY, layout.as_str());
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn save_library_layout(_layout: LibraryLayout) {}
 
 impl Tab {
     fn parse(value: &str) -> Self {
@@ -554,6 +603,11 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
 
     let items = use_signal(Vec::<CollectionItem>::new);
     let next_offset = use_signal(|| None::<u32>);
+    let mut library_layout = use_signal(LibraryLayout::default);
+    #[cfg(target_arch = "wasm32")]
+    use_effect(move || {
+        library_layout.set(load_library_layout());
+    });
     let loading = use_signal(|| false);
     let error = use_signal(|| None::<LevelError>);
     let mut status = use_signal(|| None::<String>);
@@ -886,6 +940,8 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
     let current_error = error();
     let is_loading = loading();
     let current_items = items();
+    let current_layout = library_layout();
+    let cards_active = library_uses_cards(current_layout, &current_items);
     let can_load_more = next_offset.read().is_some();
     let current_status = status();
     let crumbs = breadcrumbs();
@@ -972,6 +1028,7 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
                     } else {
                         LibraryRows {
                             items: local_matches.clone(),
+                            layout: current_layout,
                             tab: current_tab,
                             currently_playing_title: currently_playing_title.clone(),
                             on_open: open_folder,
@@ -1088,6 +1145,7 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
         rsx! {
             LibraryRows {
                 items: current_items.clone(),
+                layout: current_layout,
                 tab: current_tab,
                 currently_playing_title: currently_playing_title.clone(),
                 on_open: open_folder,
@@ -1153,6 +1211,31 @@ fn Library(source: Option<String>, tab: Option<String>, location: Option<String>
                                     }
                                 }
                             }
+                        }
+                    }
+
+                    div { class: "library-view-toggle", role: "group", aria_label: "Library layout",
+                        button {
+                            class: if !cards_active { "library-view-toggle-btn library-view-toggle-btn--active" } else { "library-view-toggle-btn" },
+                            r#type: "button",
+                            aria_label: "List view",
+                            aria_pressed: !cards_active,
+                            onclick: move |_| {
+                                library_layout.set(LibraryLayout::List);
+                                save_library_layout(LibraryLayout::List);
+                            },
+                            "List"
+                        }
+                        button {
+                            class: if cards_active { "library-view-toggle-btn library-view-toggle-btn--active" } else { "library-view-toggle-btn" },
+                            r#type: "button",
+                            aria_label: "Cards view",
+                            aria_pressed: cards_active,
+                            onclick: move |_| {
+                                library_layout.set(LibraryLayout::Cards);
+                                save_library_layout(LibraryLayout::Cards);
+                            },
+                            "Cards"
                         }
                     }
 
@@ -1236,6 +1319,17 @@ fn empty_state_body(tab: Tab) -> &'static str {
     }
 }
 
+fn library_uses_cards(layout: LibraryLayout, items: &[CollectionItem]) -> bool {
+    match layout {
+        LibraryLayout::Cards => true,
+        LibraryLayout::List => false,
+        LibraryLayout::Auto => {
+            let playable_count = items.iter().filter(|item| item.item_ref.is_some()).count();
+            !items.is_empty() && playable_count * 2 >= items.len()
+        }
+    }
+}
+
 /// Rows for one page of browse/playlists/favorites/radio results.
 ///
 /// Per-level layout follows the design brief's "art-first, list otherwise"
@@ -1247,13 +1341,13 @@ fn empty_state_body(tab: Tab) -> &'static str {
 #[component]
 fn LibraryRows(
     items: Vec<CollectionItem>,
+    layout: LibraryLayout,
     tab: Tab,
     currently_playing_title: Option<String>,
     on_open: EventHandler<(String, String)>,
     on_play: EventHandler<(String, &'static str)>,
 ) -> Element {
-    let playable_count = items.iter().filter(|i| i.item_ref.is_some()).count();
-    let grid_shaped = !items.is_empty() && playable_count * 2 >= items.len();
+    let grid_shaped = library_uses_cards(layout, &items);
 
     if grid_shaped {
         rsx! {
@@ -1715,5 +1809,24 @@ mod library_defect_pins {
         assert_eq!(next_request_offset(true, None), None);
         assert_eq!(next_request_offset(false, None), Some(0));
         assert_eq!(next_request_offset(false, Some(60)), Some(0));
+    }
+
+    #[test]
+    fn layout_preference_overrides_automatic_shape_without_changing_items() {
+        let folders = vec![CollectionItem {
+            title: "Folder".to_string(),
+            location: Some("loc_folder".to_string()),
+            ..CollectionItem::default()
+        }];
+        let tracks = vec![CollectionItem {
+            title: "Track".to_string(),
+            item_ref: Some("ref_track".to_string()),
+            ..CollectionItem::default()
+        }];
+
+        assert!(!library_uses_cards(LibraryLayout::Auto, &folders));
+        assert!(library_uses_cards(LibraryLayout::Auto, &tracks));
+        assert!(library_uses_cards(LibraryLayout::Cards, &folders));
+        assert!(!library_uses_cards(LibraryLayout::List, &tracks));
     }
 }

--- a/src/input.css
+++ b/src/input.css
@@ -495,6 +495,23 @@
     background: var(--surface-elevated);
   }
 
+  .library-view-toggle {
+    @apply flex gap-1 mb-3;
+  }
+  .library-view-toggle-btn {
+    @apply rounded-md border px-3 py-1.5 text-sm;
+    color: var(--text-secondary);
+    border-color: var(--border-subtle);
+  }
+  .library-view-toggle-btn:hover,
+  .library-view-toggle-btn--active {
+    color: var(--text-primary);
+    background: var(--surface-elevated);
+  }
+  .library-view-toggle-btn--active {
+    border-color: var(--border-default);
+  }
+
   .library-breadcrumbs {
     @apply flex flex-wrap items-center gap-1 mb-4 text-sm;
     color: var(--text-muted);


### PR DESCRIPTION
Add List and Cards controls to the library, with the selected layout saved in browser localStorage. Switching keeps loaded pages and does not refetch collections; the choice survives navigation and reload. Until a preference is chosen, the existing automatic layout remains in use.

Stacked on #708, which fixes the pagination refresh loop. Fixes #707.

Validation:
- Browser regression failed before the controls existed, then passed with the matching fullstack build.
- Both pagination and layout browser regressions pass locally and in CI against the packaged binary.
- [Combined stack CI](https://github.com/open-horizon-labs/unified-hifi-control/actions/runs/33964368000) passed all enabled jobs, including Rust tests, Linux/WASM builds and browser smoke tests.
- Live Roon check loaded 60 artists, switched Cards/List with request offsets remaining `[0, 30]`, and restored List after reload.
- Fullstack release build, library helper tests, API contract and reactive lint tests, formatting, and actionlint passed.

OH: 80222d6d
