### PR TITLE
fix: prevent Cloud snapshot bursts after scheduler stalls

### DIFF
--- a/src/cloud_connector/runtime.rs
+++ b/src/cloud_connector/runtime.rs
@@ -46,6 +46,13 @@ const ARTWORK_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_mil
 const MAX_SESSION_GRANT_RESPONSE_BYTES: usize = 16 * 1024;
 const SHUTDOWN_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
 
+fn snapshot_refresh_interval() -> tokio::time::Interval {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(20));
+    // A stalled task needs one current snapshot, not a burst of every missed tick.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    interval
+}
+
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct GrantResponse {
@@ -573,7 +580,7 @@ where
     let artwork_slots =
         std::sync::Arc::new(Semaphore::new(ARTWORK_QUEUE_CAPACITY + ARTWORK_CONCURRENCY));
     let artwork_active = std::sync::Arc::new(Semaphore::new(ARTWORK_CONCURRENCY));
-    let mut refresh = tokio::time::interval(std::time::Duration::from_secs(20));
+    let mut refresh = snapshot_refresh_interval();
     let mut watchdog_check = tokio::time::interval(PEER_HEARTBEAT_CHECK_INTERVAL);
     let mut heartbeat_step = 0u32;
     let heartbeat_check = tokio::time::sleep(super::safety::heartbeat_delay(heartbeat_step));
@@ -1269,6 +1276,20 @@ mod tests {
             Instant::now(),
             CancellationToken::new(),
         )
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn missed_snapshot_ticks_do_not_burst_after_a_stall() {
+        let mut refresh = super::snapshot_refresh_interval();
+        refresh.tick().await;
+        tokio::time::advance(std::time::Duration::from_secs(10 * 60)).await;
+        refresh.tick().await;
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(1), refresh.tick())
+                .await
+                .is_err(),
+            "missed snapshots must not catch up back-to-back"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
After a scheduler stall, the HiPhi connector's 20-second Tokio interval immediately replayed every missed snapshot tick. Production traffic for one alpha.8 installation jumped from 4–8 Durable Object invocations/minute to 183, the relay quarantined it, and later connection attempts received HTTP 429.

The snapshot interval now delays after a missed tick: UHC sends one current snapshot, then waits 20 seconds instead of catching up old ticks. A deterministic paused-time test reproduces the immediate second tick before the fix and passes afterward. Existing 23 connector and safety tests pass, including heartbeat, flood containment, recovery, and replay protection.

Production evidence strongly matches this mechanism, but retained analytics cannot classify each of the historic 183 invocations; that limit is recorded on #712.

Fixes #712

OH: 80222d6d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot refreshes now avoid running back-to-back after a delay, preventing bursts when scheduled refreshes are missed.
  * Refresh timing remains consistent following stalled or paused execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->