### PR TITLE
Run trusted x64 builds on the nuc14 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,6 +388,9 @@ jobs:
   lint:
     name: Lint
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
+    env:
+      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
+      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
 
@@ -423,6 +426,9 @@ jobs:
   test:
     name: Test
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
+    env:
+      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
+      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
 
@@ -481,6 +487,9 @@ jobs:
   build-wasm:
     name: Build WASM Assets
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
+    env:
+      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
+      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
 
@@ -538,7 +547,7 @@ jobs:
         id: cache-dx
         uses: actions/cache@v5
         with:
-          path: ~/.cargo/bin/dx
+          path: ${{ env.CARGO_HOME }}/bin/dx
           key: dx-cli-0.7.10
 
       - name: Install Dioxus CLI
@@ -601,6 +610,9 @@ jobs:
     name: Build Linux x64
     needs: [plan, build-wasm]
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
+    env:
+      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
+      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
 
@@ -630,7 +642,7 @@ jobs:
         id: cache-zigbuild
         uses: actions/cache@v5
         with:
-          path: ~/.cargo/bin/cargo-zigbuild
+          path: ${{ env.CARGO_HOME }}/bin/cargo-zigbuild
           key: cargo-zigbuild-0.20
 
       - name: Install cargo-zigbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,11 +388,13 @@ jobs:
   lint:
     name: Lint
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
-    env:
-      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
-      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
+
+      - name: Isolate mutable tool state
+        run: |
+          echo "CARGO_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/cargo" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/rustup" >> "$GITHUB_ENV"
 
       - name: Cache generated CSS
         id: cache-css
@@ -426,11 +428,13 @@ jobs:
   test:
     name: Test
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
-    env:
-      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
-      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
+
+      - name: Isolate mutable tool state
+        run: |
+          echo "CARGO_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/cargo" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/rustup" >> "$GITHUB_ENV"
 
       - name: Cache generated CSS
         id: cache-css
@@ -487,11 +491,13 @@ jobs:
   build-wasm:
     name: Build WASM Assets
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
-    env:
-      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
-      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
+
+      - name: Isolate mutable tool state
+        run: |
+          echo "CARGO_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/cargo" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/rustup" >> "$GITHUB_ENV"
 
       - name: Cache WASM build output
         id: cache-wasm
@@ -610,11 +616,13 @@ jobs:
     name: Build Linux x64
     needs: [plan, build-wasm]
     runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
-    env:
-      CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo
-      RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup
     steps:
       - uses: actions/checkout@v6
+
+      - name: Isolate mutable tool state
+        run: |
+          echo "CARGO_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/cargo" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/rustup" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -638,12 +638,21 @@ jobs:
         run: |
           ZIG_ROOT="${RUNNER_TOOL_CACHE:-$HOME/.cache/uhc-tools}/zig/0.13.0/x64"
           if [ ! -x "$ZIG_ROOT/zig" ]; then
-            mkdir -p "$(dirname "$ZIG_ROOT")"
-            TEMP_DIR=$(mktemp -d)
-            curl -L https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | tar -xJ -C "$TEMP_DIR"
-            mv "$TEMP_DIR/zig-linux-x86_64-0.13.0" "$ZIG_ROOT"
+            ZIG_PARENT=$(dirname "$ZIG_ROOT")
+            mkdir -p "$ZIG_PARENT"
+            TEMP_DIR=$(mktemp -d "$ZIG_PARENT/.zig-install.XXXXXX")
+            trap 'rm -rf "$TEMP_DIR"' EXIT
+            curl --fail --show-error --location \
+              https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | \
+              tar -xJ -C "$TEMP_DIR"
+            STAGED_ROOT="$TEMP_DIR/zig-linux-x86_64-0.13.0"
+            test -x "$STAGED_ROOT/zig"
+            rm -rf "$ZIG_ROOT"
+            mv "$STAGED_ROOT" "$ZIG_ROOT"
             rm -rf "$TEMP_DIR"
+            trap - EXIT
           fi
+          test -x "$ZIG_ROOT/zig"
           echo "$ZIG_ROOT" >> "$GITHUB_PATH"
 
       - name: Cache cargo-zigbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -706,7 +706,7 @@ jobs:
   smoke-test:
     name: Smoke Test Binary
     needs: [plan, build-linux-x64]
-    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: read
@@ -1566,7 +1566,7 @@ jobs:
     if: |
       needs.plan.outputs.build_qnap == 'true' &&
       needs.qnap-package-test.result == 'success'
-    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     # `secrets` isn't allowed directly in step `if:` conditions, so surface
     # the presence check as a job-level env var instead.
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,7 +387,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -422,7 +422,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -480,7 +480,7 @@ jobs:
   # Uses content-based caching to skip build when source unchanged
   build-wasm:
     name: Build WASM Assets
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -600,7 +600,7 @@ jobs:
   build-linux-x64:
     name: Build Linux x64
     needs: [plan, build-wasm]
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -616,9 +616,15 @@ jobs:
 
       - name: Install zig
         run: |
-          curl -L https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | tar -xJ
-          sudo mv zig-linux-x86_64-0.13.0 /opt/zig
-          echo "/opt/zig" >> $GITHUB_PATH
+          ZIG_ROOT="${RUNNER_TOOL_CACHE:-$HOME/.cache/uhc-tools}/zig/0.13.0/x64"
+          if [ ! -x "$ZIG_ROOT/zig" ]; then
+            mkdir -p "$(dirname "$ZIG_ROOT")"
+            TEMP_DIR=$(mktemp -d)
+            curl -L https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz | tar -xJ -C "$TEMP_DIR"
+            mv "$TEMP_DIR/zig-linux-x86_64-0.13.0" "$ZIG_ROOT"
+            rm -rf "$TEMP_DIR"
+          fi
+          echo "$ZIG_ROOT" >> "$GITHUB_PATH"
 
       - name: Cache cargo-zigbuild
         id: cache-zigbuild
@@ -680,7 +686,7 @@ jobs:
   smoke-test:
     name: Smoke Test Binary
     needs: [plan, build-linux-x64]
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: read
@@ -1540,7 +1546,7 @@ jobs:
     if: |
       needs.plan.outputs.build_qnap == 'true' &&
       needs.qnap-package-test.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest' }}
     # `secrets` isn't allowed directly in step `if:` conditions, so surface
     # the presence check as a job-level env var instead.
     env:

--- a/tests/ci_workflow_contract.rs
+++ b/tests/ci_workflow_contract.rs
@@ -10,6 +10,17 @@ fn workflow(name: &str) -> String {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
+fn job(source: &str, name: &str) -> String {
+    source
+        .split(&format!("\n  {name}:"))
+        .nth(1)
+        .unwrap_or_else(|| panic!("build.yml has no {name} job"))
+        .lines()
+        .take_while(|line| line.trim().is_empty() || line.starts_with("    "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[test]
 fn development_pull_requests_run_rust_and_api_contract_checks() {
     for name in ["build.yml", "api-guard.yml"] {
@@ -51,4 +62,33 @@ fn development_does_not_enable_edge_image_publication() {
         !development_branch_triggers,
         "v4 work must not enter the Docker edge publication workflow"
     );
+}
+
+#[test]
+fn trusted_expensive_linux_jobs_use_the_nuc_with_a_hosted_fork_fallback() {
+    let source = workflow("build.yml");
+    let selector = r#"vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest'"#;
+
+    for name in [
+        "lint",
+        "test",
+        "build-wasm",
+        "build-linux-x64",
+        "smoke-test",
+        "build-qnap-x64",
+    ] {
+        assert!(
+            job(&source, name).contains(selector),
+            "{name} must use nuc14 for trusted work and ubuntu-latest for fork PRs"
+        );
+    }
+}
+
+#[test]
+fn linux_x64_tool_install_is_safe_on_a_persistent_runner() {
+    let source = workflow("build.yml");
+    let linux_x64 = job(&source, "build-linux-x64");
+
+    assert!(linux_x64.contains("RUNNER_TOOL_CACHE"));
+    assert!(!linux_x64.contains("sudo mv zig-linux"));
 }

--- a/tests/ci_workflow_contract.rs
+++ b/tests/ci_workflow_contract.rs
@@ -92,3 +92,16 @@ fn linux_x64_tool_install_is_safe_on_a_persistent_runner() {
     assert!(linux_x64.contains("RUNNER_TOOL_CACHE"));
     assert!(!linux_x64.contains("sudo mv zig-linux"));
 }
+
+#[test]
+fn parallel_nuc_workers_do_not_share_mutable_rust_toolchains() {
+    let source = workflow("build.yml");
+
+    for name in ["lint", "test", "build-wasm", "build-linux-x64"] {
+        let body = job(&source, name);
+        assert!(body.contains("CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo"));
+        assert!(
+            body.contains("RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup")
+        );
+    }
+}

--- a/tests/ci_workflow_contract.rs
+++ b/tests/ci_workflow_contract.rs
@@ -96,6 +96,8 @@ fn linux_x64_tool_install_is_safe_on_a_persistent_runner() {
 
     assert!(linux_x64.contains("RUNNER_TOOL_CACHE"));
     assert!(!linux_x64.contains("sudo mv zig-linux"));
+    assert!(linux_x64.contains(r#"test -x "$STAGED_ROOT/zig""#));
+    assert!(linux_x64.contains(r#"rm -rf "$ZIG_ROOT""#));
 }
 
 #[test]

--- a/tests/ci_workflow_contract.rs
+++ b/tests/ci_workflow_contract.rs
@@ -69,17 +69,22 @@ fn trusted_expensive_linux_jobs_use_the_nuc_with_a_hosted_fork_fallback() {
     let source = workflow("build.yml");
     let selector = r#"vars.LOCAL_LINUX_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","linux","x64","nuc14"]') || 'ubuntu-latest'"#;
 
-    for name in [
-        "lint",
-        "test",
-        "build-wasm",
-        "build-linux-x64",
-        "smoke-test",
-        "build-qnap-x64",
-    ] {
+    for name in ["lint", "test", "build-wasm", "build-linux-x64"] {
         assert!(
             job(&source, name).contains(selector),
             "{name} must use nuc14 for trusted work and ubuntu-latest for fork PRs"
+        );
+    }
+}
+
+#[test]
+fn jobs_that_need_playwright_or_docker_stay_on_hosted_ubuntu() {
+    let source = workflow("build.yml");
+
+    for name in ["smoke-test", "build-qnap-x64"] {
+        assert!(
+            job(&source, name).contains("runs-on: ubuntu-latest"),
+            "{name} requires tooling absent from the nuc14 runner image"
         );
     }
 }

--- a/tests/ci_workflow_contract.rs
+++ b/tests/ci_workflow_contract.rs
@@ -99,9 +99,11 @@ fn parallel_nuc_workers_do_not_share_mutable_rust_toolchains() {
 
     for name in ["lint", "test", "build-wasm", "build-linux-x64"] {
         let body = job(&source, name);
-        assert!(body.contains("CARGO_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/cargo"));
-        assert!(
-            body.contains("RUSTUP_HOME: ${{ runner.tool_cache }}/uhc/${{ runner.name }}/rustup")
-        );
+        assert!(body.contains(
+            r#"echo "CARGO_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/cargo" >> "$GITHUB_ENV""#
+        ));
+        assert!(body.contains(
+            r#"echo "RUSTUP_HOME=${RUNNER_TOOL_CACHE}/uhc/${RUNNER_NAME}/rustup" >> "$GITHUB_ENV""#
+        ));
     }
 }


### PR DESCRIPTION
UHC's expensive Linux x64 jobs still ran on GitHub-hosted workers even though the isolated `nuc14` runner was available. This routes trusted repository events to the NUC with the same fork-safe selector used by repo-native-alignment; fork PRs continue on `ubuntu-latest`.

The native path covers lint, test, WASM, and the Linux x64 binary. Smoke testing stays on hosted Ubuntu because Playwright 1.59 does not support the runner image's Ubuntu 26.04; QPKG packaging stays hosted because the runner image intentionally has no Docker. Both consume the NUC-built binary.

The two NUC runner services originally shared one Rustup home. The first concurrent run reproduced a component-download race, so mutable Cargo/Rustup state is isolated per runner in the workflow and each NUC service now has a distinct persistent home under `/srv/agent-data/cache/github-actions/`.

Refs #698

Validation:
- End-to-end Build run 34002453444: success
- NUC: lint, test, WASM, Linux x64 all passed
- Hosted: smoke test and QPKG Docker/QDK packaging passed
- `cargo test --test ci_workflow_contract`
- `cargo test --test qnap_service_contract`
- `sh tests/qnap_package_contract.sh`
- `cargo fmt --all -- --check`
- actionlint 1.7.12 workflow validation (excluding pre-existing shellcheck findings)
